### PR TITLE
fix(tooling): preserve partially staged changes during format

### DIFF
--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -689,7 +689,7 @@ def _apply_format_chunk(clang_format_bin: str, chunk: list[str], check: bool) ->
 
 def _partially_staged_files(paths: Sequence[Path]) -> list[Path]:
     """Return staged targets whose working-tree contents differ from the index."""
-    relative_paths = [str(path.relative_to(REPOSITORY_ROOT)) for path in paths]
+    relative_paths = [os.path.relpath(path, REPOSITORY_ROOT) for path in paths]
     proc = subprocess.run(
         ["git", "diff", "--name-only", "--diff-filter=ACMR", "--", *relative_paths],
         cwd=REPOSITORY_ROOT,
@@ -727,7 +727,7 @@ def run_format(files: Sequence[str] | None = None, staged: bool = False, check: 
                 file=sys.stderr,
             )
             for path in partially_staged:
-                print(f"  {path.relative_to(REPOSITORY_ROOT)}", file=sys.stderr)
+                print(f"  {os.path.relpath(path, REPOSITORY_ROOT)}", file=sys.stderr)
             return 1
 
     file_paths = [str(f) for f in target_files]

--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -687,6 +687,22 @@ def _apply_format_chunk(clang_format_bin: str, chunk: list[str], check: bool) ->
     return execute_subprocess([clang_format_bin, "-i", *chunk])
 
 
+def _partially_staged_files(paths: Sequence[Path]) -> list[Path]:
+    """Return staged targets whose working-tree contents differ from the index."""
+    relative_paths = [str(path.relative_to(REPOSITORY_ROOT)) for path in paths]
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", "--", *relative_paths],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or "git diff failed"
+        raise RuntimeError(f"Could not inspect unstaged changes: {detail}")
+    return [REPOSITORY_ROOT / line for line in proc.stdout.splitlines() if line]
+
+
 def run_format(files: Sequence[str] | None = None, staged: bool = False, check: bool = False) -> int:
     """Format C++ source files with clang-format, with support for staged commits and dry-run check."""
     clang_format_bin = _find_clang_format()
@@ -698,6 +714,21 @@ def run_format(files: Sequence[str] | None = None, staged: bool = False, check: 
     if not target_files:
         print("No matching C++ files to format.")
         return 0
+
+    if staged and not check:
+        try:
+            partially_staged = _partially_staged_files(target_files)
+        except RuntimeError as error:
+            print(f"error: {error}", file=sys.stderr)
+            return 1
+        if partially_staged:
+            print(
+                "error: refusing to format partially staged files; stage or stash their unstaged changes first:",
+                file=sys.stderr,
+            )
+            for path in partially_staged:
+                print(f"  {path.relative_to(REPOSITORY_ROOT)}", file=sys.stderr)
+            return 1
 
     file_paths = [str(f) for f in target_files]
     chunk_size = 50

--- a/tests/python/test_dev_runner.py
+++ b/tests/python/test_dev_runner.py
@@ -425,6 +425,37 @@ def test_main_format_command_invokes_clang_format(monkeypatch: pytest.MonkeyPatc
     assert str(test_cpp) in calls[0]
 
 
+def test_staged_format_refuses_to_stage_unstaged_worktree_changes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "tests@horo.local"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Horo Tests"], cwd=tmp_path, check=True)
+    source = tmp_path / "Partial.cpp"
+    source.write_text("int value = 0;\n", encoding="utf-8")
+    subprocess.run(["git", "add", "Partial.cpp"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-qm", "initial"], cwd=tmp_path, check=True)
+
+    source.write_text("int value = 1;\n", encoding="utf-8")
+    subprocess.run(["git", "add", "Partial.cpp"], cwd=tmp_path, check=True)
+    staged_contents = subprocess.run(
+        ["git", "show", ":Partial.cpp"], cwd=tmp_path, capture_output=True, text=True, check=True
+    ).stdout
+    source.write_text("int value = 2;\n", encoding="utf-8")
+
+    format_calls: list[list[str]] = []
+    monkeypatch.setattr(dev, "REPOSITORY_ROOT", tmp_path)
+    monkeypatch.setattr(dev, "_find_clang_format", lambda: "/usr/bin/clang-format")
+    monkeypatch.setattr(dev, "_apply_format_chunk", lambda _binary, chunk, _check: format_calls.append(chunk) or 0)
+
+    assert dev.run_format(staged=True) == 1
+    assert format_calls == []
+    assert "refusing to format partially staged files" in capsys.readouterr().err
+    assert subprocess.run(
+        ["git", "show", ":Partial.cpp"], cwd=tmp_path, capture_output=True, text=True, check=True
+    ).stdout == staged_contents
+
+
 def test_doctor_runs_gracefully_with_broken_env_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     broken_env = write_env(tmp_path / LOCAL_ENV_FILENAME, "INVALID-ENV-LINE\n")
     monkeypatch.setattr(dev, "DEFAULT_ENV_FILE", broken_env)
@@ -488,6 +519,5 @@ def test_main_help_command_and_empty_arguments(capsys: pytest.CaptureFixture[str
     assert dev.main(["help", "nonexistent"]) == 2
     err = capsys.readouterr().err
     assert "unknown command 'nonexistent'" in err
-
 
 


### PR DESCRIPTION
## Summary
- Refuses staged formatting when a target file also contains unstaged working-tree changes.
- Adds regression coverage proving the Git index remains unchanged and the formatter is not invoked.

## Motivation
- Formatting working-tree copies and re-adding them could silently stage changes the developer intentionally left unstaged.

## Implementation Notes
- Detects staged targets whose working-tree copy differs from the index before formatting.
- Fails with an actionable message instead of mutating the index.

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [ ] Manual smoke tested if applicable

Commands run:
```bash
/Users/bodur/projects/fun/game/horo-engine/.venv/bin/python -m pytest tests/python/test_dev_runner.py -q
python3 -m py_compile scripts/dev.py tests/python/test_dev_runner.py
git diff --check
```

Result: 43 Python tests passed.

## Risks
- Developers with partially staged format targets must resolve or temporarily separate their working-tree changes before committing.

## Issue Links
- None.

## Reviewer Notes
- Start with the new partial-index regression test, then inspect run_format staged-mode validation.
