### PR TITLE
docs(xr): align XR and immersive AI roadmap contracts

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -67,6 +67,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Platform Abstraction](./foundation/platform-abstraction.md): paths, files,
   windows, events, processes, clocks, native dialogs, credentials, and crash
   services.
+- [Android Platform Host](./foundation/android-platform-host.md): Android
+  activity lifecycle, replaceable native surfaces, permissions, storage,
+  packaging, deployment, resource pressure, and standalone-XR prerequisites.
 - [Engine Data Bus](./foundation/engine-data-bus.md): process-scoped typed
   notifications.
 
@@ -162,9 +165,10 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Multiplayer Replication Architecture](./runtime/multiplayer-replication-architecture.md):
   replication roles, property deltas, RPCs, prediction, interest management,
   dedicated servers, and security.
-- [VR / AR Architecture](./runtime/vr-ar-architecture.md): OpenXR, stereo
-  rendering, foveated capabilities, motion/hand tracking, AR passthrough, and
-  privacy.
+- [XR Architecture](./runtime/vr-ar-architecture.md): OpenXR lifecycle,
+  runtime-driven view configurations, renderer/input boundaries, interaction,
+  mixed reality, privacy, standalone Android dependencies, and evidence-based
+  device qualification.
 
 ## Extensions
 

--- a/docs/architecture/editor/editor-ai-agent-architecture.md
+++ b/docs/architecture/editor/editor-ai-agent-architecture.md
@@ -7,12 +7,17 @@ editor-integrated side chat, viewport inline agent, magic AI tools, agent
 context model, Horo MCP tool-calling bridge, conversation persistence, and the
 internal request/response pipeline.
 
-The Editor AI Agent provides an always-available authoring assistant for the
-engine editor. The agent has **built-in, always-on** read/write access to the
-editor scene, asset database, build system, and diagnostic surfaces through the
-Horo MCP tool protocol — no configuration or plugin required. Its persistent UI
-surface is a side panel shared across all editor screens; contextual entry
-points include viewport inline prompts and magic AI tools.
+The Editor AI Agent provides an available authoring assistant for the engine
+editor when the host composition and project policy enable it. Horo ships the
+MCP-backed capability registry needed by the agent, but registration is not
+authorization: project trust, provider policy, context admission, tool
+permissions, and per-operation approval still apply. The agent never receives
+implicit unrestricted project read/write access.
+
+Its persistent UI surface is a side panel shared across editor screens;
+contextual entry points include viewport inline prompts, magic AI tools, and an
+optional immersive XR authoring surface. Every surface shares the same provider,
+context, permission, transaction, history, and audit owners.
 
 ## System Overview
 
@@ -71,7 +76,8 @@ Example flow:
    cleaner".
 5. The agent receives selection, editor camera pose, reticle hit, visible object
    set, and local scene neighborhood.
-6. The agent proposes or applies a bounded editor transaction through MCP tools.
+6. The agent proposes a bounded editor transaction through MCP tools and waits
+   for review before application.
 
 The editor camera used by inline chat is not a gameplay camera component. It is
 the authoring viewport camera owned by the editor host. Runtime scenes must not
@@ -112,6 +118,72 @@ Examples:
 These tools must expose bounded inputs and deterministic postconditions. The
 agent may choose parameters, but execution goes through editor transactions and
 can be previewed, accepted, or reverted.
+
+### Immersive Multimodal Authoring
+
+Immersive authoring lets a developer wearing an XR headset issue voice commands
+while pointing at, selecting, grabbing, or physically interacting with spatial
+content. It is an Editor AI surface, not an XR runtime subsystem and not an
+in-game NPC/dialogue feature.
+
+```text
+Audio capture -------> speech transcription ----+
+                                                  |
+XR poses/rays/actions ----------------------------+--> multimodal envelope
+                                                  |          |
+Editor selection / scene revisions ---------------+          v
+                                                     intent + tool plan
+                                                             |
+                                                             v
+                                                scene proposal + ghost preview
+                                                             |
+                                                   explicit non-voice approval
+                                                             |
+                                                             v
+                                                   editor transaction/history
+```
+
+Ownership rules:
+
+- Audio owns input-device and timestamped capture semantics. AIA consumes an
+  admitted bounded stream and does not open a native microphone directly.
+- A provider-neutral speech service owns partial/final transcription, locale,
+  confidence, cancellation, and local/cloud adapters. A transcript is evidence,
+  never approval.
+- XR owns session identity, poses, rays, actions, tracking validity, and
+  interaction-profile state. AIA consumes time-aligned snapshots and does not
+  poll OpenXR.
+- Physics, XR interaction, and gameplay own point, grab, contact, throw, and
+  trigger mechanics. AIA may adapt those events into spatial evidence but does
+  not own the mechanics or gameplay meaning.
+- MCP validates admitted tools. The editor document/command owner validates and
+  commits mutations. AIA owns orchestration and presentation only.
+
+Both editor-owned authoring proxies and real scene/gameplay objects may provide
+spatial references. Every evidence record identifies its source, timestamp,
+confidence, object generation, scene revision, and XR session generation.
+Destroyed, stale, cross-project, hidden, locked, or unauthorized identities are
+rejected before planning.
+
+Immersive requests follow an explicit presentation state machine:
+
+```text
+Idle -> Listening -> Understanding -> PreparingPreview -> ReadyForReview
+                                                       -> Rejected -> Idle
+                                                       -> Applying -> Completed
+                                                                    -> Failed
+```
+
+Voice, gaze, a pointing gesture, contact, or a physical throw cannot transition
+`ReadyForReview` to `Applying`. Approval uses an explicit admitted controller,
+keyboard, or accessible UI action bound to the exact proposal and document
+revision. Camera and world-transform changes receive heightened impact warning.
+
+Long-running transcription, planning, tool execution, and preview generation
+are cancellable and expose stable progressive feedback. They do not hide
+latency with speculative authoritative world mutation. Feedback supports
+captions, non-voice input, reduced motion, handedness, localization, and more
+than color/audio alone for critical states.
 
 ## Numeric-First Agent Perception
 
@@ -302,8 +374,8 @@ of relying on fragile visual guessing.
 
 ## Context Model
 
-The agent is always aware of the user's editor context. Before each prompt,
-the context provider assembles a structured snapshot:
+Before each request, the context provider assembles only the editor context
+admitted for that request and makes the active context visible to the user:
 
 ```cpp
 struct AgentContext {
@@ -421,10 +493,11 @@ User types message
 
 ## Tool Calling
 
-The agent has **built-in, always-on** access to the Horo MCP protocol. Every
-tool call goes through the `HoroEngineMCP` bridge — the user does not need to
-enable, configure, or install anything. The agent decides when and how to use
-tools based on the user's request.
+The host can compose the Horo MCP bridge without a third-party plugin. Every
+agent tool call goes through that bridge, but availability remains distinct from
+admission and authorization. The effective tool set is derived from host role,
+project trust, user policy, context scope, capabilities, and operation approval.
+The model may request a tool; it never decides its own authority.
 
 ## Internal IDE Communication
 
@@ -607,9 +680,11 @@ schema, bounded scope, preview output, and undoable transaction path.
 | `editor.inspect`   | Read inspector property values | No    |
 | `editor.run_tests` | Trigger project test suite     | Yes   |
 
-Write-capable tools require explicit user confirmation before execution. The
-confirmation gate is configured per-tool and can be bypassed for trusted
-workflows (configurable in project settings).
+Write-capable tools produce a reviewable proposal and require explicit user
+approval before execution. Project policy may streamline presentation for
+deterministic tools, but it cannot let model output, voice, gaze, pointing, or a
+gesture approve its own mutation. Destructive and immersive scene changes always
+retain the visible proposal and revision-bound approval boundary.
 
 ## Backend Providers
 
@@ -617,31 +692,46 @@ The system supports pluggable LLM backends:
 
 ```cpp
 enum class AgentProvider {
-    Local,    // Ollama, llama.cpp — offline, zero-latency, no data leaves machine
-    Cloud,    // Anthropic, OpenAI — higher capability, requires API key
-    Hybrid,   // Local for simple queries, cloud for complex reasoning
+    Local,
+    Cloud,
+    Hybrid,
 };
 ```
 
-### Local Provider (Ollama)
+### Local Provider
 
 - Runs the model on the developer's machine
 - Recommended for offline work, privacy-sensitive projects
-- Lower capability ceiling but zero network dependency
-- Models: Llama 3, Mistral, CodeQwen, DeepSeek Coder
+- Has no network dependency after its model/runtime is available
+- Reports model capabilities, context limits, cost class, and availability
+  through the same provider contract as remote adapters
 
 ### Cloud Provider
 
-- Connects to Anthropic (Claude) or OpenAI (GPT) APIs
-- Higher reasoning capability for complex scene operations
-- Requires API key configured in project settings
-- Data policy: only context + prompt sent; no project files uploaded
+- Connects through a provider adapter selected by host/project policy
+- Uses an opaque credential reference rather than persisting a raw secret in
+  project settings
+- Receives only the context admitted and disclosed for the current request
+- Declares retry, quota, streaming, tool-call, and data-residency capabilities
 
 ### Provider Selection
 
 The active provider is selected in the chat panel header. Per-conversation
 override is supported. System administrators can lock the provider via
 project settings.
+
+### Provider Budget And Degraded Operation
+
+Provider selection also resolves a policy-bounded budget for transcription and
+model inference. The policy can limit requests, tokens/audio duration, monetary
+estimate, concurrency, retries, and session/project totals. Usage presentation
+must distinguish an estimate from provider-authoritative billing.
+
+Rate limiting, quota exhaustion, offline state, credential loss, and provider
+failure are normal lifecycle results. They may offer an admitted local provider,
+queue a user-visible retry, or stop the request. They never trigger unbounded
+background retries, silently switch data residency, or mutate scene state.
+Cancellation and shutdown revoke retries and release provider work.
 
 ## Conversation Management
 
@@ -681,11 +771,14 @@ These are surfaced in the chat UI as context chips above the input area.
 ### Data Boundaries
 
 - **Local mode**: No data leaves the machine. The LLM runs on-device.
-- **Cloud mode**: Only the assembled prompt (system context + history + user
-  message) is sent to the API. Project files, scene data, and asset contents
-  are NOT uploaded unless the user explicitly drags a file into the chat.
+- **Cloud mode**: Only context explicitly admitted by the active policy and
+  shown to the user is sent to the provider. Project files, scene data, assets,
+  transcripts, tracking evidence, and tool results are individually classified;
+  enabling cloud inference does not admit them automatically.
 - **Tool results**: MCP tool responses are included in the LLM context. Read
-  results contain scene/asset metadata only; binary asset data is never sent.
+  results are schema-bounded and redacted before provider admission. Binary
+  assets, raw voice, continuous gaze/pose history, camera frames, and environment
+  geometry are excluded by default.
 
 ### Permission Model
 
@@ -706,14 +799,18 @@ effective permission set is displayed as a badge in the chat header.
 
 ### Audit Trail
 
-All tool invocations are logged to the editor console with:
+All tool invocations append schema-bounded, redacted audit records with:
 
 - Timestamp
-- Tool name and arguments
+- Tool name and admitted argument summary
 - Result summary (success / error code)
 - User confirmation status
+- Provider/session, operation, proposal, and document revision identities
 
-This provides a full audit trail for debugging and review.
+Raw credentials, raw voice, continuous gaze/pose history, camera frames,
+environment geometry, and unrestricted tool payloads are not copied into the
+audit store. The editor console is a projection of the audit record rather than
+its authoritative owner.
 
 ## Editor Integration
 
@@ -727,12 +824,14 @@ This provides a full audit trail for debugging and review.
 
 ### Activity Bar Button
 
-The AI Chat button is injected automatically into every right activity bar
-by the shared JavaScript. The button:
+When the AI capability is composed, the AI Chat button is contributed to the
+right activity bar through the shared panel/command registration path. The
+button:
 
 - Shows a chat bubble icon
 - Highlights blue when the panel is open
-- Is always available on editor screens; absent on modal dialogs
+- Is absent when AI is disabled or unavailable and does not appear on modal
+  dialogs
 
 ### Cross-Page State
 
@@ -786,9 +885,10 @@ first:
 3. Present inline actions: **Apply**, **Refine**, **Cancel**.
 4. Commit only through `ai.apply_transaction`.
 
-Low-risk exact requests, such as "move selected object 1m up", may commit
-directly if project policy allows trusted agent edits. Destructive actions
-always require preview or confirmation.
+Even low-risk exact requests, such as "move selected object 1m up", produce a
+reviewable proposal. The UI can keep this review compact, but agent-authored
+scene mutation does not bypass revision-bound approval. Destructive or immersive
+changes receive a more prominent impact summary.
 
 ### Example: Fix This Corner
 
@@ -888,6 +988,10 @@ The LLM should choose strategy; the editor tool should execute the strategy.
 - Preview overlays are transient editor resources; they are not scene objects and
   are never saved.
 - Every applied agent transaction must be undoable in one user-level undo step.
+- Voice/transcription and XR evidence queues are bounded; continuous audio,
+  gaze, pose, or environment history is not retained as ordinary context.
+- Disabled immersive/provider paths do not add work to the XR frame loop or
+  audio callback.
 
 ## Failure Handling
 
@@ -915,7 +1019,8 @@ JavaScript source.
 
 - **Agent-to-agent communication**: Multiple agents (e.g., architect +
   implementer) collaborating on complex tasks
-- **Voice input**: Speech-to-text for hands-free prompting
+- **In-game voice agents**: player-facing dialogue/NPC agents are a separate
+  runtime product from the editor-owned immersive authoring workflow
 - **Proactive suggestions**: Agent monitors console output and offers help
   when errors or warnings appear
 - **Code generation**: Agent writes C++ component stubs, material graphs,

--- a/docs/architecture/foundation/android-platform-host.md
+++ b/docs/architecture/foundation/android-platform-host.md
@@ -1,0 +1,212 @@
+# Android Platform Host Architecture
+
+## Purpose
+
+This document specializes the general
+[Platform Abstraction](./platform-abstraction.md) contract for Android hosts.
+It defines application/activity lifecycle, surface delivery, permissions,
+storage, packaging, deployment, diagnostics, and device-resource policy shared
+by ordinary Android applications and standalone Android-class XR targets.
+
+Android support is a platform capability. XR, game runtime, editor tooling, and
+renderer systems do not call Android APIs directly.
+
+## Composition
+
+```text
+Android application target
+  +-- Horo application composition
+  +-- Android platform adapter
+  |     activity/process lifecycle
+  |     native window generation
+  |     input, sensors, permissions
+  |     storage and user directories
+  |     device/resource snapshots
+  +-- selected renderer backend adapter
+  +-- optional OpenXR backend
+```
+
+The process composition root selects the application profile, renderer, and
+optional XR backend. The Android host does not discover and activate arbitrary
+renderers after a native surface has already been bound to another backend.
+
+## Target Contract
+
+Every shipped Android profile declares:
+
+- minimum and target API level;
+- supported CPU ABIs;
+- renderer/backend requirements;
+- application entry and packaging model;
+- required/optional permissions and hardware features;
+- runtime asset and native-library layout;
+- supported lifecycle/recreation policy;
+- device qualification matrix.
+
+An unsupported API, ABI, renderer, device feature, or native dependency fails
+preflight with a typed reason. Runtime code does not probe build/toolchain policy.
+
+## Lifecycle
+
+Android lifecycle callbacks are translated into Horo runtime transitions on the
+application owner thread:
+
+```text
+process create
+  -> activity create/start/resume
+  -> native window available
+  -> running
+  -> pause / window lost
+  -> stop
+  -> resume / replacement window
+  -> destroy
+```
+
+Callbacks can be duplicated, delayed, or interleaved with native-window and
+permission events. The platform adapter validates transitions and publishes
+generation-safe snapshots. It never mutates editor documents, scene runtime, or
+renderer resources from Java/native callbacks.
+
+Backgrounding is not shutdown. Producers pause or neutralize according to their
+runtime contracts while durable application state remains owned by the
+application. Final destruction cancels owned work and releases services in
+reverse dependency order.
+
+## Native Window And Presentation
+
+An Android native window is a replaceable, generation-scoped presentation
+capability. The platform adapter owns callback/native-reference lifetime; the
+selected renderer backend owns graphics surfaces, swapchains, framebuffers, and
+GPU synchronization.
+
+Surface loss or replacement:
+
+1. prevents new presentation work against the old generation;
+2. lets queued GPU references retire safely;
+3. destroys backend resources without normal-frame device-idle waits;
+4. imports the replacement window through the same typed contract;
+5. resumes only after framebuffer extent and presentation capability commit.
+
+Headless Android test compositions provide an explicit no-presentation profile.
+
+## Input, Sensors, Focus, And Permissions
+
+Android touch, keyboard, gamepad, and admitted sensor events enter the existing
+Horo Input pipeline. Physical/native codes remain backend details. Focus loss,
+activity pause, device removal, and permission revocation neutralize affected
+actions before the next published input frame.
+
+Permission state is not a boolean. Requests expose `NotRequested`,
+`Requesting`, `Granted`, `Denied`, `DeniedPermanently`, and `Revoked` where the
+platform can distinguish them. Sensitive sensors and capture services stop
+publication immediately after loss of permission.
+
+XR actions, poses, and headset tracking are owned by the XR backend. The Android
+input adapter must not create a competing controller/tracking path.
+
+## Storage And Assets
+
+Android adapters resolve logical Horo locations to app-private storage, cache,
+packaged assets, or explicitly user-granted document sources. Content URIs are
+opaque platform resources; they are not stored as portable project paths.
+
+Required behavior includes:
+
+- scoped-storage and grant lifetime;
+- packaged read-only asset access;
+- durable app-private writes and recovery where supported;
+- cache eviction and capacity reporting;
+- Unicode names and bounded stream access;
+- permission revocation during an operation;
+- no traversal outside an admitted root/source.
+
+Project and package formats remain platform-neutral. Android is an adapter over
+those formats, not a second asset model.
+
+## Toolchain, Packaging, And Deployment
+
+Android builds use explicit CMake/toolchain presets and declared SDK/NDK
+requirements. Preflight validates tool versions, API/ABI compatibility, native
+dependencies, signing profile availability, and runtime asset inputs.
+
+Package assembly is deterministic for identical inputs and records provenance,
+ABI contents, native libraries, runtime assets, permissions, and manifest
+features. Machine-specific SDK paths and credentials never enter committed
+metadata.
+
+Developer deployment selects a device explicitly. Install, launch, log capture,
+termination, timeout, and disconnect use argv-based process APIs and bounded
+output. Multiple connected devices never cause implicit target selection.
+
+## Diagnostics And Crash Evidence
+
+Android diagnostics may collect:
+
+- application/package/build identity;
+- OS, API level, ABI, device class, and renderer identity;
+- lifecycle and native-window generations;
+- permission/capability states;
+- thermal, memory-pressure, battery, refresh, and frame-timing summaries;
+- process-scoped Horo/platform logs and crash markers.
+
+They exclude credentials, unrelated device logs, raw camera/audio, continuous
+tracking, and personal storage paths unless a separate explicit consent policy
+admits them. Disconnect or crash during capture produces partial evidence with
+an honest completion state.
+
+## Resource And Performance Policy
+
+Thermal, memory, battery, display-mode, and background restrictions are
+immutable snapshots with monotonic revisions. Runtime and Renderer decide how
+to adapt through their own typed policies; Platform does not silently mutate
+authored quality settings.
+
+Frame-hot publication is bounded and allocation-conscious. Native callbacks do
+not perform blocking I/O, formatting, or engine-wide locking. Long-running
+pressure tests report the device, build, renderer, refresh mode, workload, and
+before/after metrics.
+
+## Standalone XR Dependency
+
+Standalone Android-class headset qualification requires both an admitted
+Android host tuple and an admitted XR tuple:
+
+```text
+Android OS/API/ABI/device/renderer evidence
+                    +
+headset/runtime/connection/profile/extensions evidence
+                    =
+qualified standalone XR tuple
+```
+
+PC Link, wireless streaming, or another tethered mode is separate evidence and
+does not qualify the standalone Android path.
+
+## Validation
+
+Required coverage includes:
+
+- cold launch, background/foreground, duplicate callbacks, activity recreation,
+  configuration change, native-window loss/replacement, and shutdown;
+- permission grant, denial, permanent denial, revocation, and settings return;
+- touch/gamepad neutralization and sensor capability loss;
+- app-private, packaged, cache, and user-granted storage behavior;
+- missing SDK/NDK, unsupported API/ABI, package inspection, install/launch,
+  multiple devices, disconnect, timeout, and log redaction;
+- memory pressure, thermal throttling, refresh changes, low battery, and recovery;
+- at least one reproducible physical-device tuple for each declared ABI/renderer
+  path.
+
+Deterministic host fakes cover lifecycle ordering and failures, but they do not
+replace physical-device qualification.
+
+## Related Documents
+
+- [System Design](./system-design.md)
+- [Platform Abstraction](./platform-abstraction.md)
+- [Runtime Lifecycle](../runtime/runtime-lifecycle.md)
+- [Rendering Architecture](../runtime/rendering-architecture.md)
+- [Input Architecture](../runtime/input-architecture.md)
+- [Asset Pipeline](../runtime/asset-pipeline.md)
+- [XR Architecture](../runtime/vr-ar-architecture.md)
+- [Application Security](../security/application-security.md)

--- a/docs/architecture/foundation/platform-abstraction.md
+++ b/docs/architecture/foundation/platform-abstraction.md
@@ -50,9 +50,15 @@ capability returns a typed error.
 
 The platform layer includes:
 
-- Windows, macOS, and Linux implementations
+- Windows, macOS, Linux, and Android implementations
 - deterministic or in-memory test implementations
 - headless implementations where appropriate
+
+Android application/activity lifecycle, replaceable native surfaces, runtime
+permissions, scoped storage, deployment, and resource-pressure specialization
+follow [Android Platform Host](./android-platform-host.md). Portable callers use
+the same capability model; they do not branch on Android APIs or lifecycle
+callbacks.
 
 ## Filesystem And Paths
 
@@ -116,6 +122,13 @@ state, not directly inside arbitrary native callbacks.
 
 Native callbacks enqueue or update platform-owned state; they do not mutate
 editor documents or application services.
+
+On mobile hosts, a native window is a replaceable capability rather than a
+process-lifetime assumption. Activity resume does not guarantee that a window
+already exists, and pause or surface destruction does not necessarily terminate
+the process. Every native-window snapshot therefore carries a generation;
+renderer presentation rejects stale generations and owns graphics-resource
+retirement.
 
 ## Time
 
@@ -247,6 +260,10 @@ Capabilities declare affinity:
 | Credential UI | Interactive main thread |
 | Monotonic clock | Any thread |
 
+Android activity and permission callbacks arrive through the platform adapter
+and are committed on the application owner thread. Native surface handoff still
+obeys the renderer's render-capable-thread contract.
+
 The platform layer does not dispatch arbitrary callbacks while holding native
 or internal locks.
 
@@ -274,6 +291,8 @@ Required tests cover:
 - [Configuration System](./configuration-system.md)
 - [Concurrency And Job System](./concurrency-and-jobs.md)
 - [Input Architecture](../runtime/input-architecture.md)
+- [Android Platform Host](./android-platform-host.md)
+- [XR Architecture](../runtime/vr-ar-architecture.md)
 - [Release Security](../release/release-security.md)
 - [Extension System](../extensions/plugin-system.md)
 - [Gameplay Module Boundary](../extensions/gameplay-module-boundary.md)

--- a/docs/architecture/runtime/audio-architecture.md
+++ b/docs/architecture/runtime/audio-architecture.md
@@ -637,6 +637,30 @@ recreate device-owned resources and resume voices according to explicit policy.
 Sample-rate, channel-layout, and buffer-size changes are committed at a safe
 boundary.
 
+## Input Capture And Speech Boundary
+
+Audio owns input-device discovery, permission-aware capture lifecycle,
+timestamped PCM format, bounded capture buffers, monitoring, and recording
+publication. Capture and output may share a platform device service, but they
+have separate stream generations, queues, permission states, and failure paths.
+
+Capture producers write into preallocated or policy-bounded buffers and never
+block the real-time callback. Consumers receive owner-backed timestamped spans
+or bounded stream reads; they do not retain native device handles. Device change,
+permission revocation, focus loss, overrun, and shutdown terminate or replace a
+capture generation explicitly.
+
+Audio does not own speech recognition, language inference, model providers,
+agent intent, or network voice transport. A provider-neutral speech service may
+consume an admitted capture stream and publish partial/final transcript results.
+The Editor AI system decides whether a transcript enters an agent request. A
+transcript is not an input-action edge and never constitutes approval for an
+editor mutation.
+
+Raw microphone data is privacy-sensitive. It is excluded from ordinary logs,
+conversation history, diagnostic bundles, and telemetry by default. Recording
+or retaining it requires a separate explicit user action and storage policy.
+
 ## Threading Rules
 
 The real-time callback cannot:
@@ -869,6 +893,11 @@ Required tests cover:
 - occlusion provider deadline miss produces stale-value fallback and metric
 - spatializer fallback emits observable metric
 - parameter/event lookup failures emit observable metric
+- capture permission denial, revocation, input-device replacement, overrun,
+  cancellation, and shutdown
+- allocation/lock checks on the capture callback path
+- speech consumers cannot obtain native device handles or convert transcripts
+  into implicit editor approval
 
 ## Editor UI Wireframes
 
@@ -979,3 +1008,5 @@ or feature plan must be updated in the same change.
 - [Game UI And HUD](./game-ui-and-hud.md)
 - [Configuration System](../foundation/configuration-system.md)
 - [Observability Metrics And Profiling](../observability/observability-performance.md)
+- [XR Architecture](./vr-ar-architecture.md)
+- [Editor AI Agent Architecture](../editor/editor-ai-agent-architecture.md)

--- a/docs/architecture/runtime/input-architecture.md
+++ b/docs/architecture/runtime/input-architecture.md
@@ -371,6 +371,37 @@ pad.SetAxis(GamepadAxis::LeftX, 1.0f);
 Virtual input commits through the same snapshot path as platform devices. Tests
 must not mutate gameplay state by bypassing the input service.
 
+## XR Input And Interaction Profiles
+
+The XR backend publishes bounded pose/action snapshots and projects admitted
+OpenXR actions into the same canonical Horo action router. Input does not poll
+OpenXR or retain native action/path handles.
+
+XR device identities include the XR session generation. Grip/aim poses,
+buttons, axes, hand joints, and haptic targets become invalid when tracking,
+focus, interaction profile, device, or session generation changes. The next
+input frame neutralizes affected actions instead of preserving stale values.
+
+Suggested-binding data is schema-versioned independently from ordinary user
+input profiles. Resolution records:
+
+- the runtime-selected interaction profile;
+- the engine action and native component-path mapping;
+- generic fallback and unsupported bindings;
+- conflicts and missing required actions;
+- active-profile changes during a session;
+- migration of compatible user overrides after schema changes.
+
+Native OpenXR paths are physical binding identities, not localized labels or
+gameplay action IDs. Presentation uses the existing glyph/label provider model.
+Frame-hot hand joints use fixed-capacity or owner-backed spans rather than one
+heap allocation per hand per frame.
+
+XR haptics follow the same ownership principles as gamepad haptics but include
+session/device generation, action/subpath target, duration, frequency where
+supported, cancellation, and explicit unsupported fallback. Ordinary input or
+focus loss cancels effects owned by the lost scope.
+
 ## Data Bus Relationship
 
 High-frequency input does not travel through `EngineDataBus` or
@@ -431,6 +462,10 @@ Required tests cover:
 - binding-specific gamepad deadzone policies
 - glyph-provider fallback when no glyph package is installed
 - virtual gamepad injection through the snapshot path
+- XR interaction-profile changes and binding-schema migration
+- XR focus/tracking/session loss neutralization
+- bounded hand-joint snapshots and stale XR device rejection
+- XR haptic cancellation and unsupported fallback
 
 ## Related Documents
 
@@ -441,3 +476,4 @@ Required tests cover:
 - [GUI Screen Host](../editor/gui-screen-host.md)
 - [Configuration System](../foundation/configuration-system.md)
 - [Platform Abstraction](../foundation/platform-abstraction.md)
+- [XR Architecture](./vr-ar-architecture.md)

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -426,6 +426,37 @@ component pools, editor widgets, or backend objects.
 Multiple views, including game, scene viewport, thumbnails, and previews, use
 separate `RenderView` descriptors over compatible snapshots.
 
+## XR Views And External Presentation Targets
+
+XR supplies a bounded runtime-driven set of view descriptors and
+generation-scoped runtime-owned image identities. Renderer does not assume that
+an XR frame contains exactly two eyes, and public render contracts do not expose
+fixed two-element matrix or target arrays.
+
+The first production implementation may explicitly admit primary stereo only.
+The contract still preserves view role, ordering, extent, projection, target,
+and configuration identity so later quad-view or foveated-inset execution does
+not require a public API migration. An unsupported view configuration is
+rejected before resource acquisition and is never silently truncated.
+
+Runtime-owned images enter the graph as typed external resources with declared:
+
+- format, extent, array/view index, and permitted uses;
+- color/depth role and composition requirements;
+- acquire/wait/release ownership;
+- synchronization and frames-in-flight lifetime;
+- session, swapchain, image, and configuration generations.
+
+Dynamic resolution, fixed or gaze-driven foveation, variable-rate shading,
+density maps, depth submission, and motion inputs are renderer capabilities.
+They are negotiated before frame execution. Foveation is not modeled as a
+generic post-process, and Horo does not implement runtime-owned asynchronous
+reprojection. Ordinary projection-layer rendering is the explicit fallback
+when optional features are unavailable.
+
+See [XR Architecture](./vr-ar-architecture.md) for session, view, capability,
+privacy, and qualification ownership.
+
 ## Frame Contract
 
 One frame:
@@ -638,6 +669,10 @@ Required tests cover:
 - shader reflection/material validation
 - null backend contract equivalence
 - backend initialization and device-loss error mapping
+- XR external-image generation, acquire/import/release ordering, and loss
+- one-view, primary-stereo, and explicitly unsupported greater-than-two view
+  configurations
+- XR dynamic-resolution/foveation capability fallback and history invalidation
 
 ## Related Documents
 
@@ -651,3 +686,4 @@ Required tests cover:
 - [Built-In Scene Primitives](./built-in-scene-primitives.md)
 - [Ownership And Resource Lifetime](../foundation/ownership-and-resource-lifetime.md)
 - [Platform Abstraction](../foundation/platform-abstraction.md)
+- [XR Architecture](./vr-ar-architecture.md)

--- a/docs/architecture/runtime/vr-ar-architecture.md
+++ b/docs/architecture/runtime/vr-ar-architecture.md
@@ -1,214 +1,418 @@
-# VR / AR Architecture
+# XR Architecture
 
 ## Purpose
 
-This document defines the virtual reality (VR) and augmented reality (AR)
-subsystem for Horo Engine. It covers OpenXR integration, VR rendering
-(instanced stereo, foveated rendering), VR input (motion controllers, hand
-tracking), VR UI, VR-specific performance considerations, and AR pass-through
-support.
+This document defines Horo Engine's virtual reality, augmented reality, and
+mixed-reality architecture. It owns the engine-facing XR contracts for runtime
+composition, session lifecycle, views, tracking, input, presentation,
+interaction, diagnostics, and qualification.
 
-## OpenXR Integration
+OpenXR is the first runtime backend. It is not the public engine API, and OpenXR
+handles or extension types do not cross Horo-owned subsystem boundaries.
 
-Horo Engine uses OpenXR as the cross-platform VR/AR API:
+## Current Status
+
+The repository does not yet contain a production OpenXR backend. The contracts
+below describe the target architecture. A runtime, headset, or platform is not
+supported merely because it appears in a design example or because an OpenXR
+loader can discover it. Support requires reproducible qualification evidence.
+
+## Ownership
+
+```text
+application composition
+  selects XR backend, renderer backend, platform host, and project policy
+          |
+          v
+XR runtime frontend
+  capabilities, sessions, spaces, frame lifecycle, bounded snapshots
+          |
+          +------> OpenXR backend
+          |          loader, instance, system, session, actions, swapchains
+          |
+          +------> Renderer
+          |          external images, N-view extraction, passes, synchronization
+          |
+          +------> Input
+          |          canonical actions and neutralized device state
+          |
+          +------> Runtime UI / Interaction / Accessibility
+          |          world-space UI, locomotion, comfort, focus
+          |
+          +------> Editor diagnostics
+                     setup, inspection, capture, qualification evidence
+```
+
+Required boundaries:
+
+- The composition root selects the concrete XR backend before session and
+  presentation resources are created.
+- The XR frontend owns engine-visible session, space, frame, capability, and
+  device identities.
+- The OpenXR backend owns native loader, instance, system, session, action,
+  swapchain, composition-layer, and extension state.
+- Renderer owns rendering work and GPU resources after a runtime image is
+  imported through a typed external-resource contract.
+- Input owns canonical game/editor action projection. It does not poll OpenXR.
+- Runtime UI and interaction consume XR rays, touches, poses, and actions through
+  adapters; they do not become a second XR source of truth.
+- The XR runtime owns neither asynchronous reprojection nor platform boundary
+  systems such as guardian/chaperone. Those remain runtime/platform behavior.
+- Editor panels are query and command clients. They do not own the active XR
+  session or directly call native runtime APIs.
+
+## Capability And Identity Model
+
+Capabilities are discovered from the selected runtime, platform host, renderer,
+device, permissions, and admitted optional extensions. They are not inferred
+from a headset product name.
 
 ```cpp
-class XRSystem {
-public:
-    Result<void> Initialize(const XRInitSettings& settings);
-    void Shutdown();
+struct XRRuntimeIdentity {
+    XRRuntimeId runtime;
+    SemanticVersion runtimeVersion;
+    XRBackendVersion backendContract;
+};
 
-    // Session
-    Result<void> BeginSession();
-    void EndSession();
-
-    // Frame
-    XRFrameState WaitFrame();
-    void BeginFrame();
-    void EndFrame();
-
-    // Views
-    std::span<const XRView> GetViews() const;
-    XRViewConfiguration GetViewConfiguration() const;
-
-    // Input
-    std::span<const XRActionState> GetActionStates() const;
-    void SuggestBindings(std::string_view interactionProfile);
+struct XRCapabilitySnapshot {
+    XRCapabilityRevision revision;
+    XRSessionGeneration sessionGeneration;
+    std::span<const XRViewConfigurationDescriptor> viewConfigurations;
+    std::span<const XRInteractionProfileDescriptor> interactionProfiles;
+    std::span<const XRExtensionCapability> extensions;
+    XRTrackingCapabilities tracking;
+    XRPresentationCapabilities presentation;
+    XRMixedRealityCapabilities mixedReality;
 };
 ```
 
-### Supported Runtimes
+Snapshots are owner-backed, immutable for their documented lifetime, and
+bounded. A capability can be `Unavailable`, `Available`, `PermissionRequired`,
+`Denied`, `TemporarilyUnavailable`, or `Lost`. Boolean feature flags are not
+sufficient for permission-sensitive or replaceable capabilities.
 
-- **SteamVR**: HTC Vive, Valve Index, Windows Mixed Reality
-- **Meta Quest**: Quest 2/3 via Oculus OpenXR runtime (native and Link)
-- **PSVR2**: PlayStation VR2 via platform OpenXR
-- **Varjo**: Varjo XR headsets
-- **Monado**: Linux open-source runtime
+Runtime discovery, project policy, feature admission, activation, and current
+availability are distinct states. Horo never silently selects another runtime,
+renderer, view configuration, interaction profile, or privacy-sensitive feature.
 
-### View Configuration
+## OpenXR Backend Lifecycle
+
+The backend follows explicit state transitions:
+
+```text
+Unconfigured
+  -> LoaderAvailable
+  -> InstanceCreated
+  -> SystemSelected
+  -> SessionCreated
+  -> Ready
+  -> Running
+  -> Stopping
+  -> Idle / Lost
+  -> Destroyed
+```
+
+Runtime events drive session transitions. Duplicate, delayed, focus-loss,
+visibility-loss, instance-loss, and session-loss events are normal inputs. Every
+session-owned handle carries a generation so stale actions, spaces, swapchain
+images, and snapshots fail before native use.
+
+Frame submission follows the runtime's predicted timing contract:
+
+```text
+poll runtime events
+  -> wait frame
+  -> begin frame
+  -> locate admitted views/spaces at predicted display time
+  -> acquire and wait for required images
+  -> render admitted views
+  -> release images
+  -> submit composition layers / end frame
+```
+
+Cancellation and shutdown finish or abandon the current frame only through
+runtime-valid transitions. The host stops producers before destroying session,
+instance, renderer, and platform dependencies.
+
+## Extension Negotiation And Graceful Degradation
+
+Optional OpenXR features use a typed negotiation record:
 
 ```cpp
-struct XRViewConfiguration {
-    XRViewType       type;           // Stereo, Mono, Foveated
-    uint32_t         viewCount;      // 2 for stereo, 1 for mono
-    uint32_t         recommendedWidth;
-    uint32_t         recommendedHeight;
-    float            refreshRate;
+struct XRExtensionAdmission {
+    XRExtensionId id;
+    XRExtensionVersion discoveredVersion;
+    XRExtensionAdmissionState state;
+    std::span<const XRExtensionId> dependencies;
+    std::optional<XRCoreVersion> promotedToCore;
+    XRCapabilityProviderId provider;
 };
 ```
 
-## VR Rendering
+The backend records discovered, requested, enabled, rejected, dependency-missing,
+and promoted-to-core states. Providers are registered only after validation and
+are invalidated when their backend/session generation ends. Unsupported optional
+extensions disable the associated capability with an actionable reason; they do
+not prevent a baseline session unless the active project capability profile
+requires them.
 
-### Instanced Stereo
+## Views And Coordinate Spaces
 
-Stereo rendering uses GPU instancing to render both eyes in a single draw call:
+Horo uses metres, a documented handedness, and explicit local/stage/view space
+identities. Poses include validity, tracking confidence, timestamp, source space,
+and session generation. Invalid orientation or position components are not
+replaced with fabricated identity values.
 
-- Each eye is a separate view instance
-- View matrices and projection matrices are stored in a uniform buffer array
-- The shader receives a backend-neutral view-instance index to select the correct view matrix
-- Reduces draw call count by ~50% compared to two-pass stereo
+View count is runtime-driven. Public and renderer-facing contracts must not use
+fixed two-element eye arrays:
 
 ```cpp
-struct XRRenderViews {
-    Matrix4    viewMatrices[2];
-    Matrix4    projectionMatrices[2];
-    Vector4    eyeOffsets[2];       // per-eye offset for stereo reconstruction
+struct XRViewDescriptor {
+    XRViewId id;
+    XRViewRole role;
+    XRPose pose;
+    XRProjection projection;
+    Extent2D recommendedExtent;
+    XRSwapchainTargetId colorTarget;
+    std::optional<XRSwapchainTargetId> depthTarget;
+};
+
+struct XRLocatedViewSet {
+    XRViewConfigurationId configuration;
+    XRSessionGeneration sessionGeneration;
+    XRTime predictedDisplayTime;
+    std::span<const XRViewDescriptor> views;
 };
 ```
 
-### Foveated Rendering
+The contract supports a bounded variable number of views. The first production
+slice may admit only primary stereo. A runtime configuration with more views is
+then reported as unsupported before image acquisition; it is never truncated to
+two views. Quad-view and foveated-inset execution can be added later without a
+public contract migration.
 
-On headsets with eye tracking, foveated rendering reduces shading cost:
+Reference-space changes, recentering, bounds changes, and world-origin rebasing
+are translated through an explicit adapter. Runtime tracking state never mutates
+authoritative gameplay transforms from a native callback.
 
-- The render target is rendered at variable resolution
-- Periphery regions are rendered at lower resolution
-- The fovea (where the user is looking) is rendered at full resolution
-- Resolution falloff is guided by the eye tracking data
+## Rendering And Presentation
 
-```cpp
-struct FoveatedRenderingSettings {
-    bool       enabled;
-    float      foveaInnerRadius;    // full-resolution region
-    float      foveaOuterRadius;    // transition region
-    float      peripheryScale;      // resolution scale in periphery (e.g., 0.25)
-    bool       useEyeTracking;
-};
-```
+The OpenXR backend supplies view descriptors and generation-safe runtime-owned
+image identities. Renderer imports those images into the render graph with
+declared format, usage, extent, array/view index, synchronization, and lifetime.
+Native image handles remain private to the concrete XR/renderer adapter.
 
-Foveated rendering is exposed as a backend-neutral `FoveatedRenderFeature` capability. Backends may implement it with native variable-rate shading or a shader-based density mask, but those details stay below the RHI contract.
+The initial implementation may render stereo as multi-pass or instanced
+multiview according to backend capability. Instanced rendering is an
+optimization, not a correctness requirement and not a claim that draw calls are
+always halved.
 
-### Performance Budget
+The external-target contract anticipates:
 
-VR rendering has strict performance requirements:
+- runtime-selected color and depth formats;
+- per-view or array-backed image layouts;
+- variable render extents and dynamic-resolution history invalidation;
+- fixed foveation, variable-rate shading, and density-map capabilities;
+- optional gaze-driven foveation after consent and valid eye tracking;
+- motion/depth/timing inputs required by admitted runtime space-warp features;
+- frames in flight, deferred destruction, loss, and swapchain recreation.
 
-- 90 Hz minimum (11.1 ms per frame) for comfortable VR
-- 72 Hz acceptable on standalone headsets
-- Late-warp (asynchronous timewarp) compensates for missed frames
-- GPU preemption support for guardian/chaperone rendering
+Foveation is a renderer/backend capability, not a generic post-process effect.
+Horo does not emulate runtime-owned asynchronous timewarp or reprojection. When
+an optional feature is unavailable, ordinary projection-layer rendering remains
+the explicit fallback.
 
-## VR Input
+Normal frames do not use device-idle waits. Image acquire, wait, import, render,
+release, and composition submission maintain explicit ownership and
+synchronization. Session or surface loss retires resources only after queued GPU
+references are safe.
 
-### Motion Controllers
+## Tracking, Actions, And Haptics
 
-Motion controllers expose position, rotation, and button state:
-
-```cpp
-struct XRControllerState {
-    XRHand          hand;            // Left, Right
-    WorldTransform  gripPose;
-    WorldTransform  aimPose;
-    Vector2         thumbstick;
-    float           trigger;         // 0-1 analog
-    float           grip;            // 0-1 analog
-    ButtonFlags     buttons;
-};
-```
-
-### Hand Tracking
-
-Optical hand tracking provides per-joint data:
+OpenXR action sets and suggested bindings are backend data. Engine systems
+consume canonical Horo actions and bounded tracking snapshots:
 
 ```cpp
-struct XRHandJoint {
-    XRHandJointId    jointId;        // wrist, thumb tip, index tip, etc.
-    WorldTransform   pose;
-    float            radius;
-    float            confidence;     // 0-1 tracking confidence
+struct XRTrackedPose {
+    XRDeviceId device;
+    XRPoseKind kind;
+    WorldTransform pose;
+    LinearVelocity linearVelocity;
+    AngularVelocity angularVelocity;
+    XRTrackingValidity validity;
+    XRTime sampleTime;
 };
 
 struct XRHandState {
-    XRHand                   hand;
-    std::vector<XRHandJoint> joints;
-    XRGesture                activeGesture;  // pinch, point, grab, open hand
+    XRHand hand;
+    XRTrackingValidity validity;
+    std::span<const XRHandJoint> joints;
 };
 ```
 
-Hand tracking is used for natural interaction: grabbing objects, pointing at
-UI, gesture-based commands.
+Frame-hot hand data uses fixed-capacity or owner-backed storage; it does not
+allocate a `std::vector` per hand per frame.
 
-### Locomotion
+Suggested-binding data has its own schema version. Resolution records the active
+interaction profile, profile changes, generic fallback, conflicts, and user
+override migration. A runtime path such as an OpenXR component path never
+becomes a localized UI label or a public gameplay identifier.
 
-VR locomotion modes:
+Focus loss, tracking loss, disconnect, profile replacement, permission
+revocation, and session replacement neutralize affected actions immediately.
+Haptic requests have explicit owner, duration, cancellation, device generation,
+and capability fallback.
 
-- **Teleport**: Point at destination and teleport instantaneously
-- **Smooth locomotion**: Continuous joystick movement
-- **Snap turn**: Discrete rotation steps (comfort setting)
-- **Arm-swing**: Physics-based movement by swinging arms
-- **Room-scale**: Physical walking within the tracked space
+## Interaction, Runtime UI, And Comfort
 
-Comfort settings (vignette during movement, snap turn angle, movement speed)
-are configurable in accessibility settings.
+XR interaction adapts ray, direct-touch, proximity, grab, and spatial hit
+evidence into existing runtime UI and gameplay contracts. It does not duplicate
+physics queries, UI focus/capture, or scene authority.
 
-## VR UI
+World-space canvases remain runtime UI documents projected into world space.
+They use the same semantic focus, navigation, accessibility, localization, and
+input-action model as non-XR UI. Stereo presentation and occlusion belong to the
+renderer/UI projection adapter.
 
-UI in VR uses world-space canvases:
+Locomotion produces intent for the character-movement owner. Teleport, smooth
+move, snap turn, arm-swing, and room-scale behavior are policy/configuration, not
+hard-coded controller logic. Comfort settings include turning, vignette,
+movement, height, seated/standing, handedness, boundary awareness, and reduced
+motion where supported.
 
-- UI panels are placed in 3D space
-- Laser pointer or hand ray for interaction
-- Proximity-based activation for touchscreens
-- Diegetic UI (in-world screens and displays) is supported
+Refresh rate, view extent, and frame budget come from runtime/device capability
+snapshots. Architecture does not prescribe a universal 90 Hz minimum. Each
+qualified tuple records its supported modes and measured comfort/performance
+evidence.
 
-```cpp
-struct VRUICanvas {
-    WorldTransform    transform;
-    Vector2           size;            // world-space meters
-    float             interactionDistance;
-    bool              useLaserPointer;
-    bool              useHandRay;
-};
+## Mixed Reality And Privacy
+
+Passthrough, anchors, plane/mesh understanding, hit testing, and light estimation
+are optional capabilities with explicit consent, permission, lifetime, and
+failure states.
+
+- Raw camera frames do not enter ordinary engine logs, captures, or public APIs.
+- Eye gaze, continuous poses, environment geometry, voice, and spatial anchors
+  are privacy-sensitive diagnostic inputs.
+- Permission revocation removes derived capability state and invalidates
+  outstanding work.
+- Persistent anchors identify localization state and failure; they do not imply
+  that every runtime supports cross-session restore.
+- Renderer consumes admitted passthrough/composition descriptors without owning
+  camera permission or environment understanding.
+
+## Android And Standalone XR
+
+Standalone Android-class headsets require the Android runtime host in addition
+to XR implementation. Android activity lifecycle, native surfaces, permissions,
+storage, ABI packaging, deployment, thermal state, and device diagnostics are a
+parallel critical path.
+
+```text
+Android runtime host --------+
+                             +--> standalone device qualification
+XR runtime/render/input -----+
 ```
 
-## AR / Mixed Reality
+PC streaming or tethered evidence does not qualify the standalone path. Each
+connection mode is a separate qualification tuple.
 
-AR support uses the same OpenXR API:
+## Immersive AI Authoring Boundary
 
-- Passthrough: Camera feed as background
-- Spatial anchors: Persistent world-locked objects
-- Plane detection: Real-world surface detection for placement
-- Ray casting: Camera-based hit testing
-- Light estimation: Match virtual lighting to real-world ambient
+Immersive AI authoring is owned by the Editor AI system, not XR. XR contributes
+timestamped poses, rays, selections, interaction events, and session identity.
+Audio contributes an admitted timestamped capture stream. A provider-neutral
+speech service contributes transcript hypotheses. AIA aligns this evidence and
+invokes approved MCP/editor capabilities.
 
-AR features are available on Meta Quest (passthrough) and Varjo XR (video
-see-through).
+Editor-owned authoring proxies and real gameplay objects may both provide
+spatial evidence. AIA does not own grabbing, throwing, contact generation,
+physics, or the gameplay meaning of those objects.
 
-## Performance And Feature Tiers
+Voice, gaze, pointing, contact, or a final transcript never constitutes
+approval. Agent-proposed scene mutations require a visible preview and an
+explicit approval bound to the proposal/document revision. Application uses the
+editor command/transaction owner so a successful proposal is one coherent undo
+entry and failures cannot partially mutate the scene.
 
-| Feature              | `es3`      | `dx11` / `dx12_vulkan` | `high_end` |
-| -------------------- | ----------- | ------------- | ------------ |
-| VR rendering         | No          | Stereo        | Stereo + foveation |
-| Foveated rendering   | No          | Fixed         | Eye-tracked  |
-| Hand tracking        | No          | Basic         | Full joints  |
-| AR passthrough       | No          | No            | Yes          |
-| Instanced stereo     | No          | Yes           | Yes          |
-| Refresh rate         | —           | 90 Hz         | 120 Hz       |
+## Diagnostics And Qualification
+
+Setup and diagnostics consume the same typed runtime snapshots as production
+code. They show loader/runtime discovery, system/session state, view
+configuration, interaction profile, optional extensions, permissions,
+swapchains, frame timing, tracking confidence, and redacted failure details.
+
+Support evidence is keyed by the full tuple:
+
+```text
+headset model
++ runtime and version
++ operating system/platform host
++ renderer backend and driver/device class
++ connection mode
++ interaction profile
++ admitted extension/capability set
+```
+
+Qualification categories describe planning intent rather than product-name
+guarantees:
+
+| Category | Meaning |
+|---|---|
+| Reference | Primary regularly tested development tuple |
+| Compatibility | Additional or constrained tuple tested for compatibility |
+| Enterprise | Hardware/access-dependent professional target |
+| Conditional | Requires an external runtime, licensed SDK, or platform target |
+| Future | Deliberately outside the current release commitment |
+
+Every result is `Passed`, `PassedWithLimitations`, `Failed`, `Blocked`, or
+`NotRun`, with evidence provenance and known issues. Simulator and replay results
+are never reported as physical-device qualification. Refresh rates and render
+extents are recorded from runtime enumeration, not a static headset table.
+
+## Performance, Concurrency, And Shutdown
+
+- Frame-hot snapshots use bounded owner-backed storage and avoid heap allocation,
+  blocking I/O, logging-string formatting, and contended locks.
+- Runtime event polling and frame submission occur on their declared owner
+  threads. Native callbacks publish bounded state and do not mutate scene data.
+- Diagnostics observe revisions and snapshots at their own cadence; they never
+  stall frame production.
+- Extension providers, action/profile state, spaces, images, and captures are
+  invalidated by session generation.
+- Shutdown stops new frame/input work, cancels owned jobs, drains valid runtime
+  transitions, retires GPU resources, and destroys dependencies in reverse order.
+
+## Validation
+
+Required automated coverage includes:
+
+- loader absent, runtime unavailable, unsupported system, and permission denial;
+- session lifecycle, focus/visibility loss, instance/session loss and recovery;
+- one-view, stereo, unsupported greater-than-two, and recorded variable-view data;
+- extension dependency, promoted-to-core, rejection and provider invalidation;
+- action/profile changes, tracking loss, hand-joint bounds, and haptic cancel;
+- image acquire/wait/import/release, resize, loss and frames-in-flight teardown;
+- fixed foveation/dynamic resolution fallback and history invalidation;
+- deterministic simulator, capture/replay and fault injection;
+- sensitive-data redaction and diagnostic bundle policy.
+
+Physical-device evidence is required for every declared supported tuple. Missing
+hardware is reported as `NotRun`; deterministic fakes do not silently satisfy a
+device release gate.
 
 ## Related Documents
 
 - [XR Setup UI Reference](./xr-setup.html)
-
-- [Rendering Architecture](./rendering-architecture.md): VR stereo rendering and foveated-rendering capabilities
-- [Input Architecture](./input-architecture.md): motion controller and hand tracking input
-- [Game UI And HUD](./game-ui-and-hud.md): VR UI canvases
-- [Accessibility Architecture](./accessibility-architecture.md): VR comfort settings
-- [Platform Services Architecture](./platform-services-architecture.md): platform VR runtime integration
-- [Post-Processing And Effects](./post-processing-and-effects-architecture.md): foveated rendering as post-process
+- [Rendering Architecture](./rendering-architecture.md)
+- [Render Backend Parity Contract](./render-backend-parity-contract.md)
+- [Input Architecture](./input-architecture.md)
+- [Physics Architecture](./physics-architecture.md)
+- [Game UI And HUD](./game-ui-and-hud.md)
+- [Accessibility Architecture](./accessibility-architecture.md)
+- [Audio Architecture](./audio-architecture.md)
+- [Runtime Lifecycle](./runtime-lifecycle.md)
+- [Platform Abstraction](../foundation/platform-abstraction.md)
+- [Android Platform Host](../foundation/android-platform-host.md)
+- [Editor AI Agent Architecture](../editor/editor-ai-agent-architecture.md)
+- [Application Security](../security/application-security.md)

--- a/docs/architecture/runtime/xr-setup.html
+++ b/docs/architecture/runtime/xr-setup.html
@@ -22,7 +22,7 @@ button{height:26px;border:1px solid var(--bd);border-radius:var(--r);background:
 <header class="header">
   <div class="header-main">
     <h1>XR Setup</h1>
-    <div class="header-meta"><span class="sub">OpenXR runtime, headset views, hand tracking, passthrough capabilities, and privacy permissions</span><span class="context">Runtime: Quest Link · 90 Hz</span></div>
+    <div class="header-meta"><span class="sub">OpenXR discovery, runtime-driven views, interaction profiles, optional capabilities, privacy, and qualification evidence</span><span class="context">Runtime-selected configuration</span></div>
   </div>
   <div class="actions">
     <button type="button">Refresh</button>
@@ -35,28 +35,29 @@ button{height:26px;border:1px solid var(--bd);border-radius:var(--r);background:
   <div class="tab" onclick="switchTab('input',this)">Input</div>
   <div class="tab" onclick="switchTab('ar',this)">AR</div>
   <div class="tab" onclick="switchTab('privacy',this)">Privacy</div>
+  <div class="tab" onclick="switchTab('qualification',this)">Qualification</div>
 </nav>
 <div class="layout">
   <aside class="side">
     <div class="label">Devices</div>
-    <div class="card active"><div class="title">OpenXR Runtime</div><div class="mut">Meta Quest Link · stereo · 90 Hz</div></div>
-    <div class="card"><div class="title">Controllers</div><div class="mut">left/right tracked · touch profile</div></div>
-    <div class="card"><div class="title">Hand Tracking</div><div class="mut">basic joints · confidence medium</div></div>
+    <div class="card active"><div class="title">Selected Runtime</div><div class="mut">discovered identity · version · connection</div></div>
+    <div class="card"><div class="title">Interaction Profiles</div><div class="mut">runtime-resolved · bindings versioned</div></div>
+    <div class="card"><div class="title">Tracking Providers</div><div class="mut">capability and confidence reported</div></div>
     <div class="label" style="margin-top:14px">Capabilities</div>
-    <div class="kv"><span>Instanced stereo</span><span class="pill ok">yes</span></div>
-    <div class="kv"><span>Foveation</span><span class="pill warn">fixed</span></div>
-    <div class="kv"><span>Passthrough</span><span class="pill ok">granted</span></div>
+    <div class="kv"><span>View configuration</span><span class="pill ok">admitted</span></div>
+    <div class="kv"><span>Foveation</span><span class="pill warn">optional</span></div>
+    <div class="kv"><span>Passthrough</span><span class="pill warn">permission</span></div>
   </aside>
   <main class="main">
     <div id="pane-runtime" class="pane active">
       <div class="grid">
-        <div class="card"><div class="label">Runtime</div><div class="kv"><span>API</span><span>OpenXR</span></div><div class="kv"><span>Runtime</span><span>Quest Link</span></div><div class="kv"><span>Refresh</span><span>90 Hz</span></div><div class="kv"><span>Frame budget</span><span>11.1 ms</span></div></div>
-        <div class="card"><div class="label">Rendering</div><div class="kv"><span>Mode</span><span>Instanced stereo</span></div><div class="kv"><span>Views</span><span>2 eyes</span></div><div class="kv"><span>Recommended size</span><span>1832×1920</span></div><div class="kv"><span>Late-warp</span><span class="pill ok">available</span></div></div>
+        <div class="card"><div class="label">Runtime</div><div class="kv"><span>API</span><span>OpenXR</span></div><div class="kv"><span>Identity</span><span>runtime reported</span></div><div class="kv"><span>Refresh modes</span><span>enumerated</span></div><div class="kv"><span>Active budget</span><span>derived</span></div></div>
+        <div class="card"><div class="label">Rendering</div><div class="kv"><span>Configuration</span><span>runtime selected</span></div><div class="kv"><span>View count</span><span>runtime reported</span></div><div class="kv"><span>Per-view extents</span><span>enumerated</span></div><div class="kv"><span>Reprojection</span><span>runtime owned</span></div></div>
       </div>
-      <div class="view-grid"><div class="eye" data-eye="LEFT EYE"><div class="pose"></div></div><div class="eye" data-eye="RIGHT EYE"><div class="pose"></div></div></div>
+      <div class="view-grid"><div class="eye" data-eye="RUNTIME VIEW SET"><div class="pose"></div></div><div class="eye" data-eye="PER-VIEW STATUS"><div class="pose"></div></div></div>
     </div>
     <div id="pane-input" class="pane">
-      <div class="card"><div class="label">Motion Controllers</div><div class="kv"><span>Interaction profile</span><span>/oculus/touch_controller</span></div><div class="kv"><span>Left grip</span><span class="pill ok">tracked</span></div><div class="kv"><span>Right grip</span><span class="pill ok">tracked</span></div><div class="kv"><span>Aim rays</span><span>stable</span></div></div>
+      <div class="card"><div class="label">Motion Controllers</div><div class="kv"><span>Interaction profile</span><span>runtime resolved</span></div><div class="kv"><span>Bindings schema</span><span>versioned</span></div><div class="kv"><span>Profile changes</span><span>observable</span></div><div class="kv"><span>Aim/grip state</span><span>confidence aware</span></div></div>
       <div class="card"><div class="label">Hand Tracking</div><div class="kv"><span>Joint set</span><span>basic</span></div><div class="kv"><span>Confidence</span><span class="pill warn">medium</span></div><div class="kv"><span>Gesture</span><span>pinch ready</span></div></div>
     </div>
     <div id="pane-ar" class="pane">
@@ -67,13 +68,17 @@ button{height:26px;border:1px solid var(--bd);border-radius:var(--r);background:
       <div class="card"><div class="label">Privacy Permissions</div><div class="kv"><span>Eye tracking</span><span class="pill warn">disabled</span></div><div class="kv"><span>Raw camera logging</span><span class="pill ok">off</span></div><div class="kv"><span>Spatial anchors</span><span>local</span></div><div class="kv"><span>Diagnostics</span><span>redacted</span></div></div>
       <div class="card"><div class="label">Data Retention</div><div class="kv"><span>Pose traces</span><span>session only</span></div><div class="kv"><span>Crash dumps</span><span>no camera frames</span></div></div>
     </div>
+    <div id="pane-qualification" class="pane">
+      <div class="card"><div class="label">Evidence Identity</div><div class="kv"><span>Headset</span><span>device reported</span></div><div class="kv"><span>Runtime / version</span><span>runtime reported</span></div><div class="kv"><span>OS / renderer</span><span>host snapshot</span></div><div class="kv"><span>Connection mode</span><span>explicit</span></div><div class="kv"><span>Interaction profile</span><span>runtime resolved</span></div><div class="kv"><span>Extensions</span><span>admitted set</span></div></div>
+      <div class="card"><div class="label">Qualification</div><div class="kv"><span>Planning category</span><span>Reference</span></div><div class="kv"><span>Device evidence</span><span class="pill warn">not run</span></div><div class="kv"><span>Simulator evidence</span><span>separate</span></div><div class="kv"><span>Known issues</span><span>tracked</span></div></div>
+    </div>
   </main>
   <aside class="detail">
     <div class="label">Session</div>
     <div class="kv"><span>state</span><span class="pill ok">ready</span></div>
-    <div class="kv"><span>view config</span><span>Stereo</span></div>
-    <div class="kv"><span>refresh</span><span>90 Hz</span></div>
-    <div class="kv"><span>budget</span><span>11.1 ms</span></div>
+    <div class="kv"><span>view config</span><span>runtime selected</span></div>
+    <div class="kv"><span>refresh</span><span>runtime mode</span></div>
+    <div class="kv"><span>budget</span><span>derived</span></div>
     <div class="label" style="margin-top:16px">Privacy</div>
     <div class="kv"><span>Passthrough</span><span class="pill ok">granted</span></div>
     <div class="kv"><span>Eye tracking</span><span class="pill warn">disabled</span></div>
@@ -81,7 +86,7 @@ button{height:26px;border:1px solid var(--bd);border-radius:var(--r);background:
     <div class="kv"><span>Camera logging</span><span>off</span></div>
   </aside>
 </div>
-<footer class="status"><span><strong>OpenXR active</strong> · privacy safe</span><span>Instanced stereo</span><span>Passthrough granted</span><span class="spacer"></span><span>dx12_vulkan · 90 Hz</span></footer>
+<footer class="status"><span><strong>OpenXR preflight</strong> · evidence pending</span><span>View configuration admitted</span><span>Optional features explicit</span><span class="spacer"></span><span>renderer · runtime refresh</span></footer>
 <script>
 function switchTab(id, tab){
   document.querySelectorAll('#page-tabs .tab').forEach(function(t){t.classList.remove('active')});


### PR DESCRIPTION
## Summary
- Align XR architecture documentation with the expanded OpenXR, device qualification, Android-host, and immersive AI roadmap.
- Replace static headset claims and stereo-only assumptions with capability-driven, runtime-qualified contracts.
- Add the Android runtime-host foundation and clarify Audio, Input, Renderer, and AI ownership boundaries.

## Motivation
- The architecture documents had fallen behind the issue roadmap and still implied implemented production XR support, fixed device lists, fixed stereo views, and weaker AI mutation boundaries.

## Implementation Notes
- Documents a bounded runtime-driven view model while retaining stereo as the first implementation baseline.
- Defines headset support as evidence for a runtime/OS/backend/connection/profile/extension tuple.
- Keeps voice, pointing, and physical interaction as context; only explicit approval may authorize an editor transaction.
- Treats Android platform work as a parallel critical path for standalone XR qualification.
- Tracks the roadmap under #2256, #2137, #2166, and #2287.

## Validation
- [x] Documentation formatting hook passed
- [x] CMake skeleton configure passed
- [x] Changed-document local links validated
- [x] XR setup HTML parsed successfully
- [ ] Runtime smoke test (documentation-only change)

Commands run:
```bash
git diff --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
python3 <changed-document link validation>
python3 <HTML parser validation>
```

## Risks
- Documentation describes planned contracts; it does not claim that the production OpenXR backend or Android host already exists.
- Two unrelated, pre-existing broken links remain in the architecture index for localization documents that are not part of this change.

## Issue Links
Related to #2256
Related to #2137
Related to #2166
Related to #2287

## Reviewer Notes
- Start with `docs/architecture/runtime/vr-ar-architecture.md` and `docs/architecture/foundation/android-platform-host.md`.
- Then review the ownership-boundary updates in the AI, Audio, Input, Renderer, and platform documents.