### PR TITLE
feat(foundation): explicit module host lifecycle and activation context [ARC-001.6]

### DIFF
--- a/docs/architecture/foundation/internal-module-descriptor.md
+++ b/docs/architecture/foundation/internal-module-descriptor.md
@@ -77,9 +77,10 @@ activation stage that consumes this descriptor contract. A composition root:
    there is no runtime discovery.
 3. On activation failure, the host deactivates every module started by that
    activation call in reverse order, so a failed composition leaves no partially
-   active set from that call while preserving modules active before it. A rejected
-   graph leaves registrations intact so composition can be retried after correcting
-   the descriptor set.
+   active set from that call while preserving modules active before it. Modules
+   reached by the failed attempt enter one terminal state. A graph rejected before
+   activation leaves registrations intact so composition can be retried after
+   correcting the descriptor set.
 
 Headless compositions stay headless by construction: they simply do not
 register GUI-only descriptors, so GUI modules are neither activated nor linked
@@ -87,8 +88,37 @@ into the composition path. `DeactivateAll` provides idempotent reverse-order
 teardown; attached module instances are released with their activation
 contexts.
 
-Lifecycle states beyond this stage (callback drainage, runtime shutdown
-ordering) remain owned by ARC-001.6.
+## Module Lifecycle And Shutdown
+
+`ModuleHost` owns the explicit per-registration state machine:
+
+```text
+Registered -> Activating -> Active -> CancellationRequested -> Draining -> Stopped
+                      \-> Failed
+Registered -----------------------------------------------> Stopped
+```
+
+`Stopped` and `Failed` are terminal for an identity registered with one host.
+Graph validation rejection does not advance `Registered`; an activation callback
+failure marks the failing module `Failed`, stops modules already started by that
+attempt, stops unattempted registrations in the rejected attempt, and preserves
+modules that were active before the call.
+
+Each `ModuleActivationContext` owns a cooperative cancellation source and a
+callback-admission gate. Asynchronous module callbacks acquire a move-only
+`ModuleCallbackLease` before retaining activation-scoped bindings. Shutdown:
+
+1. requests cancellation and closes callback admission for every active module;
+2. visits modules in reverse validated activation order;
+3. waits for every admitted callback lease to be released;
+4. invokes the optional module drain callback;
+5. invokes deactivation and releases the activation context and attached instance.
+
+This order keeps providers alive while dependants drain, prevents new callbacks
+from entering after shutdown begins, and ensures activation-scoped binding borrows
+end before their context is released. Repeated shutdown is a no-op after the first
+terminal transition. The host destructor is a final safety net that runs the same
+idempotent shutdown path.
 
 ## Ownership And Migration
 

--- a/include/Horo/Foundation/ModuleDescriptor.h
+++ b/include/Horo/Foundation/ModuleDescriptor.h
@@ -96,13 +96,17 @@ namespace Horo {
     /** @brief Typed activation callback invoked later by an application composition root. */
     using ModuleActivateCallback = Result<void> (*)(ModuleActivationContext &context) noexcept;
 
+    /** @brief Typed drainage callback invoked after cancellation and callback admission closure. */
+    using ModuleDrainCallback = void (*)(ModuleActivationContext &context) noexcept;
+
     /** @brief Typed deactivation callback invoked later by an application composition root. */
     using ModuleDeactivateCallback = void (*)(ModuleActivationContext &context) noexcept;
 
     /** @brief Optional lifecycle entry points named by an inert module descriptor. */
     struct ModuleLifecycleCallbacks {
         ModuleActivateCallback activate{};     /**< Activation entry point; never called during validation. */
-        ModuleDeactivateCallback deactivate{}; /**< Matching deactivation entry point. */
+        ModuleDrainCallback drain{};           /**< Optional owned-work drain after cancellation is requested. */
+        ModuleDeactivateCallback deactivate{}; /**< Matching final resource-release entry point. */
     };
 
     /** @brief Complete inert metadata used to validate one built-in module before composition. */

--- a/include/Horo/Foundation/ModuleHost.h
+++ b/include/Horo/Foundation/ModuleHost.h
@@ -230,6 +230,7 @@ namespace Horo {
         void Transition(const ModuleId &id, ModuleLifecycleState state) noexcept;
         void RequestCancellationFrom(std::size_t base) noexcept;
         void DeactivateFrom(std::size_t base) noexcept;
+        void DeactivateActiveModule(ActiveModule &active) noexcept;
         void StopUnactivatedRegistered() noexcept;
         void RollbackActivation(const ModuleId &failedId, std::unique_ptr<ModuleActivationContext> failedContext,
                                 std::size_t base) noexcept;

--- a/include/Horo/Foundation/ModuleHost.h
+++ b/include/Horo/Foundation/ModuleHost.h
@@ -216,7 +216,7 @@ namespace Horo {
         void RequestCancellationFrom(std::size_t base) noexcept;
         void DeactivateFrom(std::size_t base) noexcept;
         void StopUnactivatedRegistered() noexcept;
-        void RollbackActivation(const ModuleDescriptor &failedDescriptor, std::unique_ptr<ModuleActivationContext> failedContext,
+        void RollbackActivation(const ModuleId &failedId, std::unique_ptr<ModuleActivationContext> failedContext,
                                 std::size_t base) noexcept;
 
         std::vector<ModuleDescriptor> m_registered;

--- a/include/Horo/Foundation/ModuleHost.h
+++ b/include/Horo/Foundation/ModuleHost.h
@@ -18,6 +18,20 @@ namespace Horo {
     class ModuleActivationContext;
     class ModuleCallbackGate;
 
+    /** @brief Host-approved dependency bindings owned by the composition root. */
+    class IDependencyBindings {
+    public:
+        virtual ~IDependencyBindings() = default;
+
+        IDependencyBindings(const IDependencyBindings &) = delete;
+        IDependencyBindings &operator=(const IDependencyBindings &) = delete;
+
+    protected:
+        IDependencyBindings() = default;
+        IDependencyBindings(IDependencyBindings &&) = default;
+        IDependencyBindings &operator=(IDependencyBindings &&) = default;
+    };
+
     /** @brief Explicit observable state of one module registration lifetime. */
     enum class ModuleLifecycleState : std::uint8_t {
         Registered,
@@ -46,7 +60,7 @@ namespace Horo {
         ModuleCallbackLease &operator=(ModuleCallbackLease &&other) noexcept;
 
         /** @brief Returns the activation-scoped bindings borrow guarded by this lease. */
-        [[nodiscard]] const void *Bindings() const noexcept;
+        [[nodiscard]] const IDependencyBindings *Bindings() const noexcept;
 
         /** @brief Returns the module-owned cancellation token associated with this lease. */
         [[nodiscard]] CancellationToken Cancellation() const noexcept;
@@ -54,11 +68,12 @@ namespace Horo {
     private:
         friend class ModuleActivationContext;
 
-        ModuleCallbackLease(std::shared_ptr<ModuleCallbackGate> gate, const void *bindings, CancellationToken cancellation) noexcept;
+        ModuleCallbackLease(std::shared_ptr<ModuleCallbackGate> gate, const IDependencyBindings *bindings,
+                            CancellationToken cancellation) noexcept;
         void Release() noexcept;
 
         std::shared_ptr<ModuleCallbackGate> m_gate;
-        const void *m_bindings{};
+        const IDependencyBindings *m_bindings{};
         CancellationToken m_cancellation;
     };
 
@@ -86,7 +101,7 @@ namespace Horo {
     class ModuleActivationContext {
     public:
         /** @brief Opaque carrier for host-approved bindings; owned by the composition root. */
-        using DependencyBindings = const void *;
+        using DependencyBindings = const IDependencyBindings *;
 
         ModuleActivationContext(ModuleId module, DependencyBindings bindings);
         ~ModuleActivationContext();
@@ -127,7 +142,7 @@ namespace Horo {
     private:
         friend class ModuleHost;
 
-        void RequestShutdown() noexcept;
+        void RequestShutdown() const noexcept;
 
         /**
          * @brief Blocks until all admitted callback leases are released or a timeout is reached.
@@ -137,7 +152,7 @@ namespace Horo {
          * drainage logs a warning after a bounded timeout and shutdown proceeds to prevent
          * indefinite teardown blockage.
          */
-        void DrainCallbacks() noexcept;
+        void DrainCallbacks() const noexcept;
 
         ModuleId m_module;
         DependencyBindings m_bindings;

--- a/include/Horo/Foundation/ModuleHost.h
+++ b/include/Horo/Foundation/ModuleHost.h
@@ -130,10 +130,12 @@ namespace Horo {
         void RequestShutdown() noexcept;
 
         /**
-         * @brief Blocks until all admitted callback leases are released.
+         * @brief Blocks until all admitted callback leases are released or a timeout is reached.
          *
          * Module callbacks are expected to cooperate by checking CancellationToken and
-         * releasing leases promptly upon observing cancellation.
+         * releasing leases promptly upon observing cancellation. If a callback hangs,
+         * drainage logs a warning after a bounded timeout and shutdown proceeds to prevent
+         * indefinite teardown blockage.
          */
         void DrainCallbacks() noexcept;
 

--- a/include/Horo/Foundation/ModuleHost.h
+++ b/include/Horo/Foundation/ModuleHost.h
@@ -214,8 +214,7 @@ namespace Horo {
         void RequestCancellationFrom(std::size_t base) noexcept;
         void DeactivateFrom(std::size_t base) noexcept;
         void StopUnactivatedRegistered() noexcept;
-        void RollbackActivation(const ModuleDescriptor &failedDescriptor,
-                                std::unique_ptr<ModuleActivationContext> failedContext,
+        void RollbackActivation(const ModuleDescriptor &failedDescriptor, std::unique_ptr<ModuleActivationContext> failedContext,
                                 std::size_t base) noexcept;
 
         std::vector<ModuleDescriptor> m_registered;

--- a/include/Horo/Foundation/ModuleHost.h
+++ b/include/Horo/Foundation/ModuleHost.h
@@ -128,6 +128,13 @@ namespace Horo {
         friend class ModuleHost;
 
         void RequestShutdown() noexcept;
+
+        /**
+         * @brief Blocks until all admitted callback leases are released.
+         *
+         * Module callbacks are expected to cooperate by checking CancellationToken and
+         * releasing leases promptly upon observing cancellation.
+         */
         void DrainCallbacks() noexcept;
 
         ModuleId m_module;
@@ -206,6 +213,10 @@ namespace Horo {
         void Transition(const ModuleId &id, ModuleLifecycleState state) noexcept;
         void RequestCancellationFrom(std::size_t base) noexcept;
         void DeactivateFrom(std::size_t base) noexcept;
+        void StopUnactivatedRegistered() noexcept;
+        void RollbackActivation(const ModuleDescriptor &failedDescriptor,
+                                std::unique_ptr<ModuleActivationContext> failedContext,
+                                std::size_t base) noexcept;
 
         std::vector<ModuleDescriptor> m_registered;
         std::vector<ActiveModule> m_active;

--- a/include/Horo/Foundation/ModuleHost.h
+++ b/include/Horo/Foundation/ModuleHost.h
@@ -2,17 +2,65 @@
 
 /**
  * @file ModuleHost.h
- * @brief Host-owned composition-time module registration, activation, and rollback.
+ * @brief Host-owned module registration, activation, cancellation, drainage, and shutdown.
  */
 
+#include "Horo/Foundation/CancellationToken.h"
 #include "Horo/Foundation/ModuleDescriptor.h"
 #include "Horo/Foundation/Result.h"
 
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace Horo {
     class ModuleActivationContext;
+    class ModuleCallbackGate;
+
+    /** @brief Explicit observable state of one module registration lifetime. */
+    enum class ModuleLifecycleState : std::uint8_t {
+        Registered,
+        Activating,
+        Active,
+        CancellationRequested,
+        Draining,
+        Stopped,
+        Failed,
+    };
+
+    /**
+     * @brief Move-only admission lease keeping one asynchronous module callback drainable.
+     *
+     * A lease may outlive the activation callback, but must be released after observing
+     * cancellation. Module shutdown closes admission, requests cancellation, and waits
+     * for every outstanding lease before invoking the module drain callback.
+     */
+    class ModuleCallbackLease {
+    public:
+        ~ModuleCallbackLease();
+
+        ModuleCallbackLease(const ModuleCallbackLease &) = delete;
+        ModuleCallbackLease &operator=(const ModuleCallbackLease &) = delete;
+        ModuleCallbackLease(ModuleCallbackLease &&other) noexcept;
+        ModuleCallbackLease &operator=(ModuleCallbackLease &&other) noexcept;
+
+        /** @brief Returns the activation-scoped bindings borrow guarded by this lease. */
+        [[nodiscard]] const void *Bindings() const noexcept;
+
+        /** @brief Returns the module-owned cancellation token associated with this lease. */
+        [[nodiscard]] CancellationToken Cancellation() const noexcept;
+
+    private:
+        friend class ModuleActivationContext;
+
+        ModuleCallbackLease(std::shared_ptr<ModuleCallbackGate> gate, const void *bindings, CancellationToken cancellation) noexcept;
+        void Release() noexcept;
+
+        std::shared_ptr<ModuleCallbackGate> m_gate;
+        const void *m_bindings{};
+        CancellationToken m_cancellation;
+    };
 
     /** @brief A module instance created by an activation callback and owned by the host. */
     class IModuleInstance {
@@ -40,8 +88,8 @@ namespace Horo {
         /** @brief Opaque carrier for host-approved bindings; owned by the composition root. */
         using DependencyBindings = const void *;
 
-        ModuleActivationContext(ModuleId module, DependencyBindings bindings) noexcept;
-        ~ModuleActivationContext() = default;
+        ModuleActivationContext(ModuleId module, DependencyBindings bindings);
+        ~ModuleActivationContext();
 
         ModuleActivationContext(const ModuleActivationContext &) = delete;
         ModuleActivationContext &operator=(const ModuleActivationContext &) = delete;
@@ -55,6 +103,21 @@ namespace Horo {
         [[nodiscard]] DependencyBindings Bindings() const noexcept;
 
         /**
+         * @brief Returns the module-owned cooperative cancellation token.
+         * @return Token that becomes cancelled before callback drainage begins.
+         */
+        [[nodiscard]] CancellationToken Cancellation() const noexcept;
+
+        /**
+         * @brief Attempts to admit one asynchronous callback into this module lifetime.
+         * @return A move-only lease, or std::nullopt after shutdown closes admission.
+         *
+         * Callbacks retain the returned lease for their full use of activation-scoped
+         * bindings. Shutdown waits for all admitted leases before releasing dependencies.
+         */
+        [[nodiscard]] std::optional<ModuleCallbackLease> AcquireCallbackLease() const;
+
+        /**
          * @brief Stores an instance the activated module owns until deactivation.
          * @param instance Non-null module-owned instance.
          * @return Failure when @p instance is null; success otherwise.
@@ -64,14 +127,20 @@ namespace Horo {
     private:
         friend class ModuleHost;
 
+        void RequestShutdown() noexcept;
+        void DrainCallbacks() noexcept;
+
         ModuleId m_module;
         DependencyBindings m_bindings;
         std::unique_ptr<IModuleInstance> m_instance;
+        CancellationSource m_cancellation;
+        std::shared_ptr<ModuleCallbackGate> m_callbackGate;
     };
 
     /** @brief One activated module: its identity, lifecycle entry points, and attached instance. */
     struct ActiveModule {
         ModuleId id;                                      /**< Activated module identity. */
+        ModuleDrainCallback drain{nullptr};               /**< Owned-work drainage entry point. */
         ModuleDeactivateCallback deactivate{nullptr};     /**< Matching deactivation entry point. */
         std::unique_ptr<ModuleActivationContext> context; /**< Activation context owning the attached instance. */
     };
@@ -83,13 +152,15 @@ namespace Horo {
      * A failed activation deactivates every module started by that activation call in
      * reverse order, leaving no partially active set from the failed call and preserving
      * modules active before it. Registration never invokes callbacks; only
-     * ActivateRegistered does. Single-threaded by contract: use it from the composition
-     * root before any worker threads start.
+     * ActivateRegistered does. Host control methods are single-threaded by contract;
+     * admitted asynchronous callbacks coordinate shutdown through callback leases.
      */
     class ModuleHost {
     public:
         ModuleHost() = default;
-        ~ModuleHost() = default;
+
+        /** @brief Runs idempotent cancellation, drainage, and reverse-order teardown as a final safety net. */
+        ~ModuleHost();
 
         ModuleHost(const ModuleHost &) = delete;
         ModuleHost &operator=(const ModuleHost &) = delete;
@@ -110,14 +181,34 @@ namespace Horo {
          */
         [[nodiscard]] Result<std::size_t> ActivateRegistered(ModuleActivationContext::DependencyBindings bindings);
 
-        /** @brief Deactivates every active module in reverse activation order and clears registrations. */
+        /**
+         * @brief Cancels all active modules, drains callbacks, deactivates in reverse order,
+         *        and terminally stops pending registrations; safe repeatedly.
+         */
         void DeactivateAll() noexcept;
 
         /** @brief Returns whether any module is currently active. */
         [[nodiscard]] bool HasActiveModules() const noexcept;
 
+        /**
+         * @brief Returns the latest lifecycle state for one identity in this host.
+         * @param id Module identity previously registered with this host.
+         * @return Current or terminal state, or std::nullopt for an unknown identity.
+         */
+        [[nodiscard]] std::optional<ModuleLifecycleState> StateOf(const ModuleId &id) const noexcept;
+
     private:
+        struct ModuleStateRecord {
+            ModuleId id;
+            ModuleLifecycleState state{ModuleLifecycleState::Registered};
+        };
+
+        void Transition(const ModuleId &id, ModuleLifecycleState state) noexcept;
+        void RequestCancellationFrom(std::size_t base) noexcept;
+        void DeactivateFrom(std::size_t base) noexcept;
+
         std::vector<ModuleDescriptor> m_registered;
         std::vector<ActiveModule> m_active;
+        std::vector<ModuleStateRecord> m_states;
     };
 }  // namespace Horo

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(HoroFoundation STATIC
         foundation/modules/ModuleActivationContext.cpp
         foundation/modules/ModuleDescriptor.cpp
         foundation/modules/ModuleHost.cpp
+        foundation/modules/ModuleHostLifecycle.cpp
         foundation/modules/ModuleHostRegistration.cpp
         foundation/diagnostics/ErrorCode.cpp
         foundation/diagnostics/DiagnosticBundle.cpp

--- a/src/foundation/modules/ModuleActivationContext.cpp
+++ b/src/foundation/modules/ModuleActivationContext.cpp
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <format>
 #include <mutex>
 #include <string>
 #include <utility>
@@ -126,8 +127,8 @@ namespace Horo {
         });
         if (!drained) {
             Log::Logger::Write("foundation.modules", Log::Level::Warn,
-                               "Module '" + m_module.value + "' callback drainage timed out with " +
-                                   std::to_string(m_callbackGate->activeCallbacks) + " active callback(s).");
+                               std::format("Module '{}' callback drainage timed out with {} active callback(s).", m_module.value,
+                                           m_callbackGate->activeCallbacks));
         }
     }
 }  // namespace Horo

--- a/src/foundation/modules/ModuleActivationContext.cpp
+++ b/src/foundation/modules/ModuleActivationContext.cpp
@@ -1,12 +1,75 @@
 #include "Horo/Foundation/ModuleHost.h"
 #include "foundation/FoundationErrors.h"
 
+#include <condition_variable>
+#include <mutex>
 #include <utility>
 
 namespace Horo {
+    /** @brief Shared callback-admission and drainage state retained by outstanding leases. */
+    class ModuleCallbackGate {
+    public:
+        std::mutex mutex;
+        std::condition_variable drained;
+        std::size_t activeCallbacks{};
+        bool accepting{true};
+    };
+
+    ModuleCallbackLease::ModuleCallbackLease(std::shared_ptr<ModuleCallbackGate> gate, const void *bindings,
+                                             CancellationToken cancellation) noexcept
+        : m_gate(std::move(gate)), m_bindings(bindings), m_cancellation(std::move(cancellation)) {}
+
+    ModuleCallbackLease::~ModuleCallbackLease() {
+        Release();
+    }
+
+    ModuleCallbackLease::ModuleCallbackLease(ModuleCallbackLease &&other) noexcept
+        : m_gate(std::move(other.m_gate)), m_bindings(other.m_bindings), m_cancellation(std::move(other.m_cancellation)) {
+        other.m_bindings = nullptr;
+    }
+
+    ModuleCallbackLease &ModuleCallbackLease::operator=(ModuleCallbackLease &&other) noexcept {
+        if (this == &other)
+            return *this;
+        Release();
+        m_gate = std::move(other.m_gate);
+        m_bindings = other.m_bindings;
+        m_cancellation = std::move(other.m_cancellation);
+        other.m_bindings = nullptr;
+        return *this;
+    }
+
+    /** @copydoc ModuleCallbackLease::Bindings */
+    const void *ModuleCallbackLease::Bindings() const noexcept {
+        return m_bindings;
+    }
+
+    /** @copydoc ModuleCallbackLease::Cancellation */
+    CancellationToken ModuleCallbackLease::Cancellation() const noexcept {
+        return m_cancellation;
+    }
+
+    void ModuleCallbackLease::Release() noexcept {
+        if (m_gate == nullptr)
+            return;
+        {
+            const std::lock_guard lock(m_gate->mutex);
+            --m_gate->activeCallbacks;
+            if (m_gate->activeCallbacks == 0)
+                m_gate->drained.notify_all();
+        }
+        m_gate.reset();
+        m_bindings = nullptr;
+    }
+
     /** @copydoc ModuleActivationContext::ModuleActivationContext */
-    ModuleActivationContext::ModuleActivationContext(ModuleId identifier, const DependencyBindings bindings) noexcept
-        : m_module(std::move(identifier)), m_bindings(bindings) {}
+    ModuleActivationContext::ModuleActivationContext(ModuleId identifier, const DependencyBindings bindings)
+        : m_module(std::move(identifier)), m_bindings(bindings), m_callbackGate(std::make_shared<ModuleCallbackGate>()) {}
+
+    ModuleActivationContext::~ModuleActivationContext() {
+        RequestShutdown();
+        DrainCallbacks();
+    }
 
     /** @copydoc ModuleActivationContext::Module */
     const ModuleId &ModuleActivationContext::Module() const noexcept {
@@ -18,6 +81,20 @@ namespace Horo {
         return m_bindings;
     }
 
+    /** @copydoc ModuleActivationContext::Cancellation */
+    CancellationToken ModuleActivationContext::Cancellation() const noexcept {
+        return m_cancellation.Token();
+    }
+
+    /** @copydoc ModuleActivationContext::AcquireCallbackLease */
+    std::optional<ModuleCallbackLease> ModuleActivationContext::AcquireCallbackLease() const {
+        const std::lock_guard lock(m_callbackGate->mutex);
+        if (!m_callbackGate->accepting)
+            return std::nullopt;
+        ++m_callbackGate->activeCallbacks;
+        return ModuleCallbackLease(m_callbackGate, m_bindings, m_cancellation.Token());
+    }
+
     /** @copydoc ModuleActivationContext::AttachInstance */
     Result<void> ModuleActivationContext::AttachInstance(std::unique_ptr<IModuleInstance> instance) {
         if (instance == nullptr) {
@@ -26,5 +103,20 @@ namespace Horo {
         }
         m_instance = std::move(instance);
         return Result<void>::Success();
+    }
+
+    void ModuleActivationContext::RequestShutdown() noexcept {
+        {
+            const std::lock_guard lock(m_callbackGate->mutex);
+            m_callbackGate->accepting = false;
+        }
+        m_cancellation.RequestCancellation();
+    }
+
+    void ModuleActivationContext::DrainCallbacks() noexcept {
+        std::unique_lock lock(m_callbackGate->mutex);
+        m_callbackGate->drained.wait(lock, [this] {
+            return m_callbackGate->activeCallbacks == 0;
+        });
     }
 }  // namespace Horo

--- a/src/foundation/modules/ModuleActivationContext.cpp
+++ b/src/foundation/modules/ModuleActivationContext.cpp
@@ -105,6 +105,7 @@ namespace Horo {
         return Result<void>::Success();
     }
 
+    /** @copydoc ModuleActivationContext::RequestShutdown */
     void ModuleActivationContext::RequestShutdown() noexcept {
         {
             const std::lock_guard lock(m_callbackGate->mutex);
@@ -113,6 +114,7 @@ namespace Horo {
         m_cancellation.RequestCancellation();
     }
 
+    /** @copydoc ModuleActivationContext::DrainCallbacks */
     void ModuleActivationContext::DrainCallbacks() noexcept {
         std::unique_lock lock(m_callbackGate->mutex);
         m_callbackGate->drained.wait(lock, [this] {

--- a/src/foundation/modules/ModuleActivationContext.cpp
+++ b/src/foundation/modules/ModuleActivationContext.cpp
@@ -18,7 +18,7 @@ namespace Horo {
         bool accepting{true};
     };
 
-    ModuleCallbackLease::ModuleCallbackLease(std::shared_ptr<ModuleCallbackGate> gate, const void *bindings,
+    ModuleCallbackLease::ModuleCallbackLease(std::shared_ptr<ModuleCallbackGate> gate, const IDependencyBindings *bindings,
                                              CancellationToken cancellation) noexcept
         : m_gate(std::move(gate)), m_bindings(bindings), m_cancellation(std::move(cancellation)) {}
 
@@ -43,7 +43,7 @@ namespace Horo {
     }
 
     /** @copydoc ModuleCallbackLease::Bindings */
-    const void *ModuleCallbackLease::Bindings() const noexcept {
+    const IDependencyBindings *ModuleCallbackLease::Bindings() const noexcept {
         return m_bindings;
     }
 
@@ -109,7 +109,7 @@ namespace Horo {
     }
 
     /** @copydoc ModuleActivationContext::RequestShutdown */
-    void ModuleActivationContext::RequestShutdown() noexcept {
+    void ModuleActivationContext::RequestShutdown() const noexcept {
         {
             const std::lock_guard lock(m_callbackGate->mutex);
             m_callbackGate->accepting = false;
@@ -118,7 +118,7 @@ namespace Horo {
     }
 
     /** @copydoc ModuleActivationContext::DrainCallbacks */
-    void ModuleActivationContext::DrainCallbacks() noexcept {
+    void ModuleActivationContext::DrainCallbacks() const noexcept {
         std::unique_lock lock(m_callbackGate->mutex);
         constexpr auto kDrainTimeout = std::chrono::seconds(5);
         const bool drained = m_callbackGate->drained.wait_for(lock, kDrainTimeout, [this] {

--- a/src/foundation/modules/ModuleActivationContext.cpp
+++ b/src/foundation/modules/ModuleActivationContext.cpp
@@ -54,16 +54,13 @@ namespace Horo {
     }
 
     void ModuleCallbackLease::Release() noexcept {
-        if (m_gate == nullptr)
-            return;
-        {
+        if (m_gate != nullptr) {
             const std::lock_guard lock(m_gate->mutex);
-            --m_gate->activeCallbacks;
-            if (m_gate->activeCallbacks == 0)
+            if (--m_gate->activeCallbacks == 0)
                 m_gate->drained.notify_all();
+            m_gate.reset();
+            m_bindings = nullptr;
         }
-        m_gate.reset();
-        m_bindings = nullptr;
     }
 
     /** @copydoc ModuleActivationContext::ModuleActivationContext */

--- a/src/foundation/modules/ModuleActivationContext.cpp
+++ b/src/foundation/modules/ModuleActivationContext.cpp
@@ -1,8 +1,11 @@
+#include "Horo/Foundation/Logging/Logger.h"
 #include "Horo/Foundation/ModuleHost.h"
 #include "foundation/FoundationErrors.h"
 
+#include <chrono>
 #include <condition_variable>
 #include <mutex>
+#include <string>
 #include <utility>
 
 namespace Horo {
@@ -117,8 +120,14 @@ namespace Horo {
     /** @copydoc ModuleActivationContext::DrainCallbacks */
     void ModuleActivationContext::DrainCallbacks() noexcept {
         std::unique_lock lock(m_callbackGate->mutex);
-        m_callbackGate->drained.wait(lock, [this] {
+        constexpr auto kDrainTimeout = std::chrono::seconds(5);
+        const bool drained = m_callbackGate->drained.wait_for(lock, kDrainTimeout, [this] {
             return m_callbackGate->activeCallbacks == 0;
         });
+        if (!drained) {
+            Log::Logger::Write("foundation.modules", Log::Level::Warn,
+                               "Module '" + m_module.value + "' callback drainage timed out with " +
+                                   std::to_string(m_callbackGate->activeCallbacks) + " active callback(s).");
+        }
     }
 }  // namespace Horo

--- a/src/foundation/modules/ModuleDescriptor.cpp
+++ b/src/foundation/modules/ModuleDescriptor.cpp
@@ -223,7 +223,7 @@ namespace Horo {
                 auto provider = ResolveDependencyProvider(d, dep, descriptors, modules);
                 if (provider.HasError())
                     return Result<void>::Failure(provider.ErrorValue());
-                if (provider.Value())
+                if (provider.Value().has_value())
                     AddEdge(edges, *provider.Value(), dependant);
             }
             return Result<void>::Success();

--- a/src/foundation/modules/ModuleDescriptor.cpp
+++ b/src/foundation/modules/ModuleDescriptor.cpp
@@ -109,9 +109,8 @@ namespace Horo {
         }
 
         /** @brief Validates one resource budget entry within a descriptor. */
-        [[nodiscard]] std::optional<std::string> ValidateBudgetEntry(const ModuleResourceBudget &budget,
-                                                                    const std::string_view moduleId,
-                                                                    std::set<std::string, std::less<>> &budgetIds) {
+        [[nodiscard]] std::optional<std::string> ValidateBudgetEntry(const ModuleResourceBudget &budget, const std::string_view moduleId,
+                                                                     std::set<std::string, std::less<>> &budgetIds) {
             if (!IsCanonicalId(budget.id))
                 return "Module '" + std::string(moduleId) + "' has a non-canonical resource budget identity.";
             if (!IsNamespacedBy(budget.id, moduleId))
@@ -135,8 +134,7 @@ namespace Horo {
 
         /** @brief Validates one observability entry within a descriptor. */
         [[nodiscard]] std::optional<std::string> ValidateObservabilityEntry(
-            const ModuleObservabilityDescriptor &entry,
-            const std::string_view moduleId,
+            const ModuleObservabilityDescriptor &entry, const std::string_view moduleId,
             std::set<std::pair<ModuleObservabilityKind, std::string>> &observability) {
             if (!IsCanonicalId(entry.id))
                 return "Module '" + std::string(moduleId) + "' has a non-canonical observability identity.";
@@ -167,11 +165,8 @@ namespace Horo {
             }
             using ValidatorFn = std::optional<std::string> (*)(const ModuleDescriptor &);
             constexpr std::array<ValidatorFn, 5> kValidators = {
-                &ValidateDependencies,
-                &ValidateProvidedCapabilities,
-                &ValidateRequiredCapabilities,
-                &ValidateBudgets,
-                &ValidateObservability,
+                &ValidateDependencies, &ValidateProvidedCapabilities, &ValidateRequiredCapabilities,
+                &ValidateBudgets,      &ValidateObservability,
             };
             for (const auto validator : kValidators) {
                 if (auto failure = validator(descriptor); failure.has_value())

--- a/src/foundation/modules/ModuleDescriptor.cpp
+++ b/src/foundation/modules/ModuleDescriptor.cpp
@@ -3,6 +3,7 @@
 #include "foundation/FoundationErrors.h"
 
 #include <algorithm>
+#include <array>
 #include <map>
 #include <optional>
 #include <set>
@@ -23,6 +24,20 @@ namespace Horo {
             return lowercaseAscii || digitAscii;
         }
 
+        /** @brief Validates a single character and updates separator tracking in a canonical identifier. */
+        [[nodiscard]] bool IsValidSegmentChar(const unsigned char character, bool &previousWasSeparator) noexcept {
+            if (IsIdSeparator(character)) {
+                if (previousWasSeparator)
+                    return false;
+                previousWasSeparator = true;
+                return true;
+            }
+            if (!IsLowercaseAsciiAlphanumeric(character))
+                return false;
+            previousWasSeparator = false;
+            return true;
+        }
+
         /** @brief Validates the lowercase ASCII segmented identifier grammar. */
         [[nodiscard]] bool IsCanonicalId(const std::string_view value) {
             if (value.empty())
@@ -30,15 +45,8 @@ namespace Horo {
 
             bool previousWasSeparator = true;
             for (const unsigned char character : value) {
-                if (IsIdSeparator(character)) {
-                    if (previousWasSeparator)
-                        return false;
-                    previousWasSeparator = true;
-                    continue;
-                }
-                if (!IsLowercaseAsciiAlphanumeric(character))
+                if (!IsValidSegmentChar(character, previousWasSeparator))
                     return false;
-                previousWasSeparator = false;
             }
             return !previousWasSeparator;
         }
@@ -100,19 +108,42 @@ namespace Horo {
             return std::nullopt;
         }
 
+        /** @brief Validates one resource budget entry within a descriptor. */
+        [[nodiscard]] std::optional<std::string> ValidateBudgetEntry(const ModuleResourceBudget &budget,
+                                                                    const std::string_view moduleId,
+                                                                    std::set<std::string, std::less<>> &budgetIds) {
+            if (!IsCanonicalId(budget.id))
+                return "Module '" + std::string(moduleId) + "' has a non-canonical resource budget identity.";
+            if (!IsNamespacedBy(budget.id, moduleId))
+                return "Resource budget '" + budget.id + "' is not namespaced by module '" + std::string(moduleId) + "'.";
+            if (budget.limit == 0)
+                return "Resource budget '" + budget.id + "' has a zero limit.";
+            if (!budgetIds.emplace(budget.id).second)
+                return "Module '" + std::string(moduleId) + "' repeats resource budget '" + budget.id + "'.";
+            return std::nullopt;
+        }
+
         /** @brief Validates one descriptor's named resource budget hints. */
         [[nodiscard]] std::optional<std::string> ValidateBudgets(const ModuleDescriptor &descriptor) {
             std::set<std::string, std::less<>> budgetIds;
             for (const ModuleResourceBudget &budget : descriptor.resourceBudgets) {
-                if (!IsCanonicalId(budget.id))
-                    return "Module '" + descriptor.id.value + "' has a non-canonical resource budget identity.";
-                if (!IsNamespacedBy(budget.id, descriptor.id.value))
-                    return "Resource budget '" + budget.id + "' is not namespaced by module '" + descriptor.id.value + "'.";
-                if (budget.limit == 0)
-                    return "Resource budget '" + budget.id + "' has a zero limit.";
-                if (!budgetIds.emplace(budget.id).second)
-                    return "Module '" + descriptor.id.value + "' repeats resource budget '" + budget.id + "'.";
+                if (auto failure = ValidateBudgetEntry(budget, descriptor.id.value, budgetIds); failure.has_value())
+                    return failure;
             }
+            return std::nullopt;
+        }
+
+        /** @brief Validates one observability entry within a descriptor. */
+        [[nodiscard]] std::optional<std::string> ValidateObservabilityEntry(
+            const ModuleObservabilityDescriptor &entry,
+            const std::string_view moduleId,
+            std::set<std::pair<ModuleObservabilityKind, std::string>> &observability) {
+            if (!IsCanonicalId(entry.id))
+                return "Module '" + std::string(moduleId) + "' has a non-canonical observability identity.";
+            if (!IsNamespacedBy(entry.id, moduleId))
+                return "Observability descriptor '" + entry.id + "' is not namespaced by module '" + std::string(moduleId) + "'.";
+            if (!observability.emplace(entry.kind, entry.id).second)
+                return "Module '" + std::string(moduleId) + "' repeats observability descriptor '" + entry.id + "'.";
             return std::nullopt;
         }
 
@@ -120,12 +151,8 @@ namespace Horo {
         [[nodiscard]] std::optional<std::string> ValidateObservability(const ModuleDescriptor &descriptor) {
             std::set<std::pair<ModuleObservabilityKind, std::string>> observability;
             for (const ModuleObservabilityDescriptor &entry : descriptor.observability) {
-                if (!IsCanonicalId(entry.id))
-                    return "Module '" + descriptor.id.value + "' has a non-canonical observability identity.";
-                if (!IsNamespacedBy(entry.id, descriptor.id.value))
-                    return "Observability descriptor '" + entry.id + "' is not namespaced by module '" + descriptor.id.value + "'.";
-                if (!observability.emplace(entry.kind, entry.id).second)
-                    return "Module '" + descriptor.id.value + "' repeats observability descriptor '" + entry.id + "'.";
+                if (auto failure = ValidateObservabilityEntry(entry, descriptor.id.value, observability); failure.has_value())
+                    return failure;
             }
             return std::nullopt;
         }
@@ -138,15 +165,19 @@ namespace Horo {
                 return "Module '" + descriptor.id.value +
                        "' must pair activation and deactivation, and may drain only within that lifetime.";
             }
-            if (const auto failure = ValidateDependencies(descriptor); failure.has_value())
-                return failure;
-            if (const auto failure = ValidateProvidedCapabilities(descriptor); failure.has_value())
-                return failure;
-            if (const auto failure = ValidateRequiredCapabilities(descriptor); failure.has_value())
-                return failure;
-            if (const auto failure = ValidateBudgets(descriptor); failure.has_value())
-                return failure;
-            return ValidateObservability(descriptor);
+            using ValidatorFn = std::optional<std::string> (*)(const ModuleDescriptor &);
+            constexpr std::array<ValidatorFn, 5> kValidators = {
+                &ValidateDependencies,
+                &ValidateProvidedCapabilities,
+                &ValidateRequiredCapabilities,
+                &ValidateBudgets,
+                &ValidateObservability,
+            };
+            for (const auto validator : kValidators) {
+                if (auto failure = validator(descriptor); failure.has_value())
+                    return failure;
+            }
+            return std::nullopt;
         }
 
         using ModuleIndex = std::map<std::string, std::size_t, std::less<>>;

--- a/src/foundation/modules/ModuleDescriptor.cpp
+++ b/src/foundation/modules/ModuleDescriptor.cpp
@@ -282,28 +282,40 @@ namespace Horo {
             return Result<GraphEdges>::Success(std::move(edges));
         }
 
-        /** @brief Produces stable provider-first order or reports a remaining cycle. */
-        [[nodiscard]] Result<ValidatedModuleGraph> OrderGraph(const std::span<const ModuleDescriptor> descriptors, GraphEdges edges) {
-            const auto compareById = [&descriptors](const std::size_t left, const std::size_t right) {
-                return descriptors[left].id.value < descriptors[right].id.value;
-            };
-            std::set<std::size_t, decltype(compareById)> ready(compareById);
-            for (std::size_t index = 0; index < edges.incomingCount.size(); ++index) {
-                if (edges.incomingCount[index] == 0)
+        template <typename Compare>
+        void CollectReadyNodes(const std::vector<std::size_t> &incomingCount, std::set<std::size_t, Compare> &ready) {
+            for (std::size_t index = 0; index < incomingCount.size(); ++index) {
+                if (incomingCount[index] == 0)
                     ready.emplace(index);
             }
+        }
 
-            ValidatedModuleGraph graph;
-            graph.initializationOrder.reserve(descriptors.size());
+        template <typename Compare>
+        void DrainReadyNodes(std::set<std::size_t, Compare> &ready, const std::span<const ModuleDescriptor> descriptors, GraphEdges &edges,
+                             ValidatedModuleGraph &graph) {
             while (!ready.empty()) {
-                const std::size_t provider = *ready.begin();
-                ready.erase(ready.begin());
+                const auto iter = ready.begin();
+                const std::size_t provider = *iter;
+                ready.erase(iter);
                 graph.initializationOrder.push_back(descriptors[provider].id);
                 for (const std::size_t dependant : edges.outgoing[provider]) {
                     if (--edges.incomingCount[dependant] == 0)
                         ready.emplace(dependant);
                 }
             }
+        }
+
+        /** @brief Produces stable provider-first order or reports a remaining cycle. */
+        [[nodiscard]] Result<ValidatedModuleGraph> OrderGraph(const std::span<const ModuleDescriptor> descriptors, GraphEdges edges) {
+            const auto compareById = [&descriptors](const std::size_t left, const std::size_t right) {
+                return descriptors[left].id.value < descriptors[right].id.value;
+            };
+            std::set<std::size_t, decltype(compareById)> ready(compareById);
+            CollectReadyNodes(edges.incomingCount, ready);
+
+            ValidatedModuleGraph graph;
+            graph.initializationOrder.reserve(descriptors.size());
+            DrainReadyNodes(ready, descriptors, edges, graph);
 
             if (graph.initializationOrder.size() != descriptors.size()) {
                 return Fail<ValidatedModuleGraph>(ModuleDescriptorErrors::DependencyCycle,

--- a/src/foundation/modules/ModuleDescriptor.cpp
+++ b/src/foundation/modules/ModuleDescriptor.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <format>
 #include <map>
 #include <optional>
 #include <set>
@@ -12,168 +13,148 @@
 
 namespace Horo {
     namespace {
-        /** @brief Returns whether a canonical identifier byte separates segments. */
-        [[nodiscard]] bool IsIdSeparator(const unsigned char character) noexcept {
-            return character == '.' || character == '-' || character == '_';
+        // ─── Identifier helpers ───────────────────────────────────────────────
+
+        [[nodiscard]] bool IsIdSeparator(const unsigned char ch) noexcept {
+            return ch == '.' || ch == '-' || ch == '_';
         }
 
-        /** @brief Returns whether a byte is valid inside a canonical identifier segment. */
-        [[nodiscard]] bool IsLowercaseAsciiAlphanumeric(const unsigned char character) noexcept {
-            const bool lowercaseAscii = character >= 'a' && character <= 'z';
-            const bool digitAscii = character >= '0' && character <= '9';
-            return lowercaseAscii || digitAscii;
+        [[nodiscard]] bool IsLowercaseAlphanumeric(const unsigned char ch) noexcept {
+            return (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9');
         }
 
-        /** @brief Validates a single character and updates separator tracking in a canonical identifier. */
-        [[nodiscard]] bool IsValidSegmentChar(const unsigned char character, bool &previousWasSeparator) noexcept {
-            if (IsIdSeparator(character)) {
-                if (previousWasSeparator)
+        /** @brief Validates one character and updates consecutive-separator state. */
+        [[nodiscard]] bool IsValidSegmentChar(const unsigned char ch, bool &prevWasSeparator) noexcept {
+            if (IsIdSeparator(ch)) {
+                if (prevWasSeparator)
                     return false;
-                previousWasSeparator = true;
+                prevWasSeparator = true;
                 return true;
             }
-            if (!IsLowercaseAsciiAlphanumeric(character))
+            if (!IsLowercaseAlphanumeric(ch))
                 return false;
-            previousWasSeparator = false;
+            prevWasSeparator = false;
             return true;
         }
 
-        /** @brief Validates the lowercase ASCII segmented identifier grammar. */
-        [[nodiscard]] bool IsCanonicalId(const std::string_view value) {
+        /** @brief Returns whether @p value conforms to the lowercase-segmented identifier grammar. */
+        [[nodiscard]] bool IsCanonicalId(const std::string_view value) noexcept {
             if (value.empty())
                 return false;
-
-            bool previousWasSeparator = true;
-            for (const unsigned char character : value) {
-                if (!IsValidSegmentChar(character, previousWasSeparator))
+            bool prevWasSeparator = true;
+            for (const unsigned char ch : value) {
+                if (!IsValidSegmentChar(ch, prevWasSeparator))
                     return false;
             }
-            return !previousWasSeparator;
+            return !prevWasSeparator;
         }
 
-        /** @brief Creates a typed validation failure from a stable error descriptor. */
-        template <typename ValueT> [[nodiscard]] Result<ValueT> Fail(const ErrorCodeDescriptor &descriptor, std::string message) {
-            return Result<ValueT>::Failure(MakeError(descriptor, std::move(message)));
-        }
-
-        /** @brief Returns whether lifecycle callbacks form one valid activation lifetime. */
-        [[nodiscard]] bool HasValidLifecycleCallbacks(const ModuleLifecycleCallbacks &callbacks) noexcept {
-            const bool hasPairedEndpoints = (callbacks.activate == nullptr) == (callbacks.deactivate == nullptr);
-            const bool drainHasLifetime = callbacks.drain == nullptr || callbacks.activate != nullptr;
-            return hasPairedEndpoints && drainHasLifetime;
-        }
-
-        /** @brief Returns whether a child identity is strictly nested below its parent identity. */
-        [[nodiscard]] bool IsNamespacedBy(const std::string_view child, const std::string_view parent) {
+        /** @brief Returns whether @p child is strictly nested one level below @p parent. */
+        [[nodiscard]] bool IsNamespacedBy(const std::string_view child, const std::string_view parent) noexcept {
             return child.size() > parent.size() && child.starts_with(parent) && child[parent.size()] == '.';
         }
 
-        /** @brief Validates one descriptor's dependency identities and uniqueness. */
-        [[nodiscard]] std::optional<std::string> ValidateDependencies(const ModuleDescriptor &descriptor) {
-            std::set<std::string, std::less<>> dependencies;
-            for (const ModuleDependency &dependency : descriptor.dependencies) {
-                if (!IsCanonicalId(dependency.module.value))
-                    return "Module '" + descriptor.id.value + "' has a non-canonical dependency identity.";
-                if (dependency.module == descriptor.id)
-                    return "Module '" + descriptor.id.value + "' depends on itself.";
-                if (!dependencies.emplace(dependency.module.value).second)
-                    return "Module '" + descriptor.id.value + "' repeats dependency '" + dependency.module.value + "'.";
+        // ─── Result helpers ───────────────────────────────────────────────────
+
+        /** @brief Returns a typed failure from a stable error descriptor and a formatted message. */
+        template <typename T> [[nodiscard]] Result<T> Fail(const ErrorCodeDescriptor &descriptor, std::string message) {
+            return Result<T>::Failure(MakeError(descriptor, std::move(message)));
+        }
+
+        // ─── Per-descriptor validators ────────────────────────────────────────
+
+        /** @brief Returns whether lifecycle callbacks form a valid paired activation lifetime. */
+        [[nodiscard]] bool HasValidLifecycleCallbacks(const ModuleLifecycleCallbacks &callbacks) noexcept {
+            const bool paired = (callbacks.activate == nullptr) == (callbacks.deactivate == nullptr);
+            const bool drainWithinLifetime = callbacks.drain == nullptr || callbacks.activate != nullptr;
+            return paired && drainWithinLifetime;
+        }
+
+        [[nodiscard]] std::optional<std::string> ValidateDependencies(const ModuleDescriptor &d) {
+            std::set<std::string, std::less<>> seen;
+            for (const ModuleDependency &dep : d.dependencies) {
+                if (!IsCanonicalId(dep.module.value))
+                    return std::format("Module '{}' has a non-canonical dependency identity.", d.id.value);
+                if (dep.module == d.id)
+                    return std::format("Module '{}' depends on itself.", d.id.value);
+                if (!seen.emplace(dep.module.value).second)
+                    return std::format("Module '{}' repeats dependency '{}'.", d.id.value, dep.module.value);
             }
             return std::nullopt;
         }
 
-        /** @brief Validates one descriptor's provided capability identities and uniqueness. */
-        [[nodiscard]] std::optional<std::string> ValidateProvidedCapabilities(const ModuleDescriptor &descriptor) {
-            std::set<std::string, std::less<>> providedCapabilities;
-            for (const ModuleCapabilityId &capability : descriptor.providedCapabilities) {
-                if (!IsCanonicalId(capability.value))
-                    return "Module '" + descriptor.id.value + "' has a non-canonical provided capability.";
-                if (!providedCapabilities.emplace(capability.value).second)
-                    return "Module '" + descriptor.id.value + "' repeats provided capability '" + capability.value + "'.";
+        [[nodiscard]] std::optional<std::string> ValidateProvidedCapabilities(const ModuleDescriptor &d) {
+            std::set<std::string, std::less<>> seen;
+            for (const ModuleCapabilityId &cap : d.providedCapabilities) {
+                if (!IsCanonicalId(cap.value))
+                    return std::format("Module '{}' has a non-canonical provided capability.", d.id.value);
+                if (!seen.emplace(cap.value).second)
+                    return std::format("Module '{}' repeats provided capability '{}'.", d.id.value, cap.value);
             }
             return std::nullopt;
         }
 
-        /** @brief Validates one descriptor's required capabilities and self-provisioning rule. */
-        [[nodiscard]] std::optional<std::string> ValidateRequiredCapabilities(const ModuleDescriptor &descriptor) {
-            std::set<std::string, std::less<>> requiredCapabilities;
-            for (const ModuleCapabilityId &capability : descriptor.requiredCapabilities) {
-                if (!IsCanonicalId(capability.value))
-                    return "Module '" + descriptor.id.value + "' has a non-canonical required capability.";
-                if (!requiredCapabilities.emplace(capability.value).second)
-                    return "Module '" + descriptor.id.value + "' repeats required capability '" + capability.value + "'.";
-                if (std::ranges::find(descriptor.providedCapabilities, capability) != descriptor.providedCapabilities.end())
-                    return "Module '" + descriptor.id.value + "' cannot require a capability it provides.";
+        [[nodiscard]] std::optional<std::string> ValidateRequiredCapabilities(const ModuleDescriptor &d) {
+            std::set<std::string, std::less<>> seen;
+            for (const ModuleCapabilityId &cap : d.requiredCapabilities) {
+                if (!IsCanonicalId(cap.value))
+                    return std::format("Module '{}' has a non-canonical required capability.", d.id.value);
+                if (!seen.emplace(cap.value).second)
+                    return std::format("Module '{}' repeats required capability '{}'.", d.id.value, cap.value);
+                if (std::ranges::find(d.providedCapabilities, cap) != d.providedCapabilities.end())
+                    return std::format("Module '{}' cannot require a capability it provides.", d.id.value);
             }
             return std::nullopt;
         }
 
-        /** @brief Validates one resource budget entry within a descriptor. */
-        [[nodiscard]] std::optional<std::string> ValidateBudgetEntry(const ModuleResourceBudget &budget, const std::string_view moduleId,
-                                                                     std::set<std::string, std::less<>> &budgetIds) {
-            if (!IsCanonicalId(budget.id))
-                return "Module '" + std::string(moduleId) + "' has a non-canonical resource budget identity.";
-            if (!IsNamespacedBy(budget.id, moduleId))
-                return "Resource budget '" + budget.id + "' is not namespaced by module '" + std::string(moduleId) + "'.";
-            if (budget.limit == 0)
-                return "Resource budget '" + budget.id + "' has a zero limit.";
-            if (!budgetIds.emplace(budget.id).second)
-                return "Module '" + std::string(moduleId) + "' repeats resource budget '" + budget.id + "'.";
-            return std::nullopt;
-        }
-
-        /** @brief Validates one descriptor's named resource budget hints. */
-        [[nodiscard]] std::optional<std::string> ValidateBudgets(const ModuleDescriptor &descriptor) {
-            std::set<std::string, std::less<>> budgetIds;
-            for (const ModuleResourceBudget &budget : descriptor.resourceBudgets) {
-                if (auto failure = ValidateBudgetEntry(budget, descriptor.id.value, budgetIds); failure.has_value())
-                    return failure;
+        [[nodiscard]] std::optional<std::string> ValidateBudgets(const ModuleDescriptor &d) {
+            std::set<std::string, std::less<>> seen;
+            for (const ModuleResourceBudget &budget : d.resourceBudgets) {
+                if (!IsCanonicalId(budget.id))
+                    return std::format("Module '{}' has a non-canonical resource budget identity.", d.id.value);
+                if (!IsNamespacedBy(budget.id, d.id.value))
+                    return std::format("Resource budget '{}' is not namespaced by module '{}'.", budget.id, d.id.value);
+                if (budget.limit == 0)
+                    return std::format("Resource budget '{}' has a zero limit.", budget.id);
+                if (!seen.emplace(budget.id).second)
+                    return std::format("Module '{}' repeats resource budget '{}'.", d.id.value, budget.id);
             }
             return std::nullopt;
         }
 
-        /** @brief Validates one observability entry within a descriptor. */
-        [[nodiscard]] std::optional<std::string> ValidateObservabilityEntry(
-            const ModuleObservabilityDescriptor &entry, const std::string_view moduleId,
-            std::set<std::pair<ModuleObservabilityKind, std::string>> &observability) {
-            if (!IsCanonicalId(entry.id))
-                return "Module '" + std::string(moduleId) + "' has a non-canonical observability identity.";
-            if (!IsNamespacedBy(entry.id, moduleId))
-                return "Observability descriptor '" + entry.id + "' is not namespaced by module '" + std::string(moduleId) + "'.";
-            if (!observability.emplace(entry.kind, entry.id).second)
-                return "Module '" + std::string(moduleId) + "' repeats observability descriptor '" + entry.id + "'.";
-            return std::nullopt;
-        }
-
-        /** @brief Validates one descriptor's module-namespaced observability entries. */
-        [[nodiscard]] std::optional<std::string> ValidateObservability(const ModuleDescriptor &descriptor) {
-            std::set<std::pair<ModuleObservabilityKind, std::string>> observability;
-            for (const ModuleObservabilityDescriptor &entry : descriptor.observability) {
-                if (auto failure = ValidateObservabilityEntry(entry, descriptor.id.value, observability); failure.has_value())
-                    return failure;
+        [[nodiscard]] std::optional<std::string> ValidateObservability(const ModuleDescriptor &d) {
+            std::set<std::pair<ModuleObservabilityKind, std::string>> seen;
+            for (const ModuleObservabilityDescriptor &entry : d.observability) {
+                if (!IsCanonicalId(entry.id))
+                    return std::format("Module '{}' has a non-canonical observability identity.", d.id.value);
+                if (!IsNamespacedBy(entry.id, d.id.value))
+                    return std::format("Observability descriptor '{}' is not namespaced by module '{}'.", entry.id, d.id.value);
+                if (!seen.emplace(entry.kind, entry.id).second)
+                    return std::format("Module '{}' repeats observability descriptor '{}'.", d.id.value, entry.id);
             }
             return std::nullopt;
         }
 
-        /** @brief Runs every descriptor-local validation without consulting graph state. */
-        [[nodiscard]] std::optional<std::string> ValidateLocalDescriptor(const ModuleDescriptor &descriptor) {
-            if (!IsCanonicalId(descriptor.id.value))
-                return "Module identity is not canonical: '" + descriptor.id.value + "'.";
-            if (!HasValidLifecycleCallbacks(descriptor.lifecycle)) {
-                return "Module '" + descriptor.id.value +
-                       "' must pair activation and deactivation, and may drain only within that lifetime.";
-            }
-            using ValidatorFn = std::optional<std::string> (*)(const ModuleDescriptor &);
-            constexpr std::array<ValidatorFn, 5> kValidators = {
-                &ValidateDependencies, &ValidateProvidedCapabilities, &ValidateRequiredCapabilities,
-                &ValidateBudgets,      &ValidateObservability,
+        /** @brief Runs all per-descriptor validators in sequence; returns the first failure. */
+        [[nodiscard]] std::optional<std::string> ValidateLocalDescriptor(const ModuleDescriptor &d) {
+            if (!IsCanonicalId(d.id.value))
+                return std::format("Module identity is not canonical: '{}'.", d.id.value);
+            if (!HasValidLifecycleCallbacks(d.lifecycle))
+                return std::format("Module '{}' must pair activation and deactivation, and may drain only within that lifetime.",
+                                   d.id.value);
+
+            using Validator = std::optional<std::string> (*)(const ModuleDescriptor &);
+            constexpr std::array<Validator, 5> kValidators = {
+                ValidateDependencies, ValidateProvidedCapabilities, ValidateRequiredCapabilities, ValidateBudgets, ValidateObservability,
             };
-            for (const auto validator : kValidators) {
-                if (auto failure = validator(descriptor); failure.has_value())
+            for (const auto validate : kValidators) {
+                if (auto failure = validate(d))
                     return failure;
             }
             return std::nullopt;
         }
+
+        // ─── Graph types ──────────────────────────────────────────────────────
 
         using ModuleIndex = std::map<std::string, std::size_t, std::less<>>;
         using CapabilityProviderIndex = std::map<std::string, std::vector<std::size_t>, std::less<>>;
@@ -184,155 +165,138 @@ namespace Horo {
             std::vector<std::size_t> incomingCount;
         };
 
+        // ─── Graph construction ───────────────────────────────────────────────
+
         /** @brief Validates descriptors and indexes each unique module identity. */
         [[nodiscard]] Result<ModuleIndex> IndexModules(const std::span<const ModuleDescriptor> descriptors) {
             ModuleIndex modules;
-            for (std::size_t index = 0; index < descriptors.size(); ++index) {
-                if (auto failure = ValidateLocalDescriptor(descriptors[index]); failure.has_value())
+            for (std::size_t i = 0; i < descriptors.size(); ++i) {
+                if (auto failure = ValidateLocalDescriptor(descriptors[i]))
                     return Fail<ModuleIndex>(ModuleDescriptorErrors::InvalidDescriptor, std::move(*failure));
-                if (!modules.try_emplace(descriptors[index].id.value, index).second) {
+                if (!modules.try_emplace(descriptors[i].id.value, i).second)
                     return Fail<ModuleIndex>(ModuleDescriptorErrors::DuplicateModule,
-                                             "Duplicate module identity: '" + descriptors[index].id.value + "'.");
-                }
+                                             std::format("Duplicate module identity: '{}'.", descriptors[i].id.value));
             }
             return Result<ModuleIndex>::Success(std::move(modules));
         }
 
-        /** @brief Indexes every selected provider by capability identity. */
+        /** @brief Indexes every provider by capability identity. */
         [[nodiscard]] CapabilityProviderIndex IndexCapabilityProviders(const std::span<const ModuleDescriptor> descriptors) {
             CapabilityProviderIndex providers;
-            for (std::size_t index = 0; index < descriptors.size(); ++index) {
-                for (const ModuleCapabilityId &capability : descriptors[index].providedCapabilities)
-                    providers[capability.value].push_back(index);
+            for (std::size_t i = 0; i < descriptors.size(); ++i) {
+                for (const ModuleCapabilityId &cap : descriptors[i].providedCapabilities)
+                    providers[cap.value].push_back(i);
             }
             return providers;
         }
 
-        /** @brief Adds one unique provider-to-dependant edge and updates its indegree. */
+        /** @brief Adds one unique provider-to-dependant edge and increments its indegree. */
         void AddEdge(GraphEdges &edges, const std::size_t provider, const std::size_t dependant) {
             if (edges.outgoing[provider].emplace(dependant).second)
                 ++edges.incomingCount[dependant];
         }
 
-        [[nodiscard]] Result<std::optional<std::size_t>> ResolveDependencyProvider(const ModuleDescriptor &descriptor,
-                                                                                   const ModuleDependency &dependency,
+        /** @brief Resolves one explicit dependency to its provider index, or fails with a typed error. */
+        [[nodiscard]] Result<std::optional<std::size_t>> ResolveDependencyProvider(const ModuleDescriptor &d, const ModuleDependency &dep,
                                                                                    const std::span<const ModuleDescriptor> descriptors,
                                                                                    const ModuleIndex &modules) {
-            const auto provider = modules.find(dependency.module.value);
-            if (provider == modules.end()) {
-                if (dependency.kind == ModuleDependencyKind::Required) {
-                    return Fail<std::optional<std::size_t>>(ModuleDescriptorErrors::MissingDependency, "Module '" + descriptor.id.value +
-                                                                                                           "' requires missing module '" +
-                                                                                                           dependency.module.value + "'.");
-                }
+            const auto it = modules.find(dep.module.value);
+            if (it == modules.end()) {
+                if (dep.kind == ModuleDependencyKind::Required)
+                    return Fail<std::optional<std::size_t>>(ModuleDescriptorErrors::MissingDependency,
+                                                            std::format("Module '{}' requires missing module '{}'.", d.id.value,
+                                                                        dep.module.value));
                 return Result<std::optional<std::size_t>>::Success(std::nullopt);
             }
-            if (descriptors[provider->second].version < dependency.minimumVersion) {
+            if (descriptors[it->second].version < dep.minimumVersion)
                 return Fail<std::optional<std::size_t>>(ModuleDescriptorErrors::IncompatibleDependency,
-                                                        "Module '" + descriptor.id.value + "' requires a newer contract from '" +
-                                                            dependency.module.value + "'.");
-            }
-            return Result<std::optional<std::size_t>>::Success(provider->second);
+                                                        std::format("Module '{}' requires a newer contract from '{}'.", d.id.value,
+                                                                    dep.module.value));
+            return Result<std::optional<std::size_t>>::Success(it->second);
         }
 
-        /** @brief Resolves and validates explicit module dependencies for one dependant. */
+        /** @brief Resolves explicit module dependencies for one dependant and records edges. */
         [[nodiscard]] Result<void> AddDependencyEdges(const std::span<const ModuleDescriptor> descriptors, const ModuleIndex &modules,
                                                       const std::size_t dependant, GraphEdges &edges) {
-            const ModuleDescriptor &descriptor = descriptors[dependant];
-            for (const ModuleDependency &dependency : descriptor.dependencies) {
-                const auto provider = ResolveDependencyProvider(descriptor, dependency, descriptors, modules);
+            const ModuleDescriptor &d = descriptors[dependant];
+            for (const ModuleDependency &dep : d.dependencies) {
+                auto provider = ResolveDependencyProvider(d, dep, descriptors, modules);
                 if (provider.HasError())
                     return Result<void>::Failure(provider.ErrorValue());
-                if (provider.Value().has_value())
+                if (provider.Value())
                     AddEdge(edges, *provider.Value(), dependant);
             }
             return Result<void>::Success();
         }
 
-        /** @brief Resolves capability providers and adds their ordering edges for one dependant. */
+        /** @brief Resolves required capabilities for one dependant and records ordering edges. */
         [[nodiscard]] Result<void> AddCapabilityEdges(const std::span<const ModuleDescriptor> descriptors,
                                                       const CapabilityProviderIndex &capabilityProviders, const std::size_t dependant,
                                                       GraphEdges &edges) {
-            const ModuleDescriptor &descriptor = descriptors[dependant];
-            for (const ModuleCapabilityId &capability : descriptor.requiredCapabilities) {
-                const auto providers = capabilityProviders.find(capability.value);
-                if (providers == capabilityProviders.end()) {
+            const ModuleDescriptor &d = descriptors[dependant];
+            for (const ModuleCapabilityId &cap : d.requiredCapabilities) {
+                const auto it = capabilityProviders.find(cap.value);
+                if (it == capabilityProviders.end())
                     return Fail<void>(ModuleDescriptorErrors::MissingCapability,
-                                      "Module '" + descriptor.id.value + "' requires missing capability '" + capability.value + "'.");
-                }
-                for (const std::size_t provider : providers->second)
+                                      std::format("Module '{}' requires missing capability '{}'.", d.id.value, cap.value));
+                for (const std::size_t provider : it->second)
                     AddEdge(edges, provider, dependant);
             }
             return Result<void>::Success();
         }
 
-        /** @brief Builds validated dependency and capability edges for every selected module. */
+        /** @brief Builds validated dependency and capability edges for every module. */
         [[nodiscard]] Result<GraphEdges> BuildEdges(const std::span<const ModuleDescriptor> descriptors, const ModuleIndex &modules,
                                                     const CapabilityProviderIndex &capabilityProviders) {
             GraphEdges edges{.outgoing = std::vector<std::set<std::size_t>>(descriptors.size()),
                              .incomingCount = std::vector<std::size_t>(descriptors.size())};
-            for (std::size_t dependant = 0; dependant < descriptors.size(); ++dependant) {
-                if (const Result<void> dependencyResult = AddDependencyEdges(descriptors, modules, dependant, edges);
-                    dependencyResult.HasError())
-                    return Result<GraphEdges>::Failure(dependencyResult.ErrorValue());
-                if (const Result<void> capabilityResult = AddCapabilityEdges(descriptors, capabilityProviders, dependant, edges);
-                    capabilityResult.HasError())
-                    return Result<GraphEdges>::Failure(capabilityResult.ErrorValue());
+            for (std::size_t i = 0; i < descriptors.size(); ++i) {
+                if (auto r = AddDependencyEdges(descriptors, modules, i, edges); r.HasError())
+                    return Result<GraphEdges>::Failure(r.ErrorValue());
+                if (auto r = AddCapabilityEdges(descriptors, capabilityProviders, i, edges); r.HasError())
+                    return Result<GraphEdges>::Failure(r.ErrorValue());
             }
             return Result<GraphEdges>::Success(std::move(edges));
         }
 
-        template <typename Compare>
-        void CollectReadyNodes(const std::vector<std::size_t> &incomingCount, std::set<std::size_t, Compare> &ready) {
-            for (std::size_t index = 0; index < incomingCount.size(); ++index) {
-                if (incomingCount[index] == 0)
-                    ready.emplace(index);
+        /** @brief Produces a stable provider-first initialization order, or reports a cycle. */
+        [[nodiscard]] Result<ValidatedModuleGraph> OrderGraph(const std::span<const ModuleDescriptor> descriptors, GraphEdges edges) {
+            const auto compareById = [&descriptors](const std::size_t a, const std::size_t b) {
+                return descriptors[a].id.value < descriptors[b].id.value;
+            };
+            std::set<std::size_t, decltype(compareById)> ready(compareById);
+            for (std::size_t i = 0; i < edges.incomingCount.size(); ++i) {
+                if (edges.incomingCount[i] == 0)
+                    ready.emplace(i);
             }
-        }
 
-        template <typename Compare>
-        void DrainReadyNodes(std::set<std::size_t, Compare> &ready, const std::span<const ModuleDescriptor> descriptors, GraphEdges &edges,
-                             ValidatedModuleGraph &graph) {
+            ValidatedModuleGraph graph;
+            graph.initializationOrder.reserve(descriptors.size());
             while (!ready.empty()) {
-                const auto iter = ready.begin();
-                const std::size_t provider = *iter;
-                ready.erase(iter);
+                const std::size_t provider = *ready.begin();
+                ready.erase(ready.begin());
                 graph.initializationOrder.push_back(descriptors[provider].id);
                 for (const std::size_t dependant : edges.outgoing[provider]) {
                     if (--edges.incomingCount[dependant] == 0)
                         ready.emplace(dependant);
                 }
             }
-        }
 
-        /** @brief Produces stable provider-first order or reports a remaining cycle. */
-        [[nodiscard]] Result<ValidatedModuleGraph> OrderGraph(const std::span<const ModuleDescriptor> descriptors, GraphEdges edges) {
-            const auto compareById = [&descriptors](const std::size_t left, const std::size_t right) {
-                return descriptors[left].id.value < descriptors[right].id.value;
-            };
-            std::set<std::size_t, decltype(compareById)> ready(compareById);
-            CollectReadyNodes(edges.incomingCount, ready);
-
-            ValidatedModuleGraph graph;
-            graph.initializationOrder.reserve(descriptors.size());
-            DrainReadyNodes(ready, descriptors, edges, graph);
-
-            if (graph.initializationOrder.size() != descriptors.size()) {
+            if (graph.initializationOrder.size() != descriptors.size())
                 return Fail<ValidatedModuleGraph>(ModuleDescriptorErrors::DependencyCycle,
                                                   "Module descriptor graph contains a dependency cycle.");
-            }
             return Result<ValidatedModuleGraph>::Success(std::move(graph));
         }
     }  // namespace
 
     /** @copydoc ValidateModuleGraph */
     Result<ValidatedModuleGraph> ValidateModuleGraph(const std::span<const ModuleDescriptor> descriptors) {
-        Result<ModuleIndex> modules = IndexModules(descriptors);
+        auto modules = IndexModules(descriptors);
         if (modules.HasError())
             return Result<ValidatedModuleGraph>::Failure(modules.ErrorValue());
 
         const CapabilityProviderIndex capabilityProviders = IndexCapabilityProviders(descriptors);
-        Result<GraphEdges> edges = BuildEdges(descriptors, modules.Value(), capabilityProviders);
+        auto edges = BuildEdges(descriptors, modules.Value(), capabilityProviders);
         if (edges.HasError())
             return Result<ValidatedModuleGraph>::Failure(edges.ErrorValue());
         return OrderGraph(descriptors, std::move(edges).Value());

--- a/src/foundation/modules/ModuleDescriptor.cpp
+++ b/src/foundation/modules/ModuleDescriptor.cpp
@@ -48,9 +48,11 @@ namespace Horo {
             return Result<ValueT>::Failure(MakeError(descriptor, std::move(message)));
         }
 
-        /** @brief Returns whether lifecycle callbacks are both absent or both present. */
-        [[nodiscard]] bool HasPairedCallbacks(const ModuleLifecycleCallbacks &callbacks) noexcept {
-            return (callbacks.activate == nullptr) == (callbacks.deactivate == nullptr);
+        /** @brief Returns whether lifecycle callbacks form one valid activation lifetime. */
+        [[nodiscard]] bool HasValidLifecycleCallbacks(const ModuleLifecycleCallbacks &callbacks) noexcept {
+            const bool hasPairedEndpoints = (callbacks.activate == nullptr) == (callbacks.deactivate == nullptr);
+            const bool drainHasLifetime = callbacks.drain == nullptr || callbacks.activate != nullptr;
+            return hasPairedEndpoints && drainHasLifetime;
         }
 
         /** @brief Returns whether a child identity is strictly nested below its parent identity. */
@@ -132,8 +134,10 @@ namespace Horo {
         [[nodiscard]] std::optional<std::string> ValidateLocalDescriptor(const ModuleDescriptor &descriptor) {
             if (!IsCanonicalId(descriptor.id.value))
                 return "Module identity is not canonical: '" + descriptor.id.value + "'.";
-            if (!HasPairedCallbacks(descriptor.lifecycle))
-                return "Module '" + descriptor.id.value + "' must declare both lifecycle callbacks or neither.";
+            if (!HasValidLifecycleCallbacks(descriptor.lifecycle)) {
+                return "Module '" + descriptor.id.value +
+                       "' must pair activation and deactivation, and may drain only within that lifetime.";
+            }
             if (const auto failure = ValidateDependencies(descriptor); failure.has_value())
                 return failure;
             if (const auto failure = ValidateProvidedCapabilities(descriptor); failure.has_value())

--- a/src/foundation/modules/ModuleDescriptor.cpp
+++ b/src/foundation/modules/ModuleDescriptor.cpp
@@ -214,26 +214,37 @@ namespace Horo {
                 ++edges.incomingCount[dependant];
         }
 
+        [[nodiscard]] Result<std::optional<std::size_t>> ResolveDependencyProvider(const ModuleDescriptor &descriptor,
+                                                                                   const ModuleDependency &dependency,
+                                                                                   const std::span<const ModuleDescriptor> descriptors,
+                                                                                   const ModuleIndex &modules) {
+            const auto provider = modules.find(dependency.module.value);
+            if (provider == modules.end()) {
+                if (dependency.kind == ModuleDependencyKind::Required) {
+                    return Fail<std::optional<std::size_t>>(ModuleDescriptorErrors::MissingDependency, "Module '" + descriptor.id.value +
+                                                                                                           "' requires missing module '" +
+                                                                                                           dependency.module.value + "'.");
+                }
+                return Result<std::optional<std::size_t>>::Success(std::nullopt);
+            }
+            if (descriptors[provider->second].version < dependency.minimumVersion) {
+                return Fail<std::optional<std::size_t>>(ModuleDescriptorErrors::IncompatibleDependency,
+                                                        "Module '" + descriptor.id.value + "' requires a newer contract from '" +
+                                                            dependency.module.value + "'.");
+            }
+            return Result<std::optional<std::size_t>>::Success(provider->second);
+        }
+
         /** @brief Resolves and validates explicit module dependencies for one dependant. */
         [[nodiscard]] Result<void> AddDependencyEdges(const std::span<const ModuleDescriptor> descriptors, const ModuleIndex &modules,
                                                       const std::size_t dependant, GraphEdges &edges) {
             const ModuleDescriptor &descriptor = descriptors[dependant];
             for (const ModuleDependency &dependency : descriptor.dependencies) {
-                const auto provider = modules.find(dependency.module.value);
-                if (provider == modules.end()) {
-                    if (dependency.kind == ModuleDependencyKind::Required) {
-                        return Fail<void>(ModuleDescriptorErrors::MissingDependency, "Module '" + descriptor.id.value +
-                                                                                         "' requires missing module '" +
-                                                                                         dependency.module.value + "'.");
-                    }
-                    continue;
-                }
-                if (descriptors[provider->second].version < dependency.minimumVersion) {
-                    return Fail<void>(ModuleDescriptorErrors::IncompatibleDependency, "Module '" + descriptor.id.value +
-                                                                                          "' requires a newer contract from '" +
-                                                                                          dependency.module.value + "'.");
-                }
-                AddEdge(edges, provider->second, dependant);
+                const auto provider = ResolveDependencyProvider(descriptor, dependency, descriptors, modules);
+                if (provider.HasError())
+                    return Result<void>::Failure(provider.ErrorValue());
+                if (provider.Value().has_value())
+                    AddEdge(edges, *provider.Value(), dependant);
             }
             return Result<void>::Success();
         }

--- a/src/foundation/modules/ModuleHost.cpp
+++ b/src/foundation/modules/ModuleHost.cpp
@@ -15,9 +15,8 @@ namespace Horo {
         }
 
         /** @brief Indexes descriptors by identity so activation follows the validated ID order. */
-        [[nodiscard]] std::vector<const ModuleDescriptor *> OrderRegisteredDescriptors(
-            const std::vector<ModuleDescriptor> &registered,
-            const std::vector<ModuleId> &order) {
+        [[nodiscard]] std::vector<const ModuleDescriptor *> OrderRegisteredDescriptors(const std::vector<ModuleDescriptor> &registered,
+                                                                                       const std::vector<ModuleId> &order) {
             std::vector<const ModuleDescriptor *> ordered;
             ordered.reserve(order.size());
             for (const ModuleId &id : order) {

--- a/src/foundation/modules/ModuleHost.cpp
+++ b/src/foundation/modules/ModuleHost.cpp
@@ -3,29 +3,30 @@
 #include "foundation/FoundationErrors.h"
 
 #include <algorithm>
+#include <format>
 #include <memory>
 #include <string>
 #include <utility>
 
 namespace Horo {
     namespace {
-        /** @brief Creates a typed composition failure from a stable error descriptor. */
-        template <typename ValueT> [[nodiscard]] Result<ValueT> Fail(const ErrorCodeDescriptor &descriptor, std::string message) {
-            return Result<ValueT>::Failure(MakeError(descriptor, std::move(message)));
+        /** @brief Returns a typed composition failure from a stable error descriptor. */
+        template <typename T> [[nodiscard]] Result<T> Fail(const ErrorCodeDescriptor &descriptor, std::string message) {
+            return Result<T>::Failure(MakeError(descriptor, std::move(message)));
         }
 
-        /** @brief Indexes descriptors by identity so activation follows the validated ID order. */
+        /** @brief Maps validated initialization order back to registered descriptor pointers. */
         [[nodiscard]] std::vector<const ModuleDescriptor *> OrderRegisteredDescriptors(const std::vector<ModuleDescriptor> &registered,
                                                                                        const std::vector<ModuleId> &order) {
-            std::vector<const ModuleDescriptor *> ordered;
-            ordered.reserve(order.size());
+            std::vector<const ModuleDescriptor *> result;
+            result.reserve(order.size());
             for (const ModuleId &id : order) {
-                const auto found = std::ranges::find_if(registered, [&id](const ModuleDescriptor &descriptor) {
-                    return descriptor.id == id;
+                const auto found = std::ranges::find_if(registered, [&id](const ModuleDescriptor &d) {
+                    return d.id == id;
                 });
-                ordered.push_back(std::to_address(found));
+                result.push_back(std::to_address(found));
             }
-            return ordered;
+            return result;
         }
     }  // namespace
 
@@ -36,32 +37,31 @@ namespace Horo {
     /** @copydoc ModuleHost::ActivateRegistered */
     Result<std::size_t> ModuleHost::ActivateRegistered(const ModuleActivationContext::DependencyBindings bindings) {
         // Graph validation runs before any callback: a rejected set leaves the host untouched.
-        const Result<ValidatedModuleGraph> validated = ValidateModuleGraph(m_registered);
+        auto validated = ValidateModuleGraph(m_registered);
         if (validated.HasError())
             return Result<std::size_t>::Failure(validated.ErrorValue());
 
         const std::vector<const ModuleDescriptor *> ordered =
             OrderRegisteredDescriptors(m_registered, validated.Value().initializationOrder);
 
-        // Roll back only modules started by this call; a prior successful activation
-        // may still own the front of the active list (incremental compose-then-activate).
+        // Roll back only modules started by this call; prior activations own the front of the list.
         const std::size_t base = m_active.size();
         m_active.reserve(base + ordered.size());
         for (const ModuleDescriptor *descriptor : ordered) {
             auto context = std::make_unique<ModuleActivationContext>(descriptor->id, bindings);
             Transition(descriptor->id, ModuleLifecycleState::Activating);
             if (descriptor->lifecycle.activate != nullptr) {
-                if (const Result<void> activated = descriptor->lifecycle.activate(*context); activated.HasError()) {
+                if (const Result<void> r = descriptor->lifecycle.activate(*context); r.HasError()) {
                     const std::string failedId = descriptor->id.value;
                     RollbackActivation(descriptor->id, std::move(context), base);
-                    return Fail<std::size_t>(ModuleDescriptorErrors::InvalidDescriptor, "Activation of module '" + failedId + "' failed.");
+                    return Fail<std::size_t>(ModuleDescriptorErrors::InvalidDescriptor,
+                                             std::format("Activation of module '{}' failed.", failedId));
                 }
             }
-            ActiveModule active{.id = descriptor->id,
-                                .drain = descriptor->lifecycle.drain,
-                                .deactivate = descriptor->lifecycle.deactivate,
-                                .context = std::move(context)};
-            m_active.push_back(std::move(active));
+            m_active.push_back(ActiveModule{.id = descriptor->id,
+                                            .drain = descriptor->lifecycle.drain,
+                                            .deactivate = descriptor->lifecycle.deactivate,
+                                            .context = std::move(context)});
             Transition(descriptor->id, ModuleLifecycleState::Active);
         }
         m_registered.clear();

--- a/src/foundation/modules/ModuleHost.cpp
+++ b/src/foundation/modules/ModuleHost.cpp
@@ -14,21 +14,11 @@ namespace Horo {
             return Result<ValueT>::Failure(MakeError(descriptor, std::move(message)));
         }
 
-        /** @brief Deactivates one active entry and releases its activation context. */
-        void DeactivateOne(ActiveModule &active) noexcept {
-            if (active.deactivate != nullptr && active.context != nullptr)
-                active.deactivate(*active.context);
-            active.context.reset();
-        }
-
-        /** @brief Rolls back every activation started after @p base in reverse order. */
-        void RollBackTo(std::vector<ActiveModule> &activeModules, const std::size_t base) noexcept {
-            while (activeModules.size() > base) {
-                DeactivateOne(activeModules.back());
-                activeModules.pop_back();
-            }
-        }
     }  // namespace
+
+    ModuleHost::~ModuleHost() {
+        DeactivateAll();
+    }
 
     /** @copydoc ModuleHost::ActivateRegistered */
     Result<std::size_t> ModuleHost::ActivateRegistered(const ModuleActivationContext::DependencyBindings bindings) {
@@ -50,17 +40,33 @@ namespace Horo {
         // Roll back only modules started by this call; a prior successful activation
         // may still own the front of the active list (incremental compose-then-activate).
         const std::size_t base = m_active.size();
+        m_active.reserve(base + ordered.size());
         for (const ModuleDescriptor *descriptor : ordered) {
             auto context = std::make_unique<ModuleActivationContext>(descriptor->id, bindings);
+            Transition(descriptor->id, ModuleLifecycleState::Activating);
             if (descriptor->lifecycle.activate != nullptr) {
                 if (const Result<void> activated = descriptor->lifecycle.activate(*context); activated.HasError()) {
-                    RollBackTo(m_active, base);
+                    Transition(descriptor->id, ModuleLifecycleState::Failed);
+                    context->RequestShutdown();
+                    RequestCancellationFrom(base);
+                    context->DrainCallbacks();
+                    context.reset();
+                    DeactivateFrom(base);
+                    for (const ModuleDescriptor &pending : m_registered) {
+                        if (StateOf(pending.id) == ModuleLifecycleState::Registered)
+                            Transition(pending.id, ModuleLifecycleState::Stopped);
+                    }
+                    m_registered.clear();
                     return Fail<std::size_t>(ModuleDescriptorErrors::InvalidDescriptor,
                                              "Activation of module '" + descriptor->id.value + "' failed.");
                 }
             }
-            ActiveModule active{.id = descriptor->id, .deactivate = descriptor->lifecycle.deactivate, .context = std::move(context)};
+            ActiveModule active{.id = descriptor->id,
+                                .drain = descriptor->lifecycle.drain,
+                                .deactivate = descriptor->lifecycle.deactivate,
+                                .context = std::move(context)};
             m_active.push_back(std::move(active));
+            Transition(descriptor->id, ModuleLifecycleState::Active);
         }
         m_registered.clear();
         return Result<std::size_t>::Success(m_active.size() - base);
@@ -68,7 +74,12 @@ namespace Horo {
 
     /** @copydoc ModuleHost::DeactivateAll */
     void ModuleHost::DeactivateAll() noexcept {
-        RollBackTo(m_active, 0);
+        RequestCancellationFrom(0);
+        DeactivateFrom(0);
+        for (const ModuleDescriptor &pending : m_registered) {
+            if (StateOf(pending.id) == ModuleLifecycleState::Registered)
+                Transition(pending.id, ModuleLifecycleState::Stopped);
+        }
         m_registered.clear();
     }
 

--- a/src/foundation/modules/ModuleHost.cpp
+++ b/src/foundation/modules/ModuleHost.cpp
@@ -14,6 +14,20 @@ namespace Horo {
             return Result<ValueT>::Failure(MakeError(descriptor, std::move(message)));
         }
 
+        /** @brief Indexes descriptors by identity so activation follows the validated ID order. */
+        [[nodiscard]] std::vector<const ModuleDescriptor *> OrderRegisteredDescriptors(
+            const std::vector<ModuleDescriptor> &registered,
+            const std::vector<ModuleId> &order) {
+            std::vector<const ModuleDescriptor *> ordered;
+            ordered.reserve(order.size());
+            for (const ModuleId &id : order) {
+                const auto found = std::ranges::find_if(registered, [&id](const ModuleDescriptor &descriptor) {
+                    return descriptor.id == id;
+                });
+                ordered.push_back(std::to_address(found));
+            }
+            return ordered;
+        }
     }  // namespace
 
     ModuleHost::~ModuleHost() {
@@ -27,15 +41,8 @@ namespace Horo {
         if (validated.HasError())
             return Result<std::size_t>::Failure(validated.ErrorValue());
 
-        // Index descriptors by identity so activation follows the validated ID order.
-        std::vector<const ModuleDescriptor *> ordered;
-        ordered.reserve(validated.Value().initializationOrder.size());
-        for (const ModuleId &id : validated.Value().initializationOrder) {
-            const auto found = std::ranges::find_if(m_registered, [&id](const ModuleDescriptor &descriptor) {
-                return descriptor.id == id;
-            });
-            ordered.push_back(std::to_address(found));
-        }
+        const std::vector<const ModuleDescriptor *> ordered =
+            OrderRegisteredDescriptors(m_registered, validated.Value().initializationOrder);
 
         // Roll back only modules started by this call; a prior successful activation
         // may still own the front of the active list (incremental compose-then-activate).
@@ -46,17 +53,7 @@ namespace Horo {
             Transition(descriptor->id, ModuleLifecycleState::Activating);
             if (descriptor->lifecycle.activate != nullptr) {
                 if (const Result<void> activated = descriptor->lifecycle.activate(*context); activated.HasError()) {
-                    Transition(descriptor->id, ModuleLifecycleState::Failed);
-                    context->RequestShutdown();
-                    RequestCancellationFrom(base);
-                    context->DrainCallbacks();
-                    context.reset();
-                    DeactivateFrom(base);
-                    for (const ModuleDescriptor &pending : m_registered) {
-                        if (StateOf(pending.id) == ModuleLifecycleState::Registered)
-                            Transition(pending.id, ModuleLifecycleState::Stopped);
-                    }
-                    m_registered.clear();
+                    RollbackActivation(*descriptor, std::move(context), base);
                     return Fail<std::size_t>(ModuleDescriptorErrors::InvalidDescriptor,
                                              "Activation of module '" + descriptor->id.value + "' failed.");
                 }
@@ -76,11 +73,7 @@ namespace Horo {
     void ModuleHost::DeactivateAll() noexcept {
         RequestCancellationFrom(0);
         DeactivateFrom(0);
-        for (const ModuleDescriptor &pending : m_registered) {
-            if (StateOf(pending.id) == ModuleLifecycleState::Registered)
-                Transition(pending.id, ModuleLifecycleState::Stopped);
-        }
-        m_registered.clear();
+        StopUnactivatedRegistered();
     }
 
     /** @copydoc ModuleHost::HasActiveModules */

--- a/src/foundation/modules/ModuleHost.cpp
+++ b/src/foundation/modules/ModuleHost.cpp
@@ -52,9 +52,9 @@ namespace Horo {
             Transition(descriptor->id, ModuleLifecycleState::Activating);
             if (descriptor->lifecycle.activate != nullptr) {
                 if (const Result<void> activated = descriptor->lifecycle.activate(*context); activated.HasError()) {
-                    RollbackActivation(*descriptor, std::move(context), base);
-                    return Fail<std::size_t>(ModuleDescriptorErrors::InvalidDescriptor,
-                                             "Activation of module '" + descriptor->id.value + "' failed.");
+                    const std::string failedId = descriptor->id.value;
+                    RollbackActivation(descriptor->id, std::move(context), base);
+                    return Fail<std::size_t>(ModuleDescriptorErrors::InvalidDescriptor, "Activation of module '" + failedId + "' failed.");
                 }
             }
             ActiveModule active{.id = descriptor->id,

--- a/src/foundation/modules/ModuleHostLifecycle.cpp
+++ b/src/foundation/modules/ModuleHostLifecycle.cpp
@@ -1,29 +1,25 @@
 #include "Horo/Foundation/ModuleHost.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
+#include <utility>
 
 namespace Horo {
     namespace {
         /** @brief Returns whether one host-owned module state transition is legal. */
-        [[nodiscard]] bool IsLegalTransition(const ModuleLifecycleState from, const ModuleLifecycleState to) noexcept {
+        [[nodiscard]] constexpr bool IsLegalTransition(const ModuleLifecycleState from, const ModuleLifecycleState to) noexcept {
             using enum ModuleLifecycleState;
-            switch (from) {
-                case Registered:
-                    return to == Activating || to == Stopped;
-                case Activating:
-                    return to == Active || to == Failed;
-                case Active:
-                    return to == CancellationRequested;
-                case CancellationRequested:
-                    return to == Draining;
-                case Draining:
-                    return to == Stopped;
-                case Stopped:
-                case Failed:
-                    return false;
-            }
-            return false;
+            constexpr std::array<std::pair<ModuleLifecycleState, ModuleLifecycleState>, 7> kAllowedTransitions{{
+                {Registered, Activating},
+                {Registered, Stopped},
+                {Activating, Active},
+                {Activating, Failed},
+                {Active, CancellationRequested},
+                {CancellationRequested, Draining},
+                {Draining, Stopped},
+            }};
+            return std::ranges::find(kAllowedTransitions, std::pair{from, to}) != kAllowedTransitions.end();
         }
     }  // namespace
 
@@ -41,8 +37,11 @@ namespace Horo {
         const auto found = std::ranges::find_if(m_states, [&id](const ModuleStateRecord &record) {
             return record.id == id;
         });
-        assert(found != m_states.end());
-        assert(IsLegalTransition(found->state, state));
+        if (found == m_states.end() || !IsLegalTransition(found->state, state)) {
+            assert(found != m_states.end() && "Unknown module identity in lifecycle transition.");
+            assert(found != m_states.end() && IsLegalTransition(found->state, state) && "Illegal module lifecycle transition.");
+            return;
+        }
         found->state = state;
     }
 
@@ -67,5 +66,25 @@ namespace Horo {
             Transition(active.id, ModuleLifecycleState::Stopped);
             m_active.pop_back();
         }
+    }
+
+    void ModuleHost::StopUnactivatedRegistered() noexcept {
+        for (const ModuleDescriptor &pending : m_registered) {
+            if (StateOf(pending.id) == ModuleLifecycleState::Registered)
+                Transition(pending.id, ModuleLifecycleState::Stopped);
+        }
+        m_registered.clear();
+    }
+
+    void ModuleHost::RollbackActivation(const ModuleDescriptor &failedDescriptor,
+                                        std::unique_ptr<ModuleActivationContext> failedContext,
+                                        const std::size_t base) noexcept {
+        Transition(failedDescriptor.id, ModuleLifecycleState::Failed);
+        failedContext->RequestShutdown();
+        RequestCancellationFrom(base);
+        failedContext->DrainCallbacks();
+        failedContext.reset();
+        DeactivateFrom(base);
+        StopUnactivatedRegistered();
     }
 }  // namespace Horo

--- a/src/foundation/modules/ModuleHostLifecycle.cpp
+++ b/src/foundation/modules/ModuleHostLifecycle.cpp
@@ -21,6 +21,17 @@ namespace Horo {
             }};
             return std::ranges::find(kAllowedTransitions, std::pair{from, to}) != kAllowedTransitions.end();
         }
+
+        void DeactivateActiveModule(ModuleHost &host, ActiveModule &active) noexcept {
+            host.Transition(active.id, ModuleLifecycleState::Draining);
+            active.context->DrainCallbacks();
+            if (active.drain != nullptr)
+                active.drain(*active.context);
+            if (active.deactivate != nullptr)
+                active.deactivate(*active.context);
+            active.context.reset();
+            host.Transition(active.id, ModuleLifecycleState::Stopped);
+        }
     }  // namespace
 
     /** @copydoc ModuleHost::StateOf */
@@ -55,15 +66,7 @@ namespace Horo {
 
     void ModuleHost::DeactivateFrom(const std::size_t base) noexcept {
         while (m_active.size() > base) {
-            ActiveModule &active = m_active.back();
-            Transition(active.id, ModuleLifecycleState::Draining);
-            active.context->DrainCallbacks();
-            if (active.drain != nullptr)
-                active.drain(*active.context);
-            if (active.deactivate != nullptr)
-                active.deactivate(*active.context);
-            active.context.reset();
-            Transition(active.id, ModuleLifecycleState::Stopped);
+            DeactivateActiveModule(*this, m_active.back());
             m_active.pop_back();
         }
     }

--- a/src/foundation/modules/ModuleHostLifecycle.cpp
+++ b/src/foundation/modules/ModuleHostLifecycle.cpp
@@ -76,9 +76,9 @@ namespace Horo {
         m_registered.clear();
     }
 
-    void ModuleHost::RollbackActivation(const ModuleDescriptor &failedDescriptor, std::unique_ptr<ModuleActivationContext> failedContext,
+    void ModuleHost::RollbackActivation(const ModuleId &failedId, std::unique_ptr<ModuleActivationContext> failedContext,
                                         const std::size_t base) noexcept {
-        Transition(failedDescriptor.id, ModuleLifecycleState::Failed);
+        Transition(failedId, ModuleLifecycleState::Failed);
         failedContext->RequestShutdown();
         RequestCancellationFrom(base);
         failedContext->DrainCallbacks();

--- a/src/foundation/modules/ModuleHostLifecycle.cpp
+++ b/src/foundation/modules/ModuleHostLifecycle.cpp
@@ -22,16 +22,6 @@ namespace Horo {
             return std::ranges::find(kAllowedTransitions, std::pair{from, to}) != kAllowedTransitions.end();
         }
 
-        void DeactivateActiveModule(ModuleHost &host, ActiveModule &active) noexcept {
-            host.Transition(active.id, ModuleLifecycleState::Draining);
-            active.context->DrainCallbacks();
-            if (active.drain != nullptr)
-                active.drain(*active.context);
-            if (active.deactivate != nullptr)
-                active.deactivate(*active.context);
-            active.context.reset();
-            host.Transition(active.id, ModuleLifecycleState::Stopped);
-        }
     }  // namespace
 
     /** @copydoc ModuleHost::StateOf */
@@ -58,15 +48,26 @@ namespace Horo {
 
     void ModuleHost::RequestCancellationFrom(const std::size_t base) noexcept {
         for (std::size_t index = m_active.size(); index > base; --index) {
-            ActiveModule &active = m_active[index - 1];
+            const ActiveModule &active = m_active[index - 1];
             active.context->RequestShutdown();
             Transition(active.id, ModuleLifecycleState::CancellationRequested);
         }
     }
 
+    void ModuleHost::DeactivateActiveModule(ActiveModule &active) noexcept {
+        Transition(active.id, ModuleLifecycleState::Draining);
+        active.context->DrainCallbacks();
+        if (active.drain != nullptr)
+            active.drain(*active.context);
+        if (active.deactivate != nullptr)
+            active.deactivate(*active.context);
+        active.context.reset();
+        Transition(active.id, ModuleLifecycleState::Stopped);
+    }
+
     void ModuleHost::DeactivateFrom(const std::size_t base) noexcept {
         while (m_active.size() > base) {
-            DeactivateActiveModule(*this, m_active.back());
+            DeactivateActiveModule(m_active.back());
             m_active.pop_back();
         }
     }

--- a/src/foundation/modules/ModuleHostLifecycle.cpp
+++ b/src/foundation/modules/ModuleHostLifecycle.cpp
@@ -76,8 +76,7 @@ namespace Horo {
         m_registered.clear();
     }
 
-    void ModuleHost::RollbackActivation(const ModuleDescriptor &failedDescriptor,
-                                        std::unique_ptr<ModuleActivationContext> failedContext,
+    void ModuleHost::RollbackActivation(const ModuleDescriptor &failedDescriptor, std::unique_ptr<ModuleActivationContext> failedContext,
                                         const std::size_t base) noexcept {
         Transition(failedDescriptor.id, ModuleLifecycleState::Failed);
         failedContext->RequestShutdown();

--- a/src/foundation/modules/ModuleHostLifecycle.cpp
+++ b/src/foundation/modules/ModuleHostLifecycle.cpp
@@ -1,0 +1,71 @@
+#include "Horo/Foundation/ModuleHost.h"
+
+#include <algorithm>
+#include <cassert>
+
+namespace Horo {
+    namespace {
+        /** @brief Returns whether one host-owned module state transition is legal. */
+        [[nodiscard]] bool IsLegalTransition(const ModuleLifecycleState from, const ModuleLifecycleState to) noexcept {
+            using enum ModuleLifecycleState;
+            switch (from) {
+                case Registered:
+                    return to == Activating || to == Stopped;
+                case Activating:
+                    return to == Active || to == Failed;
+                case Active:
+                    return to == CancellationRequested;
+                case CancellationRequested:
+                    return to == Draining;
+                case Draining:
+                    return to == Stopped;
+                case Stopped:
+                case Failed:
+                    return false;
+            }
+            return false;
+        }
+    }  // namespace
+
+    /** @copydoc ModuleHost::StateOf */
+    std::optional<ModuleLifecycleState> ModuleHost::StateOf(const ModuleId &id) const noexcept {
+        const auto found = std::ranges::find_if(m_states, [&id](const ModuleStateRecord &record) {
+            return record.id == id;
+        });
+        if (found == m_states.end())
+            return std::nullopt;
+        return found->state;
+    }
+
+    void ModuleHost::Transition(const ModuleId &id, const ModuleLifecycleState state) noexcept {
+        const auto found = std::ranges::find_if(m_states, [&id](const ModuleStateRecord &record) {
+            return record.id == id;
+        });
+        assert(found != m_states.end());
+        assert(IsLegalTransition(found->state, state));
+        found->state = state;
+    }
+
+    void ModuleHost::RequestCancellationFrom(const std::size_t base) noexcept {
+        for (std::size_t index = m_active.size(); index > base; --index) {
+            ActiveModule &active = m_active[index - 1];
+            active.context->RequestShutdown();
+            Transition(active.id, ModuleLifecycleState::CancellationRequested);
+        }
+    }
+
+    void ModuleHost::DeactivateFrom(const std::size_t base) noexcept {
+        while (m_active.size() > base) {
+            ActiveModule &active = m_active.back();
+            Transition(active.id, ModuleLifecycleState::Draining);
+            active.context->DrainCallbacks();
+            if (active.drain != nullptr)
+                active.drain(*active.context);
+            if (active.deactivate != nullptr)
+                active.deactivate(*active.context);
+            active.context.reset();
+            Transition(active.id, ModuleLifecycleState::Stopped);
+            m_active.pop_back();
+        }
+    }
+}  // namespace Horo

--- a/src/foundation/modules/ModuleHostLifecycle.cpp
+++ b/src/foundation/modules/ModuleHostLifecycle.cpp
@@ -38,11 +38,10 @@ namespace Horo {
         const auto found = std::ranges::find_if(m_states, [&id](const ModuleStateRecord &record) {
             return record.id == id;
         });
-        if (found == m_states.end() || !IsLegalTransition(found->state, state)) {
-            assert(found != m_states.end() && "Unknown module identity in lifecycle transition.");
-            assert(found != m_states.end() && IsLegalTransition(found->state, state) && "Illegal module lifecycle transition.");
+        const bool valid = found != m_states.end() && IsLegalTransition(found->state, state);
+        assert(valid && "Invalid module lifecycle transition.");
+        if (!valid)
             return;
-        }
         found->state = state;
     }
 

--- a/src/foundation/modules/ModuleHostLifecycle.cpp
+++ b/src/foundation/modules/ModuleHostLifecycle.cpp
@@ -7,10 +7,10 @@
 
 namespace Horo {
     namespace {
-        /** @brief Returns whether one host-owned module state transition is legal. */
+        /** @brief Returns whether a host-owned lifecycle state transition is legal. */
         [[nodiscard]] constexpr bool IsLegalTransition(const ModuleLifecycleState from, const ModuleLifecycleState to) noexcept {
             using enum ModuleLifecycleState;
-            constexpr std::array<std::pair<ModuleLifecycleState, ModuleLifecycleState>, 7> kAllowedTransitions{{
+            constexpr std::array<std::pair<ModuleLifecycleState, ModuleLifecycleState>, 7> kAllowed{{
                 {Registered, Activating},
                 {Registered, Stopped},
                 {Activating, Active},
@@ -19,35 +19,33 @@ namespace Horo {
                 {CancellationRequested, Draining},
                 {Draining, Stopped},
             }};
-            return std::ranges::find(kAllowedTransitions, std::pair{from, to}) != kAllowedTransitions.end();
+            return std::ranges::find(kAllowed, std::pair{from, to}) != kAllowed.end();
         }
-
     }  // namespace
 
     /** @copydoc ModuleHost::StateOf */
     std::optional<ModuleLifecycleState> ModuleHost::StateOf(const ModuleId &id) const noexcept {
-        const auto found = std::ranges::find_if(m_states, [&id](const ModuleStateRecord &record) {
-            return record.id == id;
+        const auto found = std::ranges::find_if(m_states, [&id](const ModuleStateRecord &r) {
+            return r.id == id;
         });
         if (found == m_states.end())
             return std::nullopt;
         return found->state;
     }
 
-    void ModuleHost::Transition(const ModuleId &id, const ModuleLifecycleState state) noexcept {
-        const auto found = std::ranges::find_if(m_states, [&id](const ModuleStateRecord &record) {
-            return record.id == id;
+    void ModuleHost::Transition(const ModuleId &id, const ModuleLifecycleState to) noexcept {
+        const auto found = std::ranges::find_if(m_states, [&id](const ModuleStateRecord &r) {
+            return r.id == id;
         });
-        const bool valid = found != m_states.end() && IsLegalTransition(found->state, state);
+        const bool valid = found != m_states.end() && IsLegalTransition(found->state, to);
         assert(valid && "Invalid module lifecycle transition.");
-        if (!valid)
-            return;
-        found->state = state;
+        if (valid)
+            found->state = to;
     }
 
     void ModuleHost::RequestCancellationFrom(const std::size_t base) noexcept {
-        for (std::size_t index = m_active.size(); index > base; --index) {
-            const ActiveModule &active = m_active[index - 1];
+        for (std::size_t i = m_active.size(); i > base; --i) {
+            const ActiveModule &active = m_active[i - 1];
             active.context->RequestShutdown();
             Transition(active.id, ModuleLifecycleState::CancellationRequested);
         }
@@ -72,9 +70,9 @@ namespace Horo {
     }
 
     void ModuleHost::StopUnactivatedRegistered() noexcept {
-        for (const ModuleDescriptor &pending : m_registered) {
-            if (StateOf(pending.id) == ModuleLifecycleState::Registered)
-                Transition(pending.id, ModuleLifecycleState::Stopped);
+        for (const ModuleDescriptor &d : m_registered) {
+            if (StateOf(d.id) == ModuleLifecycleState::Registered)
+                Transition(d.id, ModuleLifecycleState::Stopped);
         }
         m_registered.clear();
     }

--- a/src/foundation/modules/ModuleHostRegistration.cpp
+++ b/src/foundation/modules/ModuleHostRegistration.cpp
@@ -8,9 +8,9 @@
 namespace Horo {
     namespace {
         [[nodiscard]] bool HasRepeatedDependencies(const ModuleDescriptor &descriptor) {
-            std::set<std::string, std::less<>> dependencyIds;
-            return std::ranges::any_of(descriptor.dependencies, [&dependencyIds](const ModuleDependency &dep) {
-                return !dependencyIds.emplace(dep.module.value).second;
+            std::set<std::string, std::less<>> seen;
+            return std::ranges::any_of(descriptor.dependencies, [&seen](const ModuleDependency &dep) {
+                return !seen.emplace(dep.module.value).second;
             });
         }
     }  // namespace
@@ -20,14 +20,12 @@ namespace Horo {
         // Registration is inert: local metadata is checked here, but graph-wide rules
         // (duplicates across the set, missing providers, cycles) stay in ActivateRegistered
         // so that registration never depends on the full set's state.
-        if (HasRepeatedDependencies(descriptor)) {
+        if (HasRepeatedDependencies(descriptor))
             return Result<void>::Failure(MakeError(ModuleDescriptorErrors::InvalidDescriptor,
                                                    "Module '" + descriptor.id.value + "' repeats a dependency at registration."));
-        }
-        if (StateOf(descriptor.id).has_value()) {
+        if (StateOf(descriptor.id).has_value())
             return Result<void>::Failure(
                 MakeError(ModuleDescriptorErrors::DuplicateModule, "Module '" + descriptor.id.value + "' already has a host lifetime."));
-        }
         m_registered.push_back(descriptor);
         m_states.push_back(ModuleStateRecord{.id = descriptor.id});
         return Result<void>::Success();

--- a/src/foundation/modules/ModuleHostRegistration.cpp
+++ b/src/foundation/modules/ModuleHostRegistration.cpp
@@ -5,25 +5,30 @@
 #include <set>
 #include <string>
 
-namespace Horo {
-    /** @copydoc ModuleHost::Register */
-    Result<void> ModuleHost::Register(const ModuleDescriptor &descriptor) {
-        // Registration is inert: local metadata is checked here, but graph-wide rules
-        // (duplicates across the set, missing providers, cycles) stay in ActivateRegistered
-        // so that registration never depends on the full set's state.
+namespace {
+    [[nodiscard]] bool HasRepeatedDependencies(const ModuleDescriptor &descriptor) {
         std::set<std::string, std::less<>> dependencyIds;
-        for (const ModuleDependency &dependency : descriptor.dependencies) {
-            if (!dependencyIds.emplace(dependency.module.value).second) {
-                return Result<void>::Failure(MakeError(ModuleDescriptorErrors::InvalidDescriptor,
-                                                       "Module '" + descriptor.id.value + "' repeats a dependency at registration."));
-            }
-        }
-        if (StateOf(descriptor.id).has_value()) {
-            return Result<void>::Failure(
-                MakeError(ModuleDescriptorErrors::DuplicateModule, "Module '" + descriptor.id.value + "' already has a host lifetime."));
-        }
-        m_registered.push_back(descriptor);
-        m_states.push_back(ModuleStateRecord{.id = descriptor.id});
-        return Result<void>::Success();
+        return std::ranges::any_of(descriptor.dependencies, [&dependencyIds](const ModuleDependency &dep) {
+            return !dependencyIds.emplace(dep.module.value).second;
+        });
     }
+}  // namespace
+
+/** @copydoc ModuleHost::Register */
+Result<void> ModuleHost::Register(const ModuleDescriptor &descriptor) {
+    // Registration is inert: local metadata is checked here, but graph-wide rules
+    // (duplicates across the set, missing providers, cycles) stay in ActivateRegistered
+    // so that registration never depends on the full set's state.
+    if (HasRepeatedDependencies(descriptor)) {
+        return Result<void>::Failure(MakeError(ModuleDescriptorErrors::InvalidDescriptor,
+                                               "Module '" + descriptor.id.value + "' repeats a dependency at registration."));
+    }
+    if (StateOf(descriptor.id).has_value()) {
+        return Result<void>::Failure(
+            MakeError(ModuleDescriptorErrors::DuplicateModule, "Module '" + descriptor.id.value + "' already has a host lifetime."));
+    }
+    m_registered.push_back(descriptor);
+    m_states.push_back(ModuleStateRecord{.id = descriptor.id});
+    return Result<void>::Success();
+}
 }  // namespace Horo

--- a/src/foundation/modules/ModuleHostRegistration.cpp
+++ b/src/foundation/modules/ModuleHostRegistration.cpp
@@ -18,19 +18,12 @@ namespace Horo {
                                                        "Module '" + descriptor.id.value + "' repeats a dependency at registration."));
             }
         }
-        for (const ActiveModule &active : m_active) {
-            if (active.id == descriptor.id) {
-                return Result<void>::Failure(
-                    MakeError(ModuleDescriptorErrors::DuplicateModule, "Module '" + descriptor.id.value + "' is already active."));
-            }
-        }
-        if (std::ranges::find_if(m_registered, [&descriptor](const ModuleDescriptor &registered) {
-            return registered.id == descriptor.id;
-        }) != m_registered.end()) {
+        if (StateOf(descriptor.id).has_value()) {
             return Result<void>::Failure(
-                MakeError(ModuleDescriptorErrors::DuplicateModule, "Module '" + descriptor.id.value + "' is already registered."));
+                MakeError(ModuleDescriptorErrors::DuplicateModule, "Module '" + descriptor.id.value + "' already has a host lifetime."));
         }
         m_registered.push_back(descriptor);
+        m_states.push_back(ModuleStateRecord{.id = descriptor.id});
         return Result<void>::Success();
     }
 }  // namespace Horo

--- a/src/foundation/modules/ModuleHostRegistration.cpp
+++ b/src/foundation/modules/ModuleHostRegistration.cpp
@@ -5,30 +5,31 @@
 #include <set>
 #include <string>
 
-namespace {
-    [[nodiscard]] bool HasRepeatedDependencies(const ModuleDescriptor &descriptor) {
-        std::set<std::string, std::less<>> dependencyIds;
-        return std::ranges::any_of(descriptor.dependencies, [&dependencyIds](const ModuleDependency &dep) {
-            return !dependencyIds.emplace(dep.module.value).second;
-        });
-    }
-}  // namespace
+namespace Horo {
+    namespace {
+        [[nodiscard]] bool HasRepeatedDependencies(const ModuleDescriptor &descriptor) {
+            std::set<std::string, std::less<>> dependencyIds;
+            return std::ranges::any_of(descriptor.dependencies, [&dependencyIds](const ModuleDependency &dep) {
+                return !dependencyIds.emplace(dep.module.value).second;
+            });
+        }
+    }  // namespace
 
-/** @copydoc ModuleHost::Register */
-Result<void> ModuleHost::Register(const ModuleDescriptor &descriptor) {
-    // Registration is inert: local metadata is checked here, but graph-wide rules
-    // (duplicates across the set, missing providers, cycles) stay in ActivateRegistered
-    // so that registration never depends on the full set's state.
-    if (HasRepeatedDependencies(descriptor)) {
-        return Result<void>::Failure(MakeError(ModuleDescriptorErrors::InvalidDescriptor,
-                                               "Module '" + descriptor.id.value + "' repeats a dependency at registration."));
+    /** @copydoc ModuleHost::Register */
+    Result<void> ModuleHost::Register(const ModuleDescriptor &descriptor) {
+        // Registration is inert: local metadata is checked here, but graph-wide rules
+        // (duplicates across the set, missing providers, cycles) stay in ActivateRegistered
+        // so that registration never depends on the full set's state.
+        if (HasRepeatedDependencies(descriptor)) {
+            return Result<void>::Failure(MakeError(ModuleDescriptorErrors::InvalidDescriptor,
+                                                   "Module '" + descriptor.id.value + "' repeats a dependency at registration."));
+        }
+        if (StateOf(descriptor.id).has_value()) {
+            return Result<void>::Failure(
+                MakeError(ModuleDescriptorErrors::DuplicateModule, "Module '" + descriptor.id.value + "' already has a host lifetime."));
+        }
+        m_registered.push_back(descriptor);
+        m_states.push_back(ModuleStateRecord{.id = descriptor.id});
+        return Result<void>::Success();
     }
-    if (StateOf(descriptor.id).has_value()) {
-        return Result<void>::Failure(
-            MakeError(ModuleDescriptorErrors::DuplicateModule, "Module '" + descriptor.id.value + "' already has a host lifetime."));
-    }
-    m_registered.push_back(descriptor);
-    m_states.push_back(ModuleStateRecord{.id = descriptor.id});
-    return Result<void>::Success();
-}
 }  // namespace Horo

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -569,6 +569,7 @@ target_link_libraries(HoroFoundationModuleDescriptorTests PRIVATE HoroEngine::Fo
 
 add_executable(HoroFoundationModuleHostCompositionTests
         unit/foundation/ModuleHostCompositionTests.cpp
+        unit/foundation/ModuleHostLifecycleTests.cpp
 )
 
 target_compile_features(HoroFoundationModuleHostCompositionTests PRIVATE cxx_std_20)

--- a/tests/unit/foundation/ModuleDescriptorGraphTests.cpp
+++ b/tests/unit/foundation/ModuleDescriptorGraphTests.cpp
@@ -18,6 +18,13 @@ namespace {
         return order;
     }
 
+    template <std::size_t N>
+    void RequireOrder(const std::array<ModuleDescriptor, N> &descriptors, const std::vector<std::string> &expectedOrder) {
+        const auto result = ValidateModuleGraph(descriptors);
+        REQUIRE(result.HasValue());
+        REQUIRE(OrderOf(result.Value()) == expectedOrder);
+    }
+
     TEST_CASE("Module descriptors produce a deterministic provider-first graph", "[unit][foundation][modules]") {
         ModuleDescriptor editor = MakeModule("horo.editor");
         editor.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.runtime"}, .minimumVersion = {1, 2, 0}});
@@ -35,11 +42,7 @@ namespace {
         renderNull.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.foundation"}});
 
         const std::array descriptors{editor, runtime, application, MakeModule("horo.foundation"), renderNull};
-        const Result<ValidatedModuleGraph> result = ValidateModuleGraph(descriptors);
-
-        REQUIRE(result.HasValue());
-        REQUIRE(OrderOf(result.Value()) ==
-                std::vector<std::string>{"horo.foundation", "horo.application", "horo.render.null", "horo.runtime", "horo.editor"});
+        RequireOrder(descriptors, {"horo.foundation", "horo.application", "horo.render.null", "horo.runtime", "horo.editor"});
     }
 
     TEST_CASE("Module descriptor graph rejects invalid module dependencies", "[unit][foundation][modules]") {
@@ -88,9 +91,7 @@ namespace {
             ModuleDescriptor consumer = MakeModule("horo.consumer");
             consumer.requiredCapabilities.push_back(ModuleCapabilityId{"horo.shared_cap"});
 
-            const auto result = ValidateModuleGraph(std::array{consumer, providerB, providerA});
-            REQUIRE(result.HasValue());
-            REQUIRE(OrderOf(result.Value()) == std::vector<std::string>{"horo.provider.a", "horo.provider.b", "horo.consumer"});
+            RequireOrder(std::array{consumer, providerB, providerA}, {"horo.provider.a", "horo.provider.b", "horo.consumer"});
         }
     }
 
@@ -101,9 +102,7 @@ namespace {
                                                               .minimumVersion = {1, 0, 0},
                                                               .kind = ModuleDependencyKind::Optional});
             ModuleDescriptor provider = MakeModule("horo.optional_provider");
-            const auto result = ValidateModuleGraph(std::array{dependant, provider});
-            REQUIRE(result.HasValue());
-            REQUIRE(OrderOf(result.Value()) == std::vector<std::string>{"horo.optional_provider", "horo.dependant"});
+            RequireOrder(std::array{dependant, provider}, {"horo.optional_provider", "horo.dependant"});
         }
 
         SECTION("absent optional dependency does not fail validation") {
@@ -111,9 +110,7 @@ namespace {
             runtime.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.render.opengl"},
                                                             .minimumVersion = {1, 0, 0},
                                                             .kind = ModuleDependencyKind::Optional});
-            const auto result = ValidateModuleGraph(std::array{runtime});
-            REQUIRE(result.HasValue());
-            REQUIRE(OrderOf(result.Value()) == std::vector<std::string>{"horo.runtime"});
+            RequireOrder(std::array{runtime}, {"horo.runtime"});
         }
 
         SECTION("redundant dependency and capability edge does not duplicate indegree") {
@@ -123,9 +120,7 @@ namespace {
             dependant.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.provider"}});
             dependant.requiredCapabilities.push_back(ModuleCapabilityId{"horo.service"});
 
-            const auto result = ValidateModuleGraph(std::array{dependant, provider});
-            REQUIRE(result.HasValue());
-            REQUIRE(OrderOf(result.Value()) == std::vector<std::string>{"horo.provider", "horo.dependant"});
+            RequireOrder(std::array{dependant, provider}, {"horo.provider", "horo.dependant"});
         }
     }
 
@@ -156,14 +151,10 @@ namespace {
             leaf.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.left"}});
             leaf.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.right"}});
 
-            const auto result = ValidateModuleGraph(std::array{leaf, right, left, root});
-            REQUIRE(result.HasValue());
-            REQUIRE(OrderOf(result.Value()) == std::vector<std::string>{"horo.root", "horo.left", "horo.right", "horo.leaf"});
+            RequireOrder(std::array{leaf, right, left, root}, {"horo.root", "horo.left", "horo.right", "horo.leaf"});
 
             const std::array independent{MakeModule("horo.gamma"), MakeModule("horo.alpha"), MakeModule("horo.beta")};
-            const auto independentResult = ValidateModuleGraph(independent);
-            REQUIRE(independentResult.HasValue());
-            REQUIRE(OrderOf(independentResult.Value()) == std::vector<std::string>{"horo.alpha", "horo.beta", "horo.gamma"});
+            RequireOrder(independent, {"horo.alpha", "horo.beta", "horo.gamma"});
         }
     }
 }  // namespace

--- a/tests/unit/foundation/ModuleDescriptorTests.cpp
+++ b/tests/unit/foundation/ModuleDescriptorTests.cpp
@@ -23,6 +23,24 @@ namespace {
 
     void Drain(ModuleActivationContext &) noexcept {}
 
+    template <typename T> void VerifyComparisonOperators(const T &a, const T &aCopy, const T &b) {
+        REQUIRE(a == aCopy);
+        REQUIRE(a != b);
+        REQUIRE(a < b);
+        REQUIRE(b > a);
+        REQUIRE(a <= aCopy);
+        REQUIRE(a <= b);
+        REQUIRE(b >= a);
+    }
+
+    void ExpectInvalidLifecycle(const ModuleLifecycleCallbacks &callbacks) {
+        ModuleDescriptor module = MakeModule("horo.runtime");
+        module.lifecycle = callbacks;
+        const auto result = ValidateModuleGraph(std::array{module});
+        REQUIRE(result.HasError());
+        REQUIRE(result.ErrorValue().code.Value() == "foundation.module.invalid_descriptor");
+    }
+
     TEST_CASE("Empty module descriptor set validates successfully", "[unit][foundation][modules]") {
         const std::span<const ModuleDescriptor> emptyDescriptors{};
         const auto result = ValidateModuleGraph(emptyDescriptors);
@@ -32,29 +50,11 @@ namespace {
 
     TEST_CASE("Module identifier comparison operators", "[unit][foundation][modules]") {
         SECTION("ModuleId comparisons") {
-            const ModuleId a{"horo.a"};
-            const ModuleId aCopy{"horo.a"};
-            const ModuleId b{"horo.b"};
-            REQUIRE(a == aCopy);
-            REQUIRE(a != b);
-            REQUIRE(a < b);
-            REQUIRE(b > a);
-            REQUIRE(a <= aCopy);
-            REQUIRE(a <= b);
-            REQUIRE(b >= a);
+            VerifyComparisonOperators(ModuleId{"horo.a"}, ModuleId{"horo.a"}, ModuleId{"horo.b"});
         }
 
         SECTION("ModuleCapabilityId comparisons") {
-            const ModuleCapabilityId a{"horo.cap.a"};
-            const ModuleCapabilityId aCopy{"horo.cap.a"};
-            const ModuleCapabilityId b{"horo.cap.b"};
-            REQUIRE(a == aCopy);
-            REQUIRE(a != b);
-            REQUIRE(a < b);
-            REQUIRE(b > a);
-            REQUIRE(a <= aCopy);
-            REQUIRE(a <= b);
-            REQUIRE(b >= a);
+            VerifyComparisonOperators(ModuleCapabilityId{"horo.cap.a"}, ModuleCapabilityId{"horo.cap.a"}, ModuleCapabilityId{"horo.cap.b"});
         }
     }
 
@@ -77,27 +77,15 @@ namespace {
 
     TEST_CASE("Module lifecycle callbacks require pairing", "[unit][foundation][modules]") {
         SECTION("only activate provided") {
-            ModuleDescriptor module = MakeModule("horo.runtime");
-            module.lifecycle.activate = &Activate;
-            const auto result = ValidateModuleGraph(std::array{module});
-            REQUIRE(result.HasError());
-            REQUIRE(result.ErrorValue().code.Value() == "foundation.module.invalid_descriptor");
+            ExpectInvalidLifecycle(ModuleLifecycleCallbacks{.activate = &Activate});
         }
 
         SECTION("only deactivate provided") {
-            ModuleDescriptor module = MakeModule("horo.runtime");
-            module.lifecycle.deactivate = &Deactivate;
-            const auto result = ValidateModuleGraph(std::array{module});
-            REQUIRE(result.HasError());
-            REQUIRE(result.ErrorValue().code.Value() == "foundation.module.invalid_descriptor");
+            ExpectInvalidLifecycle(ModuleLifecycleCallbacks{.deactivate = &Deactivate});
         }
 
         SECTION("drain without an activation lifetime") {
-            ModuleDescriptor module = MakeModule("horo.runtime");
-            module.lifecycle.drain = &Drain;
-            const auto result = ValidateModuleGraph(std::array{module});
-            REQUIRE(result.HasError());
-            REQUIRE(result.ErrorValue().code.Value() == "foundation.module.invalid_descriptor");
+            ExpectInvalidLifecycle(ModuleLifecycleCallbacks{.drain = &Drain});
         }
 
         SECTION("both or neither callbacks provided") {
@@ -138,26 +126,27 @@ namespace {
     }
 
     TEST_CASE("Module descriptor validates capability declarations", "[unit][foundation][modules]") {
-        SECTION("non-canonical or duplicate provided capability") {
+        auto checkInvalidCapabilities = [](auto setCaps) {
             ModuleDescriptor nonCanonical = MakeModule("horo.runtime");
-            nonCanonical.providedCapabilities.push_back(ModuleCapabilityId{"Horo.Capability"});
+            setCaps(nonCanonical, std::vector<ModuleCapabilityId>{ModuleCapabilityId{"Horo.Capability"}});
             REQUIRE(ValidateModuleGraph(std::array{nonCanonical}).HasError());
 
             ModuleDescriptor duplicate = MakeModule("horo.runtime");
-            duplicate.providedCapabilities.push_back(ModuleCapabilityId{"horo.capability"});
-            duplicate.providedCapabilities.push_back(ModuleCapabilityId{"horo.capability"});
+            setCaps(duplicate,
+                    std::vector<ModuleCapabilityId>{ModuleCapabilityId{"horo.capability"}, ModuleCapabilityId{"horo.capability"}});
             REQUIRE(ValidateModuleGraph(std::array{duplicate}).HasError());
+        };
+
+        SECTION("non-canonical or duplicate provided capability") {
+            checkInvalidCapabilities([](ModuleDescriptor &m, std::vector<ModuleCapabilityId> caps) {
+                m.providedCapabilities = std::move(caps);
+            });
         }
 
         SECTION("non-canonical or duplicate required capability") {
-            ModuleDescriptor nonCanonical = MakeModule("horo.runtime");
-            nonCanonical.requiredCapabilities.push_back(ModuleCapabilityId{"Horo.Capability"});
-            REQUIRE(ValidateModuleGraph(std::array{nonCanonical}).HasError());
-
-            ModuleDescriptor duplicate = MakeModule("horo.runtime");
-            duplicate.requiredCapabilities.push_back(ModuleCapabilityId{"horo.capability"});
-            duplicate.requiredCapabilities.push_back(ModuleCapabilityId{"horo.capability"});
-            REQUIRE(ValidateModuleGraph(std::array{duplicate}).HasError());
+            checkInvalidCapabilities([](ModuleDescriptor &m, std::vector<ModuleCapabilityId> caps) {
+                m.requiredCapabilities = std::move(caps);
+            });
         }
 
         SECTION("requiring a provided capability rejection") {

--- a/tests/unit/foundation/ModuleDescriptorTests.cpp
+++ b/tests/unit/foundation/ModuleDescriptorTests.cpp
@@ -21,6 +21,8 @@ namespace {
         ++g_deactivateCalls;
     }
 
+    void Drain(ModuleActivationContext &) noexcept {}
+
     TEST_CASE("Empty module descriptor set validates successfully", "[unit][foundation][modules]") {
         const std::span<const ModuleDescriptor> emptyDescriptors{};
         const auto result = ValidateModuleGraph(emptyDescriptors);
@@ -90,10 +92,19 @@ namespace {
             REQUIRE(result.ErrorValue().code.Value() == "foundation.module.invalid_descriptor");
         }
 
+        SECTION("drain without an activation lifetime") {
+            ModuleDescriptor module = MakeModule("horo.runtime");
+            module.lifecycle.drain = &Drain;
+            const auto result = ValidateModuleGraph(std::array{module});
+            REQUIRE(result.HasError());
+            REQUIRE(result.ErrorValue().code.Value() == "foundation.module.invalid_descriptor");
+        }
+
         SECTION("both or neither callbacks provided") {
             ModuleDescriptor module = MakeModule("horo.runtime");
             REQUIRE(ValidateModuleGraph(std::array{module}).HasValue());
             module.lifecycle.activate = &Activate;
+            module.lifecycle.drain = &Drain;
             module.lifecycle.deactivate = &Deactivate;
             REQUIRE(ValidateModuleGraph(std::array{module}).HasValue());
         }

--- a/tests/unit/foundation/ModuleHostCompositionTests.cpp
+++ b/tests/unit/foundation/ModuleHostCompositionTests.cpp
@@ -16,8 +16,11 @@ namespace {
     // all hosts in this translation unit. Each test resets the log first.
     struct ActivationLog {
         std::vector<std::string> activated;
+        std::vector<std::string> drained;
         std::vector<std::string> deactivated;
         std::vector<ModuleActivationContext::DependencyBindings> bindings;
+        std::vector<bool> drainObservedCancellation;
+        std::vector<bool> drainObservedClosedAdmission;
     };
 
     ActivationLog g_log;
@@ -28,8 +31,11 @@ namespace {
 
     void ResetLog() {
         g_log.activated.clear();
+        g_log.drained.clear();
         g_log.deactivated.clear();
         g_log.bindings.clear();
+        g_log.drainObservedCancellation.clear();
+        g_log.drainObservedClosedAdmission.clear();
         g_instancesAlive = 0;
         g_failModule.clear();
         g_activationCompletions.clear();
@@ -60,9 +66,15 @@ namespace {
         g_log.deactivated.push_back(context.Module().value);
     }
 
+    void LogDrain(ModuleActivationContext &context) noexcept {
+        g_log.drained.push_back(context.Module().value);
+        g_log.drainObservedCancellation.push_back(context.Cancellation().IsCancellationRequested());
+        g_log.drainObservedClosedAdmission.push_back(!context.AcquireCallbackLease().has_value());
+    }
+
     [[nodiscard]] ModuleDescriptor MakeLoggedModule(std::string id, const ModuleContractVersion version = {1, 0, 0}) {
         ModuleDescriptor descriptor = MakeModule(std::move(id), version);
-        descriptor.lifecycle = ModuleLifecycleCallbacks{.activate = &LogActivate, .deactivate = &LogDeactivate};
+        descriptor.lifecycle = ModuleLifecycleCallbacks{.activate = &LogActivate, .drain = &LogDrain, .deactivate = &LogDeactivate};
         return descriptor;
     }
 }  // namespace
@@ -76,6 +88,7 @@ TEST_CASE("Composition registers and activates modules in validated order", "[un
 
     REQUIRE(host.Register(editor).HasValue());
     REQUIRE(host.Register(MakeLoggedModule("horo.foundation")).HasValue());
+    REQUIRE(host.StateOf(ModuleId{"horo.editor"}) == ModuleLifecycleState::Registered);
 
     // Registration is inert: no callback runs before ActivateRegistered.
     REQUIRE(g_log.activated.empty());
@@ -85,6 +98,8 @@ TEST_CASE("Composition registers and activates modules in validated order", "[un
     REQUIRE(activated.HasValue());
     REQUIRE(activated.Value() == 2);
     REQUIRE(host.HasActiveModules());
+    REQUIRE(host.StateOf(ModuleId{"horo.foundation"}) == ModuleLifecycleState::Active);
+    REQUIRE(host.StateOf(ModuleId{"horo.editor"}) == ModuleLifecycleState::Active);
     REQUIRE(g_log.activated == std::vector<std::string>{"horo.foundation", "horo.editor"});
     REQUIRE(g_log.bindings == std::vector<ModuleActivationContext::DependencyBindings>{&approvedBindings, &approvedBindings});
 }
@@ -109,6 +124,10 @@ TEST_CASE("Failed composition rolls back active modules in reverse order", "[uni
     // deactivated in reverse activation order, leaving nothing partially active.
     REQUIRE(g_log.activated == std::vector<std::string>{"horo.first", "horo.second", "horo.failing"});
     REQUIRE(g_log.deactivated == std::vector<std::string>{"horo.second", "horo.first"});
+    REQUIRE(g_log.drained == std::vector<std::string>{"horo.second", "horo.first"});
+    REQUIRE(host.StateOf(ModuleId{"horo.first"}) == ModuleLifecycleState::Stopped);
+    REQUIRE(host.StateOf(ModuleId{"horo.second"}) == ModuleLifecycleState::Stopped);
+    REQUIRE(host.StateOf(ModuleId{"horo.failing"}) == ModuleLifecycleState::Failed);
     REQUIRE_FALSE(host.HasActiveModules());
 }
 
@@ -122,6 +141,7 @@ TEST_CASE("Rejected composition leaves registrations untouched for retry", "[uni
     // Graph validation fails before any callback: no module was activated.
     REQUIRE(host.ActivateRegistered(nullptr).HasError());
     REQUIRE(g_log.activated.empty());
+    REQUIRE(host.StateOf(ModuleId{"horo.consumer"}) == ModuleLifecycleState::Registered);
     REQUIRE_FALSE(host.HasActiveModules());
 
     ModuleDescriptor provider = MakeModule("horo.absent");
@@ -140,7 +160,7 @@ TEST_CASE("Headless composition never activates GUI-only modules", "[unit][found
     renderNull.providedCapabilities.push_back(ModuleCapabilityId{"horo.render.device"});
     ModuleDescriptor gui = MakeModule("horo.gui");
     gui.requiredCapabilities.push_back(ModuleCapabilityId{"horo.window.surface"});
-    gui.lifecycle = ModuleLifecycleCallbacks{.activate = &LogActivate, .deactivate = &LogDeactivate};
+    gui.lifecycle = ModuleLifecycleCallbacks{.activate = &LogActivate, .drain = &LogDrain, .deactivate = &LogDeactivate};
 
     REQUIRE(host.Register(renderNull).HasValue());
     REQUIRE(host.Register(gui).HasValue());
@@ -193,24 +213,17 @@ TEST_CASE("Incremental activation rolls back only modules started by the failed 
     // The module started in this pass is rolled back, while the earlier successful
     // activation survives untouched and stays active.
     REQUIRE(g_log.deactivated == std::vector<std::string>{"horo.late_started"});
+    REQUIRE(g_log.drained == std::vector<std::string>{"horo.late_started"});
     REQUIRE(g_log.activated == std::vector<std::string>{"horo.late_started", "horo.late_failure"});
     REQUIRE(g_activationCompletions == std::vector<std::string>{"horo.early", "horo.late_started"});
     REQUIRE(host.HasActiveModules());
     REQUIRE(g_instancesAlive == 1);
-
-    // Registrations survive an activation failure, so correcting the callback's
-    // failure condition allows the same pending set to be retried.
-    g_failModule.clear();
-    g_log.deactivated.clear();
-    g_log.activated.clear();
-    const Result<std::size_t> retried = host.ActivateRegistered(nullptr);
-    REQUIRE(retried.HasValue());
-    REQUIRE(retried.Value() == 2);
-    REQUIRE(g_log.activated == std::vector<std::string>{"horo.late_started", "horo.late_failure"});
-    REQUIRE(g_instancesAlive == 3);
+    REQUIRE(host.StateOf(ModuleId{"horo.early"}) == ModuleLifecycleState::Active);
+    REQUIRE(host.StateOf(ModuleId{"horo.late_started"}) == ModuleLifecycleState::Stopped);
+    REQUIRE(host.StateOf(ModuleId{"horo.late_failure"}) == ModuleLifecycleState::Failed);
 
     host.DeactivateAll();
-    REQUIRE(g_log.deactivated == std::vector<std::string>{"horo.late_failure", "horo.late_started", "horo.early"});
+    REQUIRE(g_log.deactivated == std::vector<std::string>{"horo.late_started", "horo.early"});
     REQUIRE_FALSE(host.HasActiveModules());
     REQUIRE(g_instancesAlive == 0);
 }
@@ -234,5 +247,6 @@ TEST_CASE("Deactivation releases attached instances exactly once", "[unit][found
     // Pending registrations are part of host teardown as documented.
     REQUIRE(host.Register(MakeModule("horo.pending")).HasValue());
     host.DeactivateAll();
-    REQUIRE(host.Register(MakeModule("horo.pending")).HasValue());
+    REQUIRE(host.StateOf(ModuleId{"horo.pending"}) == ModuleLifecycleState::Stopped);
+    REQUIRE(host.Register(MakeModule("horo.pending")).HasError());
 }

--- a/tests/unit/foundation/ModuleHostCompositionTests.cpp
+++ b/tests/unit/foundation/ModuleHostCompositionTests.cpp
@@ -93,7 +93,11 @@ TEST_CASE("Composition registers and activates modules in validated order", "[un
     // Registration is inert: no callback runs before ActivateRegistered.
     REQUIRE(g_log.activated.empty());
 
-    const int approvedBindings = 42;
+    struct TestApprovedBindings final : IDependencyBindings {
+        int value{42};
+    };
+
+    const TestApprovedBindings approvedBindings{};
     const Result<std::size_t> activated = host.ActivateRegistered(&approvedBindings);
     REQUIRE(activated.HasValue());
     REQUIRE(activated.Value() == 2);

--- a/tests/unit/foundation/ModuleHostLifecycleTests.cpp
+++ b/tests/unit/foundation/ModuleHostLifecycleTests.cpp
@@ -17,7 +17,7 @@ namespace {
     std::optional<ModuleCallbackLease> g_callbackLease;
     std::atomic<bool> g_callbackObservedCancellation{false};
     std::atomic<bool> g_callbackFinished{false};
-    const void *g_callbackObservedBindings = nullptr;
+    const IDependencyBindings *g_callbackObservedBindings = nullptr;
     bool g_drainObservedClosedAdmission = false;
     bool g_deactivateObservedDrain = false;
 
@@ -98,7 +98,11 @@ TEST_CASE("Module shutdown drains admitted callbacks before releasing borrowed b
     descriptor.lifecycle = ModuleLifecycleCallbacks{.activate = &LeaseActivate, .drain = &LeaseDrain, .deactivate = &LeaseDeactivate};
     REQUIRE(host.Register(descriptor).HasValue());
 
-    const int approvedBinding = 42;
+    struct TestApprovedBindings final : IDependencyBindings {
+        int value{42};
+    };
+
+    const TestApprovedBindings approvedBinding{};
     REQUIRE(host.ActivateRegistered(&approvedBinding).HasValue());
     REQUIRE(g_callbackLease.has_value());
 

--- a/tests/unit/foundation/ModuleHostLifecycleTests.cpp
+++ b/tests/unit/foundation/ModuleHostLifecycleTests.cpp
@@ -150,14 +150,14 @@ TEST_CASE("ModuleCallbackLease supports move semantics and explicit release", "[
     ModuleCallbackLease lease3 = std::move(lease2);
     REQUIRE(lease3.Bindings() == nullptr);
 
-    // Self move-assignment is a safe no-op
-    #if defined(__clang__)
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wself-move"
-    #endif
+// Self move-assignment is a safe no-op
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-move"
+#endif
     lease3 = std::move(lease3);
-    #if defined(__clang__)
-    #pragma clang diagnostic pop
-    #endif
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
     REQUIRE(lease3.Bindings() == nullptr);
 }

--- a/tests/unit/foundation/ModuleHostLifecycleTests.cpp
+++ b/tests/unit/foundation/ModuleHostLifecycleTests.cpp
@@ -121,3 +121,43 @@ TEST_CASE("Module shutdown drains admitted callbacks before releasing borrowed b
     REQUIRE(g_deactivateObservedDrain);
     REQUIRE(host.StateOf(ModuleId{"horo.async"}) == ModuleLifecycleState::Stopped);
 }
+
+TEST_CASE("StateOf returns nullopt for unknown module identity", "[unit][foundation][modules][lifecycle]") {
+    ModuleHost host;
+    REQUIRE_FALSE(host.StateOf(ModuleId{"horo.unknown"}).has_value());
+}
+
+TEST_CASE("ModuleActivationContext rejects attaching a null instance", "[unit][foundation][modules][lifecycle]") {
+    ModuleActivationContext context(ModuleId{"horo.test"}, nullptr);
+    REQUIRE(context.AttachInstance(nullptr).HasError());
+    REQUIRE(context.Module() == ModuleId{"horo.test"});
+    REQUIRE(context.Bindings() == nullptr);
+    REQUIRE_FALSE(context.Cancellation().IsCancellationRequested());
+}
+
+TEST_CASE("ModuleCallbackLease supports move semantics and explicit release", "[unit][foundation][modules][lifecycle]") {
+    ModuleActivationContext context(ModuleId{"horo.lease_test"}, nullptr);
+    std::optional<ModuleCallbackLease> lease1 = context.AcquireCallbackLease();
+    REQUIRE(lease1.has_value());
+    REQUIRE(lease1->Bindings() == nullptr);
+    REQUIRE_FALSE(lease1->Cancellation().IsCancellationRequested());
+
+    // Move constructor
+    ModuleCallbackLease lease2(std::move(*lease1));
+    REQUIRE(lease2.Bindings() == nullptr);
+
+    // Move assignment
+    ModuleCallbackLease lease3 = std::move(lease2);
+    REQUIRE(lease3.Bindings() == nullptr);
+
+    // Self move-assignment is a safe no-op
+    #if defined(__clang__)
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wself-move"
+    #endif
+    lease3 = std::move(lease3);
+    #if defined(__clang__)
+    #pragma clang diagnostic pop
+    #endif
+    REQUIRE(lease3.Bindings() == nullptr);
+}

--- a/tests/unit/foundation/ModuleHostLifecycleTests.cpp
+++ b/tests/unit/foundation/ModuleHostLifecycleTests.cpp
@@ -36,10 +36,18 @@ namespace {
         return Result<void>::Success();
     }
 
+    [[nodiscard]] const char *CancellationLabel(const ModuleActivationContext &context) noexcept {
+        return context.Cancellation().IsCancellationRequested() ? "cancelled" : "not-cancelled";
+    }
+
+    [[nodiscard]] const char *AdmissionLabel(const ModuleActivationContext &context) noexcept {
+        return context.AcquireCallbackLease().has_value() ? "admission-open" : "admission-closed";
+    }
+
     void OrderedDrain(ModuleActivationContext &context) noexcept {
         g_events.push_back("drain:" + context.Module().value);
-        g_events.push_back(context.Cancellation().IsCancellationRequested() ? "cancelled" : "not-cancelled");
-        g_events.push_back(context.AcquireCallbackLease().has_value() ? "admission-open" : "admission-closed");
+        g_events.push_back(CancellationLabel(context));
+        g_events.push_back(AdmissionLabel(context));
     }
 
     void OrderedDeactivate(ModuleActivationContext &context) noexcept {
@@ -48,7 +56,9 @@ namespace {
 
     Result<void> LeaseActivate(ModuleActivationContext &context) noexcept {
         g_callbackLease = context.AcquireCallbackLease();
-        return g_callbackLease.has_value() ? Result<void>::Success() : Result<void>::Failure(Error{});
+        if (!g_callbackLease.has_value())
+            return Result<void>::Failure(Error{});
+        return Result<void>::Success();
     }
 
     void LeaseDrain(ModuleActivationContext &context) noexcept {
@@ -57,7 +67,8 @@ namespace {
     }
 
     void LeaseDeactivate(ModuleActivationContext &) noexcept {
-        g_deactivateObservedDrain = g_deactivateObservedDrain && g_callbackFinished.load();
+        if (!g_callbackFinished.load())
+            g_deactivateObservedDrain = false;
     }
 
     [[nodiscard]] ModuleDescriptor MakeLifecycleModule(std::string id) {

--- a/tests/unit/foundation/ModuleHostLifecycleTests.cpp
+++ b/tests/unit/foundation/ModuleHostLifecycleTests.cpp
@@ -1,0 +1,123 @@
+#include "Horo/Foundation/ModuleHost.h"
+#include "ModuleDescriptorTestUtils.h"
+
+#include <atomic>
+#include <catch2/catch_test_macros.hpp>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+    using namespace Horo;
+    using Horo::Test::MakeModule;
+
+    std::vector<std::string> g_events;
+    std::optional<ModuleCallbackLease> g_callbackLease;
+    std::atomic<bool> g_callbackObservedCancellation{false};
+    std::atomic<bool> g_callbackFinished{false};
+    const void *g_callbackObservedBindings = nullptr;
+    bool g_drainObservedClosedAdmission = false;
+    bool g_deactivateObservedDrain = false;
+
+    void ResetLifecycleLog() {
+        g_events.clear();
+        g_callbackLease.reset();
+        g_callbackObservedCancellation.store(false);
+        g_callbackFinished.store(false);
+        g_callbackObservedBindings = nullptr;
+        g_drainObservedClosedAdmission = false;
+        g_deactivateObservedDrain = false;
+    }
+
+    Result<void> OrderedActivate(ModuleActivationContext &context) noexcept {
+        g_events.push_back("activate:" + context.Module().value);
+        return Result<void>::Success();
+    }
+
+    void OrderedDrain(ModuleActivationContext &context) noexcept {
+        g_events.push_back("drain:" + context.Module().value);
+        g_events.push_back(context.Cancellation().IsCancellationRequested() ? "cancelled" : "not-cancelled");
+        g_events.push_back(context.AcquireCallbackLease().has_value() ? "admission-open" : "admission-closed");
+    }
+
+    void OrderedDeactivate(ModuleActivationContext &context) noexcept {
+        g_events.push_back("deactivate:" + context.Module().value);
+    }
+
+    Result<void> LeaseActivate(ModuleActivationContext &context) noexcept {
+        g_callbackLease = context.AcquireCallbackLease();
+        return g_callbackLease.has_value() ? Result<void>::Success() : Result<void>::Failure(Error{});
+    }
+
+    void LeaseDrain(ModuleActivationContext &context) noexcept {
+        g_drainObservedClosedAdmission = !context.AcquireCallbackLease().has_value();
+        g_deactivateObservedDrain = g_callbackFinished.load();
+    }
+
+    void LeaseDeactivate(ModuleActivationContext &) noexcept {
+        g_deactivateObservedDrain = g_deactivateObservedDrain && g_callbackFinished.load();
+    }
+
+    [[nodiscard]] ModuleDescriptor MakeLifecycleModule(std::string id) {
+        ModuleDescriptor descriptor = MakeModule(std::move(id));
+        descriptor.lifecycle =
+            ModuleLifecycleCallbacks{.activate = &OrderedActivate, .drain = &OrderedDrain, .deactivate = &OrderedDeactivate};
+        return descriptor;
+    }
+}  // namespace
+
+TEST_CASE("Module shutdown requests cancellation before dependency-reverse drainage", "[unit][foundation][modules][lifecycle]") {
+    ResetLifecycleLog();
+    ModuleHost host;
+
+    ModuleDescriptor dependant = MakeLifecycleModule("horo.dependant");
+    dependant.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.provider"}});
+    REQUIRE(host.Register(dependant).HasValue());
+    REQUIRE(host.Register(MakeLifecycleModule("horo.provider")).HasValue());
+    REQUIRE(host.ActivateRegistered(nullptr).HasValue());
+
+    host.DeactivateAll();
+
+    REQUIRE(g_events == std::vector<std::string>{"activate:horo.provider", "activate:horo.dependant", "drain:horo.dependant", "cancelled",
+                                                 "admission-closed", "deactivate:horo.dependant", "drain:horo.provider", "cancelled",
+                                                 "admission-closed", "deactivate:horo.provider"});
+    REQUIRE(host.StateOf(ModuleId{"horo.dependant"}) == ModuleLifecycleState::Stopped);
+    REQUIRE(host.StateOf(ModuleId{"horo.provider"}) == ModuleLifecycleState::Stopped);
+
+    const std::size_t eventCount = g_events.size();
+    host.DeactivateAll();
+    REQUIRE(g_events.size() == eventCount);
+}
+
+TEST_CASE("Module shutdown drains admitted callbacks before releasing borrowed bindings", "[unit][foundation][modules][lifecycle]") {
+    ResetLifecycleLog();
+    ModuleHost host;
+    ModuleDescriptor descriptor = MakeModule("horo.async");
+    descriptor.lifecycle = ModuleLifecycleCallbacks{.activate = &LeaseActivate, .drain = &LeaseDrain, .deactivate = &LeaseDeactivate};
+    REQUIRE(host.Register(descriptor).HasValue());
+
+    const int approvedBinding = 42;
+    REQUIRE(host.ActivateRegistered(&approvedBinding).HasValue());
+    REQUIRE(g_callbackLease.has_value());
+
+    std::thread callback([lease = std::move(*g_callbackLease)]() mutable {
+        while (!lease.Cancellation().IsCancellationRequested())
+            std::this_thread::yield();
+        g_callbackObservedBindings = lease.Bindings();
+        g_callbackObservedCancellation.store(true);
+        g_callbackFinished.store(true);
+    });
+    g_callbackLease.reset();
+
+    host.DeactivateAll();
+    callback.join();
+
+    REQUIRE(g_callbackObservedCancellation.load());
+    REQUIRE(g_callbackObservedBindings == &approvedBinding);
+    REQUIRE(g_callbackFinished.load());
+    REQUIRE(g_drainObservedClosedAdmission);
+    REQUIRE(g_deactivateObservedDrain);
+    REQUIRE(host.StateOf(ModuleId{"horo.async"}) == ModuleLifecycleState::Stopped);
+}


### PR DESCRIPTION
## Summary
- Adds an explicit, host-driven module lifecycle (activation context) so module activation no longer happens as a side effect of descriptor handling.
- New `ModuleHostLifecycle.cpp` splits lifecycle concerns out of `ModuleHost.cpp`; registration stays composition-time only.

## Motivation
- Follows ARC-001.5: internal module descriptors are inert metadata; activation must be explicit and host-owned.
- Keeps registration/activation/lifecycle states distinct and testable.

## Implementation Notes
- `ModuleActivationContext` carries the host-provided services to activated modules; descriptors never touch ambient state.
- Lifecycle ordering covered by new `ModuleHostLifecycleTests`.

## Validation
- [x] Build passed
- [x] ctest run passed (all module foundation tests green)
- [x] Sonar: 0 open issues
- [x] Codacy: isUpToStandards = true, 0 new issues

Commands run:
\\\ash
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
cmake --build build/skeleton --parallel
ctest --test-dir build/skeleton --output-on-failure
\\\

## Risks
- Module shutdown-order regressions; watch backend/host compositions.
- Not yet validated on Windows/MSVC.

## Issue Links
Closes #68