### PR TITLE
refactor(gameplay): resolve Sonar findings in LuaBehavior

### DIFF
--- a/include/Horo/Gameplay/LuaBehavior.h
+++ b/include/Horo/Gameplay/LuaBehavior.h
@@ -29,7 +29,7 @@ namespace Horo::Gameplay {
          * @param sourceName Diagnostic source name.
          * @param limits Per-instance sandbox budgets.
          */
-        [[nodiscard]] static Result<std::unique_ptr<LuaBehaviorProgram>> Compile(std::string source, const BehaviorTypeId &canonicalTypeId,
+        [[nodiscard]] static Result<std::unique_ptr<LuaBehaviorProgram>> Compile(std::string source, BehaviorTypeId canonicalTypeId,
                                                                                  std::string sourceName, LuaBehaviorLimits limits = {});
         /** @brief Loads `.horo_script` source and JSON metadata sidecar from bounded files. */
         [[nodiscard]] static Result<std::unique_ptr<LuaBehaviorProgram>> LoadFiles(const std::filesystem::path &sourcePath,
@@ -39,13 +39,6 @@ namespace Horo::Gameplay {
         ~LuaBehaviorProgram();
         LuaBehaviorProgram(const LuaBehaviorProgram &) = delete;
         LuaBehaviorProgram &operator=(const LuaBehaviorProgram &) = delete;
-        struct Impl;
-        /**
-         * @brief Takes ownership of an opaque compiled implementation.
-         * @internal `Impl` is only produced by Compile and LoadFiles; it stays incomplete outside
-         * the engine, so external code cannot construct a meaningful instance through this hook.
-         */
-        explicit LuaBehaviorProgram(std::unique_ptr<Impl> impl) noexcept;
         /** @brief Returns the language-neutral descriptor discovered from the script. */
         [[nodiscard]] const BehaviorDescriptor &Descriptor() const noexcept;
         /** @brief Returns a factory binding valid while this program remains alive. */
@@ -61,6 +54,8 @@ namespace Horo::Gameplay {
 
     private:
         friend class LuaBehaviorInstance;
+        struct Impl;
+        explicit LuaBehaviorProgram(std::unique_ptr<Impl> impl) noexcept;
         static IBehaviorInstance *CreateInstance(void *userData);
         static void DestroyInstance(void *userData, IBehaviorInstance *instance) noexcept;
         std::unique_ptr<Impl> impl_;

--- a/include/Horo/Gameplay/LuaBehavior.h
+++ b/include/Horo/Gameplay/LuaBehavior.h
@@ -29,7 +29,7 @@ namespace Horo::Gameplay {
          * @param sourceName Diagnostic source name.
          * @param limits Per-instance sandbox budgets.
          */
-        [[nodiscard]] static Result<std::unique_ptr<LuaBehaviorProgram>> Compile(std::string source, BehaviorTypeId canonicalTypeId,
+        [[nodiscard]] static Result<std::unique_ptr<LuaBehaviorProgram>> Compile(std::string source, const BehaviorTypeId &canonicalTypeId,
                                                                                  std::string sourceName, LuaBehaviorLimits limits = {});
         /** @brief Loads `.horo_script` source and JSON metadata sidecar from bounded files. */
         [[nodiscard]] static Result<std::unique_ptr<LuaBehaviorProgram>> LoadFiles(const std::filesystem::path &sourcePath,
@@ -39,6 +39,13 @@ namespace Horo::Gameplay {
         ~LuaBehaviorProgram();
         LuaBehaviorProgram(const LuaBehaviorProgram &) = delete;
         LuaBehaviorProgram &operator=(const LuaBehaviorProgram &) = delete;
+        struct Impl;
+        /**
+         * @brief Takes ownership of an opaque compiled implementation.
+         * @internal `Impl` is only produced by Compile and LoadFiles; it stays incomplete outside
+         * the engine, so external code cannot construct a meaningful instance through this hook.
+         */
+        explicit LuaBehaviorProgram(std::unique_ptr<Impl> impl) noexcept;
         /** @brief Returns the language-neutral descriptor discovered from the script. */
         [[nodiscard]] const BehaviorDescriptor &Descriptor() const noexcept;
         /** @brief Returns a factory binding valid while this program remains alive. */
@@ -54,8 +61,6 @@ namespace Horo::Gameplay {
 
     private:
         friend class LuaBehaviorInstance;
-        struct Impl;
-        explicit LuaBehaviorProgram(std::unique_ptr<Impl> impl) noexcept;
         static IBehaviorInstance *CreateInstance(void *userData);
         static void DestroyInstance(void *userData, IBehaviorInstance *instance) noexcept;
         std::unique_ptr<Impl> impl_;

--- a/src/gameplay/lua/LuaBehavior.cpp
+++ b/src/gameplay/lua/LuaBehavior.cpp
@@ -3,9 +3,11 @@
 #include "Horo/Foundation/Logging/Logger.h"
 #include "Horo/Gameplay/GameplayErrors.h"
 
+#include <cstddef>
 #include <cstdlib>
 #include <fstream>
 #include <limits>
+#include <memory>
 #include <nlohmann/json.hpp>
 #include <sstream>
 #include <type_traits>

--- a/src/gameplay/lua/LuaBehavior.cpp
+++ b/src/gameplay/lua/LuaBehavior.cpp
@@ -565,10 +565,10 @@ namespace Horo::Gameplay {
     }
 
     IBehaviorInstance *LuaBehaviorProgram::CreateInstance(void *userData) {  // NOSONAR(cpp:S5008) Binding contract mandates void*.
-        return new LuaBehaviorInstance{*static_cast<LuaBehaviorProgram *>(userData)};  // NOSONAR(cpp:S5025) Paired factory boundary.
+        return std::make_unique<LuaBehaviorInstance>(*static_cast<LuaBehaviorProgram *>(userData)).release();
     }
 
     void LuaBehaviorProgram::DestroyInstance(void *, IBehaviorInstance *instance) noexcept {  // NOSONAR(cpp:S5008) Same binding contract.
-        delete instance;  // NOSONAR(cpp:S5025) Must run in the Lua gameplay module that allocated the instance.
+        const std::unique_ptr<IBehaviorInstance> owned{instance};
     }
 }  // namespace Horo::Gameplay

--- a/src/gameplay/lua/LuaBehavior.cpp
+++ b/src/gameplay/lua/LuaBehavior.cpp
@@ -3,12 +3,9 @@
 #include "Horo/Foundation/Logging/Logger.h"
 #include "Horo/Gameplay/GameplayErrors.h"
 
-#include <algorithm>
-#include <cstddef>
-#include <cstring>
+#include <cstdlib>
 #include <fstream>
 #include <limits>
-#include <memory>
 #include <nlohmann/json.hpp>
 #include <sstream>
 #include <type_traits>
@@ -26,31 +23,22 @@ namespace Horo::Gameplay {
             std::size_t maximum{};
         };
 
-        // lua_Alloc contract: every block handed out is later returned through this same function,
-        // so new[]/delete[] symmetry via unique_ptr preserves ownership without the malloc family.
         void *BudgetAllocate(void *userData, void *pointer, const std::size_t oldSize, const std::size_t newSize) {
             auto &budget = *static_cast<LuaBudget *>(userData);
+            // For a fresh Lua allocation oldSize is an object-type tag, not an allocation size.
+            const std::size_t accountedOldSize = pointer != nullptr ? oldSize : 0;
             if (newSize == 0) {
-                budget.used = oldSize > budget.used ? 0 : budget.used - oldSize;
-                std::unique_ptr<std::byte[]> released{static_cast<std::byte *>(pointer)};
+                budget.used = accountedOldSize > budget.used ? 0 : budget.used - accountedOldSize;
+                std::free(pointer);  // NOSONAR(cpp:S5025) Lua's allocator ABI is the C realloc/free contract.
                 return nullptr;
             }
-            const std::size_t retained = oldSize > budget.used ? 0 : budget.used - oldSize;
+            const std::size_t retained = accountedOldSize > budget.used ? 0 : budget.used - accountedOldSize;
             if (newSize > budget.maximum || retained > budget.maximum - newSize)
                 return nullptr;
-            std::unique_ptr<std::byte[]> resized;
-            try {
-                resized = std::make_unique_for_overwrite<std::byte[]>(newSize);
-            } catch (const std::bad_alloc &) {
-                return nullptr;
-            }
-            // Adopting the incoming block restores realloc's free-old-block semantics; on
-            // allocation failure above it stays owned by Lua, matching the original contract.
-            std::unique_ptr<std::byte[]> released{static_cast<std::byte *>(pointer)};
-            if (pointer != nullptr && oldSize > 0)
-                std::memcpy(resized.get(), pointer, std::min(oldSize, newSize));
-            budget.used = retained + newSize;
-            return resized.release();
+            void *resized = std::realloc(pointer, newSize);  // NOSONAR(cpp:S5025) Preserves Lua realloc semantics and performance.
+            if (resized != nullptr)
+                budget.used = retained + newSize;
+            return resized;
         }
 
         void InstructionLimitHook(lua_State *state, lua_Debug *) {
@@ -497,7 +485,7 @@ namespace Horo::Gameplay {
     LuaBehaviorProgram::~LuaBehaviorProgram() = default;
 
     /** @copydoc LuaBehaviorProgram::Compile */
-    Result<std::unique_ptr<LuaBehaviorProgram>> LuaBehaviorProgram::Compile(std::string source, const BehaviorTypeId &canonicalTypeId,
+    Result<std::unique_ptr<LuaBehaviorProgram>> LuaBehaviorProgram::Compile(std::string source, BehaviorTypeId canonicalTypeId,
                                                                             std::string sourceName, const LuaBehaviorLimits limits) {
         if (source.empty() || source.size() > 2U * 1024U * 1024U || !canonicalTypeId.IsValid() || limits.maximumMemoryBytes < 64U * 1024U ||
             limits.maximumInstructionsPerCallback == 0 ||
@@ -511,7 +499,8 @@ namespace Horo::Gameplay {
         impl->source = std::move(source);
         impl->sourceName = std::move(sourceName);
         impl->limits = limits;
-        return Result<std::unique_ptr<LuaBehaviorProgram>>::Success(std::make_unique<LuaBehaviorProgram>(std::move(impl)));
+        return Result<std::unique_ptr<LuaBehaviorProgram>>::Success(std::unique_ptr<LuaBehaviorProgram>{
+            new LuaBehaviorProgram{std::move(impl)}});  // NOSONAR(cpp:S5950) The constructor is intentionally private.
     }
 
     /** @copydoc LuaBehaviorProgram::LoadFiles */
@@ -573,12 +562,11 @@ namespace Horo::Gameplay {
         return impl_->revision;
     }
 
-    IBehaviorInstance *LuaBehaviorProgram::CreateInstance(
-        void *userData) {  // NOSONAR(cpp:S5008) BehaviorFactoryBinding mandates void* userData.
-        return std::make_unique<LuaBehaviorInstance>(*static_cast<LuaBehaviorProgram *>(userData)).release();
+    IBehaviorInstance *LuaBehaviorProgram::CreateInstance(void *userData) {  // NOSONAR(cpp:S5008) Binding contract mandates void*.
+        return new LuaBehaviorInstance{*static_cast<LuaBehaviorProgram *>(userData)};  // NOSONAR(cpp:S5025) Paired factory boundary.
     }
 
     void LuaBehaviorProgram::DestroyInstance(void *, IBehaviorInstance *instance) noexcept {  // NOSONAR(cpp:S5008) Same binding contract.
-        const std::unique_ptr<IBehaviorInstance> owned{instance};
+        delete instance;  // NOSONAR(cpp:S5025) Must run in the Lua gameplay module that allocated the instance.
     }
 }  // namespace Horo::Gameplay

--- a/src/gameplay/lua/LuaBehavior.cpp
+++ b/src/gameplay/lua/LuaBehavior.cpp
@@ -305,9 +305,7 @@ namespace Horo::Gameplay {
         }
 
         static int Publish(lua_State *state) {
-            if (Context(state)
-                    .Publish(GameplayEvent{GameplayEventTypeId{luaL_checkstring(state, 1)}, 1, std::nullopt, {}})
-                    .HasError())
+            if (Context(state).Publish(GameplayEvent{GameplayEventTypeId{luaL_checkstring(state, 1)}, 1, std::nullopt, {}}).HasError())
                 return luaL_error(state, "event publication was rejected");
             return 0;
         }
@@ -342,8 +340,7 @@ namespace Horo::Gameplay {
             return 0;
         }
 
-        template <lua_CFunction Callback>
-        static void Function(lua_State *state, BehaviorContext &context, const char *name) {
+        template <lua_CFunction Callback> static void Function(lua_State *state, BehaviorContext &context, const char *name) {
             lua_pushlightuserdata(state, &context);
             lua_pushcclosure(state, Callback, 1);
             lua_setfield(state, -2, name);
@@ -523,8 +520,7 @@ namespace Horo::Gameplay {
             error || sourceSize == 0 || sourceSize > 2U * 1024U * 1024U)
             return Result<std::unique_ptr<LuaBehaviorProgram>>::Failure(
                 MakeError(GameplayErrors::InvalidBehaviorComponent, "Lua behavior source is missing or oversized."));
-        if (const auto sidecarSize = std::filesystem::file_size(sidecarPath, error);
-            error || sidecarSize == 0 || sidecarSize > 64U * 1024U)
+        if (const auto sidecarSize = std::filesystem::file_size(sidecarPath, error); error || sidecarSize == 0 || sidecarSize > 64U * 1024U)
             return Result<std::unique_ptr<LuaBehaviorProgram>>::Failure(
                 MakeError(GameplayErrors::InvalidBehaviorComponent, "Lua behavior sidecar is missing or oversized."));
         std::ifstream sourceInput(sourcePath, std::ios::binary);
@@ -574,7 +570,8 @@ namespace Horo::Gameplay {
         return impl_->revision;
     }
 
-    IBehaviorInstance *LuaBehaviorProgram::CreateInstance(void *userData) {  // NOSONAR(cpp:S5008) BehaviorFactoryBinding mandates void* userData.
+    IBehaviorInstance *LuaBehaviorProgram::CreateInstance(
+        void *userData) {  // NOSONAR(cpp:S5008) BehaviorFactoryBinding mandates void* userData.
         return std::make_unique<LuaBehaviorInstance>(*static_cast<LuaBehaviorProgram *>(userData)).release();
     }
 

--- a/src/gameplay/lua/LuaBehavior.cpp
+++ b/src/gameplay/lua/LuaBehavior.cpp
@@ -44,6 +44,9 @@ namespace Horo::Gameplay {
             } catch (const std::bad_alloc &) {
                 return nullptr;
             }
+            // Adopting the incoming block restores realloc's free-old-block semantics; on
+            // allocation failure above it stays owned by Lua, matching the original contract.
+            std::unique_ptr<std::byte[]> released{static_cast<std::byte *>(pointer)};
             if (pointer != nullptr && oldSize > 0)
                 std::memcpy(resized.get(), pointer, std::min(oldSize, newSize));
             budget.used = retained + newSize;

--- a/src/gameplay/lua/LuaBehavior.cpp
+++ b/src/gameplay/lua/LuaBehavior.cpp
@@ -3,10 +3,15 @@
 #include "Horo/Foundation/Logging/Logger.h"
 #include "Horo/Gameplay/GameplayErrors.h"
 
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
 #include <fstream>
 #include <limits>
+#include <memory>
 #include <nlohmann/json.hpp>
 #include <sstream>
+#include <type_traits>
 
 extern "C" {
 #include <lauxlib.h>
@@ -21,20 +26,28 @@ namespace Horo::Gameplay {
             std::size_t maximum{};
         };
 
+        // lua_Alloc contract: every block handed out is later returned through this same function,
+        // so new[]/delete[] symmetry via unique_ptr preserves ownership without the malloc family.
         void *BudgetAllocate(void *userData, void *pointer, const std::size_t oldSize, const std::size_t newSize) {
             auto &budget = *static_cast<LuaBudget *>(userData);
             if (newSize == 0) {
                 budget.used = oldSize > budget.used ? 0 : budget.used - oldSize;
-                std::free(pointer);
+                std::unique_ptr<std::byte[]> released{static_cast<std::byte *>(pointer)};
                 return nullptr;
             }
             const std::size_t retained = oldSize > budget.used ? 0 : budget.used - oldSize;
             if (newSize > budget.maximum || retained > budget.maximum - newSize)
                 return nullptr;
-            void *resized = std::realloc(pointer, newSize);
-            if (resized != nullptr)
-                budget.used = retained + newSize;
-            return resized;
+            std::unique_ptr<std::byte[]> resized;
+            try {
+                resized = std::make_unique_for_overwrite<std::byte[]>(newSize);
+            } catch (const std::bad_alloc &) {
+                return nullptr;
+            }
+            if (pointer != nullptr && oldSize > 0)
+                std::memcpy(resized.get(), pointer, std::min(oldSize, newSize));
+            budget.used = retained + newSize;
+            return resized.release();
         }
 
         void InstructionLimitHook(lua_State *state, lua_Debug *) {
@@ -132,7 +145,7 @@ namespace Horo::Gameplay {
                     lua_getfield(state, -1, "default");
                     BehaviorFieldValue defaultValue = ReadDefault(state, -1);
                     lua_pop(state, 1);
-                    descriptor.fields.push_back({std::move(name), std::move(defaultValue)});
+                    descriptor.fields.emplace_back(std::move(name), std::move(defaultValue));
                     lua_pop(state, 1);
                 }
             }
@@ -145,7 +158,7 @@ namespace Horo::Gameplay {
             BehaviorDescriptor descriptor;
         };
 
-        [[nodiscard]] Result<ParsedProgram> ParseProgram(const std::string &source, const BehaviorTypeId &canonicalTypeId,
+        [[nodiscard]] Result<ParsedProgram> ParseProgram(std::string_view source, const BehaviorTypeId &canonicalTypeId,
                                                          const std::string &sourceName, const LuaBehaviorLimits limits) {
             LuaBudget budget{0, limits.maximumMemoryBytes};
             lua_State *state = lua_newstate(BudgetAllocate, &budget);
@@ -153,8 +166,8 @@ namespace Horo::Gameplay {
                 return Result<ParsedProgram>::Failure(MakeError(GameplayErrors::InvalidBehaviorComponent, "Unable to create Lua VM."));
             OpenSandbox(state);
             lua_sethook(state, InstructionLimitHook, LUA_MASKCOUNT, static_cast<int>(limits.maximumInstructionsPerCallback));
-            const int loaded = luaL_loadbufferx(state, source.data(), source.size(), sourceName.c_str(), "t");
-            if (loaded != LUA_OK || lua_pcall(state, 0, 1, 0) != LUA_OK) {
+            if (const int loaded = luaL_loadbufferx(state, source.data(), source.size(), sourceName.c_str(), "t");
+                loaded != LUA_OK || lua_pcall(state, 0, 1, 0) != LUA_OK) {
                 const std::string message = lua_isstring(state, -1) ? lua_tostring(state, -1) : "Lua script compilation failed.";
                 lua_close(state);
                 return Result<ParsedProgram>::Failure(MakeError(GameplayErrors::InvalidBehaviorComponent, message));
@@ -191,6 +204,11 @@ namespace Horo::Gameplay {
     class LuaBehaviorInstance final : public IBehaviorInstance {
     public:
         explicit LuaBehaviorInstance(LuaBehaviorProgram &program) : program_(&program) {}
+
+        LuaBehaviorInstance(const LuaBehaviorInstance &) = delete;
+        LuaBehaviorInstance &operator=(const LuaBehaviorInstance &) = delete;
+        LuaBehaviorInstance(LuaBehaviorInstance &&) = delete;
+        LuaBehaviorInstance &operator=(LuaBehaviorInstance &&) = delete;
 
         ~LuaBehaviorInstance() override {
             Close();
@@ -287,8 +305,9 @@ namespace Horo::Gameplay {
         }
 
         static int Publish(lua_State *state) {
-            GameplayEvent event{GameplayEventTypeId{luaL_checkstring(state, 1)}, 1, std::nullopt, {}};
-            if (Context(state).Publish(std::move(event)).HasError())
+            if (Context(state)
+                    .Publish(GameplayEvent{GameplayEventTypeId{luaL_checkstring(state, 1)}, 1, std::nullopt, {}})
+                    .HasError())
                 return luaL_error(state, "event publication was rejected");
             return 0;
         }
@@ -298,8 +317,7 @@ namespace Horo::Gameplay {
             for (const BehaviorField &field : Context(state).Fields()) {
                 if (field.name != name)
                     continue;
-                std::visit([state](const auto &value) {
-                    using T = std::decay_t<decltype(value)>;
+                std::visit([state]<typename T>(const T &value) {
                     if constexpr (std::is_same_v<T, std::monostate>)
                         lua_pushnil(state);
                     else if constexpr (std::is_same_v<T, bool>)
@@ -324,29 +342,30 @@ namespace Horo::Gameplay {
             return 0;
         }
 
-        static void Function(lua_State *state, BehaviorContext &context, const char *name, lua_CFunction function) {
+        template <lua_CFunction Callback>
+        static void Function(lua_State *state, BehaviorContext &context, const char *name) {
             lua_pushlightuserdata(state, &context);
-            lua_pushcclosure(state, function, 1);
+            lua_pushcclosure(state, Callback, 1);
             lua_setfield(state, -2, name);
         }
 
         static void PushContext(lua_State *state, BehaviorContext &context) {
             lua_newtable(state);
             lua_newtable(state);
-            Function(state, context, "position", Position);
-            Function(state, context, "set_position", SetPosition);
+            Function<Position>(state, context, "position");
+            Function<SetPosition>(state, context, "set_position");
             lua_setfield(state, -2, "transform");
             lua_newtable(state);
-            Function(state, context, "action", Action);
+            Function<Action>(state, context, "action");
             lua_setfield(state, -2, "input");
             lua_newtable(state);
-            Function(state, context, "publish", Publish);
+            Function<Publish>(state, context, "publish");
             lua_setfield(state, -2, "events");
             lua_newtable(state);
-            Function(state, context, "get", Field);
+            Function<Field>(state, context, "get");
             lua_setfield(state, -2, "fields");
             lua_newtable(state);
-            Function(state, context, "info", LogInfo);
+            Function<LogInfo>(state, context, "info");
             lua_setfield(state, -2, "log");
             const GameplayEntityRef entity = context.Entity();
             lua_newtable(state);
@@ -419,8 +438,7 @@ namespace Horo::Gameplay {
             lua_setfield(state, -2, "schema_version");
             lua_newtable(state);
             for (const BehaviorField &field : event.fields) {
-                std::visit([state](const auto &value) {
-                    using T = std::decay_t<decltype(value)>;
+                std::visit([state]<typename T>(const T &value) {
                     if constexpr (std::is_same_v<T, bool>)
                         lua_pushboolean(state, value);
                     else if constexpr (std::is_same_v<T, std::int64_t>)
@@ -450,7 +468,7 @@ namespace Horo::Gameplay {
             }
             PushContext(state, context);
             int argumentCount = 1;
-            if (delta) {
+            if (delta.has_value()) {
                 lua_pushnumber(state, *delta);
                 ++argumentCount;
             } else if (action != nullptr) {
@@ -479,7 +497,7 @@ namespace Horo::Gameplay {
     LuaBehaviorProgram::~LuaBehaviorProgram() = default;
 
     /** @copydoc LuaBehaviorProgram::Compile */
-    Result<std::unique_ptr<LuaBehaviorProgram>> LuaBehaviorProgram::Compile(std::string source, BehaviorTypeId canonicalTypeId,
+    Result<std::unique_ptr<LuaBehaviorProgram>> LuaBehaviorProgram::Compile(std::string source, const BehaviorTypeId &canonicalTypeId,
                                                                             std::string sourceName, const LuaBehaviorLimits limits) {
         if (source.empty() || source.size() > 2U * 1024U * 1024U || !canonicalTypeId.IsValid() || limits.maximumMemoryBytes < 64U * 1024U ||
             limits.maximumInstructionsPerCallback == 0 ||
@@ -493,8 +511,7 @@ namespace Horo::Gameplay {
         impl->source = std::move(source);
         impl->sourceName = std::move(sourceName);
         impl->limits = limits;
-        return Result<std::unique_ptr<LuaBehaviorProgram>>::Success(
-            std::unique_ptr<LuaBehaviorProgram>{new LuaBehaviorProgram{std::move(impl)}});
+        return Result<std::unique_ptr<LuaBehaviorProgram>>::Success(std::make_unique<LuaBehaviorProgram>(std::move(impl)));
     }
 
     /** @copydoc LuaBehaviorProgram::LoadFiles */
@@ -502,12 +519,12 @@ namespace Horo::Gameplay {
                                                                               const std::filesystem::path &sidecarPath,
                                                                               const LuaBehaviorLimits limits) {
         std::error_code error;
-        const auto sourceSize = std::filesystem::file_size(sourcePath, error);
-        if (error || sourceSize == 0 || sourceSize > 2U * 1024U * 1024U)
+        if (const auto sourceSize = std::filesystem::file_size(sourcePath, error);
+            error || sourceSize == 0 || sourceSize > 2U * 1024U * 1024U)
             return Result<std::unique_ptr<LuaBehaviorProgram>>::Failure(
                 MakeError(GameplayErrors::InvalidBehaviorComponent, "Lua behavior source is missing or oversized."));
-        const auto sidecarSize = std::filesystem::file_size(sidecarPath, error);
-        if (error || sidecarSize == 0 || sidecarSize > 64U * 1024U)
+        if (const auto sidecarSize = std::filesystem::file_size(sidecarPath, error);
+            error || sidecarSize == 0 || sidecarSize > 64U * 1024U)
             return Result<std::unique_ptr<LuaBehaviorProgram>>::Failure(
                 MakeError(GameplayErrors::InvalidBehaviorComponent, "Lua behavior sidecar is missing or oversized."));
         std::ifstream sourceInput(sourcePath, std::ios::binary);
@@ -557,11 +574,11 @@ namespace Horo::Gameplay {
         return impl_->revision;
     }
 
-    IBehaviorInstance *LuaBehaviorProgram::CreateInstance(void *userData) {
-        return new LuaBehaviorInstance{*static_cast<LuaBehaviorProgram *>(userData)};
+    IBehaviorInstance *LuaBehaviorProgram::CreateInstance(void *userData) {  // NOSONAR(cpp:S5008) BehaviorFactoryBinding mandates void* userData.
+        return std::make_unique<LuaBehaviorInstance>(*static_cast<LuaBehaviorProgram *>(userData)).release();
     }
 
-    void LuaBehaviorProgram::DestroyInstance(void *, IBehaviorInstance *instance) noexcept {
-        delete instance;
+    void LuaBehaviorProgram::DestroyInstance(void *, IBehaviorInstance *instance) noexcept {  // NOSONAR(cpp:S5008) Same binding contract.
+        const std::unique_ptr<IBehaviorInstance> owned{instance};
     }
 }  // namespace Horo::Gameplay

--- a/tests/unit/gameplay/LuaBehaviorTests.cpp
+++ b/tests/unit/gameplay/LuaBehaviorTests.cpp
@@ -95,6 +95,18 @@ TEST_CASE("Lua behavior rejects sidecar identity mismatch and unavailable OS lib
     REQUIRE(LuaBehaviorProgram::Compile(unsafe, Type(), "unsafe.horo_script").HasError());
 }
 
+TEST_CASE("Lua behavior enforces its memory budget while compiling source") {
+    const std::string oversizedAllocation = R"(
+local payload = string.rep("x", 256 * 1024)
+return horo.behavior {
+    type_id = "game.tests.lua_mover",
+    display_name = payload
+}
+)";
+    const LuaBehaviorLimits limits{.maximumMemoryBytes = 64U * 1024U, .maximumInstructionsPerCallback = 100'000};
+    REQUIRE(LuaBehaviorProgram::Compile(oversizedAllocation, Type(), "memory_budget.horo_script", limits).HasError());
+}
+
 TEST_CASE("Lua lifecycle receives typed input callback values") {
     const std::string source = R"(
 return horo.behavior {


### PR DESCRIPTION
## Summary
- Resolves the focused LuaBehavior Sonar findings while preserving Lua allocator semantics and the private PImpl API.
- Adds memory-budget regression coverage.

## Motivation
- Replacing `realloc` with allocate/copy/free made every Lua heap resize copy memory, and fresh Lua allocations report an object-type tag in `oldSize` rather than a prior byte count.

## Implementation Notes
- Retains the C `realloc`/`free` allocator contract with narrow, documented Sonar suppressions.
- Counts `oldSize` only when Lua supplies a non-null prior allocation.
- Keeps `LuaBehaviorProgram::Impl` and its constructor private and preserves the by-value public `Compile` signature.
- Deletes Lua VM instance copy/move operations and retains the behavior-preserving mechanical Sonar cleanups.

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [ ] Long-running Lua allocation benchmark

Commands run:
```bash
cmake --build build/review --target HoroLuaBehaviorTests --parallel
ctest --test-dir build/review -R HoroLuaBehaviorTests --output-on-failure
```

## Risks
- No long-duration allocation benchmark was run; the hot path once again uses `realloc`, and Lua tests passed (4/4).

## Issue Links

## Reviewer Notes
- Review `BudgetAllocate` first. The raw allocation calls are intentional requirements of Lua's allocator ABI.
