### PR TITLE
fix(editor): retain project mutation lease during metadata write

### DIFF
--- a/src/editor/project_model/ProjectOpenService.cpp
+++ b/src/editor/project_model/ProjectOpenService.cpp
@@ -83,9 +83,9 @@ namespace Horo::Editor {
         [[nodiscard]] Result<void> UpdatePatchMarker(DurableFileSystem &files, const ProjectMutationCoordinator &mutations,
                                                      const std::filesystem::path &projectRoot, const ReleaseCompatibilityDecision &target,
                                                      const ProjectOpenOperationId operation) {
-            if (auto lease =
-                    mutations.TryAcquire({projectRoot, ProjectMutationOwner::Migration, std::format("project-open-{}", operation.value)});
-                lease.HasError()) {
+            auto lease =
+                mutations.TryAcquire({projectRoot, ProjectMutationOwner::Migration, std::format("project-open-{}", operation.value)});
+            if (lease.HasError()) {
                 return Result<void>::Failure(lease.ErrorValue());
             }
             const auto metadataPath = projectRoot / ".horo/project.json";


### PR DESCRIPTION
## Summary
- Keeps the project mutation lease alive throughout the patch-marker metadata read-modify-write.
- Prevents concurrent project-open or migration operations from racing on .horo/project.json.

## Motivation
- The lease was scoped to an if-init statement and released before the protected metadata operation.

## Implementation Notes
- Hoists the move-only RAII lease into function scope.
- Preserves the existing error handling and metadata update behavior.

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [ ] Manual smoke tested if applicable

Commands run:
```bash
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
cmake --build build/skeleton --target HoroProjectOpenServiceTests --parallel
ctest --test-dir build/skeleton -R '^HoroProjectOpenServiceTests::' --output-on-failure
```

## Risks
- Low-risk lifetime correction; no public contract changes.
- No dedicated concurrent-process stress test was added.

## Issue Links
- None.

## Reviewer Notes
- Review ProjectOpenService::UpdatePatchMarker and verify the lease lifetime extends past the metadata write.
