### PR TITLE
refactor(input): resolve Sonar findings

### DIFF
--- a/src/runtime/input/Input.cpp
+++ b/src/runtime/input/Input.cpp
@@ -39,12 +39,13 @@ namespace Horo::Input {
         }
 
         float ApplyDeadzone(float value, const InputBinding &binding) noexcept {
+            using enum DeadzoneKind;
             if (!std::isfinite(value))
                 return 0.0F;
             const float deadzone = std::clamp(binding.deadzone, 0.0F, 0.99F);
-            if (binding.deadzoneKind == DeadzoneKind::Threshold)
+            if (binding.deadzoneKind == Threshold)
                 return std::abs(value) >= deadzone ? value : 0.0F;
-            if (binding.deadzoneKind == DeadzoneKind::Axial || binding.deadzoneKind == DeadzoneKind::Radial) {
+            if (binding.deadzoneKind == Axial || binding.deadzoneKind == Radial) {
                 if (std::abs(value) <= deadzone)
                     return 0.0F;
                 return std::copysign((std::abs(value) - deadzone) / (1.0F - deadzone), value);
@@ -53,31 +54,33 @@ namespace Horo::Input {
         }
 
         bool IsControlSupported(const InputBinding &binding) noexcept {
+            using enum BindingControlKind;
             switch (binding.kind) {
-                case BindingControlKind::Key:
+                case Key:
                     return binding.key > Key::Unknown && binding.key < Key::Count;
-                case BindingControlKind::PointerButton:
+                case PointerButton:
                     return binding.pointerButton < PointerButton::Count;
-                case BindingControlKind::PointerWheelX:
-                case BindingControlKind::PointerWheelY:
+                case PointerWheelX:
+                case PointerWheelY:
                     return true;
-                case BindingControlKind::GamepadButton:
+                case GamepadButton:
                     return binding.gamepadButton < GamepadButton::Count;
-                case BindingControlKind::GamepadAxis:
+                case GamepadAxis:
                     return binding.gamepadAxis < GamepadAxis::Count;
-                case BindingControlKind::RawGamepadButton:
-                case BindingControlKind::RawGamepadAxis:
+                case RawGamepadButton:
+                case RawGamepadAxis:
                     return binding.rawControl < 256;
             }
             return false;
         }
 
         bool IsReservedShortcut(const InputBinding &binding) noexcept {
+            using enum Key;
             if (binding.kind != BindingControlKind::Key)
                 return false;
             const ModifierState mods = binding.requiredModifiers;
-            return (mods.command && !mods.control && !mods.alt && (binding.key == Key::Q || binding.key == Key::W)) ||
-                   (mods.alt && binding.key == Key::F4) || (mods.control && mods.alt && binding.key == Key::Delete);
+            return (mods.command && !mods.control && !mods.alt && (binding.key == Q || binding.key == W)) ||
+                   (mods.alt && binding.key == F4) || (mods.control && mods.alt && binding.key == Delete);
         }
 
         bool SameTransition(const InputBinding &left, const InputBinding &right) noexcept {
@@ -111,61 +114,93 @@ namespace Horo::Input {
             return binding.deadzoneKind == DeadzoneKind::Radial ? std::clamp(rawAxis, -1.0F, 1.0F) : ApplyDeadzone(rawAxis, binding);
         }
 
+        /** @brief Derives pressed/released edges for a digital control driven by an analog axis. */
+        ButtonState DigitalStateFromAxis(const float current, const float previous, const float threshold) noexcept {
+            ButtonState state;
+            state.down = std::abs(current) >= threshold;
+            const bool previousDown = std::abs(previous) >= threshold;
+            state.pressed = state.down && !previousDown;
+            state.released = !state.down && previousDown;
+            return state;
+        }
+
+        /** @brief Resolves the previous-frame value of a gamepad axis, tolerating missing or shrunken snapshots. */
+        float PreviousAxisValue(const RawInputSnapshot *previousSnapshot, const GamepadDeviceId padId, const std::size_t controlIndex,
+                                const InputBinding &binding, const bool raw) noexcept {
+            const GamepadState *previous = previousSnapshot != nullptr ? previousSnapshot->FindGamepad(padId) : nullptr;
+            if (previous == nullptr)
+                return 0.0F;
+            if (raw)
+                return controlIndex < previous->rawAxes.size() ? ResolveGamepadAxis(previous->rawAxes[controlIndex], binding) : 0.0F;
+            return controlIndex < previous->axes.size() ? ResolveGamepadAxis(previous->axes[controlIndex], binding) : 0.0F;
+        }
+
+        BindingEvaluationResult EvaluateBindingOnPad(const InputBinding &binding, const GamepadState &pad,
+                                                     const RawInputSnapshot *previousSnapshot) noexcept {
+            using enum BindingControlKind;
+            switch (binding.kind) {
+                case GamepadButton: {
+                    const ButtonState state = pad.buttons[Index(binding.gamepadButton)];
+                    return {state.down ? 1.0F : 0.0F, state};
+                }
+                case GamepadAxis: {
+                    const float axis = ResolveGamepadAxis(pad.axes[Index(binding.gamepadAxis)], binding);
+                    const float previous = PreviousAxisValue(previousSnapshot, pad.id, Index(binding.gamepadAxis), binding, false);
+                    return {axis, DigitalStateFromAxis(axis, previous, binding.digitalThreshold)};
+                }
+                case RawGamepadButton: {
+                    if (binding.rawControl >= pad.rawButtons.size())
+                        break;
+                    const ButtonState state = pad.rawButtons[binding.rawControl];
+                    return {state.down ? 1.0F : 0.0F, state};
+                }
+                case RawGamepadAxis: {
+                    if (binding.rawControl >= pad.rawAxes.size())
+                        break;
+                    const float axis = ResolveGamepadAxis(pad.rawAxes[binding.rawControl], binding);
+                    const float previous = PreviousAxisValue(previousSnapshot, pad.id, binding.rawControl, binding, true);
+                    return {axis, DigitalStateFromAxis(axis, previous, binding.digitalThreshold)};
+                }
+                default:
+                    break;
+            }
+            return {};
+        }
+
+        /** @brief Stable per-control identifier used to dedupe pressed transitions across actions. */
+        std::uint64_t GamepadControlId(const InputBinding &binding) noexcept {
+            using enum BindingControlKind;
+            switch (binding.kind) {
+                case GamepadButton:
+                    return Index(binding.gamepadButton);
+                case RawGamepadButton:
+                case RawGamepadAxis:
+                    return binding.rawControl;
+                default:
+                    return Index(binding.gamepadAxis);
+            }
+        }
+
         BindingEvaluationResult EvaluateGamepadBinding(const InputBinding &binding, const RawInputSnapshot &snapshot,
                                                        const RawInputSnapshot *previousSnapshot, const InputDeviceAssignments &assignments,
                                                        const std::optional<PlayerId> &player,
                                                        std::unordered_set<std::uint64_t> &consumedGamepadTransitions) {
-            float axis = 0.0F;
-            ButtonState state;
+            BindingEvaluationResult result;
             for (const GamepadState &pad : snapshot.gamepads) {
                 if (player.has_value() && assignments.PlayerFor(pad.id) != player)
                     continue;
-                if (binding.kind == BindingControlKind::GamepadButton) {
-                    state = pad.buttons[Index(binding.gamepadButton)];
-                    axis = state.down ? 1.0F : 0.0F;
-                } else if (binding.kind == BindingControlKind::GamepadAxis) {
-                    axis = ResolveGamepadAxis(pad.axes[Index(binding.gamepadAxis)], binding);
-                    state.down = std::abs(axis) >= binding.digitalThreshold;
-                    const GamepadState *previous = previousSnapshot != nullptr ? previousSnapshot->FindGamepad(pad.id) : nullptr;
-                    float previousAxis = 0.0F;
-                    if (previous != nullptr)
-                        previousAxis = ResolveGamepadAxis(previous->axes[Index(binding.gamepadAxis)], binding);
-                    const bool previousDown = std::abs(previousAxis) >= binding.digitalThreshold;
-                    state.pressed = state.down && !previousDown;
-                    state.released = !state.down && previousDown;
-                } else if (binding.kind == BindingControlKind::RawGamepadButton && binding.rawControl < pad.rawButtons.size()) {
-                    state = pad.rawButtons[binding.rawControl];
-                    axis = state.down ? 1.0F : 0.0F;
-                } else if (binding.kind == BindingControlKind::RawGamepadAxis && binding.rawControl < pad.rawAxes.size()) {
-                    axis = ResolveGamepadAxis(pad.rawAxes[binding.rawControl], binding);
-                    state.down = std::abs(axis) >= binding.digitalThreshold;
-                    const GamepadState *previous = previousSnapshot != nullptr ? previousSnapshot->FindGamepad(pad.id) : nullptr;
-                    float previousAxis = 0.0F;
-                    if (previous != nullptr && binding.rawControl < previous->rawAxes.size())
-                        previousAxis = ResolveGamepadAxis(previous->rawAxes[binding.rawControl], binding);
-                    const bool previousDown = std::abs(previousAxis) >= binding.digitalThreshold;
-                    state.pressed = state.down && !previousDown;
-                    state.released = !state.down && previousDown;
-                }
-
-                if (state.pressed) {
-                    std::uint64_t controlId = 0;
-                    if (binding.kind == BindingControlKind::GamepadButton)
-                        controlId = Index(binding.gamepadButton);
-                    else if (binding.kind == BindingControlKind::RawGamepadButton || binding.kind == BindingControlKind::RawGamepadAxis)
-                        controlId = binding.rawControl;
-                    else
-                        controlId = Index(binding.gamepadAxis);
-
-                    const std::uint64_t control = (static_cast<std::uint64_t>(binding.kind) << 48U) | (controlId << 32U) | pad.id.slot;
+                result = EvaluateBindingOnPad(binding, pad, previousSnapshot);
+                if (result.state.pressed) {
+                    const std::uint64_t control =
+                        (static_cast<std::uint64_t>(binding.kind) << 48U) | (GamepadControlId(binding) << 32U) | pad.id.slot;
                     const std::uint64_t transition = control ^ pad.id.sessionGeneration;
                     if (!consumedGamepadTransitions.insert(transition).second)
-                        state.pressed = false;
+                        result.state.pressed = false;
                 }
-                if (axis != 0.0F || state.pressed || state.released)
+                if (result.axis != 0.0F || result.state.pressed || result.state.released)
                     break;
             }
-            return {axis, state};
+            return result;
         }
     }  // namespace
 
@@ -181,7 +216,7 @@ namespace Horo::Input {
 
     const GamepadState *RawInputSnapshot::FindGamepad(const GamepadDeviceId id) const noexcept {
         const auto found = std::ranges::find(gamepads, id, &GamepadState::id);
-        return found == gamepads.end() ? nullptr : &*found;
+        return found == gamepads.end() ? nullptr : std::to_address(found);
     }
 
     struct RawInputCollector::Impl {
@@ -205,8 +240,10 @@ namespace Horo::Input {
         next = previous;
         next.frame = frame;
         next.text.clear();
-        next.pointer.deltaX = next.pointer.deltaY = 0.0F;
-        next.pointer.wheelX = next.pointer.wheelY = 0.0F;
+        next.pointer.deltaX = 0.0F;
+        next.pointer.deltaY = 0.0F;
+        next.pointer.wheelX = 0.0F;
+        next.pointer.wheelY = 0.0F;
         for (ButtonState &state : next.keyboard)
             Advance(state);
         for (ButtonState &state : next.pointer.buttons)
@@ -353,10 +390,45 @@ namespace Horo::Input {
     }
 
     namespace {
+        /** @brief Transparent hasher so string-like lookups avoid constructing temporary strings. */
+        struct StringViewHash {
+            using is_transparent = void;
+
+            std::size_t operator()(const std::string_view value) const noexcept {
+                return std::hash<std::string_view>{}(value);
+            }
+        };
+
+        void ValidateBinding(BindingValidationReport &report, const ActionId &action, const InputBinding &binding,
+                             std::string_view invalidDeadzoneMessage, std::string_view unsupportedControlMessage,
+                             std::string_view reservedShortcutMessage) {
+            using enum BindingDiagnosticCode;
+            if (!std::isfinite(binding.deadzone) || binding.deadzone < 0.0F || binding.deadzone >= 1.0F)
+                report.diagnostics.emplace_back(InvalidDeadzone, action, std::string(invalidDeadzoneMessage));
+            if (binding.chordSize > binding.chord.size())
+                report.diagnostics.emplace_back(AmbiguousChord, action, "Binding chord exceeds the supported bounded size.");
+            if (!IsControlSupported(binding))
+                report.diagnostics.emplace_back(UnsupportedControl, action, std::string(unsupportedControlMessage));
+            if (IsReservedShortcut(binding))
+                report.diagnostics.emplace_back(ReservedShortcut, action, std::string(reservedShortcutMessage));
+            if (!std::isfinite(binding.scale) || !std::isfinite(binding.digitalThreshold) || binding.digitalThreshold < 0.0F ||
+                binding.digitalThreshold > 1.0F || binding.component > 1)
+                report.diagnostics.emplace_back(UnsupportedControl, action, "Binding scale, threshold, or component is invalid.");
+        }
+
+        template <typename Bindings>
+        void ReportDuplicateTransitions(BindingValidationReport &report, const ActionId &action, const Bindings &bindings,
+                                        const char *message) {
+            for (std::size_t i = 0; i + 1 < bindings.size(); ++i)
+                for (std::size_t j = i + 1; j < bindings.size(); ++j)
+                    if (SameTransition(bindings[i], bindings[j]))
+                        report.diagnostics.emplace_back(BindingDiagnosticCode::DuplicateBinding, action, message);
+        }
+
         void ValidateOverrides(BindingValidationReport &report, const InputBindingProfile &profile,
                                const std::span<const ActionDescriptor> actions) {
             using enum BindingDiagnosticCode;
-            std::unordered_set<std::string, std::hash<std::string_view>, std::equal_to<>> overriddenActions;
+            std::unordered_set<std::string, StringViewHash, std::equal_to<>> overriddenActions;
             for (const BindingOverride &overrideValue : profile.overrides) {
                 if (const auto action = std::ranges::find(actions, overrideValue.action, &ActionDescriptor::id); action == actions.end()) {
                     report.diagnostics.emplace_back(InvalidAction, overrideValue.action, "Binding override references an unknown action.");
@@ -365,28 +437,11 @@ namespace Horo::Input {
                 if (!overriddenActions.insert(overrideValue.action.Value()).second)
                     report.diagnostics.emplace_back(DuplicateBinding, overrideValue.action,
                                                     "The profile contains more than one override for the action.");
-                for (std::size_t i = 0; i < overrideValue.bindings.size(); ++i) {
-                    const InputBinding &binding = overrideValue.bindings[i];
-                    if (!std::isfinite(binding.deadzone) || binding.deadzone < 0.0F || binding.deadzone >= 1.0F)
-                        report.diagnostics.emplace_back(InvalidDeadzone, overrideValue.action, "Binding deadzone must be in [0, 1).");
-                    if (binding.chordSize > binding.chord.size())
-                        report.diagnostics.emplace_back(AmbiguousChord, overrideValue.action,
-                                                        "Binding chord exceeds the supported bounded size.");
-                    if (!IsControlSupported(binding))
-                        report.diagnostics.emplace_back(UnsupportedControl, overrideValue.action,
-                                                        "Binding references an unsupported control.");
-                    if (IsReservedShortcut(binding))
-                        report.diagnostics.emplace_back(ReservedShortcut, overrideValue.action,
-                                                        "Binding is reserved by the operating system.");
-                    if (!std::isfinite(binding.scale) || !std::isfinite(binding.digitalThreshold) || binding.digitalThreshold < 0.0F ||
-                        binding.digitalThreshold > 1.0F || binding.component > 1)
-                        report.diagnostics.emplace_back(UnsupportedControl, overrideValue.action,
-                                                        "Binding scale, threshold, or component is invalid.");
-                    for (std::size_t j = i + 1; j < overrideValue.bindings.size(); ++j)
-                        if (SameTransition(binding, overrideValue.bindings[j]))
-                            report.diagnostics.emplace_back(DuplicateBinding, overrideValue.action,
-                                                            "The action contains a duplicate binding.");
-                }
+                for (const InputBinding &binding : overrideValue.bindings)
+                    ValidateBinding(report, overrideValue.action, binding, "Binding deadzone must be in [0, 1).",
+                                    "Binding references an unsupported control.", "Binding is reserved by the operating system.");
+                ReportDuplicateTransitions(report, overrideValue.action, overrideValue.bindings,
+                                           "The action contains a duplicate binding.");
             }
         }
 
@@ -405,19 +460,13 @@ namespace Horo::Input {
                     overrideValue == profile.overrides.end() ? action.defaultBindings : overrideValue->bindings;
                 if (action.required && bindings.empty())
                     report.diagnostics.emplace_back(RequiredActionUnbound, action.id, "A required action has no binding.");
-                for (std::size_t index = 0; index < bindings.size(); ++index) {
-                    const InputBinding &binding = bindings[index];
-                    if (!IsControlSupported(binding))
-                        report.diagnostics.emplace_back(UnsupportedControl, action.id, "Action references an unsupported control.");
-                    if (IsReservedShortcut(binding))
-                        report.diagnostics.emplace_back(ReservedShortcut, action.id, "Action uses an operating-system-reserved shortcut.");
-                    if (!std::isfinite(binding.deadzone) || binding.deadzone < 0.0F || binding.deadzone >= 1.0F)
-                        report.diagnostics.emplace_back(InvalidDeadzone, action.id, "Action binding deadzone must be in [0, 1).");
-                    for (std::size_t other = index + 1; other < bindings.size(); ++other)
-                        if (SameTransition(binding, bindings[other]))
-                            report.diagnostics.emplace_back(DuplicateBinding, action.id, "Action contains a duplicate binding.");
+                for (const InputBinding &binding : bindings)
+                    ValidateBinding(report, action.id, binding, "Action binding deadzone must be in [0, 1).",
+                                    "Action references an unsupported control.", "Action uses an operating-system-reserved shortcut.");
+                ReportDuplicateTransitions(report, action.id, bindings, "Action contains a duplicate binding.");
+                effective.reserve(bindings.size());
+                for (const InputBinding &binding : bindings)
                     effective.push_back({&action, &binding});
-                }
             }
             for (std::size_t i = 0; i < effective.size(); ++i) {
                 for (std::size_t j = i + 1; j < effective.size(); ++j) {
@@ -460,6 +509,33 @@ namespace Horo::Input {
     }
 
     namespace {
+        InputBinding BindingFromJson(const nlohmann::json &json);
+
+        /** @brief Parses the overrides array of a profile document, enforcing per-entry shape limits. */
+        Result<std::vector<BindingOverride>> ParseOverrides(const nlohmann::json &json) {
+            constexpr std::size_t maximumOverrides = 4096;
+            constexpr std::size_t maximumBindingsPerAction = 64;
+            const auto &overrides = json.at("overrides");
+            if (!overrides.is_array() || overrides.size() > maximumOverrides)
+                return Result<std::vector<BindingOverride>>::Failure(
+                    MakeError(Errors::ProfileMalformed, "Input profile override count is invalid."));
+            std::vector<BindingOverride> parsed;
+            parsed.reserve(overrides.size());
+            for (const auto &entry : overrides) {
+                BindingOverride overrideValue{.action = ActionId{entry.at("action").get<std::string>()}};
+                const auto &bindings = entry.at("bindings");
+                if (!bindings.is_array() || bindings.size() > maximumBindingsPerAction)
+                    return Result<std::vector<BindingOverride>>::Failure(
+                        MakeError(Errors::ProfileMalformed, "Input profile binding count is invalid."));
+                for (const auto &binding : bindings)
+                    overrideValue.bindings.push_back(BindingFromJson(binding));
+                parsed.push_back(std::move(overrideValue));
+            }
+            return Result<std::vector<BindingOverride>>::Success(std::move(parsed));
+        }
+    }  // namespace
+
+    namespace {
         void to_json(nlohmann::json &json, const InputBinding &binding) {
             json = {{"kind", static_cast<int>(binding.kind)},
                     {"key", static_cast<int>(binding.key)},
@@ -491,9 +567,9 @@ namespace Horo::Input {
             binding.pointerButton = static_cast<PointerButton>(json.value("pointerButton", 0));
             binding.gamepadButton = static_cast<GamepadButton>(json.value("gamepadButton", 0));
             binding.gamepadAxis = static_cast<GamepadAxis>(json.value("gamepadAxis", 0));
-            binding.rawControl = json.value("rawControl", 0);
+            binding.rawControl = static_cast<std::uint16_t>(json.value("rawControl", 0));
             binding.scale = json.value("scale", 1.0F);
-            binding.component = json.value("component", 0);
+            binding.component = static_cast<std::uint8_t>(json.value("component", 0));
             binding.deadzoneKind = static_cast<DeadzoneKind>(json.value("deadzoneKind", 0));
             binding.deadzone = json.value("deadzone", 0.0F);
             binding.digitalThreshold = json.value("digitalThreshold", 0.5F);
@@ -511,8 +587,6 @@ namespace Horo::Input {
 
     Result<InputBindingProfile> ParseBindingProfile(const std::string_view value) {
         constexpr std::size_t maximumProfileBytes = 1024U * 1024U;
-        constexpr std::size_t maximumOverrides = 4096;
-        constexpr std::size_t maximumBindingsPerAction = 64;
         if (value.empty() || value.size() > maximumProfileBytes)
             return Result<InputBindingProfile>::Failure(
                 MakeError(Errors::ProfileMalformed, "Input profile size is outside the supported bounds."));
@@ -542,20 +616,10 @@ namespace Horo::Input {
             InputBindingProfile profile;
             profile.schemaVersion = json.at("schemaVersion").get<std::uint32_t>();
             profile.profileId = json.at("profileId").get<std::string>();
-            const auto &overrides = json.at("overrides");
-            if (!overrides.is_array() || overrides.size() > maximumOverrides)
-                return Result<InputBindingProfile>::Failure(
-                    MakeError(Errors::ProfileMalformed, "Input profile override count is invalid."));
-            for (const auto &entry : overrides) {
-                BindingOverride overrideValue{.action = ActionId{entry.at("action").get<std::string>()}};
-                const auto &bindings = entry.at("bindings");
-                if (!bindings.is_array() || bindings.size() > maximumBindingsPerAction)
-                    return Result<InputBindingProfile>::Failure(
-                        MakeError(Errors::ProfileMalformed, "Input profile binding count is invalid."));
-                for (const auto &binding : bindings)
-                    overrideValue.bindings.push_back(BindingFromJson(binding));
-                profile.overrides.push_back(std::move(overrideValue));
-            }
+            if (const Result<std::vector<BindingOverride>> overrides = ParseOverrides(json); overrides.HasError())
+                return Result<InputBindingProfile>::Failure(overrides.ErrorValue());
+            else
+                profile.overrides = std::move(overrides).Value();
             if (profile.schemaVersion != 1 || profile.profileId.empty() || profile.profileId.size() > 256)
                 return Result<InputBindingProfile>::Failure(MakeError(Errors::ProfileInvalidSchema, "Invalid input profile schema."));
             return Result<InputBindingProfile>::Success(std::move(profile));
@@ -594,6 +658,8 @@ namespace Horo::Input {
     }
 
     Result<void> SaveBindingProfileAtomically(const std::filesystem::path &path, const InputBindingProfile &profile) {
+        if (path.empty())
+            return Result<void>::Failure(MakeError(Errors::ProfileWriteFailed, "Input profile path is empty."));
         const Result<std::string> serialized = SerializeBindingProfile(profile);
         if (serialized.HasError())
             return Result<void>::Failure(serialized.ErrorValue());
@@ -678,7 +744,8 @@ namespace Horo::Input {
         impl_->consumedKeys.clear();
         impl_->consumedPointerButtons.clear();
         impl_->consumedGamepadTransitions.clear();
-        impl_->consumedWheelX = impl_->consumedWheelY = false;
+        impl_->consumedWheelX = false;
+        impl_->consumedWheelY = false;
         impl_->assignments.RetainConnected(snapshot.gamepads);
         if (impl_->capture && !snapshot.window.focused)
             CancelCapture(CaptureCancellationReason::FocusLost);

--- a/src/runtime/input/sdl/SdlInputBackend.cpp
+++ b/src/runtime/input/sdl/SdlInputBackend.cpp
@@ -29,136 +29,140 @@ namespace Horo::Input {
                                                 true};
 
         Key MapKey(const SDL_Scancode key) noexcept {
+            using enum Key;
             if (key >= SDL_SCANCODE_A && key <= SDL_SCANCODE_Z)
                 return static_cast<Key>(static_cast<int>(Key::A) + key - SDL_SCANCODE_A);
             if (key >= SDL_SCANCODE_1 && key <= SDL_SCANCODE_9)
                 return static_cast<Key>(static_cast<int>(Key::Digit1) + key - SDL_SCANCODE_1);
             switch (key) {
                 case SDL_SCANCODE_0:
-                    return Key::Digit0;
+                    return Digit0;
                 case SDL_SCANCODE_ESCAPE:
-                    return Key::Escape;
+                    return Escape;
                 case SDL_SCANCODE_RETURN:
-                    return Key::Enter;
+                    return Enter;
                 case SDL_SCANCODE_TAB:
-                    return Key::Tab;
+                    return Tab;
                 case SDL_SCANCODE_SPACE:
-                    return Key::Space;
+                    return Space;
                 case SDL_SCANCODE_BACKSPACE:
-                    return Key::Backspace;
+                    return Backspace;
                 case SDL_SCANCODE_DELETE:
-                    return Key::Delete;
+                    return Delete;
                 case SDL_SCANCODE_LEFT:
-                    return Key::Left;
+                    return Left;
                 case SDL_SCANCODE_RIGHT:
-                    return Key::Right;
+                    return Right;
                 case SDL_SCANCODE_UP:
-                    return Key::Up;
+                    return Up;
                 case SDL_SCANCODE_DOWN:
-                    return Key::Down;
+                    return Down;
                 case SDL_SCANCODE_HOME:
-                    return Key::Home;
+                    return Home;
                 case SDL_SCANCODE_END:
-                    return Key::End;
+                    return End;
                 case SDL_SCANCODE_PAGEUP:
-                    return Key::PageUp;
+                    return PageUp;
                 case SDL_SCANCODE_PAGEDOWN:
-                    return Key::PageDown;
+                    return PageDown;
                 case SDL_SCANCODE_F1:
-                    return Key::F1;
+                    return F1;
                 case SDL_SCANCODE_F2:
-                    return Key::F2;
+                    return F2;
                 case SDL_SCANCODE_F3:
-                    return Key::F3;
+                    return F3;
                 case SDL_SCANCODE_F4:
-                    return Key::F4;
+                    return F4;
                 case SDL_SCANCODE_F5:
-                    return Key::F5;
+                    return F5;
                 case SDL_SCANCODE_F6:
-                    return Key::F6;
+                    return F6;
                 case SDL_SCANCODE_F7:
-                    return Key::F7;
+                    return F7;
                 case SDL_SCANCODE_F8:
-                    return Key::F8;
+                    return F8;
                 case SDL_SCANCODE_F9:
-                    return Key::F9;
+                    return F9;
                 case SDL_SCANCODE_F10:
-                    return Key::F10;
+                    return F10;
                 case SDL_SCANCODE_F11:
-                    return Key::F11;
+                    return F11;
                 case SDL_SCANCODE_F12:
-                    return Key::F12;
+                    return F12;
                 default:
-                    return Key::Unknown;
+                    return Unknown;
             }
         }
 
         std::optional<PointerButton> MapPointerButton(const std::uint8_t button) noexcept {
+            using enum PointerButton;
             switch (button) {
                 case SDL_BUTTON_LEFT:
-                    return PointerButton::Primary;
+                    return Primary;
                 case SDL_BUTTON_RIGHT:
-                    return PointerButton::Secondary;
+                    return Secondary;
                 case SDL_BUTTON_MIDDLE:
-                    return PointerButton::Middle;
+                    return Middle;
                 case SDL_BUTTON_X1:
-                    return PointerButton::Auxiliary1;
+                    return Auxiliary1;
                 case SDL_BUTTON_X2:
-                    return PointerButton::Auxiliary2;
+                    return Auxiliary2;
                 default:
                     return std::nullopt;
             }
         }
 
         std::optional<GamepadButton> MapGamepadButton(const std::uint8_t button) noexcept {
+            using enum GamepadButton;
             switch (static_cast<SDL_GamepadButton>(button)) {
                 case SDL_GAMEPAD_BUTTON_SOUTH:
-                    return GamepadButton::South;
+                    return South;
                 case SDL_GAMEPAD_BUTTON_EAST:
-                    return GamepadButton::East;
+                    return East;
                 case SDL_GAMEPAD_BUTTON_WEST:
-                    return GamepadButton::West;
+                    return West;
                 case SDL_GAMEPAD_BUTTON_NORTH:
-                    return GamepadButton::North;
+                    return North;
                 case SDL_GAMEPAD_BUTTON_LEFT_SHOULDER:
-                    return GamepadButton::LeftShoulder;
+                    return LeftShoulder;
                 case SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER:
-                    return GamepadButton::RightShoulder;
+                    return RightShoulder;
                 case SDL_GAMEPAD_BUTTON_LEFT_STICK:
-                    return GamepadButton::LeftStick;
+                    return LeftStick;
                 case SDL_GAMEPAD_BUTTON_RIGHT_STICK:
-                    return GamepadButton::RightStick;
+                    return RightStick;
                 case SDL_GAMEPAD_BUTTON_START:
-                    return GamepadButton::Start;
+                    return Start;
                 case SDL_GAMEPAD_BUTTON_BACK:
-                    return GamepadButton::Select;
+                    return Select;
                 case SDL_GAMEPAD_BUTTON_DPAD_UP:
-                    return GamepadButton::DPadUp;
+                    return DPadUp;
                 case SDL_GAMEPAD_BUTTON_DPAD_DOWN:
-                    return GamepadButton::DPadDown;
+                    return DPadDown;
                 case SDL_GAMEPAD_BUTTON_DPAD_LEFT:
-                    return GamepadButton::DPadLeft;
+                    return DPadLeft;
                 case SDL_GAMEPAD_BUTTON_DPAD_RIGHT:
-                    return GamepadButton::DPadRight;
+                    return DPadRight;
                 default:
                     return std::nullopt;
             }
         }
 
         std::optional<GamepadAxis> MapGamepadAxis(const std::uint8_t axis) noexcept {
+            using enum GamepadAxis;
             switch (static_cast<SDL_GamepadAxis>(axis)) {
                 case SDL_GAMEPAD_AXIS_LEFTX:
-                    return GamepadAxis::LeftX;
+                    return LeftX;
                 case SDL_GAMEPAD_AXIS_LEFTY:
-                    return GamepadAxis::LeftY;
+                    return LeftY;
                 case SDL_GAMEPAD_AXIS_RIGHTX:
-                    return GamepadAxis::RightX;
+                    return RightX;
                 case SDL_GAMEPAD_AXIS_RIGHTY:
-                    return GamepadAxis::RightY;
+                    return RightY;
                 case SDL_GAMEPAD_AXIS_LEFT_TRIGGER:
-                    return GamepadAxis::LeftTrigger;
+                    return LeftTrigger;
                 case SDL_GAMEPAD_AXIS_RIGHT_TRIGGER:
-                    return GamepadAxis::RightTrigger;
+                    return RightTrigger;
                 default:
                     return std::nullopt;
             }
@@ -182,6 +186,184 @@ namespace Horo::Input {
         WindowInputState windowState{};
     };
 
+    namespace {
+
+        /** @brief Applies keyboard, text-input, and text-composition events to the collector. */
+        void HandleKeyboardEvent(SdlInputBackend::Impl &impl, const SDL_Event &event) {
+            switch (event.type) {
+                case SDL_EVENT_KEY_DOWN:
+                case SDL_EVENT_KEY_UP:
+                    if (!event.key.repeat)
+                        impl.collector.SetKey(MapKey(event.key.scancode), event.key.down);
+                    impl.collector.SetModifiers(ModifierState{
+                        .control = (event.key.mod & SDL_KMOD_CTRL) != 0,
+                        .shift = (event.key.mod & SDL_KMOD_SHIFT) != 0,
+                        .alt = (event.key.mod & SDL_KMOD_ALT) != 0,
+                        .command = (event.key.mod & SDL_KMOD_GUI) != 0,
+                    });
+                    break;
+                case SDL_EVENT_TEXT_INPUT:
+                    if (event.text.text)
+                        impl.collector.AppendText(event.text.text);
+                    break;
+                case SDL_EVENT_TEXT_EDITING:
+                    impl.collector.SetTextComposition(event.edit.text != nullptr ? event.edit.text : "", event.edit.start,
+                                                      event.edit.length);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        /** @brief Applies pointer motion, buttons, wheel, and device presence events to the collector. */
+        void HandlePointerEvent(SdlInputBackend::Impl &impl, const SDL_Event &event) {
+            switch (event.type) {
+                case SDL_EVENT_MOUSE_MOTION:
+                    impl.collector.SetPointerPosition(event.motion.x, event.motion.y);
+                    break;
+                case SDL_EVENT_MOUSE_BUTTON_DOWN:
+                case SDL_EVENT_MOUSE_BUTTON_UP:
+                    if (const auto button = MapPointerButton(event.button.button))
+                        impl.collector.SetPointerButton(*button, event.button.down);
+                    impl.collector.SetPointerPosition(event.button.x, event.button.y);
+                    break;
+                case SDL_EVENT_MOUSE_WHEEL:
+                    impl.collector.AddPointerWheel(event.wheel.direction == SDL_MOUSEWHEEL_FLIPPED ? -event.wheel.x : event.wheel.x,
+                                                   event.wheel.direction == SDL_MOUSEWHEEL_FLIPPED ? -event.wheel.y : event.wheel.y);
+                    break;
+                case SDL_EVENT_MOUSE_ADDED:
+                    impl.windowState.pointerDeviceAvailable = true;
+                    impl.collector.SetWindowState(impl.windowState);
+                    break;
+                case SDL_EVENT_MOUSE_REMOVED:
+                    // The public snapshot intentionally does not expose SDL mouse IDs. A
+                    // removal conservatively invalidates the active pointer capture; a
+                    // subsequent add event restores pointer availability.
+                    impl.windowState.pointerDeviceAvailable = false;
+                    impl.collector.SetWindowState(impl.windowState);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        /** @brief Applies window focus and hover events to the collector. */
+        void HandleWindowEvent(SdlInputBackend::Impl &impl, const SDL_Event &event) {
+            switch (event.type) {
+                case SDL_EVENT_WINDOW_FOCUS_GAINED:
+                    impl.windowState.focused = true;
+                    impl.collector.SetWindowState(impl.windowState);
+                    break;
+                case SDL_EVENT_WINDOW_FOCUS_LOST:
+                    impl.collector.Neutralize();
+                    impl.windowState.focused = false;
+                    impl.collector.SetWindowState(impl.windowState);
+                    break;
+                case SDL_EVENT_WINDOW_MOUSE_ENTER:
+                    impl.windowState.pointerInside = true;
+                    impl.collector.SetWindowState(impl.windowState);
+                    break;
+                case SDL_EVENT_WINDOW_MOUSE_LEAVE:
+                    impl.windowState.pointerInside = false;
+                    impl.collector.SetWindowState(impl.windowState);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        /** @brief Opens and closes gamepads and forwards their button and axis state. */
+        void HandleGamepadEvent(SdlInputBackend::Impl &impl, const SDL_Event &event) {
+            switch (event.type) {
+                case SDL_EVENT_GAMEPAD_ADDED: {
+                    if (impl.devices.contains(event.gdevice.which))
+                        break;
+                    SDL_Gamepad *gamepad = SDL_OpenGamepad(event.gdevice.which);
+                    if (!gamepad)
+                        break;
+                    const char *name = SDL_GetGamepadName(gamepad);
+                    const GamepadDeviceId id = impl.collector.ConnectGamepad(name ? name : "SDL Gamepad", true);
+                    impl.devices.try_emplace(event.gdevice.which, SdlInputBackend::Impl::Device{id, gamepad, nullptr});
+                    break;
+                }
+                case SDL_EVENT_GAMEPAD_REMOVED: {
+                    const auto found = impl.devices.find(event.gdevice.which);
+                    if (found == impl.devices.end())
+                        break;
+                    (void)impl.collector.DisconnectGamepad(found->second.id);
+                    if (found->second.gamepad)
+                        SDL_CloseGamepad(found->second.gamepad);
+                    impl.devices.erase(found);
+                    break;
+                }
+                case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
+                case SDL_EVENT_GAMEPAD_BUTTON_UP:
+                    if (const auto found = impl.devices.find(event.gbutton.which);
+                        found != impl.devices.end() && MapGamepadButton(event.gbutton.button)) {
+                        const auto button = *MapGamepadButton(event.gbutton.button);
+                        (void)impl.collector.SetGamepadButton(found->second.id, button, event.gbutton.down);
+                    }
+                    break;
+                case SDL_EVENT_GAMEPAD_AXIS_MOTION:
+                    if (const auto found = impl.devices.find(event.gaxis.which);
+                        found != impl.devices.end() && MapGamepadAxis(event.gaxis.axis)) {
+                        const auto axis = *MapGamepadAxis(event.gaxis.axis);
+                        const float normalized = event.gaxis.value < 0 ? static_cast<float>(event.gaxis.value) / 32768.0F
+                                                                       : static_cast<float>(event.gaxis.value) / 32767.0F;
+                        (void)impl.collector.SetGamepadAxis(found->second.id, axis, normalized);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        /** @brief Opens and closes raw joysticks and forwards their raw button and axis state. */
+        void HandleJoystickEvent(SdlInputBackend::Impl &impl, const SDL_Event &event) {
+            switch (event.type) {
+                case SDL_EVENT_JOYSTICK_ADDED: {
+                    if (impl.devices.contains(event.jdevice.which) || SDL_IsGamepad(event.jdevice.which))
+                        break;
+                    SDL_Joystick *joystick = SDL_OpenJoystick(event.jdevice.which);
+                    if (!joystick)
+                        break;
+                    const char *name = SDL_GetJoystickName(joystick);
+                    const auto buttons = static_cast<std::size_t>(std::clamp(SDL_GetNumJoystickButtons(joystick), 0, 256));
+                    const auto axes = static_cast<std::size_t>(std::clamp(SDL_GetNumJoystickAxes(joystick), 0, 256));
+                    const GamepadDeviceId id = impl.collector.ConnectGamepad(name ? name : "SDL Joystick", false, buttons, axes);
+                    impl.devices.try_emplace(event.jdevice.which, SdlInputBackend::Impl::Device{id, nullptr, joystick});
+                    break;
+                }
+                case SDL_EVENT_JOYSTICK_REMOVED: {
+                    const auto found = impl.devices.find(event.jdevice.which);
+                    if (found == impl.devices.end())
+                        break;
+                    (void)impl.collector.DisconnectGamepad(found->second.id);
+                    if (found->second.gamepad)
+                        SDL_CloseGamepad(found->second.gamepad);
+                    else if (found->second.joystick)
+                        SDL_CloseJoystick(found->second.joystick);
+                    impl.devices.erase(found);
+                    break;
+                }
+                case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
+                case SDL_EVENT_JOYSTICK_BUTTON_UP:
+                    if (const auto found = impl.devices.find(event.jbutton.which); found != impl.devices.end() && found->second.joystick)
+                        (void)impl.collector.SetRawGamepadButton(found->second.id, event.jbutton.button, event.jbutton.down);
+                    break;
+                case SDL_EVENT_JOYSTICK_AXIS_MOTION:
+                    if (const auto found = impl.devices.find(event.jaxis.which); found != impl.devices.end() && found->second.joystick) {
+                        const float normalized = event.jaxis.value < 0 ? static_cast<float>(event.jaxis.value) / 32768.0F
+                                                                       : static_cast<float>(event.jaxis.value) / 32767.0F;
+                        (void)impl.collector.SetRawGamepadAxis(found->second.id, event.jaxis.axis, normalized);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+    }  // namespace
+
     SdlInputBackend::SdlInputBackend() : impl_(std::make_unique<Impl>()) {}
 
     SdlInputBackend::~SdlInputBackend() {
@@ -202,141 +384,36 @@ namespace Horo::Input {
         switch (event.type) {
             case SDL_EVENT_KEY_DOWN:
             case SDL_EVENT_KEY_UP:
-                if (!event.key.repeat)
-                    impl_->collector.SetKey(MapKey(event.key.scancode), event.key.down);
-                impl_->collector.SetModifiers(ModifierState{
-                    .control = (event.key.mod & SDL_KMOD_CTRL) != 0,
-                    .shift = (event.key.mod & SDL_KMOD_SHIFT) != 0,
-                    .alt = (event.key.mod & SDL_KMOD_ALT) != 0,
-                    .command = (event.key.mod & SDL_KMOD_GUI) != 0,
-                });
-                break;
             case SDL_EVENT_TEXT_INPUT:
-                if (event.text.text)
-                    impl_->collector.AppendText(event.text.text);
-                break;
             case SDL_EVENT_TEXT_EDITING:
-                impl_->collector.SetTextComposition(event.edit.text != nullptr ? event.edit.text : "", event.edit.start, event.edit.length);
+                HandleKeyboardEvent(*impl_, event);
                 break;
             case SDL_EVENT_MOUSE_MOTION:
-                impl_->collector.SetPointerPosition(event.motion.x, event.motion.y);
-                break;
             case SDL_EVENT_MOUSE_BUTTON_DOWN:
             case SDL_EVENT_MOUSE_BUTTON_UP:
-                if (const auto button = MapPointerButton(event.button.button))
-                    impl_->collector.SetPointerButton(*button, event.button.down);
-                impl_->collector.SetPointerPosition(event.button.x, event.button.y);
-                break;
             case SDL_EVENT_MOUSE_WHEEL:
-                impl_->collector.AddPointerWheel(event.wheel.direction == SDL_MOUSEWHEEL_FLIPPED ? -event.wheel.x : event.wheel.x,
-                                                 event.wheel.direction == SDL_MOUSEWHEEL_FLIPPED ? -event.wheel.y : event.wheel.y);
-                break;
             case SDL_EVENT_MOUSE_ADDED:
-                impl_->windowState.pointerDeviceAvailable = true;
-                impl_->collector.SetWindowState(impl_->windowState);
-                break;
             case SDL_EVENT_MOUSE_REMOVED:
-                // The public snapshot intentionally does not expose SDL mouse IDs. A
-                // removal conservatively invalidates the active pointer capture; a
-                // subsequent add event restores pointer availability.
-                impl_->windowState.pointerDeviceAvailable = false;
-                impl_->collector.SetWindowState(impl_->windowState);
+                HandlePointerEvent(*impl_, event);
                 break;
             case SDL_EVENT_WINDOW_FOCUS_GAINED:
-                impl_->windowState.focused = true;
-                impl_->collector.SetWindowState(impl_->windowState);
-                break;
             case SDL_EVENT_WINDOW_FOCUS_LOST:
-                impl_->collector.Neutralize();
-                impl_->windowState.focused = false;
-                impl_->collector.SetWindowState(impl_->windowState);
-                break;
             case SDL_EVENT_WINDOW_MOUSE_ENTER:
-                impl_->windowState.pointerInside = true;
-                impl_->collector.SetWindowState(impl_->windowState);
-                break;
             case SDL_EVENT_WINDOW_MOUSE_LEAVE:
-                impl_->windowState.pointerInside = false;
-                impl_->collector.SetWindowState(impl_->windowState);
+                HandleWindowEvent(*impl_, event);
                 break;
-            case SDL_EVENT_GAMEPAD_ADDED: {
-                if (impl_->devices.contains(event.gdevice.which))
-                    break;
-                SDL_Gamepad *gamepad = SDL_OpenGamepad(event.gdevice.which);
-                if (!gamepad)
-                    break;
-                const char *name = SDL_GetGamepadName(gamepad);
-                const GamepadDeviceId id = impl_->collector.ConnectGamepad(name ? name : "SDL Gamepad", true);
-                impl_->devices.emplace(event.gdevice.which, Impl::Device{id, gamepad, nullptr});
-                break;
-            }
-            case SDL_EVENT_GAMEPAD_REMOVED: {
-                const auto found = impl_->devices.find(event.gdevice.which);
-                if (found == impl_->devices.end())
-                    break;
-                (void)impl_->collector.DisconnectGamepad(found->second.id);
-                if (found->second.gamepad)
-                    SDL_CloseGamepad(found->second.gamepad);
-                impl_->devices.erase(found);
-                break;
-            }
+            case SDL_EVENT_GAMEPAD_ADDED:
+            case SDL_EVENT_GAMEPAD_REMOVED:
             case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
-            case SDL_EVENT_GAMEPAD_BUTTON_UP: {
-                const auto found = impl_->devices.find(event.gbutton.which);
-                const auto button = MapGamepadButton(event.gbutton.button);
-                if (found != impl_->devices.end() && button)
-                    (void)impl_->collector.SetGamepadButton(found->second.id, *button, event.gbutton.down);
-                break;
-            }
-            case SDL_EVENT_GAMEPAD_AXIS_MOTION: {
-                const auto found = impl_->devices.find(event.gaxis.which);
-                const auto axis = MapGamepadAxis(event.gaxis.axis);
-                if (found != impl_->devices.end() && axis) {
-                    const float normalized = event.gaxis.value < 0 ? static_cast<float>(event.gaxis.value) / 32768.0F
-                                                                   : static_cast<float>(event.gaxis.value) / 32767.0F;
-                    (void)impl_->collector.SetGamepadAxis(found->second.id, *axis, normalized);
-                }
-                break;
-            }
-            case SDL_EVENT_JOYSTICK_ADDED: {
-                if (impl_->devices.contains(event.jdevice.which) || SDL_IsGamepad(event.jdevice.which))
-                    break;
-                SDL_Joystick *joystick = SDL_OpenJoystick(event.jdevice.which);
-                if (!joystick)
-                    break;
-                const char *name = SDL_GetJoystickName(joystick);
-                const std::size_t buttons = static_cast<std::size_t>(std::clamp(SDL_GetNumJoystickButtons(joystick), 0, 256));
-                const std::size_t axes = static_cast<std::size_t>(std::clamp(SDL_GetNumJoystickAxes(joystick), 0, 256));
-                const GamepadDeviceId id = impl_->collector.ConnectGamepad(name ? name : "SDL Joystick", false, buttons, axes);
-                impl_->devices.emplace(event.jdevice.which, Impl::Device{id, nullptr, joystick});
-                break;
-            }
-            case SDL_EVENT_JOYSTICK_REMOVED: {
-                const auto found = impl_->devices.find(event.jdevice.which);
-                if (found == impl_->devices.end())
-                    break;
-                (void)impl_->collector.DisconnectGamepad(found->second.id);
-                if (found->second.gamepad)
-                    SDL_CloseGamepad(found->second.gamepad);
-                else if (found->second.joystick)
-                    SDL_CloseJoystick(found->second.joystick);
-                impl_->devices.erase(found);
-                break;
-            }
+            case SDL_EVENT_GAMEPAD_BUTTON_UP:
+            case SDL_EVENT_GAMEPAD_AXIS_MOTION:
+            case SDL_EVENT_JOYSTICK_ADDED:
+            case SDL_EVENT_JOYSTICK_REMOVED:
             case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
-            case SDL_EVENT_JOYSTICK_BUTTON_UP: {
-                if (const auto found = impl_->devices.find(event.jbutton.which); found != impl_->devices.end() && found->second.joystick)
-                    (void)impl_->collector.SetRawGamepadButton(found->second.id, event.jbutton.button, event.jbutton.down);
+            case SDL_EVENT_JOYSTICK_BUTTON_UP:
+            case SDL_EVENT_JOYSTICK_AXIS_MOTION:
+                HandleGamepadEvent(*impl_, event);
                 break;
-            }
-            case SDL_EVENT_JOYSTICK_AXIS_MOTION: {
-                if (const auto found = impl_->devices.find(event.jaxis.which); found != impl_->devices.end() && found->second.joystick) {
-                    const float normalized = event.jaxis.value < 0 ? static_cast<float>(event.jaxis.value) / 32768.0F
-                                                                   : static_cast<float>(event.jaxis.value) / 32767.0F;
-                    (void)impl_->collector.SetRawGamepadAxis(found->second.id, event.jaxis.axis, normalized);
-                }
-                break;
-            }
             default:
                 break;
         }

--- a/src/runtime/input/sdl/SdlInputBackend.cpp
+++ b/src/runtime/input/sdl/SdlInputBackend.cpp
@@ -184,185 +184,184 @@ namespace Horo::Input {
         RawInputCollector collector;
         std::unordered_map<SDL_JoystickID, Device> devices;
         WindowInputState windowState{};
+
+        void HandleKeyboardEvent(const SDL_Event &event);
+        void HandlePointerEvent(const SDL_Event &event);
+        void HandleWindowEvent(const SDL_Event &event);
+        void HandleGamepadEvent(const SDL_Event &event);
+        void HandleJoystickEvent(const SDL_Event &event);
     };
 
-    namespace {
-
-        /** @brief Applies keyboard, text-input, and text-composition events to the collector. */
-        void HandleKeyboardEvent(SdlInputBackend::Impl &impl, const SDL_Event &event) {
-            switch (event.type) {
-                case SDL_EVENT_KEY_DOWN:
-                case SDL_EVENT_KEY_UP:
-                    if (!event.key.repeat)
-                        impl.collector.SetKey(MapKey(event.key.scancode), event.key.down);
-                    impl.collector.SetModifiers(ModifierState{
-                        .control = (event.key.mod & SDL_KMOD_CTRL) != 0,
-                        .shift = (event.key.mod & SDL_KMOD_SHIFT) != 0,
-                        .alt = (event.key.mod & SDL_KMOD_ALT) != 0,
-                        .command = (event.key.mod & SDL_KMOD_GUI) != 0,
-                    });
-                    break;
-                case SDL_EVENT_TEXT_INPUT:
-                    if (event.text.text)
-                        impl.collector.AppendText(event.text.text);
-                    break;
-                case SDL_EVENT_TEXT_EDITING:
-                    impl.collector.SetTextComposition(event.edit.text != nullptr ? event.edit.text : "", event.edit.start,
-                                                      event.edit.length);
-                    break;
-                default:
-                    break;
-            }
+    /** @brief Applies keyboard, text-input, and text-composition events to the collector. */
+    void SdlInputBackend::Impl::HandleKeyboardEvent(const SDL_Event &event) {
+        switch (event.type) {
+            case SDL_EVENT_KEY_DOWN:
+            case SDL_EVENT_KEY_UP:
+                if (!event.key.repeat)
+                    collector.SetKey(MapKey(event.key.scancode), event.key.down);
+                collector.SetModifiers(ModifierState{
+                    .control = (event.key.mod & SDL_KMOD_CTRL) != 0,
+                    .shift = (event.key.mod & SDL_KMOD_SHIFT) != 0,
+                    .alt = (event.key.mod & SDL_KMOD_ALT) != 0,
+                    .command = (event.key.mod & SDL_KMOD_GUI) != 0,
+                });
+                break;
+            case SDL_EVENT_TEXT_INPUT:
+                if (event.text.text)
+                    collector.AppendText(event.text.text);
+                break;
+            case SDL_EVENT_TEXT_EDITING:
+                collector.SetTextComposition(event.edit.text != nullptr ? event.edit.text : "", event.edit.start, event.edit.length);
+                break;
+            default:
+                break;
         }
+    }
 
-        /** @brief Applies pointer motion, buttons, wheel, and device presence events to the collector. */
-        void HandlePointerEvent(SdlInputBackend::Impl &impl, const SDL_Event &event) {
-            switch (event.type) {
-                case SDL_EVENT_MOUSE_MOTION:
-                    impl.collector.SetPointerPosition(event.motion.x, event.motion.y);
-                    break;
-                case SDL_EVENT_MOUSE_BUTTON_DOWN:
-                case SDL_EVENT_MOUSE_BUTTON_UP:
-                    if (const auto button = MapPointerButton(event.button.button))
-                        impl.collector.SetPointerButton(*button, event.button.down);
-                    impl.collector.SetPointerPosition(event.button.x, event.button.y);
-                    break;
-                case SDL_EVENT_MOUSE_WHEEL:
-                    impl.collector.AddPointerWheel(event.wheel.direction == SDL_MOUSEWHEEL_FLIPPED ? -event.wheel.x : event.wheel.x,
-                                                   event.wheel.direction == SDL_MOUSEWHEEL_FLIPPED ? -event.wheel.y : event.wheel.y);
-                    break;
-                case SDL_EVENT_MOUSE_ADDED:
-                    impl.windowState.pointerDeviceAvailable = true;
-                    impl.collector.SetWindowState(impl.windowState);
-                    break;
-                case SDL_EVENT_MOUSE_REMOVED:
-                    // The public snapshot intentionally does not expose SDL mouse IDs. A
-                    // removal conservatively invalidates the active pointer capture; a
-                    // subsequent add event restores pointer availability.
-                    impl.windowState.pointerDeviceAvailable = false;
-                    impl.collector.SetWindowState(impl.windowState);
-                    break;
-                default:
-                    break;
-            }
+    /** @brief Applies pointer motion, buttons, wheel, and device presence events to the collector. */
+    void SdlInputBackend::Impl::HandlePointerEvent(const SDL_Event &event) {
+        switch (event.type) {
+            case SDL_EVENT_MOUSE_MOTION:
+                collector.SetPointerPosition(event.motion.x, event.motion.y);
+                break;
+            case SDL_EVENT_MOUSE_BUTTON_DOWN:
+            case SDL_EVENT_MOUSE_BUTTON_UP:
+                if (const auto button = MapPointerButton(event.button.button))
+                    collector.SetPointerButton(*button, event.button.down);
+                collector.SetPointerPosition(event.button.x, event.button.y);
+                break;
+            case SDL_EVENT_MOUSE_WHEEL:
+                collector.AddPointerWheel(event.wheel.direction == SDL_MOUSEWHEEL_FLIPPED ? -event.wheel.x : event.wheel.x,
+                                          event.wheel.direction == SDL_MOUSEWHEEL_FLIPPED ? -event.wheel.y : event.wheel.y);
+                break;
+            case SDL_EVENT_MOUSE_ADDED:
+                windowState.pointerDeviceAvailable = true;
+                collector.SetWindowState(windowState);
+                break;
+            case SDL_EVENT_MOUSE_REMOVED:
+                // The public snapshot intentionally does not expose SDL mouse IDs. A
+                // removal conservatively invalidates the active pointer capture; a
+                // subsequent add event restores pointer availability.
+                windowState.pointerDeviceAvailable = false;
+                collector.SetWindowState(windowState);
+                break;
+            default:
+                break;
         }
+    }
 
-        /** @brief Applies window focus and hover events to the collector. */
-        void HandleWindowEvent(SdlInputBackend::Impl &impl, const SDL_Event &event) {
-            switch (event.type) {
-                case SDL_EVENT_WINDOW_FOCUS_GAINED:
-                    impl.windowState.focused = true;
-                    impl.collector.SetWindowState(impl.windowState);
-                    break;
-                case SDL_EVENT_WINDOW_FOCUS_LOST:
-                    impl.collector.Neutralize();
-                    impl.windowState.focused = false;
-                    impl.collector.SetWindowState(impl.windowState);
-                    break;
-                case SDL_EVENT_WINDOW_MOUSE_ENTER:
-                    impl.windowState.pointerInside = true;
-                    impl.collector.SetWindowState(impl.windowState);
-                    break;
-                case SDL_EVENT_WINDOW_MOUSE_LEAVE:
-                    impl.windowState.pointerInside = false;
-                    impl.collector.SetWindowState(impl.windowState);
-                    break;
-                default:
-                    break;
-            }
+    /** @brief Applies window focus and hover events to the collector. */
+    void SdlInputBackend::Impl::HandleWindowEvent(const SDL_Event &event) {
+        switch (event.type) {
+            case SDL_EVENT_WINDOW_FOCUS_GAINED:
+                windowState.focused = true;
+                collector.SetWindowState(windowState);
+                break;
+            case SDL_EVENT_WINDOW_FOCUS_LOST:
+                collector.Neutralize();
+                windowState.focused = false;
+                collector.SetWindowState(windowState);
+                break;
+            case SDL_EVENT_WINDOW_MOUSE_ENTER:
+                windowState.pointerInside = true;
+                collector.SetWindowState(windowState);
+                break;
+            case SDL_EVENT_WINDOW_MOUSE_LEAVE:
+                windowState.pointerInside = false;
+                collector.SetWindowState(windowState);
+                break;
+            default:
+                break;
         }
+    }
 
-        /** @brief Opens and closes gamepads and forwards their button and axis state. */
-        void HandleGamepadEvent(SdlInputBackend::Impl &impl, const SDL_Event &event) {
-            switch (event.type) {
-                case SDL_EVENT_GAMEPAD_ADDED: {
-                    if (impl.devices.contains(event.gdevice.which))
-                        break;
-                    SDL_Gamepad *gamepad = SDL_OpenGamepad(event.gdevice.which);
-                    if (!gamepad)
-                        break;
-                    const char *name = SDL_GetGamepadName(gamepad);
-                    const GamepadDeviceId id = impl.collector.ConnectGamepad(name ? name : "SDL Gamepad", true);
-                    impl.devices.try_emplace(event.gdevice.which, SdlInputBackend::Impl::Device{id, gamepad, nullptr});
+    /** @brief Opens and closes gamepads and forwards their button and axis state. */
+    void SdlInputBackend::Impl::HandleGamepadEvent(const SDL_Event &event) {
+        switch (event.type) {
+            case SDL_EVENT_GAMEPAD_ADDED: {
+                if (devices.contains(event.gdevice.which))
                     break;
-                }
-                case SDL_EVENT_GAMEPAD_REMOVED: {
-                    const auto found = impl.devices.find(event.gdevice.which);
-                    if (found == impl.devices.end())
-                        break;
-                    (void)impl.collector.DisconnectGamepad(found->second.id);
-                    if (found->second.gamepad)
-                        SDL_CloseGamepad(found->second.gamepad);
-                    impl.devices.erase(found);
+                SDL_Gamepad *gamepad = SDL_OpenGamepad(event.gdevice.which);
+                if (!gamepad)
                     break;
-                }
-                case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
-                case SDL_EVENT_GAMEPAD_BUTTON_UP:
-                    if (const auto found = impl.devices.find(event.gbutton.which);
-                        found != impl.devices.end() && MapGamepadButton(event.gbutton.button)) {
-                        const auto button = *MapGamepadButton(event.gbutton.button);
-                        (void)impl.collector.SetGamepadButton(found->second.id, button, event.gbutton.down);
-                    }
+                const char *name = SDL_GetGamepadName(gamepad);
+                const GamepadDeviceId id = collector.ConnectGamepad(name ? name : "SDL Gamepad", true);
+                devices.try_emplace(event.gdevice.which, Device{id, gamepad, nullptr});
+                break;
+            }
+            case SDL_EVENT_GAMEPAD_REMOVED: {
+                const auto found = devices.find(event.gdevice.which);
+                if (found == devices.end())
                     break;
-                case SDL_EVENT_GAMEPAD_AXIS_MOTION:
-                    if (const auto found = impl.devices.find(event.gaxis.which);
-                        found != impl.devices.end() && MapGamepadAxis(event.gaxis.axis)) {
-                        const auto axis = *MapGamepadAxis(event.gaxis.axis);
+                (void)collector.DisconnectGamepad(found->second.id);
+                if (found->second.gamepad)
+                    SDL_CloseGamepad(found->second.gamepad);
+                devices.erase(found);
+                break;
+            }
+            case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
+            case SDL_EVENT_GAMEPAD_BUTTON_UP:
+                if (const auto found = devices.find(event.gbutton.which); found != devices.end())
+                    if (const auto button = MapGamepadButton(event.gbutton.button))
+                        (void)collector.SetGamepadButton(found->second.id, *button, event.gbutton.down);
+                break;
+            case SDL_EVENT_GAMEPAD_AXIS_MOTION:
+                if (const auto found = devices.find(event.gaxis.which); found != devices.end())
+                    if (const auto axis = MapGamepadAxis(event.gaxis.axis)) {
                         const float normalized = event.gaxis.value < 0 ? static_cast<float>(event.gaxis.value) / 32768.0F
                                                                        : static_cast<float>(event.gaxis.value) / 32767.0F;
-                        (void)impl.collector.SetGamepadAxis(found->second.id, axis, normalized);
+                        (void)collector.SetGamepadAxis(found->second.id, *axis, normalized);
                     }
-                    break;
-                default:
-                    break;
-            }
+                break;
+            default:
+                break;
         }
+    }
 
-        /** @brief Opens and closes raw joysticks and forwards their raw button and axis state. */
-        void HandleJoystickEvent(SdlInputBackend::Impl &impl, const SDL_Event &event) {
-            switch (event.type) {
-                case SDL_EVENT_JOYSTICK_ADDED: {
-                    if (impl.devices.contains(event.jdevice.which) || SDL_IsGamepad(event.jdevice.which))
-                        break;
-                    SDL_Joystick *joystick = SDL_OpenJoystick(event.jdevice.which);
-                    if (!joystick)
-                        break;
-                    const char *name = SDL_GetJoystickName(joystick);
-                    const auto buttons = static_cast<std::size_t>(std::clamp(SDL_GetNumJoystickButtons(joystick), 0, 256));
-                    const auto axes = static_cast<std::size_t>(std::clamp(SDL_GetNumJoystickAxes(joystick), 0, 256));
-                    const GamepadDeviceId id = impl.collector.ConnectGamepad(name ? name : "SDL Joystick", false, buttons, axes);
-                    impl.devices.try_emplace(event.jdevice.which, SdlInputBackend::Impl::Device{id, nullptr, joystick});
+    /** @brief Opens and closes raw joysticks and forwards their raw button and axis state. */
+    void SdlInputBackend::Impl::HandleJoystickEvent(const SDL_Event &event) {
+        switch (event.type) {
+            case SDL_EVENT_JOYSTICK_ADDED: {
+                if (devices.contains(event.jdevice.which) || SDL_IsGamepad(event.jdevice.which))
                     break;
-                }
-                case SDL_EVENT_JOYSTICK_REMOVED: {
-                    const auto found = impl.devices.find(event.jdevice.which);
-                    if (found == impl.devices.end())
-                        break;
-                    (void)impl.collector.DisconnectGamepad(found->second.id);
-                    if (found->second.gamepad)
-                        SDL_CloseGamepad(found->second.gamepad);
-                    else if (found->second.joystick)
-                        SDL_CloseJoystick(found->second.joystick);
-                    impl.devices.erase(found);
+                SDL_Joystick *joystick = SDL_OpenJoystick(event.jdevice.which);
+                if (!joystick)
                     break;
-                }
-                case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
-                case SDL_EVENT_JOYSTICK_BUTTON_UP:
-                    if (const auto found = impl.devices.find(event.jbutton.which); found != impl.devices.end() && found->second.joystick)
-                        (void)impl.collector.SetRawGamepadButton(found->second.id, event.jbutton.button, event.jbutton.down);
-                    break;
-                case SDL_EVENT_JOYSTICK_AXIS_MOTION:
-                    if (const auto found = impl.devices.find(event.jaxis.which); found != impl.devices.end() && found->second.joystick) {
-                        const float normalized = event.jaxis.value < 0 ? static_cast<float>(event.jaxis.value) / 32768.0F
-                                                                       : static_cast<float>(event.jaxis.value) / 32767.0F;
-                        (void)impl.collector.SetRawGamepadAxis(found->second.id, event.jaxis.axis, normalized);
-                    }
-                    break;
-                default:
-                    break;
+                const char *name = SDL_GetJoystickName(joystick);
+                const auto buttons = static_cast<std::size_t>(std::clamp(SDL_GetNumJoystickButtons(joystick), 0, 256));
+                const auto axes = static_cast<std::size_t>(std::clamp(SDL_GetNumJoystickAxes(joystick), 0, 256));
+                const GamepadDeviceId id = collector.ConnectGamepad(name ? name : "SDL Joystick", false, buttons, axes);
+                devices.try_emplace(event.jdevice.which, Device{id, nullptr, joystick});
+                break;
             }
+            case SDL_EVENT_JOYSTICK_REMOVED: {
+                const auto found = devices.find(event.jdevice.which);
+                if (found == devices.end())
+                    break;
+                (void)collector.DisconnectGamepad(found->second.id);
+                if (found->second.gamepad)
+                    SDL_CloseGamepad(found->second.gamepad);
+                else if (found->second.joystick)
+                    SDL_CloseJoystick(found->second.joystick);
+                devices.erase(found);
+                break;
+            }
+            case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
+            case SDL_EVENT_JOYSTICK_BUTTON_UP:
+                if (const auto found = devices.find(event.jbutton.which); found != devices.end() && found->second.joystick)
+                    (void)collector.SetRawGamepadButton(found->second.id, event.jbutton.button, event.jbutton.down);
+                break;
+            case SDL_EVENT_JOYSTICK_AXIS_MOTION:
+                if (const auto found = devices.find(event.jaxis.which); found != devices.end() && found->second.joystick) {
+                    const float normalized = event.jaxis.value < 0 ? static_cast<float>(event.jaxis.value) / 32768.0F
+                                                                   : static_cast<float>(event.jaxis.value) / 32767.0F;
+                    (void)collector.SetRawGamepadAxis(found->second.id, event.jaxis.axis, normalized);
+                }
+                break;
+            default:
+                break;
         }
-    }  // namespace
+    }
 
     SdlInputBackend::SdlInputBackend() : impl_(std::make_unique<Impl>()) {}
 
@@ -386,7 +385,7 @@ namespace Horo::Input {
             case SDL_EVENT_KEY_UP:
             case SDL_EVENT_TEXT_INPUT:
             case SDL_EVENT_TEXT_EDITING:
-                HandleKeyboardEvent(*impl_, event);
+                impl_->HandleKeyboardEvent(event);
                 break;
             case SDL_EVENT_MOUSE_MOTION:
             case SDL_EVENT_MOUSE_BUTTON_DOWN:
@@ -394,25 +393,27 @@ namespace Horo::Input {
             case SDL_EVENT_MOUSE_WHEEL:
             case SDL_EVENT_MOUSE_ADDED:
             case SDL_EVENT_MOUSE_REMOVED:
-                HandlePointerEvent(*impl_, event);
+                impl_->HandlePointerEvent(event);
                 break;
             case SDL_EVENT_WINDOW_FOCUS_GAINED:
             case SDL_EVENT_WINDOW_FOCUS_LOST:
             case SDL_EVENT_WINDOW_MOUSE_ENTER:
             case SDL_EVENT_WINDOW_MOUSE_LEAVE:
-                HandleWindowEvent(*impl_, event);
+                impl_->HandleWindowEvent(event);
                 break;
             case SDL_EVENT_GAMEPAD_ADDED:
             case SDL_EVENT_GAMEPAD_REMOVED:
             case SDL_EVENT_GAMEPAD_BUTTON_DOWN:
             case SDL_EVENT_GAMEPAD_BUTTON_UP:
             case SDL_EVENT_GAMEPAD_AXIS_MOTION:
+                impl_->HandleGamepadEvent(event);
+                break;
             case SDL_EVENT_JOYSTICK_ADDED:
             case SDL_EVENT_JOYSTICK_REMOVED:
             case SDL_EVENT_JOYSTICK_BUTTON_DOWN:
             case SDL_EVENT_JOYSTICK_BUTTON_UP:
             case SDL_EVENT_JOYSTICK_AXIS_MOTION:
-                HandleGamepadEvent(*impl_, event);
+                impl_->HandleJoystickEvent(event);
                 break;
             default:
                 break;

--- a/src/runtime/input/sdl/SdlInputBackend.h
+++ b/src/runtime/input/sdl/SdlInputBackend.h
@@ -22,8 +22,10 @@ namespace Horo::Input {
         [[nodiscard]] Result<void> PlayRumble(GamepadDeviceId id, RumbleEffect effect) override;
         [[nodiscard]] Result<void> Stop(GamepadDeviceId id) override;
 
-    private:
+        /** @brief Pimpl state. The type is public so file-local event helpers can take it; data stays encapsulated behind impl_. */
         struct Impl;
+
+    private:
         std::unique_ptr<Impl> impl_;
     };
 }  // namespace Horo::Input

--- a/src/runtime/input/sdl/SdlInputBackend.h
+++ b/src/runtime/input/sdl/SdlInputBackend.h
@@ -22,10 +22,8 @@ namespace Horo::Input {
         [[nodiscard]] Result<void> PlayRumble(GamepadDeviceId id, RumbleEffect effect) override;
         [[nodiscard]] Result<void> Stop(GamepadDeviceId id) override;
 
-        /** @brief Pimpl state. The type is public so file-local event helpers can take it; data stays encapsulated behind impl_. */
-        struct Impl;
-
     private:
+        struct Impl;
         std::unique_ptr<Impl> impl_;
     };
 }  // namespace Horo::Input


### PR DESCRIPTION
## Summary
- Resolves the targeted Sonar findings in the SDL input backend.
- Fixes raw joystick events being routed to the gamepad handler and avoids mapping gamepad controls twice per event.

## Motivation
- The original refactor made raw SDL joysticks non-functional and exposed the PImpl type only to support file-local helpers.

## Implementation Notes
- Event handlers are private `SdlInputBackend::Impl` members, keeping implementation state out of the public surface.
- Gamepad and raw-joystick event families have separate dispatch paths.
- Button and axis mappings are evaluated once and reused.

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [ ] Manual smoke tested with physical gamepad/joystick hardware

Commands run:
```bash
cmake --build build/review --target HoroInputTests HoroInputSdl --parallel
ctest --test-dir build/review -R HoroInputTests --output-on-failure
```

## Risks
- Physical SDL device hotplug was not manually exercised; automated input tests passed (11/11).

## Issue Links

## Reviewer Notes
- Review `SdlInputBackend::ProcessEvent` first, followed by the gamepad and joystick handlers.
