### PR TITLE
fix(editor): bound queued snackbar notifications

### DIFF
--- a/include/Horo/Editor/EditorSnackbarHost.h
+++ b/include/Horo/Editor/EditorSnackbarHost.h
@@ -48,6 +48,8 @@ namespace Horo::Editor {
         void Clear();
 
     private:
+        friend struct EditorSnackbarHostTestAccess;
+
         void OnNotificationEvent(const NotificationEvent &event);
         void DismissAt(std::size_t index);
 

--- a/src/editor/design_system/components/EditorSnackbarHost.cpp
+++ b/src/editor/design_system/components/EditorSnackbarHost.cpp
@@ -28,6 +28,7 @@ namespace Horo::Editor {
         constexpr float kProgressBottom = 6.0f;
         constexpr float kProgressHeight = 2.0f;
         constexpr std::size_t kMaxVisibleSnackbars = 3;
+        constexpr std::size_t kMaxQueuedSnackbars = 64;
 
         enum class IconKind {
             Cross,
@@ -137,6 +138,19 @@ namespace Horo::Editor {
                     snackbars.erase(snackbars.begin() + static_cast<std::ptrdiff_t>(i));
                 } else {
                     ++i;
+                }
+            }
+        }
+
+        void EnforceQueueLimit(std::deque<ActiveSnackbar> &snackbars) {
+            while (snackbars.size() > kMaxQueuedSnackbars) {
+                const auto oldestTransient = std::ranges::find_if(snackbars, [](const ActiveSnackbar &item) {
+                    return item.event.durationSeconds > 0.0f;
+                });
+                if (oldestTransient != snackbars.end()) {
+                    snackbars.erase(oldestTransient);
+                } else {
+                    snackbars.pop_front();
                 }
             }
         }
@@ -334,7 +348,7 @@ namespace Horo::Editor {
                     it->event.actions = event.actions;
                 }
                 it->event.severity = event.severity;
-                it->event.durationSeconds = event.durationSeconds > 0.0f ? event.durationSeconds : 8.0f;
+                it->event.durationSeconds = event.durationSeconds >= 0.0f ? event.durationSeconds : 8.0f;
                 it->repeatCount++;
                 it->elapsedSeconds = 0.0f;
                 return;
@@ -342,11 +356,12 @@ namespace Horo::Editor {
         }
 
         NotificationEvent copy = event;
-        if (copy.durationSeconds <= 0.0f) {
+        if (copy.durationSeconds < 0.0f) {
             copy.durationSeconds = 8.0f;
         }
 
         activeSnackbars_.push_back(ActiveSnackbar{.event = std::move(copy), .elapsedSeconds = 0.0f, .repeatCount = 1});
+        EnforceQueueLimit(activeSnackbars_);
     }
 
     /** @copydoc EditorSnackbarHost::DismissAt */

--- a/src/editor/design_system/components/EditorSnackbarHost.cpp
+++ b/src/editor/design_system/components/EditorSnackbarHost.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cmath>
 #include <imgui.h>
+#include <iterator>
 
 namespace Horo::Editor {
     namespace {
@@ -144,10 +145,11 @@ namespace Horo::Editor {
 
         void EnforceQueueLimit(std::deque<ActiveSnackbar> &snackbars) {
             while (snackbars.size() > kMaxQueuedSnackbars) {
-                const auto oldestTransient = std::ranges::find_if(snackbars, [](const ActiveSnackbar &item) {
+                const auto newest = std::prev(snackbars.end());
+                const auto oldestTransient = std::find_if(snackbars.begin(), newest, [](const ActiveSnackbar &item) {
                     return item.event.durationSeconds > 0.0f;
                 });
-                if (oldestTransient != snackbars.end()) {
+                if (oldestTransient != newest) {
                     snackbars.erase(oldestTransient);
                 } else {
                     snackbars.pop_front();

--- a/tests/unit/editor/EditorUiComponentsRenderTests.cpp
+++ b/tests/unit/editor/EditorUiComponentsRenderTests.cpp
@@ -28,7 +28,7 @@ namespace Horo::Editor {
     };
 }  // namespace Horo::Editor
 
-TEST_CASE("Snackbar host bounds queued notifications while preserving persistent entries", "[unit][editor][gui][design-system]") {
+TEST_CASE("Snackbar host bounds queued notifications while retaining the newest entry", "[unit][editor][gui][design-system]") {
     using namespace Horo::Editor;
 
     EditorDataBus events;
@@ -40,8 +40,8 @@ TEST_CASE("Snackbar host bounds queued notifications while preserving persistent
     events.Publish(NotificationEvent{.id = 65, .message = "transient", .durationSeconds = 5.0f});
     const auto &afterTransient = EditorSnackbarHostTestAccess::Queued(host);
     REQUIRE(afterTransient.size() == 64);
-    REQUIRE(afterTransient.front().event.id == 1);
-    REQUIRE(afterTransient.back().event.id == 64);
+    REQUIRE(afterTransient.front().event.id == 2);
+    REQUIRE(afterTransient.back().event.id == 65);
 
     events.Publish(NotificationEvent{.id = 66, .message = "persistent", .durationSeconds = 0.0f});
     const auto &afterPersistent = EditorSnackbarHostTestAccess::Queued(host);

--- a/tests/unit/editor/EditorUiComponentsRenderTests.cpp
+++ b/tests/unit/editor/EditorUiComponentsRenderTests.cpp
@@ -1,4 +1,5 @@
 #include "Horo/Editor/EditorIcons.h"
+#include "Horo/Editor/EditorSnackbarHost.h"
 #include "Horo/Editor/EditorTheme.h"
 #include "Horo/Editor/EditorUiComponents.h"
 
@@ -18,6 +19,36 @@ namespace {
         gClipboardText = text;
     }
 }  // namespace
+
+namespace Horo::Editor {
+    struct EditorSnackbarHostTestAccess {
+        [[nodiscard]] static const std::deque<ActiveSnackbar> &Queued(const EditorSnackbarHost &host) {
+            return host.activeSnackbars_;
+        }
+    };
+}  // namespace Horo::Editor
+
+TEST_CASE("Snackbar host bounds queued notifications while preserving persistent entries", "[unit][editor][gui][design-system]") {
+    using namespace Horo::Editor;
+
+    EditorDataBus events;
+    EditorSnackbarHost host{events};
+    for (std::uint64_t id = 1; id <= 64; ++id) {
+        events.Publish(NotificationEvent{.id = id, .message = std::to_string(id), .durationSeconds = 0.0f});
+    }
+
+    events.Publish(NotificationEvent{.id = 65, .message = "transient", .durationSeconds = 5.0f});
+    const auto &afterTransient = EditorSnackbarHostTestAccess::Queued(host);
+    REQUIRE(afterTransient.size() == 64);
+    REQUIRE(afterTransient.front().event.id == 1);
+    REQUIRE(afterTransient.back().event.id == 64);
+
+    events.Publish(NotificationEvent{.id = 66, .message = "persistent", .durationSeconds = 0.0f});
+    const auto &afterPersistent = EditorSnackbarHostTestAccess::Queued(host);
+    REQUIRE(afterPersistent.size() == 64);
+    REQUIRE(afterPersistent.front().event.id == 2);
+    REQUIRE(afterPersistent.back().event.id == 66);
+}
 
 TEST_CASE("Editor icon registry resolves canonical and catalog tokens", "[unit][editor][gui][design-system]") {
     using Horo::Editor::Ui::UiIcon;


### PR DESCRIPTION
## Summary
- Bounds the editor snackbar queue at 64 entries when Draw is not running.
- Evicts the oldest transient notification first and falls back to the oldest persistent entry.
- Preserves durationSeconds == 0 as the documented persistent-notification behavior.

## Motivation
- Bursts during startup or blocking editor work could grow the queue without bound because timer pruning only runs from Draw.

## Implementation Notes
- Applies the queue limit after accepting a non-deduplicated notification.
- Adds focused regression coverage for transient-first and persistent fallback eviction.

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [ ] Manual smoke tested if applicable

Commands run:
```bash
cmake -S . -B build/review -DBUILD_TESTING=ON -DHORO_BUILD_EDITOR_GUI=OFF -DHORO_BUILD_RENDER_OPENGL=OFF -DHORO_BUILD_RENDER_METAL=OFF -DHORO_BUILD_EXAMPLES=OFF
cmake --build build/review --target HoroEditorUiComponentsRenderTests --parallel 4
ctest --test-dir build/review -R '^HoroEditorUiComponentsRenderTests::' --output-on-failure
```

Result: 7 tests passed.

## Risks
- In an extreme all-persistent burst, the oldest persistent snackbar is evicted after the cap is reached.
- No manual visual editor smoke test was run.

## Issue Links
- None.

## Reviewer Notes
- Review EnforceQueueLimit first, followed by the test-access regression cases.
