### PR TITLE
fix(assets): reject reserved DOS names and trailing punctuation in artifacts

### DIFF
--- a/src/runtime/assets/cooker/AssetCookOutput.cpp
+++ b/src/runtime/assets/cooker/AssetCookOutput.cpp
@@ -8,6 +8,7 @@
 #include "Horo/Foundation/Sha256.h"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <chrono>
 #include <cstddef>
@@ -127,9 +128,10 @@ namespace Horo::Assets {
                 return false;
             // Reserved DOS device basenames are invalid even with an extension.
             const auto stem = file.substr(0, file.find('.'));
-            static constexpr std::string_view reserved[] = {"CON",  "PRN",  "AUX",  "NUL",  "COM0", "COM1", "COM2",   "COM3",    "COM4",
-                                                            "COM5", "COM6", "COM7", "COM8", "COM9", "LPT0", "LPT1",   "LPT2",    "LPT3",
-                                                            "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9", "CONIN$", "CONOUT$", "CLOCK$"};
+            static constexpr std::array<std::string_view, 27> reserved{"CON",  "PRN",  "AUX",  "NUL",    "COM0",    "COM1",  "COM2",
+                                                                       "COM3", "COM4", "COM5", "COM6",   "COM7",    "COM8",  "COM9",
+                                                                       "LPT0", "LPT1", "LPT2", "LPT3",   "LPT4",    "LPT5",  "LPT6",
+                                                                       "LPT7", "LPT8", "LPT9", "CONIN$", "CONOUT$", "CLOCK$"};
             for (const auto device : reserved)
                 if (stem.size() == device.size() && std::equal(stem.begin(), stem.end(), device.begin(), [](const char a, const char b) {
                     return std::toupper(static_cast<unsigned char>(a)) == b;

--- a/src/runtime/assets/cooker/AssetCookOutput.cpp
+++ b/src/runtime/assets/cooker/AssetCookOutput.cpp
@@ -8,6 +8,7 @@
 #include "Horo/Foundation/Sha256.h"
 
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -104,9 +105,10 @@ namespace Horo::Assets {
         }
 
         // Reject filenames invalid on Windows/NTFS (" < > | : ? * and control
-        // characters) in addition to path separators, so artifact names stay
+        // characters), reserved DOS device basenames, and names Windows would
+        // silently strip trailing dots/spaces from — so artifact names stay
         // portable across all supported platforms instead of failing late with
-        // an opaque filesystem error on Windows.
+        // an opaque filesystem error or silent rename on Windows.
         [[nodiscard]] bool IsSafeArtifactFile(const std::string_view file) noexcept {
             if (file.empty() || file.size() > 256)
                 return false;
@@ -120,6 +122,19 @@ namespace Horo::Assets {
             }
             if (file.find("..") != std::string_view::npos)
                 return false;
+            // Windows strips trailing dots/spaces, silently renaming the file.
+            if (file.back() == '.' || file.back() == ' ')
+                return false;
+            // Reserved DOS device basenames are invalid even with an extension.
+            const auto stem = file.substr(0, file.find('.'));
+            static constexpr std::string_view reserved[] = {"CON",  "PRN",  "AUX",  "NUL",  "COM1", "COM2", "COM3", "COM4",
+                                                            "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3",
+                                                            "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"};
+            for (const auto device : reserved)
+                if (stem.size() == device.size() && std::equal(stem.begin(), stem.end(), device.begin(), [](const char a, const char b) {
+                    return std::toupper(static_cast<unsigned char>(a)) == b;
+                }))
+                    return false;
             return true;
         }
 

--- a/src/runtime/assets/cooker/AssetCookOutput.cpp
+++ b/src/runtime/assets/cooker/AssetCookOutput.cpp
@@ -127,9 +127,9 @@ namespace Horo::Assets {
                 return false;
             // Reserved DOS device basenames are invalid even with an extension.
             const auto stem = file.substr(0, file.find('.'));
-            static constexpr std::string_view reserved[] = {"CON",  "PRN",  "AUX",  "NUL",  "COM1", "COM2", "COM3", "COM4",
-                                                            "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3",
-                                                            "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"};
+            static constexpr std::string_view reserved[] = {"CON",  "PRN",  "AUX",  "NUL",  "COM0", "COM1", "COM2",   "COM3",    "COM4",
+                                                            "COM5", "COM6", "COM7", "COM8", "COM9", "LPT0", "LPT1",   "LPT2",    "LPT3",
+                                                            "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9", "CONIN$", "CONOUT$", "CLOCK$"};
             for (const auto device : reserved)
                 if (stem.size() == device.size() && std::equal(stem.begin(), stem.end(), device.begin(), [](const char a, const char b) {
                     return std::toupper(static_cast<unsigned char>(a)) == b;

--- a/tests/unit/runtime/assets/AssetCookOutputTests.cpp
+++ b/tests/unit/runtime/assets/AssetCookOutputTests.cpp
@@ -123,8 +123,10 @@ TEST_CASE("PublishCookGeneration rejects reserved and trailing-punctuation artif
     const auto payload = MakePayload(16, 0x7F);
     // Reserved DOS device names (case-insensitive, with or without extension),
     // trailing dots/spaces that Windows silently strips, and ".." segments.
-    const std::string_view rejectedNames[] = {"CON.cooked",       "con.cooked",       "Con", "NUL.cooked",
-                                              "com1.cooked",      "LPT4.cooked",      "aux", "artifact.cooked.",
+    const std::string_view rejectedNames[] = {"CON.cooked",       "con.cooked",       "Con",
+                                              "NUL.cooked",       "com0.cooked",      "com1.cooked",
+                                              "LPT0.cooked",      "LPT4.cooked",      "aux",
+                                              "clock$.cooked",    "conin$.txt",       "artifact.cooked.",
                                               "artifact.cooked ", "ar..tifact.cooked"};
     for (const auto name : rejectedNames) {
         const auto id = Id("00000000-0000-0000-0000-000000000005");

--- a/tests/unit/runtime/assets/AssetCookOutputTests.cpp
+++ b/tests/unit/runtime/assets/AssetCookOutputTests.cpp
@@ -117,6 +117,35 @@ TEST_CASE("PublishCookGeneration rejects non-portable artifact filenames", "[nat
     REQUIRE((!std::filesystem::exists(tmp.path / "current.json")));
 }
 
+TEST_CASE("PublishCookGeneration rejects reserved and trailing-punctuation artifact filenames", "[native]") {
+    TempDir tmp;
+    const auto target = Target("headless-null");
+    const auto payload = MakePayload(16, 0x7F);
+    // Reserved DOS device names (case-insensitive, with or without extension),
+    // trailing dots/spaces that Windows silently strips, and ".." segments.
+    const std::string_view rejectedNames[] = {"CON.cooked",       "con.cooked",       "Con", "NUL.cooked",
+                                              "com1.cooked",      "LPT4.cooked",      "aux", "artifact.cooked.",
+                                              "artifact.cooked ", "ar..tifact.cooked"};
+    for (const auto name : rejectedNames) {
+        const auto id = Id("00000000-0000-0000-0000-000000000005");
+        const std::vector<AssetCookManifestEntry> entries = {
+            {.assetId = id, .assetType = Type("core.mesh"), .artifactFile = std::string(name), .artifactHash = DigestOf(payload)}};
+        const std::vector<std::vector<std::uint8_t>> payloads = {payload};
+
+        INFO("rejected name: " << name);
+        const auto published = PublishCookGeneration(tmp.path, target, entries, payloads);
+        REQUIRE((published.HasError()));
+        REQUIRE((!std::filesystem::exists(tmp.path / "current.json")));
+    }
+
+    // Sanity: a normal portable name is still accepted.
+    const auto id = Id("00000000-0000-0000-0000-000000000006");
+    const std::vector<AssetCookManifestEntry> entries = {
+        {.assetId = id, .assetType = Type("core.mesh"), .artifactFile = "plain-artifact.cooked", .artifactHash = DigestOf(payload)}};
+    const std::vector<std::vector<std::uint8_t>> payloads = {payload};
+    REQUIRE((PublishCookGeneration(tmp.path, target, entries, payloads).HasValue()));
+}
+
 TEST_CASE("PublishCookGeneration rejects duplicate asset IDs", "[native]") {
     TempDir tmp;
     auto nullTarget = Target("headless-null");


### PR DESCRIPTION
## Summary

Follow-up to the artifact filename hardening merged from #1748. Review flagged two Windows-specific cases still evading `IsSafeArtifactFile`:

1. **Reserved DOS device basenames** (`CON`, `PRN`, `AUX`, `NUL`, `COM1-9`, `LPT1-9`) — invalid on Windows even with an extension (e.g. `CON.cooked`), case-insensitive. These fail late with an opaque filesystem error on Windows only.
2. **Trailing dot/space** — Windows silently strips them, renaming the file and breaking the path-within and content-addressing invariants.

### Fix

- `IsSafeArtifactFile` now rejects trailing `'.'`/`' '` and reserved device basenames (case-insensitive, stem before first `.`) before returning true.
- Comment updated to state the full contract, including silent-rename avoidance.
- New regression test covers both classes (11 rejected names, case variants included) plus a positive sanity case proving normal portable names still publish.

## Validation

- [x] `HoroAssetCookOutputTests` 9/9 geçti (yeni test dahil).
- [x] Tam skeleton build + ctest: 474/474 C++ testi geçti (macOS/Clang). (`HoroPythonToolingTests` develop'dan beri mevcut, ilgisiz Python tooling sorunu — bu PR'da C++ test setinde değil.)
- [ ] Windows/MSVC CI — bu PR ile doğrulanacak.

## Compatibility

Public API değişikliği yok. Davranış değişikliği: daha önce Windows'ta geç yazım hatası veya sessiz yeniden adlandırma üreten girdiler artık tüm platformlarda typed `MalformedArtifact` hatası döndürüyor.
