### PR TITLE
ci(codacy): add clang-tidy analysis upload

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,27 @@
+---
+Checks: >
+  -*,
+  clang-analyzer-core.*,
+  clang-analyzer-cplusplus.*,
+  clang-analyzer-deadcode.*,
+  clang-analyzer-security.*,
+  clang-analyzer-unix.*,
+  bugprone-dangling-handle,
+  bugprone-infinite-loop,
+  bugprone-sizeof-expression,
+  bugprone-suspicious-memory-comparison,
+  bugprone-unchecked-optional-access,
+  bugprone-use-after-move,
+  concurrency-*,
+  cppcoreguidelines-special-member-functions,
+  cppcoreguidelines-virtual-class-destructor,
+  performance-*,
+  portability-*
+WarningsAsErrors: ''
+HeaderFilterRegex: '(^|.*[/\\])(include[/\\]Horo|src|apps)[/\\]'
+FormatStyle: file
+CheckOptions:
+  bugprone-unchecked-optional-access.IgnoreSmartPointerDereference: 'true'
+  bugprone-unchecked-optional-access.IgnoreValueCalls: 'false'
+  cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor: 'true'
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,7 +18,7 @@ Checks: >
   performance-*,
   portability-*
 WarningsAsErrors: ''
-HeaderFilterRegex: '(^|.*[/\\])(include[/\\]Horo|src|apps)[/\\]'
+HeaderFilterRegex: '^(?!.*(\.cmake|_deps|build|submodules)).*(include[/\\]Horo|src|apps)[/\\]'
 FormatStyle: file
 CheckOptions:
   bugprone-unchecked-optional-access.IgnoreSmartPointerDereference: 'true'

--- a/.codacy/instructions/review.md
+++ b/.codacy/instructions/review.md
@@ -1,0 +1,44 @@
+# Horo Engine PR Review Instructions
+
+## Purpose
+
+- Horo Engine is an actively developed C++20 game engine and AI-centric editor IDE.
+- Prioritize correctness, ownership and lifetime safety, architecture consistency, and regression prevention.
+
+## Architecture
+
+- `include/Horo/` is the narrow, backend-neutral public API.
+- `src/` contains engine implementations; `apps/` owns executable composition and process entry points.
+- `tests/` contains unit, integration, editor/UI, and GPU smoke coverage.
+- `docs/architecture/` is normative for dependency direction, ownership, lifecycle, capabilities, and subsystem contracts.
+- `deprecated/` is migration reference only; do not extend or repair it unless the PR explicitly targets migration.
+
+## Stack and conventions
+
+- Use simple, explicit C++20 with RAII, value semantics, typed IDs/configuration/results/events, and clear state transitions.
+- Keep native platform and renderer types private to concrete backend targets. Public contracts expose Horo types only.
+- Follow local style and `clang-format`; avoid style-only rewrites, unnecessary allocation, virtual dispatch, macros, or template complexity.
+- Public header declarations own complete Doxygen contracts. `.cpp` definitions use `@copydoc` and remain thin.
+- New user-visible editor text must use localization and keep `assets/localization/editor/en-US.json` and `tr-TR.json` structurally aligned.
+
+## Review priorities
+
+- Check ownership, lifetime, cancellation, shutdown, rollback, partial initialization, and invalid state transitions.
+- Check dependency direction and reject feature code that selects or instantiates concrete platform/render backends.
+- For renderer changes, require parity across OpenGL, Metal where supported, combined-backend, and headless/test compositions; do not introduce normal-frame GPU waits.
+- For editor UI changes, check shared design-system controls, narrow layouts, long/localized text, and normal/hovered/active/disabled/focused/open-popup states where relevant.
+- For serialization, metadata, paths, and file operations, check malformed, duplicate, missing, oversized, version-skewed, whitespace, non-ASCII, and platform-specific cases as applicable.
+- Require regression coverage for behavior changes when practical. Do not claim tests passed unless the PR provides evidence.
+
+## Project validation
+
+- Canonical validation is `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`, `cmake --build build/skeleton --parallel`, and `ctest --test-dir build/skeleton --output-on-failure`.
+- GPU smoke tests are opt-in and must not be treated as passed without a compatible display and graphics device.
+- Review the relevant architecture document before accepting cross-module or public-contract changes.
+
+## PR scope
+
+- Prefer narrow root-cause fixes over unrelated cleanup or broad refactors.
+- Breaking public contracts requires a written reason, affected callers, migration path, and regression coverage.
+- Do not accept generated build output, caches, logs, screenshots, credentials, or machine-specific paths.
+- Use Conventional Commits with an imperative, truthful, focused subject. Do not commit, push, rewrite history, or change branches as part of review.

--- a/.github/workflows/codacy-clang-tidy.yml
+++ b/.github/workflows/codacy-clang-tidy.yml
@@ -76,17 +76,21 @@ jobs:
             -DHORO_ENABLE_OPENTELEMETRY=ON \
             -DHORO_ENABLE_IMGUI_UI_TESTS=OFF
 
+      - name: Build generated headers
+        run: |
+          cmake --build build/codacy-clang-tidy --target HoroBuildInfo HoroProjectCompatibilityCatalog HoroProjectMigrationCatalog
+
       - name: Run Clang-Tidy
         run: |
           run-clang-tidy-18 \
             -p build/codacy-clang-tidy \
             -j "$(nproc)" \
             -quiet \
-            '(^|.*/)(src|apps)/.*\.(c|cc|cpp|cxx)$' \
-            > clang-tidy-output.txt 2>&1 || true
+            '^(?!.*(\.cmake|_deps|build|submodules)).*(src|apps)/.*\.(c|cc|cpp|cxx)$' \
+            2>&1 | tee clang-tidy-output.txt || true
 
           test -f clang-tidy-output.txt
-          sed -n '1,200p' clang-tidy-output.txt
+          echo "Clang-Tidy execution finished. Total output lines: $(wc -l < clang-tidy-output.txt)"
 
       - name: Upload Clang-Tidy results to Codacy
         uses: codacy/codacy-analysis-cli-action@d43360362776a6789b47b99ae8973510854e2d3d

--- a/.github/workflows/codacy-clang-tidy.yml
+++ b/.github/workflows/codacy-clang-tidy.yml
@@ -1,0 +1,101 @@
+name: Codacy Clang-Tidy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  clang-tidy:
+    name: Clang-Tidy · Linux
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout source commit
+        uses: actions/checkout@f548e57e544e1ff5a4c46bf1e1b8685f8e4a348a
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install analysis dependencies
+        run: |
+          if ! sudo apt-get update; then
+            sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
+            sudo apt-get update
+          fi
+          sudo apt-get install -y --no-install-recommends \
+            clang-18 \
+            clang-tidy-18 \
+            clang-tools-18 \
+            ninja-build \
+            libwayland-dev \
+            wayland-protocols \
+            libxkbcommon-dev \
+            libx11-dev \
+            libxrandr-dev \
+            libxinerama-dev \
+            libxcursor-dev \
+            libxi-dev \
+            libxext-dev \
+            libxss-dev \
+            libxtst-dev \
+            libxxf86vm-dev \
+            libgl1-mesa-dev \
+            libglu1-mesa-dev
+
+      - name: Cache FetchContent dependencies
+        uses: actions/cache@3edfce9056124e459a23f683a21433670d47daca
+        with:
+          path: ${{ github.workspace }}/.cmake/fetchcontent
+          key: codacy-clang-tidy-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**') }}
+          restore-keys: codacy-clang-tidy-${{ runner.os }}-
+
+      - name: Generate compilation database
+        env:
+          CC: clang-18
+          CXX: clang++-18
+          FETCHCONTENT_BASE_DIR: ${{ github.workspace }}/.cmake/fetchcontent
+        run: |
+          cmake -S . -B build/codacy-clang-tidy -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DBUILD_TESTING=ON \
+            -DHORO_BUILD_EDITOR_GUI=ON \
+            -DHORO_BUILD_RENDER_OPENGL=ON \
+            -DHORO_BUILD_RENDER_METAL=OFF \
+            -DHORO_ENABLE_TELEMETRY=ON \
+            -DHORO_ENABLE_OPENTELEMETRY=ON \
+            -DHORO_ENABLE_IMGUI_UI_TESTS=OFF
+
+      - name: Run Clang-Tidy
+        run: |
+          set +e
+          run-clang-tidy-18 \
+            -p build/codacy-clang-tidy \
+            -quiet \
+            '(^|.*/)(src|apps)/.*\.(cpp|cc|cxx)$' \
+            > clang-tidy-output.txt 2>&1
+          status=$?
+          set -e
+
+          echo "Clang-Tidy exit code: $status"
+          test -f clang-tidy-output.txt
+          sed -n '1,200p' clang-tidy-output.txt
+
+      - name: Upload Clang-Tidy results to Codacy
+        uses: codacy/codacy-analysis-cli-action@d43360362776a6789b47b99ae8973510854e2d3d
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          clang-tidy-output: clang-tidy-output.txt
+          run-docker-tools: 'false'
+          upload: 'true'
+          max-allowed-issues: '2147483647'

--- a/.github/workflows/codacy-clang-tidy.yml
+++ b/.github/workflows/codacy-clang-tidy.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   clang-tidy:
@@ -82,15 +82,33 @@ jobs:
 
       - name: Run Clang-Tidy
         run: |
+          test -f build/codacy-clang-tidy/compile_commands.json
+
+          matched_files=$(grep -E '"file":' build/codacy-clang-tidy/compile_commands.json | grep -Ev '(\.cmake|_deps|build|submodules)' | grep -E '(src|apps)/.*\.(c|cc|cpp|cxx)' | wc -l)
+          echo "Found ${matched_files} matching translation units to analyze."
+          if [ "${matched_files}" -le 0 ]; then
+            echo "::error::No matching translation units found in compilation database."
+            exit 1
+          fi
+
+          set +e
           run-clang-tidy-18 \
             -p build/codacy-clang-tidy \
             -j "$(nproc)" \
             -quiet \
             '^(?!.*(\.cmake|_deps|build|submodules)).*(src|apps)/.*\.(c|cc|cpp|cxx)$' \
-            2>&1 | tee clang-tidy-output.txt || true
+            2>&1 | tee clang-tidy-output.txt
+          status="${PIPESTATUS[0]}"
+          set -e
 
           test -f clang-tidy-output.txt
-          echo "Clang-Tidy execution finished. Total output lines: $(wc -l < clang-tidy-output.txt)"
+
+          if [ "${status}" -ne 0 ] && [ ! -s clang-tidy-output.txt ]; then
+            echo "::error::run-clang-tidy-18 failed with exit status ${status} and produced no output."
+            exit 1
+          fi
+
+          echo "Clang-Tidy execution finished with tool exit status ${status}. Total output lines: $(wc -l < clang-tidy-output.txt)"
 
       - name: Upload Clang-Tidy results to Codacy
         uses: codacy/codacy-analysis-cli-action@d43360362776a6789b47b99ae8973510854e2d3d

--- a/.github/workflows/codacy-clang-tidy.yml
+++ b/.github/workflows/codacy-clang-tidy.yml
@@ -83,7 +83,7 @@ jobs:
             -j "$(nproc)" \
             -quiet \
             '(^|.*/)(src|apps)/.*\.(c|cc|cpp|cxx)$' \
-            > clang-tidy-output.txt 2>&1
+            > clang-tidy-output.txt 2>&1 || true
 
           test -f clang-tidy-output.txt
           sed -n '1,200p' clang-tidy-output.txt

--- a/.github/workflows/codacy-clang-tidy.yml
+++ b/.github/workflows/codacy-clang-tidy.yml
@@ -78,16 +78,13 @@ jobs:
 
       - name: Run Clang-Tidy
         run: |
-          set +e
           run-clang-tidy-18 \
             -p build/codacy-clang-tidy \
+            -j "$(nproc)" \
             -quiet \
-            '(^|.*/)(src|apps)/.*\.(cpp|cc|cxx)$' \
+            '(^|.*/)(src|apps)/.*\.(c|cc|cpp|cxx)$' \
             > clang-tidy-output.txt 2>&1
-          status=$?
-          set -e
 
-          echo "Clang-Tidy exit code: $status"
           test -f clang-tidy-output.txt
           sed -n '1,200p' clang-tidy-output.txt
 


### PR DESCRIPTION
## Summary
- Adds a focused repository-level `.clang-tidy` policy for analyzer, bug-prone, concurrency, performance, portability, and selected C++ Core Guidelines checks.
- Adds a pinned GitHub Actions workflow that generates a CMake compilation database, runs Clang-Tidy 18, and uploads standalone results to Codacy.

## Motivation
- Codacy's server-side C++ analyzer does not provide Clang-Tidy coverage.
- Client-side upload gives the engine an additional compiler-aware C++ correctness and performance gate.

## Implementation Notes
- Analysis covers production translation units under `src/` and `apps/`; headers under `include/Horo`, `src`, and `apps` are included through the header filter.
- The upload action and standard GitHub actions are pinned to immutable commit SHAs.
- Fork pull requests are skipped because GitHub does not expose repository secrets to them.
- Codacy Cloud's standalone Clang-Tidy tool and the `CODACY_PROJECT_TOKEN` Actions secret are already configured.

## Validation
- [ ] Build passed
- [ ] Relevant tests passed
- [ ] Manual smoke tested if applicable

Commands run:
```bash
actionlint .github/workflows/codacy-clang-tidy.yml
# YAML parsing for .clang-tidy and the workflow
git diff --cached --check
```

The first complete Clang-Tidy/CMake execution is expected from this PR's Linux workflow because Clang-Tidy 18 is not installed in the local Windows environment.

## Risks
- The initial Clang-Tidy run may expose pre-existing findings and increase CI duration while FetchContent dependencies are cold.
- The workflow uploads findings without failing early on the raw Clang-Tidy exit code so Codacy can finalize the commit analysis.

## Issue Links
- None.

## Reviewer Notes
- Review `.clang-tidy` first for policy scope, then `.github/workflows/codacy-clang-tidy.yml` for build and upload behavior.