### PR TITLE
[ARC-001.6] Preserve Callback Borrow Lifetime During Shutdown

### DIFF
--- a/docs/architecture/foundation/internal-module-descriptor.md
+++ b/docs/architecture/foundation/internal-module-descriptor.md
@@ -116,11 +116,11 @@ callback-admission gate. Asynchronous module callbacks acquire a move-only
 
 This order keeps providers alive while dependants drain, prevents new callbacks
 from entering after shutdown begins, and ensures activation-scoped binding borrows
-end before their context is released. A callback that does not cooperate may delay
-shutdown and produces periodic diagnostics; the host must not trade a bounded wait
-for releasing a dependency that an admitted callback can still borrow. Repeated
-shutdown is a no-op after the first terminal transition. The host destructor is a
-final safety net that runs the same idempotent shutdown path.
+end before their context is released. A callback that does not cooperate delays
+shutdown; the host must not trade a bounded wait for releasing a dependency that
+an admitted callback can still borrow. Repeated shutdown is a no-op after the
+first terminal transition. The host destructor is a final safety net that runs
+the same idempotent shutdown path.
 
 ## Ownership And Migration
 

--- a/docs/architecture/foundation/internal-module-descriptor.md
+++ b/docs/architecture/foundation/internal-module-descriptor.md
@@ -116,9 +116,11 @@ callback-admission gate. Asynchronous module callbacks acquire a move-only
 
 This order keeps providers alive while dependants drain, prevents new callbacks
 from entering after shutdown begins, and ensures activation-scoped binding borrows
-end before their context is released. Repeated shutdown is a no-op after the first
-terminal transition. The host destructor is a final safety net that runs the same
-idempotent shutdown path.
+end before their context is released. A callback that does not cooperate may delay
+shutdown and produces periodic diagnostics; the host must not trade a bounded wait
+for releasing a dependency that an admitted callback can still borrow. Repeated
+shutdown is a no-op after the first terminal transition. The host destructor is a
+final safety net that runs the same idempotent shutdown path.
 
 ## Ownership And Migration
 

--- a/include/Horo/Foundation/ModuleHost.h
+++ b/include/Horo/Foundation/ModuleHost.h
@@ -145,12 +145,12 @@ namespace Horo {
         void RequestShutdown() const noexcept;
 
         /**
-         * @brief Blocks until all admitted callback leases are released or a timeout is reached.
+         * @brief Blocks until all admitted callback leases are released.
          *
          * Module callbacks are expected to cooperate by checking CancellationToken and
-         * releasing leases promptly upon observing cancellation. If a callback hangs,
-         * drainage logs a warning after a bounded timeout and shutdown proceeds to prevent
-         * indefinite teardown blockage.
+         * releasing leases promptly upon observing cancellation. Drainage logs periodic
+         * warnings while a callback remains outstanding, but never releases activation-scoped
+         * dependencies while a lease can still borrow them.
          */
         void DrainCallbacks() const noexcept;
 

--- a/include/Horo/Foundation/ModuleHost.h
+++ b/include/Horo/Foundation/ModuleHost.h
@@ -148,9 +148,8 @@ namespace Horo {
          * @brief Blocks until all admitted callback leases are released.
          *
          * Module callbacks are expected to cooperate by checking CancellationToken and
-         * releasing leases promptly upon observing cancellation. Drainage logs periodic
-         * warnings while a callback remains outstanding, but never releases activation-scoped
-         * dependencies while a lease can still borrow them.
+         * releasing leases promptly upon observing cancellation. Drainage never releases
+         * activation-scoped dependencies while a lease can still borrow them.
          */
         void DrainCallbacks() const noexcept;
 

--- a/src/foundation/modules/ModuleActivationContext.cpp
+++ b/src/foundation/modules/ModuleActivationContext.cpp
@@ -118,13 +118,12 @@ namespace Horo {
     /** @copydoc ModuleActivationContext::DrainCallbacks */
     void ModuleActivationContext::DrainCallbacks() const noexcept {
         std::unique_lock lock(m_callbackGate->mutex);
-        constexpr auto kDrainTimeout = std::chrono::seconds(5);
-        const bool drained = m_callbackGate->drained.wait_for(lock, kDrainTimeout, [this] {
+        constexpr auto kDrainWarningInterval = std::chrono::seconds(5);
+        while (!m_callbackGate->drained.wait_for(lock, kDrainWarningInterval, [this] {
             return m_callbackGate->activeCallbacks == 0;
-        });
-        if (!drained) {
+        })) {
             Log::Logger::Write("foundation.modules", Log::Level::Warn,
-                               std::format("Module '{}' callback drainage timed out with {} active callback(s).", m_module.value,
+                               std::format("Module '{}' is still draining {} active callback(s).", m_module.value,
                                            m_callbackGate->activeCallbacks));
         }
     }

--- a/src/foundation/modules/ModuleActivationContext.cpp
+++ b/src/foundation/modules/ModuleActivationContext.cpp
@@ -1,10 +1,7 @@
-#include "Horo/Foundation/Logging/Logger.h"
 #include "Horo/Foundation/ModuleHost.h"
 #include "foundation/FoundationErrors.h"
 
-#include <chrono>
 #include <condition_variable>
-#include <format>
 #include <mutex>
 #include <string>
 #include <utility>
@@ -118,13 +115,8 @@ namespace Horo {
     /** @copydoc ModuleActivationContext::DrainCallbacks */
     void ModuleActivationContext::DrainCallbacks() const noexcept {
         std::unique_lock lock(m_callbackGate->mutex);
-        constexpr auto kDrainWarningInterval = std::chrono::seconds(5);
-        while (!m_callbackGate->drained.wait_for(lock, kDrainWarningInterval, [this] {
+        m_callbackGate->drained.wait(lock, [this] {
             return m_callbackGate->activeCallbacks == 0;
-        })) {
-            Log::Logger::Write("foundation.modules", Log::Level::Warn,
-                               std::format("Module '{}' is still draining {} active callback(s).", m_module.value,
-                                           m_callbackGate->activeCallbacks));
-        }
+        });
     }
 }  // namespace Horo

--- a/tests/unit/foundation/ModuleHostLifecycleTests.cpp
+++ b/tests/unit/foundation/ModuleHostLifecycleTests.cpp
@@ -137,6 +137,40 @@ TEST_CASE("Module shutdown drains admitted callbacks before releasing borrowed b
     REQUIRE(host.StateOf(ModuleId{"horo.async"}) == ModuleLifecycleState::Stopped);
 }
 
+TEST_CASE("Module shutdown cannot stop while a callback lease still borrows bindings", "[unit][foundation][modules][lifecycle]") {
+    ResetLifecycleLog();
+    ModuleHost host;
+    ModuleDescriptor descriptor = MakeModule("horo.blocked_callback");
+    descriptor.lifecycle = ModuleLifecycleCallbacks{.activate = &LeaseActivate, .drain = &LeaseDrain, .deactivate = &LeaseDeactivate};
+    REQUIRE(host.Register(descriptor).HasValue());
+
+    struct TestApprovedBindings final : IDependencyBindings {};
+
+    const TestApprovedBindings approvedBinding{};
+    REQUIRE(host.ActivateRegistered(&approvedBinding).HasValue());
+    REQUIRE(g_callbackLease.has_value());
+
+    std::atomic<bool> shutdownReturned{false};
+    std::thread shutdown([&host, &shutdownReturned] {
+        host.DeactivateAll();
+        shutdownReturned.store(true);
+    });
+
+    while (!g_callbackLease->Cancellation().IsCancellationRequested())
+        std::this_thread::yield();
+    const bool returnedBeforeLeaseRelease = shutdownReturned.load();
+    const IDependencyBindings *bindingsDuringDrain = g_callbackLease->Bindings();
+
+    g_callbackFinished.store(true);
+    g_callbackLease.reset();
+    shutdown.join();
+
+    REQUIRE_FALSE(returnedBeforeLeaseRelease);
+    REQUIRE(bindingsDuringDrain == &approvedBinding);
+    REQUIRE(shutdownReturned.load());
+    REQUIRE(host.StateOf(ModuleId{"horo.blocked_callback"}) == ModuleLifecycleState::Stopped);
+}
+
 TEST_CASE("StateOf returns nullopt for unknown module identity", "[unit][foundation][modules][lifecycle]") {
     ModuleHost host;
     REQUIRE_FALSE(host.StateOf(ModuleId{"horo.unknown"}).has_value());


### PR DESCRIPTION
## Summary
- keep module shutdown in the draining state until every admitted callback lease is released
- never release activation-scoped dependencies while an outstanding callback can still borrow them
- add regression coverage proving shutdown cannot reach Stopped while a lease still holds bindings

## Motivation
ARC-001.6 requires that no callback or borrowed dependency remain usable after its owner stops. The previous five-second timeout allowed teardown to proceed while an outstanding lease could still expose the raw dependency bindings pointer.

## Implementation Notes
- DrainCallbacks now waits on the callback gate until every admitted lease is released.
- Cancellation and callback-admission closure still happen before drainage.
- The architecture contract now explicitly prioritizes borrow safety over bounded teardown for a non-cooperative module.

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [ ] Manual smoke tested if applicable

Commands and checks run:
- Repository CI full build/test matrix passed on Linux/GCC, macOS/Clang, and Windows/MSVC for the initial revision.
- Focused current-revision manual build/link: 13/13 module-host test cases and 102 assertions passed.
- python3 scripts/dev.py format --check passed.
- git diff --check passed.

## Risks
- A module that ignores cancellation and retains a callback lease now delays shutdown indefinitely. This preserves the ownership invariant; releasing its borrowed dependencies would create a dangling borrow.
- GPU smoke tests were not run; this changes only Foundation lifecycle coordination.

## Issue Links
Closes #68

## Reviewer Notes
Review ModuleActivationContext drainage first, then the new lifecycle regression test and architecture wording.