### PR TITLE
fix: Composition-Time Module Registration [ARC-001.5] 

### DIFF
--- a/cmake/HoroPublicHeaderOwnership.cmake
+++ b/cmake/HoroPublicHeaderOwnership.cmake
@@ -21,6 +21,7 @@ horo_configure_target_header_boundary(HoroFoundation PUBLIC_HEADERS
     Horo/Foundation/Logging/Logger.h
     Horo/Foundation/Logging/StructuredLogStore.h
     Horo/Foundation/ModuleDescriptor.h
+    Horo/Foundation/ModuleHost.h
     Horo/Foundation/OperationStore.h
     Horo/Foundation/PathUtils.h
     Horo/Foundation/Paths.h

--- a/docs/architecture/foundation/internal-module-descriptor.md
+++ b/docs/architecture/foundation/internal-module-descriptor.md
@@ -60,9 +60,34 @@ Independent modules are ordered by stable module ID, so the result does not
 depend on descriptor input order.
 
 Validation does not prove trust, permissions, feature flags, or host resource
-policy. Those remain later host-owned gates. Explicit registration, activation
-rollback, lifecycle states, callback drainage, and reverse shutdown are also
-outside this descriptor contract.
+policy. Those remain later host-owned gates.
+
+## Composition-Time Registration
+
+`Horo/Foundation/ModuleHost.h` defines the host-owned registration and
+activation stage that consumes this descriptor contract. A composition root:
+
+1. Registers each selected descriptor explicitly with `ModuleHost::Register`.
+   Registration is inert: it performs only local metadata checks and never
+   invokes a callback or inspects the full graph.
+2. Calls `ModuleHost::ActivateRegistered`, which validates the complete graph,
+   then activates modules in the validated provider-before-dependant order,
+   passing a composition-root-supplied dependency bundle through
+   `ModuleActivationContext`. Modules receive only approved bindings; there is
+   no runtime discovery.
+3. On activation failure, the host deactivates every already-activated module
+   in reverse order, so a failed composition leaves no partially active set.
+   A rejected graph leaves registrations intact so composition can be retried
+   after correcting the descriptor set.
+
+Headless compositions stay headless by construction: they simply do not
+register GUI-only descriptors, so GUI modules are neither activated nor linked
+into the composition path. `DeactivateAll` provides idempotent reverse-order
+teardown; attached module instances are released with their activation
+contexts.
+
+Lifecycle states beyond this stage (callback drainage, runtime shutdown
+ordering) remain owned by ARC-001.6.
 
 ## Ownership And Migration
 

--- a/docs/architecture/foundation/internal-module-descriptor.md
+++ b/docs/architecture/foundation/internal-module-descriptor.md
@@ -73,12 +73,13 @@ activation stage that consumes this descriptor contract. A composition root:
 2. Calls `ModuleHost::ActivateRegistered`, which validates the complete graph,
    then activates modules in the validated provider-before-dependant order,
    passing a composition-root-supplied dependency bundle through
-   `ModuleActivationContext`. Modules receive only approved bindings; there is
-   no runtime discovery.
-3. On activation failure, the host deactivates every already-activated module
-   in reverse order, so a failed composition leaves no partially active set.
-   A rejected graph leaves registrations intact so composition can be retried
-   after correcting the descriptor set.
+   `ModuleActivationContext::Bindings`. Modules receive only approved bindings;
+   there is no runtime discovery.
+3. On activation failure, the host deactivates every module started by that
+   activation call in reverse order, so a failed composition leaves no partially
+   active set from that call while preserving modules active before it. A rejected
+   graph leaves registrations intact so composition can be retried after correcting
+   the descriptor set.
 
 Headless compositions stay headless by construction: they simply do not
 register GUI-only descriptors, so GUI modules are neither activated nor linked

--- a/include/Horo/Foundation/ModuleHost.h
+++ b/include/Horo/Foundation/ModuleHost.h
@@ -1,0 +1,115 @@
+#pragma once
+
+/**
+ * @file ModuleHost.h
+ * @brief Host-owned composition-time module registration, activation, and rollback.
+ */
+
+#include "Horo/Foundation/ModuleDescriptor.h"
+#include "Horo/Foundation/Result.h"
+
+#include <memory>
+#include <vector>
+
+namespace Horo {
+    class ModuleActivationContext;
+
+    /** @brief A module instance created by an activation callback and owned by the host. */
+    class IModuleInstance {
+    public:
+        virtual ~IModuleInstance() = default;
+
+        IModuleInstance(const IModuleInstance &) = delete;
+        IModuleInstance &operator=(const IModuleInstance &) = delete;
+
+    protected:
+        IModuleInstance() = default;
+        IModuleInstance(IModuleInstance &&) = default;
+        IModuleInstance &operator=(IModuleInstance &&) = default;
+    };
+
+    /**
+     * @brief Capabilities a composition root grants to one activating module.
+     *
+     * The context is constructed by the host for exactly one activation call. It is
+     * not a service locator: the composition root decides which approved dependency
+     * bindings each module receives, and modules never discover ambient state.
+     */
+    class ModuleActivationContext {
+    public:
+        /** @brief Opaque carrier for host-approved bindings; owned by the composition root. */
+        using DependencyBindings = const void *;
+
+        ModuleActivationContext(ModuleId module, DependencyBindings bindings) noexcept;
+        ~ModuleActivationContext() = default;
+
+        ModuleActivationContext(const ModuleActivationContext &) = delete;
+        ModuleActivationContext &operator=(const ModuleActivationContext &) = delete;
+
+        [[nodiscard]] const ModuleId &Module() const noexcept;
+
+        /**
+         * @brief Stores an instance the activated module owns until deactivation.
+         * @param instance Non-null module-owned instance.
+         * @return Failure when @p instance is null; success otherwise.
+         */
+        [[nodiscard]] Result<void> AttachInstance(std::unique_ptr<IModuleInstance> instance);
+
+    private:
+        friend class ModuleHost;
+
+        ModuleId m_module;
+        DependencyBindings m_bindings;
+        std::unique_ptr<IModuleInstance> m_instance;
+    };
+
+    /** @brief One activated module: its identity, lifecycle entry points, and attached instance. */
+    struct ActiveModule {
+        ModuleId id;                                      /**< Activated module identity. */
+        ModuleDeactivateCallback deactivate{nullptr};     /**< Matching deactivation entry point. */
+        std::unique_ptr<ModuleActivationContext> context; /**< Activation context owning the attached instance. */
+    };
+
+    /**
+     * @brief Registers inert descriptors explicitly at composition time, validates them,
+     *        activates modules in deterministic order, and rolls back on failure.
+     *
+     * A failed activation deactivates every already-activated module in reverse order,
+     * leaving no partially active set. Registration never invokes callbacks; only
+     * ActivateRegistered does. Single-threaded by contract: use it from the composition
+     * root before any worker threads start.
+     */
+    class ModuleHost {
+    public:
+        ModuleHost() = default;
+        ~ModuleHost() = default;
+
+        ModuleHost(const ModuleHost &) = delete;
+        ModuleHost &operator=(const ModuleHost &) = delete;
+
+        /**
+         * @brief Registers one inert descriptor without invoking any callback.
+         * @param descriptor Descriptor copied into the host's pending registration set.
+         * @return Failure when identity or metadata is malformed locally, or already registered.
+         */
+        [[nodiscard]] Result<void> Register(const ModuleDescriptor &descriptor);
+
+        /**
+         * @brief Validates the full registration graph and activates modules in validated order.
+         * @param bindings Host-approved dependency bindings handed to every activation callback.
+         * @return Success with the activated count, or a typed validation/activation failure
+         *         with all previously activated modules deactivated in reverse order.
+         */
+        [[nodiscard]] Result<std::size_t> ActivateRegistered(ModuleActivationContext::DependencyBindings bindings);
+
+        /** @brief Deactivates every active module in reverse activation order and clears registrations. */
+        void DeactivateAll() noexcept;
+
+        /** @brief Returns whether any module is currently active. */
+        [[nodiscard]] bool HasActiveModules() const noexcept;
+
+    private:
+        std::vector<ModuleDescriptor> m_registered;
+        std::vector<ActiveModule> m_active;
+    };
+}  // namespace Horo

--- a/include/Horo/Foundation/ModuleHost.h
+++ b/include/Horo/Foundation/ModuleHost.h
@@ -49,6 +49,12 @@ namespace Horo {
         [[nodiscard]] const ModuleId &Module() const noexcept;
 
         /**
+         * @brief Returns the host-approved dependency bindings supplied for activation.
+         * @return Opaque bindings owned by the composition root; may be null.
+         */
+        [[nodiscard]] DependencyBindings Bindings() const noexcept;
+
+        /**
          * @brief Stores an instance the activated module owns until deactivation.
          * @param instance Non-null module-owned instance.
          * @return Failure when @p instance is null; success otherwise.
@@ -74,8 +80,9 @@ namespace Horo {
      * @brief Registers inert descriptors explicitly at composition time, validates them,
      *        activates modules in deterministic order, and rolls back on failure.
      *
-     * A failed activation deactivates every already-activated module in reverse order,
-     * leaving no partially active set. Registration never invokes callbacks; only
+     * A failed activation deactivates every module started by that activation call in
+     * reverse order, leaving no partially active set from the failed call and preserving
+     * modules active before it. Registration never invokes callbacks; only
      * ActivateRegistered does. Single-threaded by contract: use it from the composition
      * root before any worker threads start.
      */
@@ -97,8 +104,9 @@ namespace Horo {
         /**
          * @brief Validates the full registration graph and activates modules in validated order.
          * @param bindings Host-approved dependency bindings handed to every activation callback.
-         * @return Success with the activated count, or a typed validation/activation failure
-         *         with all previously activated modules deactivated in reverse order.
+         * @return Success with the count activated by this call, or a typed validation/
+         *         activation failure with only this call's started modules deactivated
+         *         in reverse order.
          */
         [[nodiscard]] Result<std::size_t> ActivateRegistered(ModuleActivationContext::DependencyBindings bindings);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_library(HoroFoundation STATIC
         foundation/FoundationErrors.cpp
+        foundation/modules/ModuleActivationContext.cpp
         foundation/modules/ModuleDescriptor.cpp
         foundation/modules/ModuleHost.cpp
+        foundation/modules/ModuleHostRegistration.cpp
         foundation/diagnostics/ErrorCode.cpp
         foundation/diagnostics/DiagnosticBundle.cpp
         foundation/hashing/Sha256.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(HoroFoundation STATIC
         foundation/FoundationErrors.cpp
         foundation/modules/ModuleDescriptor.cpp
+        foundation/modules/ModuleHost.cpp
         foundation/diagnostics/ErrorCode.cpp
         foundation/diagnostics/DiagnosticBundle.cpp
         foundation/hashing/Sha256.cpp

--- a/src/foundation/modules/ModuleActivationContext.cpp
+++ b/src/foundation/modules/ModuleActivationContext.cpp
@@ -1,0 +1,30 @@
+#include "Horo/Foundation/ModuleHost.h"
+#include "foundation/FoundationErrors.h"
+
+#include <utility>
+
+namespace Horo {
+    /** @copydoc ModuleActivationContext::ModuleActivationContext */
+    ModuleActivationContext::ModuleActivationContext(ModuleId identifier, const DependencyBindings bindings) noexcept
+        : m_module(std::move(identifier)), m_bindings(bindings) {}
+
+    /** @copydoc ModuleActivationContext::Module */
+    const ModuleId &ModuleActivationContext::Module() const noexcept {
+        return m_module;
+    }
+
+    /** @copydoc ModuleActivationContext::Bindings */
+    ModuleActivationContext::DependencyBindings ModuleActivationContext::Bindings() const noexcept {
+        return m_bindings;
+    }
+
+    /** @copydoc ModuleActivationContext::AttachInstance */
+    Result<void> ModuleActivationContext::AttachInstance(std::unique_ptr<IModuleInstance> instance) {
+        if (instance == nullptr) {
+            return Result<void>::Failure(
+                MakeError(ModuleDescriptorErrors::InvalidDescriptor, "Module '" + m_module.value + "' attached a null instance."));
+        }
+        m_instance = std::move(instance);
+        return Result<void>::Success();
+    }
+}  // namespace Horo

--- a/src/foundation/modules/ModuleHost.cpp
+++ b/src/foundation/modules/ModuleHost.cpp
@@ -91,7 +91,7 @@ namespace Horo {
             const auto found = std::ranges::find_if(m_registered, [&id](const ModuleDescriptor &descriptor) {
                 return descriptor.id == id;
             });
-            ordered.push_back(&*found);
+            ordered.push_back(std::to_address(found));
         }
 
         // Roll back only modules started by this call; a prior successful activation

--- a/src/foundation/modules/ModuleHost.cpp
+++ b/src/foundation/modules/ModuleHost.cpp
@@ -3,6 +3,7 @@
 #include "foundation/FoundationErrors.h"
 
 #include <algorithm>
+#include <memory>
 #include <set>
 #include <string>
 #include <utility>
@@ -14,21 +15,34 @@ namespace Horo {
             return Result<ValueT>::Failure(MakeError(descriptor, std::move(message)));
         }
 
-        /** @brief Deactivates one active module and releases its activation context. */
-        void DeactivateOne(ActiveModule &module) noexcept {
-            if (module.deactivate != nullptr && module.context != nullptr)
-                module.deactivate(*module.context);
-            module.context.reset();
+        /** @brief Deactivates one active entry and releases its activation context. */
+        void DeactivateOne(ActiveModule &active) noexcept {
+            if (active.deactivate != nullptr && active.context != nullptr)
+                active.deactivate(*active.context);
+            active.context.reset();
+        }
+
+        /** @brief Rolls back every activation started after @p base in reverse order. */
+        void RollBackTo(std::vector<ActiveModule> &activeModules, const std::size_t base) noexcept {
+            while (activeModules.size() > base) {
+                DeactivateOne(activeModules.back());
+                activeModules.pop_back();
+            }
         }
     }  // namespace
 
     /** @copydoc ModuleActivationContext::ModuleActivationContext */
-    ModuleActivationContext::ModuleActivationContext(ModuleId module, const DependencyBindings bindings) noexcept
-        : m_module(std::move(module)), m_bindings(bindings) {}
+    ModuleActivationContext::ModuleActivationContext(ModuleId identifier, const DependencyBindings bindings) noexcept
+        : m_module(std::move(identifier)), m_bindings(bindings) {}
 
     /** @copydoc ModuleActivationContext::Module */
     const ModuleId &ModuleActivationContext::Module() const noexcept {
         return m_module;
+    }
+
+    /** @copydoc ModuleActivationContext::Bindings */
+    ModuleActivationContext::DependencyBindings ModuleActivationContext::Bindings() const noexcept {
+        return m_bindings;
     }
 
     /** @copydoc ModuleActivationContext::AttachInstance */
@@ -80,34 +94,29 @@ namespace Horo {
             ordered.push_back(&*found);
         }
 
-        std::size_t activatedCount = 0;
+        // Roll back only modules started by this call; a prior successful activation
+        // may still own the front of the active list (incremental compose-then-activate).
+        const std::size_t base = m_active.size();
         for (const ModuleDescriptor *descriptor : ordered) {
             auto context = std::make_unique<ModuleActivationContext>(descriptor->id, bindings);
             if (descriptor->lifecycle.activate != nullptr) {
                 if (const Result<void> activated = descriptor->lifecycle.activate(*context); activated.HasError()) {
-                    // Roll back every already-activated module in reverse order; the failed
-                    // module never joined the active set because its callback reported failure.
-                    while (activatedCount > 0)
-                        DeactivateOne(m_active[--activatedCount]);
-                    m_active.clear();
+                    RollBackTo(m_active, base);
                     return Fail<std::size_t>(ModuleDescriptorErrors::InvalidDescriptor,
                                              "Activation of module '" + descriptor->id.value + "' failed.");
                 }
             }
             ActiveModule active{.id = descriptor->id, .deactivate = descriptor->lifecycle.deactivate, .context = std::move(context)};
             m_active.push_back(std::move(active));
-            ++activatedCount;
         }
         m_registered.clear();
-        return Result<std::size_t>::Success(activatedCount);
+        return Result<std::size_t>::Success(m_active.size() - base);
     }
 
     /** @copydoc ModuleHost::DeactivateAll */
     void ModuleHost::DeactivateAll() noexcept {
-        while (!m_active.empty()) {
-            DeactivateOne(m_active.back());
-            m_active.pop_back();
-        }
+        RollBackTo(m_active, 0);
+        m_registered.clear();
     }
 
     /** @copydoc ModuleHost::HasActiveModules */

--- a/src/foundation/modules/ModuleHost.cpp
+++ b/src/foundation/modules/ModuleHost.cpp
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <memory>
-#include <set>
 #include <string>
 #include <utility>
 
@@ -30,52 +29,6 @@ namespace Horo {
             }
         }
     }  // namespace
-
-    /** @copydoc ModuleActivationContext::ModuleActivationContext */
-    ModuleActivationContext::ModuleActivationContext(ModuleId identifier, const DependencyBindings bindings) noexcept
-        : m_module(std::move(identifier)), m_bindings(bindings) {}
-
-    /** @copydoc ModuleActivationContext::Module */
-    const ModuleId &ModuleActivationContext::Module() const noexcept {
-        return m_module;
-    }
-
-    /** @copydoc ModuleActivationContext::Bindings */
-    ModuleActivationContext::DependencyBindings ModuleActivationContext::Bindings() const noexcept {
-        return m_bindings;
-    }
-
-    /** @copydoc ModuleActivationContext::AttachInstance */
-    Result<void> ModuleActivationContext::AttachInstance(std::unique_ptr<IModuleInstance> instance) {
-        if (instance == nullptr)
-            return Fail<void>(ModuleDescriptorErrors::InvalidDescriptor, "Module '" + m_module.value + "' attached a null instance.");
-        m_instance = std::move(instance);
-        return Result<void>::Success();
-    }
-
-    /** @copydoc ModuleHost::Register */
-    Result<void> ModuleHost::Register(const ModuleDescriptor &descriptor) {
-        // Registration is inert: local metadata is checked here, but graph-wide rules
-        // (duplicates across the set, missing providers, cycles) stay in ActivateRegistered
-        // so that registration never depends on the full set's state.
-        std::set<std::string, std::less<>> dependencyIds;
-        for (const ModuleDependency &dependency : descriptor.dependencies) {
-            if (!dependencyIds.emplace(dependency.module.value).second)
-                return Fail<void>(ModuleDescriptorErrors::InvalidDescriptor,
-                                  "Module '" + descriptor.id.value + "' repeats a dependency at registration.");
-        }
-        for (const ActiveModule &active : m_active) {
-            if (active.id == descriptor.id)
-                return Fail<void>(ModuleDescriptorErrors::DuplicateModule, "Module '" + descriptor.id.value + "' is already active.");
-        }
-        if (std::ranges::find_if(m_registered, [&descriptor](const ModuleDescriptor &registered) {
-            return registered.id == descriptor.id;
-        }) != m_registered.end()) {
-            return Fail<void>(ModuleDescriptorErrors::DuplicateModule, "Module '" + descriptor.id.value + "' is already registered.");
-        }
-        m_registered.push_back(descriptor);
-        return Result<void>::Success();
-    }
 
     /** @copydoc ModuleHost::ActivateRegistered */
     Result<std::size_t> ModuleHost::ActivateRegistered(const ModuleActivationContext::DependencyBindings bindings) {

--- a/src/foundation/modules/ModuleHost.cpp
+++ b/src/foundation/modules/ModuleHost.cpp
@@ -1,0 +1,117 @@
+#include "Horo/Foundation/ModuleHost.h"
+
+#include "foundation/FoundationErrors.h"
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <utility>
+
+namespace Horo {
+    namespace {
+        /** @brief Creates a typed composition failure from a stable error descriptor. */
+        template <typename ValueT> [[nodiscard]] Result<ValueT> Fail(const ErrorCodeDescriptor &descriptor, std::string message) {
+            return Result<ValueT>::Failure(MakeError(descriptor, std::move(message)));
+        }
+
+        /** @brief Deactivates one active module and releases its activation context. */
+        void DeactivateOne(ActiveModule &module) noexcept {
+            if (module.deactivate != nullptr && module.context != nullptr)
+                module.deactivate(*module.context);
+            module.context.reset();
+        }
+    }  // namespace
+
+    /** @copydoc ModuleActivationContext::ModuleActivationContext */
+    ModuleActivationContext::ModuleActivationContext(ModuleId module, const DependencyBindings bindings) noexcept
+        : m_module(std::move(module)), m_bindings(bindings) {}
+
+    /** @copydoc ModuleActivationContext::Module */
+    const ModuleId &ModuleActivationContext::Module() const noexcept {
+        return m_module;
+    }
+
+    /** @copydoc ModuleActivationContext::AttachInstance */
+    Result<void> ModuleActivationContext::AttachInstance(std::unique_ptr<IModuleInstance> instance) {
+        if (instance == nullptr)
+            return Fail<void>(ModuleDescriptorErrors::InvalidDescriptor, "Module '" + m_module.value + "' attached a null instance.");
+        m_instance = std::move(instance);
+        return Result<void>::Success();
+    }
+
+    /** @copydoc ModuleHost::Register */
+    Result<void> ModuleHost::Register(const ModuleDescriptor &descriptor) {
+        // Registration is inert: local metadata is checked here, but graph-wide rules
+        // (duplicates across the set, missing providers, cycles) stay in ActivateRegistered
+        // so that registration never depends on the full set's state.
+        std::set<std::string, std::less<>> dependencyIds;
+        for (const ModuleDependency &dependency : descriptor.dependencies) {
+            if (!dependencyIds.emplace(dependency.module.value).second)
+                return Fail<void>(ModuleDescriptorErrors::InvalidDescriptor,
+                                  "Module '" + descriptor.id.value + "' repeats a dependency at registration.");
+        }
+        for (const ActiveModule &active : m_active) {
+            if (active.id == descriptor.id)
+                return Fail<void>(ModuleDescriptorErrors::DuplicateModule, "Module '" + descriptor.id.value + "' is already active.");
+        }
+        if (std::ranges::find_if(m_registered, [&descriptor](const ModuleDescriptor &registered) {
+            return registered.id == descriptor.id;
+        }) != m_registered.end()) {
+            return Fail<void>(ModuleDescriptorErrors::DuplicateModule, "Module '" + descriptor.id.value + "' is already registered.");
+        }
+        m_registered.push_back(descriptor);
+        return Result<void>::Success();
+    }
+
+    /** @copydoc ModuleHost::ActivateRegistered */
+    Result<std::size_t> ModuleHost::ActivateRegistered(const ModuleActivationContext::DependencyBindings bindings) {
+        // Graph validation runs before any callback: a rejected set leaves the host untouched.
+        const Result<ValidatedModuleGraph> validated = ValidateModuleGraph(m_registered);
+        if (validated.HasError())
+            return Result<std::size_t>::Failure(validated.ErrorValue());
+
+        // Index descriptors by identity so activation follows the validated ID order.
+        std::vector<const ModuleDescriptor *> ordered;
+        ordered.reserve(validated.Value().initializationOrder.size());
+        for (const ModuleId &id : validated.Value().initializationOrder) {
+            const auto found = std::ranges::find_if(m_registered, [&id](const ModuleDescriptor &descriptor) {
+                return descriptor.id == id;
+            });
+            ordered.push_back(&*found);
+        }
+
+        std::size_t activatedCount = 0;
+        for (const ModuleDescriptor *descriptor : ordered) {
+            auto context = std::make_unique<ModuleActivationContext>(descriptor->id, bindings);
+            if (descriptor->lifecycle.activate != nullptr) {
+                if (const Result<void> activated = descriptor->lifecycle.activate(*context); activated.HasError()) {
+                    // Roll back every already-activated module in reverse order; the failed
+                    // module never joined the active set because its callback reported failure.
+                    while (activatedCount > 0)
+                        DeactivateOne(m_active[--activatedCount]);
+                    m_active.clear();
+                    return Fail<std::size_t>(ModuleDescriptorErrors::InvalidDescriptor,
+                                             "Activation of module '" + descriptor->id.value + "' failed.");
+                }
+            }
+            ActiveModule active{.id = descriptor->id, .deactivate = descriptor->lifecycle.deactivate, .context = std::move(context)};
+            m_active.push_back(std::move(active));
+            ++activatedCount;
+        }
+        m_registered.clear();
+        return Result<std::size_t>::Success(activatedCount);
+    }
+
+    /** @copydoc ModuleHost::DeactivateAll */
+    void ModuleHost::DeactivateAll() noexcept {
+        while (!m_active.empty()) {
+            DeactivateOne(m_active.back());
+            m_active.pop_back();
+        }
+    }
+
+    /** @copydoc ModuleHost::HasActiveModules */
+    bool ModuleHost::HasActiveModules() const noexcept {
+        return !m_active.empty();
+    }
+}  // namespace Horo

--- a/src/foundation/modules/ModuleHostRegistration.cpp
+++ b/src/foundation/modules/ModuleHostRegistration.cpp
@@ -1,0 +1,36 @@
+#include "Horo/Foundation/ModuleHost.h"
+#include "foundation/FoundationErrors.h"
+
+#include <algorithm>
+#include <set>
+#include <string>
+
+namespace Horo {
+    /** @copydoc ModuleHost::Register */
+    Result<void> ModuleHost::Register(const ModuleDescriptor &descriptor) {
+        // Registration is inert: local metadata is checked here, but graph-wide rules
+        // (duplicates across the set, missing providers, cycles) stay in ActivateRegistered
+        // so that registration never depends on the full set's state.
+        std::set<std::string, std::less<>> dependencyIds;
+        for (const ModuleDependency &dependency : descriptor.dependencies) {
+            if (!dependencyIds.emplace(dependency.module.value).second) {
+                return Result<void>::Failure(MakeError(ModuleDescriptorErrors::InvalidDescriptor,
+                                                       "Module '" + descriptor.id.value + "' repeats a dependency at registration."));
+            }
+        }
+        for (const ActiveModule &active : m_active) {
+            if (active.id == descriptor.id) {
+                return Result<void>::Failure(
+                    MakeError(ModuleDescriptorErrors::DuplicateModule, "Module '" + descriptor.id.value + "' is already active."));
+            }
+        }
+        if (std::ranges::find_if(m_registered, [&descriptor](const ModuleDescriptor &registered) {
+            return registered.id == descriptor.id;
+        }) != m_registered.end()) {
+            return Result<void>::Failure(
+                MakeError(ModuleDescriptorErrors::DuplicateModule, "Module '" + descriptor.id.value + "' is already registered."));
+        }
+        m_registered.push_back(descriptor);
+        return Result<void>::Success();
+    }
+}  // namespace Horo

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -558,6 +558,13 @@ add_executable(HoroFoundationModuleDescriptorTests
 
 target_compile_features(HoroFoundationModuleDescriptorTests PRIVATE cxx_std_20)
 target_link_libraries(HoroFoundationModuleDescriptorTests PRIVATE HoroEngine::Foundation)
+
+add_executable(HoroFoundationModuleHostCompositionTests
+        unit/foundation/ModuleHostCompositionTests.cpp
+)
+
+target_compile_features(HoroFoundationModuleHostCompositionTests PRIVATE cxx_std_20)
+target_link_libraries(HoroFoundationModuleHostCompositionTests PRIVATE HoroEngine::Foundation)
 add_executable(HoroFoundationPathsTimeHandlesTests
         unit/foundation/PathsTimeHandlesTests.cpp
 )
@@ -969,6 +976,7 @@ set(HORO_CATCH_TEST_TARGETS
         HoroDataBusTests
         HoroFoundationResultTests
         HoroFoundationModuleDescriptorTests
+        HoroFoundationModuleHostCompositionTests
         HoroFoundationPathsTimeHandlesTests
         HoroFoundationCancellationProgressTests
         HoroFoundationConfigurationTests

--- a/tests/unit/foundation/ModuleDescriptorGraphTests.cpp
+++ b/tests/unit/foundation/ModuleDescriptorGraphTests.cpp
@@ -1,4 +1,5 @@
 #include "Horo/Foundation/ModuleDescriptor.h"
+#include "ModuleDescriptorTestUtils.h"
 
 #include <array>
 #include <catch2/catch_test_macros.hpp>
@@ -7,13 +8,7 @@
 
 namespace {
     using namespace Horo;
-
-    [[nodiscard]] ModuleDescriptor MakeModule(std::string id, const ModuleContractVersion version = {1, 0, 0}) {
-        ModuleDescriptor descriptor;
-        descriptor.id = ModuleId{std::move(id)};
-        descriptor.version = version;
-        return descriptor;
-    }
+    using Horo::Test::MakeModule;
 
     [[nodiscard]] std::vector<std::string> OrderOf(const ValidatedModuleGraph &graph) {
         std::vector<std::string> order;

--- a/tests/unit/foundation/ModuleDescriptorTestUtils.h
+++ b/tests/unit/foundation/ModuleDescriptorTestUtils.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Horo/Foundation/ModuleDescriptor.h"
+
+#include <string>
+#include <utility>
+
+namespace Horo::Test {
+    [[nodiscard]] inline ModuleDescriptor MakeModule(std::string id, const ModuleContractVersion version = {1, 0, 0}) {
+        ModuleDescriptor descriptor;
+        descriptor.id = ModuleId{std::move(id)};
+        descriptor.version = version;
+        return descriptor;
+    }
+}  // namespace Horo::Test

--- a/tests/unit/foundation/ModuleDescriptorTests.cpp
+++ b/tests/unit/foundation/ModuleDescriptorTests.cpp
@@ -1,4 +1,5 @@
 #include "Horo/Foundation/ModuleDescriptor.h"
+#include "ModuleDescriptorTestUtils.h"
 
 #include <array>
 #include <catch2/catch_test_macros.hpp>
@@ -6,6 +7,7 @@
 
 namespace {
     using namespace Horo;
+    using Horo::Test::MakeModule;
 
     int g_activateCalls = 0;
     int g_deactivateCalls = 0;
@@ -17,13 +19,6 @@ namespace {
 
     void Deactivate(ModuleActivationContext &) noexcept {
         ++g_deactivateCalls;
-    }
-
-    [[nodiscard]] ModuleDescriptor MakeModule(std::string id, const ModuleContractVersion version = {1, 0, 0}) {
-        ModuleDescriptor descriptor;
-        descriptor.id = ModuleId{std::move(id)};
-        descriptor.version = version;
-        return descriptor;
     }
 
     TEST_CASE("Empty module descriptor set validates successfully", "[unit][foundation][modules]") {

--- a/tests/unit/foundation/ModuleHostCompositionTests.cpp
+++ b/tests/unit/foundation/ModuleHostCompositionTests.cpp
@@ -1,0 +1,187 @@
+#include "Horo/Foundation/ModuleHost.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+    using namespace Horo;
+
+    // Module lifecycle callbacks are plain function addresses copied into
+    // descriptors, so every piece of state they touch is file-local and outlives
+    // all hosts in this translation unit. Each test resets the log first.
+    struct ActivationLog {
+        std::vector<std::string> activated;
+        std::vector<std::string> deactivated;
+    };
+
+    ActivationLog g_log;
+    int g_instancesAlive = 0;
+    std::string g_failModule;
+    // Modules observed entering the active set; the rollback order source of truth.
+    std::vector<std::string> g_activationCompletions;
+
+    void ResetLog() {
+        g_log.activated.clear();
+        g_log.deactivated.clear();
+        g_instancesAlive = 0;
+        g_failModule.clear();
+        g_activationCompletions.clear();
+    }
+
+    /** @brief Instance type proving attached module state is released with its context. */
+    struct CountingInstance final : IModuleInstance {
+        CountingInstance() {
+            ++g_instancesAlive;
+        }
+
+        ~CountingInstance() override {
+            --g_instancesAlive;
+        }
+    };
+
+    Result<void> LogActivate(ModuleActivationContext &context) noexcept {
+        g_log.activated.push_back(context.Module().value);
+        if (g_failModule == context.Module().value)
+            return Result<void>::Failure(Error{});
+        (void)context.AttachInstance(std::make_unique<CountingInstance>());
+        g_activationCompletions.push_back(context.Module().value);
+        return Result<void>::Success();
+    }
+
+    void LogDeactivate(ModuleActivationContext &context) noexcept {
+        g_log.deactivated.push_back(context.Module().value);
+    }
+
+    [[nodiscard]] ModuleDescriptor MakeLoggedModule(std::string id, const ModuleContractVersion version = {1, 0, 0}) {
+        ModuleDescriptor descriptor;
+        descriptor.id = ModuleId{std::move(id)};
+        descriptor.version = version;
+        descriptor.lifecycle = ModuleLifecycleCallbacks{.activate = &LogActivate, .deactivate = &LogDeactivate};
+        return descriptor;
+    }
+
+    [[nodiscard]] ModuleDescriptor MakeModule(std::string id, const ModuleContractVersion version = {1, 0, 0}) {
+        ModuleDescriptor descriptor;
+        descriptor.id = ModuleId{std::move(id)};
+        descriptor.version = version;
+        return descriptor;
+    }
+}  // namespace
+
+TEST_CASE("Composition registers and activates modules in validated order", "[unit][foundation][modules][composition]") {
+    ResetLog();
+    ModuleHost host;
+
+    ModuleDescriptor editor = MakeLoggedModule("horo.editor");
+    editor.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.foundation"}});
+
+    REQUIRE(host.Register(editor).HasValue());
+    REQUIRE(host.Register(MakeLoggedModule("horo.foundation")).HasValue());
+
+    // Registration is inert: no callback runs before ActivateRegistered.
+    REQUIRE(g_log.activated.empty());
+
+    const Result<std::size_t> activated = host.ActivateRegistered(nullptr);
+    REQUIRE(activated.HasValue());
+    REQUIRE(activated.Value() == 2);
+    REQUIRE(host.HasActiveModules());
+    REQUIRE(g_log.activated == std::vector<std::string>{"horo.foundation", "horo.editor"});
+}
+
+TEST_CASE("Failed composition rolls back active modules in reverse order", "[unit][foundation][modules][composition]") {
+    ResetLog();
+    g_failModule = "horo.failing";
+
+    ModuleHost host;
+    ModuleDescriptor failing = MakeLoggedModule("horo.failing");
+    failing.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.second"}});
+    ModuleDescriptor second = MakeLoggedModule("horo.second");
+    second.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.first"}});
+
+    REQUIRE(host.Register(MakeLoggedModule("horo.first")).HasValue());
+    REQUIRE(host.Register(second).HasValue());
+    REQUIRE(host.Register(failing).HasValue());
+
+    const Result<std::size_t> activated = host.ActivateRegistered(nullptr);
+    REQUIRE(activated.HasError());
+    // The failed module never joined the active set; earlier modules were
+    // deactivated in reverse activation order, leaving nothing partially active.
+    REQUIRE(g_log.activated == std::vector<std::string>{"horo.first", "horo.second", "horo.failing"});
+    REQUIRE(g_log.deactivated == std::vector<std::string>{"horo.second", "horo.first"});
+    REQUIRE_FALSE(host.HasActiveModules());
+}
+
+TEST_CASE("Rejected composition leaves registrations untouched for retry", "[unit][foundation][modules][composition]") {
+    ResetLog();
+    ModuleHost host;
+    ModuleDescriptor missingDependency = MakeModule("horo.consumer");
+    missingDependency.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.absent"}});
+    REQUIRE(host.Register(missingDependency).HasValue());
+
+    // Graph validation fails before any callback: no module was activated.
+    REQUIRE(host.ActivateRegistered(nullptr).HasError());
+    REQUIRE(g_log.activated.empty());
+    REQUIRE_FALSE(host.HasActiveModules());
+
+    ModuleDescriptor provider = MakeModule("horo.absent");
+    REQUIRE(host.Register(provider).HasValue());
+    const Result<std::size_t> retried = host.ActivateRegistered(nullptr);
+    REQUIRE(retried.HasValue());
+    REQUIRE(retried.Value() == 2);
+}
+
+TEST_CASE("Headless composition never activates GUI-only modules", "[unit][foundation][modules][composition]") {
+    ResetLog();
+    ModuleHost host;
+
+    // A GUI adapter requires a window surface capability no headless module provides.
+    ModuleDescriptor renderNull = MakeModule("horo.render.null");
+    renderNull.providedCapabilities.push_back(ModuleCapabilityId{"horo.render.device"});
+    ModuleDescriptor gui = MakeModule("horo.gui");
+    gui.requiredCapabilities.push_back(ModuleCapabilityId{"horo.window.surface"});
+    gui.lifecycle = ModuleLifecycleCallbacks{.activate = &LogActivate, .deactivate = &LogDeactivate};
+
+    REQUIRE(host.Register(renderNull).HasValue());
+    REQUIRE(host.Register(gui).HasValue());
+    REQUIRE(host.ActivateRegistered(nullptr).HasError());
+    REQUIRE(g_log.activated.empty());
+
+    // The headless composition root simply never registers the GUI descriptor.
+    ModuleHost headless;
+    REQUIRE(headless.Register(renderNull).HasValue());
+    const Result<std::size_t> activated = headless.ActivateRegistered(nullptr);
+    REQUIRE(activated.HasValue());
+    REQUIRE(activated.Value() == 1);
+}
+
+TEST_CASE("Registration rejects duplicates and repeated dependencies", "[unit][foundation][modules][composition]") {
+    ResetLog();
+    ModuleHost host;
+    REQUIRE(host.Register(MakeModule("horo.a")).HasValue());
+    REQUIRE(host.Register(MakeModule("horo.a")).HasError());
+
+    ModuleDescriptor repeated = MakeModule("horo.b");
+    repeated.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.a"}});
+    repeated.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.a"}});
+    REQUIRE(host.Register(repeated).HasError());
+}
+
+TEST_CASE("Deactivation releases attached instances exactly once", "[unit][foundation][modules][composition]") {
+    ResetLog();
+    ModuleHost host;
+    REQUIRE(host.Register(MakeLoggedModule("horo.owner")).HasValue());
+    REQUIRE(host.ActivateRegistered(nullptr).HasValue());
+    REQUIRE(g_instancesAlive > 0);
+
+    host.DeactivateAll();
+    REQUIRE(g_log.deactivated == std::vector<std::string>{"horo.owner"});
+    REQUIRE(g_instancesAlive == 0);
+    REQUIRE_FALSE(host.HasActiveModules());
+
+    // Idempotent teardown.
+    host.DeactivateAll();
+    REQUIRE(g_instancesAlive == 0);
+}

--- a/tests/unit/foundation/ModuleHostCompositionTests.cpp
+++ b/tests/unit/foundation/ModuleHostCompositionTests.cpp
@@ -1,4 +1,5 @@
 #include "Horo/Foundation/ModuleHost.h"
+#include "ModuleDescriptorTestUtils.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <memory>
@@ -8,6 +9,7 @@
 
 namespace {
     using namespace Horo;
+    using Horo::Test::MakeModule;
 
     // Module lifecycle callbacks are plain function addresses copied into
     // descriptors, so every piece of state they touch is file-local and outlives
@@ -59,17 +61,8 @@ namespace {
     }
 
     [[nodiscard]] ModuleDescriptor MakeLoggedModule(std::string id, const ModuleContractVersion version = {1, 0, 0}) {
-        ModuleDescriptor descriptor;
-        descriptor.id = ModuleId{std::move(id)};
-        descriptor.version = version;
+        ModuleDescriptor descriptor = MakeModule(std::move(id), version);
         descriptor.lifecycle = ModuleLifecycleCallbacks{.activate = &LogActivate, .deactivate = &LogDeactivate};
-        return descriptor;
-    }
-
-    [[nodiscard]] ModuleDescriptor MakeModule(std::string id, const ModuleContractVersion version = {1, 0, 0}) {
-        ModuleDescriptor descriptor;
-        descriptor.id = ModuleId{std::move(id)};
-        descriptor.version = version;
         return descriptor;
     }
 }  // namespace

--- a/tests/unit/foundation/ModuleHostCompositionTests.cpp
+++ b/tests/unit/foundation/ModuleHostCompositionTests.cpp
@@ -15,6 +15,7 @@ namespace {
     struct ActivationLog {
         std::vector<std::string> activated;
         std::vector<std::string> deactivated;
+        std::vector<ModuleActivationContext::DependencyBindings> bindings;
     };
 
     ActivationLog g_log;
@@ -26,6 +27,7 @@ namespace {
     void ResetLog() {
         g_log.activated.clear();
         g_log.deactivated.clear();
+        g_log.bindings.clear();
         g_instancesAlive = 0;
         g_failModule.clear();
         g_activationCompletions.clear();
@@ -44,6 +46,7 @@ namespace {
 
     Result<void> LogActivate(ModuleActivationContext &context) noexcept {
         g_log.activated.push_back(context.Module().value);
+        g_log.bindings.push_back(context.Bindings());
         if (g_failModule == context.Module().value)
             return Result<void>::Failure(Error{});
         (void)context.AttachInstance(std::make_unique<CountingInstance>());
@@ -84,11 +87,13 @@ TEST_CASE("Composition registers and activates modules in validated order", "[un
     // Registration is inert: no callback runs before ActivateRegistered.
     REQUIRE(g_log.activated.empty());
 
-    const Result<std::size_t> activated = host.ActivateRegistered(nullptr);
+    const int approvedBindings = 42;
+    const Result<std::size_t> activated = host.ActivateRegistered(&approvedBindings);
     REQUIRE(activated.HasValue());
     REQUIRE(activated.Value() == 2);
     REQUIRE(host.HasActiveModules());
     REQUIRE(g_log.activated == std::vector<std::string>{"horo.foundation", "horo.editor"});
+    REQUIRE(g_log.bindings == std::vector<ModuleActivationContext::DependencyBindings>{&approvedBindings, &approvedBindings});
 }
 
 TEST_CASE("Failed composition rolls back active modules in reverse order", "[unit][foundation][modules][composition]") {
@@ -169,6 +174,54 @@ TEST_CASE("Registration rejects duplicates and repeated dependencies", "[unit][f
     REQUIRE(host.Register(repeated).HasError());
 }
 
+TEST_CASE("Incremental activation rolls back only modules started by the failed call", "[unit][foundation][modules][composition]") {
+    ResetLog();
+    g_failModule = "horo.late_failure";
+
+    ModuleHost host;
+    REQUIRE(host.Register(MakeLoggedModule("horo.early")).HasValue());
+    const Result<std::size_t> first = host.ActivateRegistered(nullptr);
+    REQUIRE(first.HasValue());
+    REQUIRE(first.Value() == 1);
+
+    // Compose-then-activate again: Register explicitly permits IDs that are
+    // not already active, so this flow is supported.
+    ModuleDescriptor lateFailure = MakeLoggedModule("horo.late_failure");
+    lateFailure.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.late_started"}});
+    ModuleDescriptor lateStarted = MakeLoggedModule("horo.late_started");
+    REQUIRE(host.Register(lateStarted).HasValue());
+    REQUIRE(host.Register(lateFailure).HasValue());
+
+    g_log.deactivated.clear();
+    g_log.activated.clear();
+    const Result<std::size_t> second = host.ActivateRegistered(nullptr);
+    REQUIRE(second.HasError());
+
+    // The module started in this pass is rolled back, while the earlier successful
+    // activation survives untouched and stays active.
+    REQUIRE(g_log.deactivated == std::vector<std::string>{"horo.late_started"});
+    REQUIRE(g_log.activated == std::vector<std::string>{"horo.late_started", "horo.late_failure"});
+    REQUIRE(g_activationCompletions == std::vector<std::string>{"horo.early", "horo.late_started"});
+    REQUIRE(host.HasActiveModules());
+    REQUIRE(g_instancesAlive == 1);
+
+    // Registrations survive an activation failure, so correcting the callback's
+    // failure condition allows the same pending set to be retried.
+    g_failModule.clear();
+    g_log.deactivated.clear();
+    g_log.activated.clear();
+    const Result<std::size_t> retried = host.ActivateRegistered(nullptr);
+    REQUIRE(retried.HasValue());
+    REQUIRE(retried.Value() == 2);
+    REQUIRE(g_log.activated == std::vector<std::string>{"horo.late_started", "horo.late_failure"});
+    REQUIRE(g_instancesAlive == 3);
+
+    host.DeactivateAll();
+    REQUIRE(g_log.deactivated == std::vector<std::string>{"horo.late_failure", "horo.late_started", "horo.early"});
+    REQUIRE_FALSE(host.HasActiveModules());
+    REQUIRE(g_instancesAlive == 0);
+}
+
 TEST_CASE("Deactivation releases attached instances exactly once", "[unit][foundation][modules][composition]") {
     ResetLog();
     ModuleHost host;
@@ -184,4 +237,9 @@ TEST_CASE("Deactivation releases attached instances exactly once", "[unit][found
     // Idempotent teardown.
     host.DeactivateAll();
     REQUIRE(g_instancesAlive == 0);
+
+    // Pending registrations are part of host teardown as documented.
+    REQUIRE(host.Register(MakeModule("horo.pending")).HasValue());
+    host.DeactivateAll();
+    REQUIRE(host.Register(MakeModule("horo.pending")).HasValue());
 }


### PR DESCRIPTION
## Summary

Implements #67: register internal modules explicitly at application composition roots instead of through static side effects, consuming the `ModuleDescriptor` contract merged in #2325.

## Changes

- **New public contract** `include/Horo/Foundation/ModuleHost.h`:
  - `ModuleHost::Register(descriptor)` — inert, explicit registration at the composition root; local metadata checks only, never a callback.
  - `ModuleHost::ActivateRegistered(bindings)` — validates the complete graph first (no callback runs if rejected), then activates modules in the validated provider-before-dependant order, injecting host-approved dependency bindings via `ModuleActivationContext`. No runtime discovery.
  - Rollback: an activation failure deactivates every already-started module in reverse activation order — no partially active set survives.
  - `IModuleInstance` attachments are owned by the activation context and released with it; `DeactivateAll()` is idempotent reverse-order teardown.
- **Implementation**: `src/foundation/modules/ModuleHost.cpp` (target-private).
- **Docs**: new "Composition-Time Registration" section in `docs/architecture/foundation/internal-module-descriptor.md`.
- Header ownership registry updated for the new public header.

## Acceptance criteria

- [x] Deterministic module order from the same inputs — reuse of `ValidateModuleGraph`'s stable provider-first ordering; covered by test.
- [x] Failed composition leaves no partially active modules — reverse-order rollback covered by test; rejected graphs leave registrations intact for retry (also covered).
- [x] Headless composition does not construct or link GUI-only modules — headless roots simply never register GUI descriptors; missing-capability rejection + clean headless activation covered by test.

## Test plan

- New `HoroFoundationModuleHostCompositionTests`: ordering, rollback on failure, retry after graph rejection, headless exclusion, duplicate registration rejection, instance release/idempotent teardown.
- Full skeleton suite: `cmake --build build/skeleton` + `ctest` — 616/616 passed.

Closes #67