### PR TITLE
refactor(editor): clear post-merge Sonar findings

### DIFF
--- a/src/editor/screens/workspace/panels/global_dock/panes/console/GlobalDockConsolePane.cpp
+++ b/src/editor/screens/workspace/panels/global_dock/panes/console/GlobalDockConsolePane.cpp
@@ -173,8 +173,8 @@ namespace Horo::Editor {
             };
             const std::array<const char *, 5> filterLabels{filterText[0].c_str(), filterText[1].c_str(), filterText[2].c_str(),
                                                            filterText[3].c_str(), filterText[4].c_str()};
-            const std::string &levelsLabel = context.localization.Get("editor", "workspace.global_dock.console.levels");
-            if (Ui::MultiSelectField("##ConsoleLevels", levelsLabel.c_str(), filterLabels, m_levelEnabled, fonts, 104.0F,
+            if (const std::string &levelsLabel = context.localization.Get("editor", "workspace.global_dock.console.levels");
+                Ui::MultiSelectField("##ConsoleLevels", levelsLabel.c_str(), filterLabels, m_levelEnabled, fonts, 104.0F,
                                      Ui::ComponentSize::Small))
                 m_filterDirty = true;
             return;

--- a/src/editor/screens/workspace/panels/hierarchy/HierarchyPanel.cpp
+++ b/src/editor/screens/workspace/panels/hierarchy/HierarchyPanel.cpp
@@ -368,8 +368,7 @@ namespace Horo::Editor {
         return controls;
     }
 
-    void HierarchyPanel::DrawRowPresentation(const RowFrame &frame, const RowControls &controls, const EditorGuiContext &context) {
-        const bool hovered = controls.IsHovered(frame);
+    void HierarchyPanel::DrawRowBackground(const RowFrame &frame, const bool hovered) {
         if (frame.selected) {
             ImVec4 selectedBackground = Theme::Accent();
             selectedBackground.w = hovered ? 0.17F : 0.13F;
@@ -385,8 +384,9 @@ namespace Horo::Editor {
         if (frame.rowFocused)
             frame.drawList.AddRect(frame.geometry.rowMin, frame.geometry.rowMax, Theme::U32(Theme::BorderStrong()), 2.0F * frame.uiScale, 0,
                                    frame.uiScale);
+    }
 
-        const float centerY = frame.geometry.rowMin.y + frame.geometry.layout.height * 0.5F;
+    void HierarchyPanel::DrawRowTree(const RowFrame &frame, const RowControls &controls, const float centerY) {
         const float chevronCenterX = (frame.geometry.chevronMin.x + frame.geometry.chevronMax.x) * 0.5F;
         if (frame.row.depth > 0) {
             const float guideX = chevronCenterX - 12.0F * frame.uiScale;
@@ -405,7 +405,9 @@ namespace Horo::Editor {
                                                  {chevronCenterX + 2.0F * frame.uiScale, centerY},
                                                  Theme::U32(controls.chevronHovered ? Theme::Text() : Theme::Dim()));
         }
+    }
 
+    void HierarchyPanel::DrawRowTypeIcon(const RowFrame &frame, const EditorGuiContext &context, const float centerY) {
         const HierarchyIconPresentation icon = GetIconPresentation(frame.node.type);
         const float iconSize = 16.0F * frame.uiScale;
         ImVec4 typeColor = icon.color;
@@ -415,7 +417,9 @@ namespace Horo::Editor {
                            Theme::U32(typeColor));
         if (icon.tooltipKey != nullptr && ImGui::IsMouseHoveringRect(frame.geometry.typeIconMin, frame.geometry.typeIconMax))
             ImGui::SetTooltip("%s", context.localization.Get("editor", icon.tooltipKey).c_str());
+    }
 
+    void HierarchyPanel::DrawRowActions(const RowFrame &frame, const RowControls &controls) {
         if (frame.geometry.layout.visibilityAction.Width() <= 0.0F)
             return;
         const float actionIconSize =
@@ -440,6 +444,14 @@ namespace Horo::Editor {
                    frame.node.hiddenByParent && frame.node.locallyVisible);
         drawAction(Ui::UiIcon::Lock, frame.geometry.lockMin, frame.geometry.lockMax, controls.lockHovered, frame.node.effectivelyLocked,
                    frame.node.lockedByParent && !frame.node.locallyLocked);
+    }
+
+    void HierarchyPanel::DrawRowPresentation(const RowFrame &frame, const RowControls &controls, const EditorGuiContext &context) {
+        DrawRowBackground(frame, controls.IsHovered(frame));
+        const float centerY = frame.geometry.rowMin.y + frame.geometry.layout.height * 0.5F;
+        DrawRowTree(frame, controls, centerY);
+        DrawRowTypeIcon(frame, context, centerY);
+        DrawRowActions(frame, controls);
     }
 
     void HierarchyPanel::ApplyRowInteraction(const RowFrame &frame, const RowControls &controls, const bool workspaceEligible,
@@ -475,15 +487,16 @@ namespace Horo::Editor {
     void HierarchyPanel::DrawRowLabel(const RowFrame &frame, EditorWorkspaceViewCommandData &command) {
         const float centerY = frame.geometry.rowMin.y + frame.geometry.layout.height * 0.5F;
         if (renamingId_ != frame.node.id) {
-            const bool truncated = DrawHierarchyLabel({.drawList = frame.drawList,
-                                                       .font = frame.nameFont,
-                                                       .fontSize = frame.nameFontSize,
-                                                       .minimum = frame.geometry.labelMin,
-                                                       .maximum = frame.geometry.labelMax,
-                                                       .centerY = centerY,
-                                                       .color = Theme::U32(frame.node.effectivelyLocked ? Theme::Muted() : Theme::Text()),
-                                                       .text = frame.node.name});
-            if (truncated && ImGui::IsMouseHoveringRect(frame.geometry.labelMin, frame.geometry.labelMax))
+            if (const bool truncated =
+                    DrawHierarchyLabel({.drawList = frame.drawList,
+                                        .font = frame.nameFont,
+                                        .fontSize = frame.nameFontSize,
+                                        .minimum = frame.geometry.labelMin,
+                                        .maximum = frame.geometry.labelMax,
+                                        .centerY = centerY,
+                                        .color = Theme::U32(frame.node.effectivelyLocked ? Theme::Muted() : Theme::Text()),
+                                        .text = frame.node.name});
+                truncated && ImGui::IsMouseHoveringRect(frame.geometry.labelMin, frame.geometry.labelMax))
                 ImGui::SetTooltip("%s", frame.node.name.c_str());
             return;
         }
@@ -645,11 +658,11 @@ namespace Horo::Editor {
 
         if (interaction.workspaceEligible && interaction.panelFocused && !interaction.searchActive && !renamingId_.has_value() &&
             editSession_.SelectedId().has_value()) {
+            using enum Input::Key;
             const Input::ModifierState &modifiers = inputRouter_->Snapshot().modifiers;
-            if ((HierarchyEditSession::IsDeleteShortcut(Input::Key::Delete, modifiers) &&
-                 inputRouter_->ConsumeKey(*workspaceInputContext_, Input::Key::Delete)) ||
-                (HierarchyEditSession::IsDeleteShortcut(Input::Key::Backspace, modifiers) &&
-                 inputRouter_->ConsumeKey(*workspaceInputContext_, Input::Key::Backspace))) {
+            if ((HierarchyEditSession::IsDeleteShortcut(Delete, modifiers) && inputRouter_->ConsumeKey(*workspaceInputContext_, Delete)) ||
+                (HierarchyEditSession::IsDeleteShortcut(Backspace, modifiers) &&
+                 inputRouter_->ConsumeKey(*workspaceInputContext_, Backspace))) {
                 pendingDelete = true;
             }
         }

--- a/src/editor/screens/workspace/panels/hierarchy/HierarchyPanel.cpp
+++ b/src/editor/screens/workspace/panels/hierarchy/HierarchyPanel.cpp
@@ -222,6 +222,15 @@ namespace Horo::Editor {
         }
     };
 
+    struct HierarchyPanel::RowActionIcon {
+        Ui::UiIcon icon{Ui::UiIcon::Visibility};
+        ImVec2 minimum{};
+        ImVec2 maximum{};
+        bool hovered{false};
+        bool active{false};
+        bool inherited{false};
+    };
+
     void HierarchyPanel::OnAttach(PanelContext &context) {
         inputRouter_ = context.inputRouter;
         workspaceInputContext_ = context.workspaceInputContext;
@@ -419,6 +428,19 @@ namespace Horo::Editor {
             ImGui::SetTooltip("%s", context.localization.Get("editor", icon.tooltipKey).c_str());
     }
 
+    void HierarchyPanel::DrawRowActionIcon(const RowFrame &frame, const float iconSize, const RowActionIcon &action) {
+        if (iconSize <= 0.0F)
+            return;
+        ImVec4 color = action.hovered || action.active ? Theme::Text() : Theme::Muted();
+        if (action.active && !action.hovered)
+            color.w *= 0.82F;
+        if (action.inherited)
+            color.w *= 0.55F;
+        const ImVec2 position{action.minimum.x + ((action.maximum.x - action.minimum.x) - iconSize) * 0.5F,
+                              action.minimum.y + ((action.maximum.y - action.minimum.y) - iconSize) * 0.5F};
+        Ui::DrawEditorIcon(&frame.drawList, action.icon, position, {iconSize, iconSize}, Theme::U32(color));
+    }
+
     void HierarchyPanel::DrawRowActions(const RowFrame &frame, const RowControls &controls) {
         if (frame.geometry.layout.visibilityAction.Width() <= 0.0F)
             return;
@@ -426,24 +448,24 @@ namespace Horo::Editor {
             std::max(0.0F, std::min({15.0F * frame.uiScale, frame.geometry.layout.visibilityAction.Width() - 4.0F * frame.uiScale,
                                      frame.geometry.layout.lockAction.Width() - 4.0F * frame.uiScale,
                                      frame.geometry.layout.height - 4.0F * frame.uiScale}));
-        const auto drawAction = [&](const Ui::UiIcon actionIcon, const ImVec2 minimum, const ImVec2 maximum, const bool actionHovered,
-                                    const bool active, const bool inherited) {
-            if (actionIconSize <= 0.0F)
-                return;
-            ImVec4 color = actionHovered || active ? Theme::Text() : Theme::Muted();
-            if (active && !actionHovered)
-                color.w *= 0.82F;
-            if (inherited)
-                color.w *= 0.55F;
-            const ImVec2 position{minimum.x + ((maximum.x - minimum.x) - actionIconSize) * 0.5F,
-                                  minimum.y + ((maximum.y - minimum.y) - actionIconSize) * 0.5F};
-            Ui::DrawEditorIcon(&frame.drawList, actionIcon, position, {actionIconSize, actionIconSize}, Theme::U32(color));
-        };
-        drawAction(frame.node.effectivelyVisible ? Ui::UiIcon::Visibility : Ui::UiIcon::VisibilityOff, frame.geometry.visibilityMin,
-                   frame.geometry.visibilityMax, controls.visibilityHovered, !frame.node.effectivelyVisible,
-                   frame.node.hiddenByParent && frame.node.locallyVisible);
-        drawAction(Ui::UiIcon::Lock, frame.geometry.lockMin, frame.geometry.lockMax, controls.lockHovered, frame.node.effectivelyLocked,
-                   frame.node.lockedByParent && !frame.node.locallyLocked);
+        DrawRowActionIcon(frame, actionIconSize,
+                          {
+                              .icon = frame.node.effectivelyVisible ? Ui::UiIcon::Visibility : Ui::UiIcon::VisibilityOff,
+                              .minimum = frame.geometry.visibilityMin,
+                              .maximum = frame.geometry.visibilityMax,
+                              .hovered = controls.visibilityHovered,
+                              .active = !frame.node.effectivelyVisible,
+                              .inherited = frame.node.hiddenByParent && frame.node.locallyVisible,
+                          });
+        DrawRowActionIcon(frame, actionIconSize,
+                          {
+                              .icon = Ui::UiIcon::Lock,
+                              .minimum = frame.geometry.lockMin,
+                              .maximum = frame.geometry.lockMax,
+                              .hovered = controls.lockHovered,
+                              .active = frame.node.effectivelyLocked,
+                              .inherited = frame.node.lockedByParent && !frame.node.locallyLocked,
+                          });
     }
 
     void HierarchyPanel::DrawRowPresentation(const RowFrame &frame, const RowControls &controls, const EditorGuiContext &context) {

--- a/src/editor/screens/workspace/panels/hierarchy/HierarchyPanel.h
+++ b/src/editor/screens/workspace/panels/hierarchy/HierarchyPanel.h
@@ -52,6 +52,10 @@ namespace Horo::Editor {
                                 const EditorGuiContext &context);
         [[nodiscard]] RowControls DrawRowControls(const RowFrame &frame, bool workspaceEligible, const EditorGuiContext &context);
         static void DrawRowPresentation(const RowFrame &frame, const RowControls &controls, const EditorGuiContext &context);
+        static void DrawRowBackground(const RowFrame &frame, bool hovered);
+        static void DrawRowTree(const RowFrame &frame, const RowControls &controls, float centerY);
+        static void DrawRowTypeIcon(const RowFrame &frame, const EditorGuiContext &context, float centerY);
+        static void DrawRowActions(const RowFrame &frame, const RowControls &controls);
         void ApplyRowInteraction(const RowFrame &frame, const RowControls &controls, bool workspaceEligible,
                                  EditorWorkspaceViewCommandData &command);
         void DrawRowLabel(const RowFrame &frame, EditorWorkspaceViewCommandData &command);

--- a/src/editor/screens/workspace/panels/hierarchy/HierarchyPanel.h
+++ b/src/editor/screens/workspace/panels/hierarchy/HierarchyPanel.h
@@ -40,6 +40,7 @@ namespace Horo::Editor {
         struct PanelInteractionState;
         struct RowFrame;
         struct RowControls;
+        struct RowActionIcon;
 
         void BeginRename(HierarchyNodeId id);
         [[nodiscard]] PanelInteractionState DrawSearch(float panelWidth, float uiScale, const EditorGuiContext &context);
@@ -55,6 +56,7 @@ namespace Horo::Editor {
         static void DrawRowBackground(const RowFrame &frame, bool hovered);
         static void DrawRowTree(const RowFrame &frame, const RowControls &controls, float centerY);
         static void DrawRowTypeIcon(const RowFrame &frame, const EditorGuiContext &context, float centerY);
+        static void DrawRowActionIcon(const RowFrame &frame, float iconSize, const RowActionIcon &action);
         static void DrawRowActions(const RowFrame &frame, const RowControls &controls);
         void ApplyRowInteraction(const RowFrame &frame, const RowControls &controls, bool workspaceEligible,
                                  EditorWorkspaceViewCommandData &command);

--- a/src/editor/screens/workspace/panels/viewport/interaction/ViewportInteractionController.cpp
+++ b/src/editor/screens/workspace/panels/viewport/interaction/ViewportInteractionController.cpp
@@ -22,17 +22,17 @@ namespace Horo::Editor {
         if (router == nullptr || capture_.WorkspaceContext() == nullptr)
             return;
         const Input::RawInputSnapshot &input = router->Snapshot();
-        const TransformGizmoDrawContext gizmoContext{
-            .origin = context.origin,
-            .width = context.width,
-            .height = context.height,
-            .hovered = context.hovered,
-            .input = input,
-            .viewModel = context.viewModel,
-            .command = context.command,
-            .depthRange = context.depthRange,
-        };
-        if (gizmo_.Draw(context.drawList, gizmoContext, capture_))
+        if (const TransformGizmoDrawContext gizmoContext{
+                .origin = context.origin,
+                .width = context.width,
+                .height = context.height,
+                .hovered = context.hovered,
+                .input = input,
+                .viewModel = context.viewModel,
+                .command = context.command,
+                .depthRange = context.depthRange,
+            };
+            gizmo_.Draw(context.drawList, gizmoContext, capture_))
             return;
         navigation_.Update(
             ViewportNavigationUpdateContext{

--- a/src/editor/screens/workspace/panels/viewport/navigation/ViewportNavigationController.cpp
+++ b/src/editor/screens/workspace/panels/viewport/navigation/ViewportNavigationController.cpp
@@ -55,43 +55,56 @@ namespace Horo::Editor {
         }
     }
 
-    EditorViewportNavigationDelta ViewportNavigationController::BuildNavigationDelta(const ViewportNavigationUpdateContext &context) const {
+    void ViewportNavigationController::ApplyPointerNavigation(const ViewportNavigationUpdateContext &context, const float orbitSensitivity,
+                                                              const float panSensitivity, EditorViewportNavigationDelta &navigation) const {
         using enum Mode;
         const Input::RawInputSnapshot &input = context.input;
         const EditorWorkspaceViewModel &viewModel = context.viewModel;
+        if (mode_ == Fly || mode_ == Orbit) {
+            const float lookSensitivity = 0.003F * orbitSensitivity;
+            navigation.yawRadians = -input.pointer.deltaX * lookSensitivity;
+            navigation.pitchRadians = -input.pointer.deltaY * lookSensitivity * (context.gui.settings.settings.invertOrbitY ? -1.0F : 1.0F);
+            navigation.orbit = mode_ == Orbit;
+            return;
+        }
+
+        const float viewportHeight = std::max(context.height, 1.0F);
+        const float targetDistance = Math::Length(viewModel.viewportCamera.target - viewModel.viewportCamera.position);
+        const float worldUnitsPerPixel =
+            viewModel.viewportCamera.projection == Runtime::CameraProjection::Perspective
+                ? 2.0F * targetDistance * std::tan(viewModel.viewportCamera.verticalFovRadians * 0.5F) / viewportHeight
+                : viewModel.viewportCamera.orthographicHeight / viewportHeight;
+        navigation.moveRight = -input.pointer.deltaX * worldUnitsPerPixel * panSensitivity;
+        navigation.moveUp = input.pointer.deltaY * worldUnitsPerPixel * panSensitivity;
+    }
+
+    void ViewportNavigationController::ApplyFlyNavigation(const ViewportNavigationUpdateContext &context,
+                                                          EditorViewportNavigationDelta &navigation) const {
+        using enum Mode;
+        using enum Input::Key;
+        if (mode_ != Fly)
+            return;
+        const Input::RawInputSnapshot &input = context.input;
+        const float speed =
+            (input.modifiers.shift ? FastFlyMovementSpeed : FlyMovementSpeed) * std::clamp(context.deltaSeconds, 0.0F, 0.1F);
+        navigation.moveForward = (input.State(W).down ? speed : 0.0F) - (input.State(S).down ? speed : 0.0F);
+        navigation.moveRight += (input.State(D).down ? speed : 0.0F) - (input.State(A).down ? speed : 0.0F);
+        navigation.moveUp += (input.State(E).down ? speed : 0.0F) - (input.State(Q).down ? speed : 0.0F);
+    }
+
+    EditorViewportNavigationDelta ViewportNavigationController::BuildNavigationDelta(const ViewportNavigationUpdateContext &context) const {
+        using enum Mode;
         EditorViewportNavigationDelta navigation;
         if (mode_ != None) {
             ImGui::SetMouseCursor(ImGuiMouseCursor_None);
             const float orbitSensitivity =
                 std::clamp(static_cast<float>(context.gui.settings.settings.orbitSensitivity) / 100.0F, 0.1F, 3.0F);
             const float panSensitivity = std::clamp(static_cast<float>(context.gui.settings.settings.panSensitivity) / 100.0F, 0.1F, 3.0F);
-            const float lookSensitivity = 0.003F * orbitSensitivity;
-            if (mode_ == Fly || mode_ == Orbit) {
-                navigation.yawRadians = -input.pointer.deltaX * lookSensitivity;
-                navigation.pitchRadians =
-                    -input.pointer.deltaY * lookSensitivity * (context.gui.settings.settings.invertOrbitY ? -1.0F : 1.0F);
-                navigation.orbit = mode_ == Orbit;
-            } else {
-                const float viewportHeight = std::max(context.height, 1.0F);
-                const float targetDistance = Math::Length(viewModel.viewportCamera.target - viewModel.viewportCamera.position);
-                const float worldUnitsPerPixel =
-                    viewModel.viewportCamera.projection == Runtime::CameraProjection::Perspective
-                        ? 2.0F * targetDistance * std::tan(viewModel.viewportCamera.verticalFovRadians * 0.5F) / viewportHeight
-                        : viewModel.viewportCamera.orthographicHeight / viewportHeight;
-                navigation.moveRight = -input.pointer.deltaX * worldUnitsPerPixel * panSensitivity;
-                navigation.moveUp = input.pointer.deltaY * worldUnitsPerPixel * panSensitivity;
-            }
-            if (mode_ == Fly) {
-                using enum Input::Key;
-                const float speed =
-                    (input.modifiers.shift ? FastFlyMovementSpeed : FlyMovementSpeed) * std::clamp(context.deltaSeconds, 0.0F, 0.1F);
-                navigation.moveForward = (input.State(W).down ? speed : 0.0F) - (input.State(S).down ? speed : 0.0F);
-                navigation.moveRight += (input.State(D).down ? speed : 0.0F) - (input.State(A).down ? speed : 0.0F);
-                navigation.moveUp += (input.State(E).down ? speed : 0.0F) - (input.State(Q).down ? speed : 0.0F);
-            }
+            ApplyPointerNavigation(context, orbitSensitivity, panSensitivity, navigation);
+            ApplyFlyNavigation(context, navigation);
         }
-        if (mode_ == None && context.hovered && input.pointer.wheelY != 0.0F)
-            navigation.dollyScale = std::exp(-input.pointer.wheelY * 0.15F);
+        if (mode_ == None && context.hovered && context.input.pointer.wheelY != 0.0F)
+            navigation.dollyScale = std::exp(-context.input.pointer.wheelY * 0.15F);
         return navigation;
     }
 

--- a/src/editor/screens/workspace/panels/viewport/navigation/ViewportNavigationController.h
+++ b/src/editor/screens/workspace/panels/viewport/navigation/ViewportNavigationController.h
@@ -43,6 +43,9 @@ namespace Horo::Editor {
         void TryBeginNavigation(const ViewportNavigationUpdateContext &context, ViewportInteractionCapture &capture);
         void EndReleasedNavigation(const Input::RawInputSnapshot &input, ViewportInteractionCapture &capture);
         [[nodiscard]] EditorViewportNavigationDelta BuildNavigationDelta(const ViewportNavigationUpdateContext &context) const;
+        void ApplyPointerNavigation(const ViewportNavigationUpdateContext &context, float orbitSensitivity, float panSensitivity,
+                                    EditorViewportNavigationDelta &navigation) const;
+        void ApplyFlyNavigation(const ViewportNavigationUpdateContext &context, EditorViewportNavigationDelta &navigation) const;
         void EmitNavigationCommand(const ViewportNavigationUpdateContext &context, const EditorViewportNavigationDelta &navigation,
                                    const ViewportInteractionCapture &capture) const;
 

--- a/src/foundation/telemetry/OpenTelemetrySink.cpp
+++ b/src/foundation/telemetry/OpenTelemetrySink.cpp
@@ -37,7 +37,7 @@ namespace Horo::Telemetry {
                 });
                 if (!curlReady)
                     return false;
-                CURL *curl = curl_easy_init();
+                CURL *curl = curl_easy_init();  // NOSONAR(cpp:S4423) TLS 1.3 is required before curl_easy_perform().
                 if (curl == nullptr)
                     return false;
                 const char *suffix{};


### PR DESCRIPTION
## Summary
- Resolves the seven SonarCloud findings reported after PR #2320 merged.
- Splits hierarchy row presentation and viewport navigation delta calculation into genuinely lower-complexity helpers.
- Applies the four reported init-statement/enum cleanups.
- Keeps TLS 1.3 enforcement unchanged and places the false-positive suppression on the `curl_easy_init` operation Sonar reports.

## Motivation
- The post-merge `main` analysis revealed that two extractions moved complexity without reducing it and identified four mechanical follow-ups.
- The remaining TLS vulnerability is a symbolic-execution false positive: `CURLOPT_SSLVERSION` requires TLS 1.3 before `curl_easy_perform`.

## Implementation Notes
- Hierarchy drawing is separated into background, tree guides, type icon, and row action layers.
- Navigation separates pointer look/pan from fly-key movement.
- No public API or runtime behavior changes are intended.

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [ ] Manual smoke tested if applicable

Commands run:
```bash
rtk cmake --build build/dev-editor --target HoroGui HoroOpenTelemetry HoroOpenTelemetryTests HoroHierarchyPanelRenderTests HoroViewportPanelRenderTests --parallel
ctest --test-dir build/dev-editor -R "Horo(HierarchyPanelRender|HierarchyEditSession|ViewportPanelRender|OpenTelemetry)Tests" --output-on-failure
python scripts/dev.py format --check <changed C++ files>
git diff --check
```

## Risks
- Editor drawing/navigation changes are structural and covered by targeted tests, but no manual GUI smoke test was run.
- Sonar must re-analyze the PR to confirm its symbolic-execution issue is suppressed at the reported operation.

## Issue Links
- Follow-up to #2320
- SonarCloud new-code issues: https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&sinceLeakPeriod=true&id=abdullahbodur_horo-engine

## Reviewer Notes
- Review hierarchy helper boundaries, then navigation helper boundaries, then the line-scoped TLS false-positive rationale.
