### PR TITLE
fix(assets): reject Windows-invalid artifact filenames

### DIFF
--- a/src/runtime/assets/cooker/AssetCookOutput.cpp
+++ b/src/runtime/assets/cooker/AssetCookOutput.cpp
@@ -103,11 +103,18 @@ namespace Horo::Assets {
             return json;
         }
 
+        // Reject filenames invalid on Windows/NTFS (" < > | : ? * and control
+        // characters) in addition to path separators, so artifact names stay
+        // portable across all supported platforms instead of failing late with
+        // an opaque filesystem error on Windows.
         [[nodiscard]] bool IsSafeArtifactFile(const std::string_view file) noexcept {
             if (file.empty() || file.size() > 256)
                 return false;
             for (const char c : file) {
-                if (c == '/' || c == '\\' || c == ':')
+                const auto character = static_cast<unsigned char>(c);
+                if (character == '/' || character == '\\' || character == ':')
+                    return false;
+                if (character < 0x20 || character == '"' || character == '<' || character == '>' || character == '|' || character == '?')
                     return false;
             }
             if (file.find("..") != std::string_view::npos)

--- a/src/runtime/assets/cooker/AssetCookOutput.cpp
+++ b/src/runtime/assets/cooker/AssetCookOutput.cpp
@@ -114,7 +114,8 @@ namespace Horo::Assets {
                 const auto character = static_cast<unsigned char>(c);
                 if (character == '/' || character == '\\' || character == ':')
                     return false;
-                if (character < 0x20 || character == '"' || character == '<' || character == '>' || character == '|' || character == '?')
+                if (character < 0x20 || character == '"' || character == '<' || character == '>' || character == '|' || character == '?' ||
+                    character == '*')
                     return false;
             }
             if (file.find("..") != std::string_view::npos)

--- a/tests/unit/runtime/assets/AssetCookOutputTests.cpp
+++ b/tests/unit/runtime/assets/AssetCookOutputTests.cpp
@@ -92,24 +92,22 @@ TEST_CASE("PublishCookGeneration creates current.json and manifest.json", "[nati
     REQUIRE((std::filesystem::exists(tmp.path / "current.json")));
 }
 
-TEST_CASE("PublishCookGeneration escapes manifest strings", "[native]") {
+// `"` is invalid in Windows/NTFS filenames. IsSafeArtifactFile must reject such
+// names explicitly (MalformedArtifact) on every platform rather than letting
+// them fail late with an opaque filesystem error on Windows.
+TEST_CASE("PublishCookGeneration rejects Windows-invalid artifact filenames", "[native]") {
     TempDir tmp;
     const auto target = Target("headless-null");
     const auto id = Id("00000000-0000-0000-0000-000000000003");
     const auto payload = MakePayload(16, 0x7F);
-    const std::string artifactFile = "quoted\"artifact.cooked";
     const std::vector<AssetCookManifestEntry> entries = {
-        {.assetId = id, .assetType = Type("core.mesh"), .artifactFile = artifactFile, .artifactHash = DigestOf(payload)}};
+        {.assetId = id, .assetType = Type("core.mesh"), .artifactFile = "quoted\"artifact.cooked", .artifactHash = DigestOf(payload)}};
     const std::vector<std::vector<std::uint8_t>> payloads = {payload};
 
     const auto published = PublishCookGeneration(tmp.path, target, entries, payloads);
-    REQUIRE((published.HasValue()));
-    std::ifstream manifestStream(published.Value().generationRoot / "manifest.json");
-    const std::string manifest{std::istreambuf_iterator<char>{manifestStream}, std::istreambuf_iterator<char>{}};
-
-    REQUIRE((manifest.find(R"("target":"headless-null")") != std::string::npos));
-    REQUIRE((manifest.find("\"artifact\":\"quoted\\\"artifact.cooked\"") != std::string::npos));
-    REQUIRE((std::filesystem::exists(published.Value().generationRoot / artifactFile)));
+    REQUIRE((published.HasError()));
+    // current.json is written last: a rejected generation must leave no authority behind.
+    REQUIRE((!std::filesystem::exists(tmp.path / "current.json")));
 }
 
 TEST_CASE("PublishCookGeneration rejects duplicate asset IDs", "[native]") {

--- a/tests/unit/runtime/assets/AssetCookOutputTests.cpp
+++ b/tests/unit/runtime/assets/AssetCookOutputTests.cpp
@@ -92,10 +92,17 @@ TEST_CASE("PublishCookGeneration creates current.json and manifest.json", "[nati
     REQUIRE((std::filesystem::exists(tmp.path / "current.json")));
 }
 
-// `"` is invalid in Windows/NTFS filenames. IsSafeArtifactFile must reject such
-// names explicitly (MalformedArtifact) on every platform rather than letting
-// them fail late with an opaque filesystem error on Windows.
-TEST_CASE("PublishCookGeneration rejects Windows-invalid artifact filenames", "[native]") {
+// Filenames that are not portable across supported platforms (Windows/NTFS
+// reserves " < > | : ? * and control characters) must be rejected explicitly
+// with MalformedArtifact on every platform, instead of failing late with an
+// opaque filesystem error on Windows only.
+//
+// Note: this replaces the former "escapes manifest strings" test. That test's
+// intent — exercising AppendJsonString escaping — is unreachable through
+// PublishCookGeneration because all manifest string inputs (target ID, type ID,
+// artifact filename) are canonicalized/validated before they reach the JSON
+// writer. AppendJsonString remains as a defense-in-depth layer.
+TEST_CASE("PublishCookGeneration rejects non-portable artifact filenames", "[native]") {
     TempDir tmp;
     const auto target = Target("headless-null");
     const auto id = Id("00000000-0000-0000-0000-000000000003");


### PR DESCRIPTION
## Summary

PR #47 (develop) Windows/MSVC CI'da 590 testten birini düşürüyordu:
`HoroAssetCookOutputTests::PublishCookGeneration escapes manifest strings`.

### Root cause

Test, artifact dosya adı olarak `quoted"artifact.cooked` kullanıyordu. `"` NTFS'te geçersiz bir filename karakteri olduğu için `PublishCookGeneration` disk yazımında Windows'ta başarısız oluyor ve publish `HasValue() == false` döndürüyordu. Linux/macOS'ta `"` legal olduğundan CI yeşildi.

### Fix

- `IsSafeArtifactFile` (src/runtime/assets/cooker/AssetCookOutput.cpp) artık `" < > | ? *` ve `< 0x20` kontrol karakterlerini reddediyor. Geçersiz adlar tüm platformlarda erken ve açık bir `MalformedArtifact` hatasıyla eleniyor; Windows'ta opak filesystem hatası kalmıyor.
- Kırılan test, yeni sözleşmeyi doğrulayan `PublishCookGeneration rejects Windows-invalid artifact filenames` ile değiştirildi: reddedilme + current.json authority'sinin arkada bırakılmadığı doğrulanıyor.
- Eski escape testi zaten public API üzerinden ulaşılamaz bir yolu test ediyordu (`AssetCookTargetId::Parse` kanonik ad zorunlu kılar).

## Validation

- [x] Skeleton build + tam ctest: 590/590 C++ testi geçti (macOS/Clang).
- [x] `HoroAssetCookOutputTests` 8/8 geçti.
- [ ] Windows/MSVC CI — bu PR ile doğrulanacak.
- Not: develop'taki mevcut `HoroPythonToolingTests` failure'ı bu değişiklikle ilgisizdir; temiz ağaçta da düşüyor (`test_staged_format_refuses_to_stage_unstaged_worktree_changes`).

## Compatibility

Public API değişikliği yok; davranış değişikliği daha önce Windows'ta sessizce filesystem hatası üreten girdilerin artık tüm platformlarda typed error döndürmesi.
