### PR TITLE
fix(tests): use MSVC-compatible manifest literal

### DIFF
--- a/tests/unit/runtime/assets/AssetCookOutputTests.cpp
+++ b/tests/unit/runtime/assets/AssetCookOutputTests.cpp
@@ -108,7 +108,7 @@ TEST_CASE("PublishCookGeneration escapes manifest strings", "[native]") {
     const std::string manifest{std::istreambuf_iterator<char>{manifestStream}, std::istreambuf_iterator<char>{}};
 
     REQUIRE((manifest.find(R"("target":"headless-null")") != std::string::npos));
-    REQUIRE((manifest.find(R"horo("artifact":"quoted\"artifact.cooked")horo") != std::string::npos));
+    REQUIRE((manifest.find("\"artifact\":\"quoted\\\"artifact.cooked\"") != std::string::npos));
     REQUIRE((std::filesystem::exists(published.Value().generationRoot / artifactFile)));
 }
 


### PR DESCRIPTION
## Summary
- Replaces the manifest assertion raw string with an equivalent escaped string literal.
- Fixes the MSVC C3688/C2017 parse failure in HoroAssetCookOutputTests.

## Motivation
- The Windows CI compiler rejected the raw-string expression around the escaped artifact path.

## Implementation Notes
- The expected JSON substring remains exactly the same at runtime.
- Production asset cooking behavior is unchanged.

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [ ] Manual smoke tested if applicable

Commands run:
```bash
cmake -S . -B build/review -DBUILD_TESTING=ON -DHORO_BUILD_EDITOR_GUI=OFF -DHORO_BUILD_RENDER_OPENGL=OFF -DHORO_BUILD_RENDER_METAL=OFF -DHORO_BUILD_EXAMPLES=OFF
cmake --build build/review --target HoroAssetCookOutputTests --parallel 4
ctest --test-dir build/review -R '^HoroAssetCookOutputTests::' --output-on-failure
clang-format --dry-run --Werror tests/unit/runtime/assets/AssetCookOutputTests.cpp
git diff --check
```

Result: 8 tests passed locally. Windows/MSVC confirmation is delegated to CI.

## Risks
- Local validation used Clang on macOS; the target MSVC validation depends on the Windows CI run.

## Issue Links
- None.

## Reviewer Notes
- Review the single assertion at AssetCookOutputTests.cpp:111.
