### PR TITLE
refactor(editor): clarify UUID version and variant names

### DIFF
--- a/src/editor/screens/workspace/EditorWorkspaceControllerContentBrowser.cpp
+++ b/src/editor/screens/workspace/EditorWorkspaceControllerContentBrowser.cpp
@@ -210,10 +210,10 @@ namespace Horo::Editor {
                 std::array<std::uint8_t, 16> bytes{};
                 for (std::uint8_t &byte : bytes)
                     byte = static_cast<std::uint8_t>(random());
-                const auto variant = static_cast<std::byte>(bytes[6]);
-                const auto version = static_cast<std::byte>(bytes[8]);
-                bytes[6] = std::to_integer<std::uint8_t>((variant & std::byte{0x0fU}) | std::byte{0x40U});
-                bytes[8] = std::to_integer<std::uint8_t>((version & std::byte{0x3fU}) | std::byte{0x80U});
+                const auto version = static_cast<std::byte>(bytes[6]);
+                const auto variant = static_cast<std::byte>(bytes[8]);
+                bytes[6] = std::to_integer<std::uint8_t>((version & std::byte{0x0fU}) | std::byte{0x40U});
+                bytes[8] = std::to_integer<std::uint8_t>((variant & std::byte{0x3fU}) | std::byte{0x80U});
                 if (const Assets::AssetId candidate = Assets::AssetId::FromBytes(bytes);
                     candidate.IsValid() && snapshot.Find(candidate) == nullptr)
                     return candidate;


### PR DESCRIPTION
## Summary
- Corrects swapped local variable names for the UUID version nibble and variant bits.
- Leaves generated bytes and behavior unchanged.

## Motivation
- The prior names contradicted the RFC 4122 field layout and made future maintenance error-prone.

## Implementation Notes
- bytes[6] is now named version.
- bytes[8] is now named variant.

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [ ] Manual smoke tested if applicable

Commands run:
```bash
cmake -S . -B build/review -DBUILD_TESTING=ON -DHORO_BUILD_EDITOR_GUI=OFF -DHORO_BUILD_RENDER_OPENGL=OFF -DHORO_BUILD_RENDER_METAL=OFF -DHORO_BUILD_EXAMPLES=OFF
cmake --build build/review --target HoroEditorWorkspaceControllerTests --parallel 4
ctest --test-dir build/review -R '^HoroEditorWorkspaceControllerTests::' --output-on-failure
```

Result: 55 tests passed.

## Risks
- Naming-only refactor; generated asset IDs are unchanged.

## Issue Links
- None.

## Reviewer Notes
- Verify only the two local names and their uses changed.
