### PR TITLE
[ARC-001.5] Compose Real Module Graphs in Supported Hosts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ jobs:
               --root "$CIRCLE_WORKING_DIRECTORY" \
               --filter "$CIRCLE_WORKING_DIRECTORY/include" \
               --filter "$CIRCLE_WORKING_DIRECTORY/src" \
+              --filter "$CIRCLE_WORKING_DIRECTORY/apps/common" \
               --exclude-throw-branches \
               --exclude-unreachable-branches \
               --exclude-noncode-lines \

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,3 +1,12 @@
+add_library(HoroHostModuleComposition STATIC
+    common/HostModuleComposition.cpp
+)
+target_compile_features(HoroHostModuleComposition PUBLIC cxx_std_20)
+target_include_directories(HoroHostModuleComposition PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/common
+)
+target_link_libraries(HoroHostModuleComposition PUBLIC HoroEngine::Foundation)
+
 # The terminal/headless composition remains available without GUI or GPU targets.
 add_executable(horo-engine
     horo-engine/main.cpp
@@ -8,7 +17,7 @@ target_compile_definitions(horo-engine PRIVATE
     HORO_BUILD_CONFIGURATION="$<CONFIG>"
     HORO_SOURCE_REVISION="${HORO_SOURCE_REVISION}"
 )
-target_link_libraries(horo-engine PRIVATE HoroEngine::Application)
+target_link_libraries(horo-engine PRIVATE HoroEngine::Application HoroHostModuleComposition)
 
 # The graphical executable is an optional composition root. Foundation and
 # headless hosts must remain buildable when the GUI adapter is intentionally off.
@@ -69,6 +78,7 @@ if(HORO_BUILD_EDITOR_GUI)
             HoroEngine::Platform
             HoroEngine::ProjectMigrations
             HoroEngine::InputSdl
+            HoroHostModuleComposition
             HoroThirdParty::ImGui
     )
 

--- a/apps/HoroEditor/app/HoroEditorApp.cpp
+++ b/apps/HoroEditor/app/HoroEditorApp.cpp
@@ -1121,10 +1121,14 @@ namespace Horo::Editor {
         opts.rendererBackend = moduleInfo->id.Value();
         const RendererAvailabilitySnapshot rendererAvailability = BuildRendererAvailabilitySnapshot(opts.rendererBackend);
 
-        const Application::Internal::HostRenderer selectedRenderer =
-            opts.rendererBackend == "opengl" ? Application::Internal::HostRenderer::OpenGL : Application::Internal::HostRenderer::Metal;
+        auto selectedRenderer = Application::Internal::HostRendererFromBackendId(opts.rendererBackend);
+        if (selectedRenderer.HasError()) {
+            LOG_CRITICAL("editor.renderer", "%s", selectedRenderer.ErrorValue().message.c_str());
+            Log::Logger::Shutdown();
+            return 1;
+        }
         auto composedModules = Application::Internal::ComposeHostModules({.host = Application::Internal::HostKind::Editor,
-                                                                          .renderer = selectedRenderer,
+                                                                          .renderer = selectedRenderer.Value(),
 #if defined(HORO_HAS_OPENTELEMETRY)
                                                                           .includeOpenTelemetry = true
 #else

--- a/apps/HoroEditor/app/HoroEditorApp.cpp
+++ b/apps/HoroEditor/app/HoroEditorApp.cpp
@@ -39,6 +39,7 @@
 #include "Horo/Runtime/Input.h"
 #include "Horo/Runtime/Render/RenderFrontend.h"
 #include "Horo/Runtime/RuntimeHost.h"
+#include "HostModuleComposition.h"
 #include "editor/EditorServiceErrors.h"
 #include "editor/document/EditorViewportSceneExtractor.h"
 #include "editor/input/EditorInputActions.h"
@@ -1120,6 +1121,23 @@ namespace Horo::Editor {
         opts.rendererBackend = moduleInfo->id.Value();
         const RendererAvailabilitySnapshot rendererAvailability = BuildRendererAvailabilitySnapshot(opts.rendererBackend);
 
+        const Application::Internal::HostRenderer selectedRenderer =
+            opts.rendererBackend == "opengl" ? Application::Internal::HostRenderer::OpenGL : Application::Internal::HostRenderer::Metal;
+        auto composedModules = Application::Internal::ComposeHostModules({.host = Application::Internal::HostKind::Editor,
+                                                                          .renderer = selectedRenderer,
+#if defined(HORO_HAS_OPENTELEMETRY)
+                                                                          .includeOpenTelemetry = true
+#else
+                                                                          .includeOpenTelemetry = false
+#endif
+        });
+        if (composedModules.HasError()) {
+            LOG_CRITICAL("editor.startup", "Module composition failed: %s", composedModules.ErrorValue().message.c_str());
+            Log::Logger::Shutdown();
+            return 1;
+        }
+        std::unique_ptr<ModuleHost> moduleHost = std::move(composedModules).Value();
+
         SDL_Window *w = nullptr;
         if (!InitializeSdlAndCreateWindow(w, moduleInfo->windowRequirements))
             return 1;
@@ -1239,6 +1257,7 @@ namespace Horo::Editor {
             return RelaunchEditorForProject(argv[0], *rendererRestart);
         }
 
+        moduleHost->DeactivateAll();
         Log::Logger::Shutdown();
         return 0;
     }

--- a/apps/common/HostModuleComposition.cpp
+++ b/apps/common/HostModuleComposition.cpp
@@ -28,80 +28,6 @@ namespace Horo::Application::Internal {
                                             .message = std::move(message)});
         }
 
-        void AddEditorFoundationModules(std::vector<ModuleDescriptor> &modules) {
-            modules.push_back(Describe("horo.foundation"));
-            modules.push_back(Describe("horo.application", {"horo.foundation"}));
-            modules.push_back(Describe("horo.application.project_migrations", {"horo.application"}));
-            modules.push_back(Describe("horo.platform", {"horo.foundation"}));
-            modules.push_back(Describe("horo.runtime", {"horo.foundation"}));
-            modules.push_back(Describe("horo.assets", {"horo.foundation"}));
-            modules.push_back(Describe("horo.input", {"horo.foundation"}));
-            modules.push_back(Describe("horo.input.sdl", {"horo.input"}));
-        }
-
-        void AddEditorGameplayModules(std::vector<ModuleDescriptor> &modules) {
-            modules.push_back(Describe("horo.gameplay.api", {"horo.foundation"}));
-            modules.push_back(Describe("horo.render.api", {"horo.foundation"}));
-            modules.push_back(Describe("horo.scene.model", {"horo.foundation", "horo.render.api"}));
-            modules.push_back(Describe("horo.runtime.scene",
-                                       {"horo.foundation", "horo.runtime", "horo.assets", "horo.gameplay.api", "horo.scene.model"}));
-            modules.push_back(Describe("horo.gameplay.runtime", {"horo.gameplay.api", "horo.runtime.scene"}));
-            modules.push_back(Describe("horo.gameplay.module_host", {"horo.gameplay.runtime", "horo.platform"}));
-            modules.push_back(Describe("horo.gameplay.build", {"horo.foundation", "horo.platform", "horo.gameplay.module_host"}));
-            modules.push_back(Describe("horo.gameplay.lua", {"horo.gameplay.runtime"}));
-        }
-
-        void AddEditorRenderModules(std::vector<ModuleDescriptor> &modules, const HostRenderer renderer) {
-            modules.push_back(Describe("horo.render.backend_registry", {"horo.render.api"}));
-            modules.push_back(Describe("horo.render.frontend", {"horo.render.api", "horo.render.backend_registry"}));
-
-            if (renderer == HostRenderer::OpenGL) {
-                modules.push_back(Describe("horo.render.opengl", {"horo.render.backend_registry"}));
-                modules.push_back(Describe("horo.editor.viewport.opengl", {"horo.editor.viewport_scene", "horo.render.opengl"}));
-            } else {
-                modules.push_back(Describe("horo.render.metal", {"horo.render.backend_registry"}));
-                modules.push_back(Describe("horo.editor.viewport.metal", {"horo.editor.viewport_scene", "horo.render.metal"}));
-            }
-        }
-
-        void AddEditorFeatureModules(std::vector<ModuleDescriptor> &modules) {
-            modules.push_back(Describe("horo.editor.model", {"horo.foundation", "horo.scene.model", "horo.runtime.scene"}));
-            modules.push_back(Describe("horo.editor.viewport_scene", {"horo.editor.model"}));
-            modules.push_back(Describe("horo.editor.render_extraction", {"horo.editor.model", "horo.editor.viewport_scene"}));
-            modules.push_back(Describe("horo.editor.services", {"horo.foundation", "horo.application", "horo.platform", "horo.editor.model",
-                                                                "horo.gameplay.module_host", "horo.gameplay.build", "horo.gameplay.lua",
-                                                                "horo.input", "horo.application.project_migrations", "horo.assets"}));
-            modules.push_back(Describe("horo.extensions", {"horo.foundation", "horo.platform", "horo.assets"}));
-            modules.push_back(
-                Describe("horo.gui", {"horo.editor.services", "horo.foundation", "horo.editor.render_extraction", "horo.extensions"}));
-        }
-
-        void AddEditorHost(std::vector<ModuleDescriptor> &modules, const HostModuleSelection &selection) {
-            std::vector<std::string_view> dependencies{
-                "horo.gui",
-                "horo.editor.services",
-                "horo.editor.render_extraction",
-                "horo.render.frontend",
-                "horo.runtime",
-                "horo.runtime.scene",
-                "horo.extensions",
-                "horo.platform",
-                "horo.input.sdl",
-                "horo.application.project_migrations",
-            };
-            dependencies.push_back(selection.renderer == HostRenderer::OpenGL ? "horo.editor.viewport.opengl"
-                                                                              : "horo.editor.viewport.metal");
-            if (selection.includeOpenTelemetry)
-                dependencies.push_back("horo.observability.opentelemetry");
-
-            ModuleDescriptor host = Describe("horo.host.editor");
-            host.dependencies.reserve(dependencies.size());
-            for (const std::string_view dependency : dependencies) {
-                host.dependencies.push_back(
-                    ModuleDependency{.module = ModuleId{std::string{dependency}}, .minimumVersion = kContractVersion});
-            }
-            modules.push_back(std::move(host));
-        }
     }  // namespace
 
     /** @copydoc DescribeHostModules */
@@ -124,15 +50,52 @@ namespace Horo::Application::Internal {
                 "The graphical editor host requires one concrete interactive renderer module.");
         }
 
-        std::vector<ModuleDescriptor> modules;
-        modules.reserve(27);
-        AddEditorFoundationModules(modules);
-        AddEditorGameplayModules(modules);
-        AddEditorFeatureModules(modules);
-        AddEditorRenderModules(modules, selection.renderer);
+        std::vector<ModuleDescriptor> modules{
+            Describe("horo.foundation"),
+            Describe("horo.application", {"horo.foundation"}),
+            Describe("horo.application.project_migrations", {"horo.application"}),
+            Describe("horo.platform", {"horo.foundation"}),
+            Describe("horo.runtime", {"horo.foundation"}),
+            Describe("horo.assets", {"horo.foundation"}),
+            Describe("horo.input", {"horo.foundation"}),
+            Describe("horo.input.sdl", {"horo.input"}),
+            Describe("horo.gameplay.api", {"horo.foundation"}),
+            Describe("horo.render.api", {"horo.foundation"}),
+            Describe("horo.scene.model", {"horo.foundation", "horo.render.api"}),
+            Describe("horo.runtime.scene", {"horo.foundation", "horo.runtime", "horo.assets", "horo.gameplay.api", "horo.scene.model"}),
+            Describe("horo.gameplay.runtime", {"horo.gameplay.api", "horo.runtime.scene"}),
+            Describe("horo.gameplay.module_host", {"horo.gameplay.runtime", "horo.platform"}),
+            Describe("horo.gameplay.build", {"horo.foundation", "horo.platform", "horo.gameplay.module_host"}),
+            Describe("horo.gameplay.lua", {"horo.gameplay.runtime"}),
+            Describe("horo.render.backend_registry", {"horo.render.api"}),
+            Describe("horo.render.frontend", {"horo.render.api", "horo.render.backend_registry"}),
+            Describe("horo.editor.model", {"horo.foundation", "horo.scene.model", "horo.runtime.scene"}),
+            Describe("horo.editor.viewport_scene", {"horo.editor.model"}),
+            Describe("horo.editor.render_extraction", {"horo.editor.model", "horo.editor.viewport_scene"}),
+            Describe("horo.editor.services",
+                     {"horo.foundation", "horo.application", "horo.platform", "horo.editor.model", "horo.gameplay.module_host",
+                      "horo.gameplay.build", "horo.gameplay.lua", "horo.input", "horo.application.project_migrations", "horo.assets"}),
+            Describe("horo.extensions", {"horo.foundation", "horo.platform", "horo.assets"}),
+            Describe("horo.gui", {"horo.editor.services", "horo.foundation", "horo.editor.render_extraction", "horo.extensions"}),
+        };
+
+        const bool useOpenGL = selection.renderer == HostRenderer::OpenGL;
+        const std::string_view rendererModule = useOpenGL ? "horo.render.opengl" : "horo.render.metal";
+        const std::string_view viewportModule = useOpenGL ? "horo.editor.viewport.opengl" : "horo.editor.viewport.metal";
+        modules.push_back(Describe(std::string{rendererModule}, {"horo.render.backend_registry"}));
+        modules.push_back(Describe(std::string{viewportModule}, {"horo.editor.viewport_scene", rendererModule}));
         if (selection.includeOpenTelemetry)
             modules.push_back(Describe("horo.observability.opentelemetry", {"horo.foundation"}));
-        AddEditorHost(modules, selection);
+
+        ModuleDescriptor host =
+            Describe("horo.host.editor", {"horo.gui", "horo.editor.services", "horo.editor.render_extraction", "horo.render.frontend",
+                                          "horo.runtime", "horo.runtime.scene", "horo.extensions", "horo.platform", "horo.input.sdl",
+                                          "horo.application.project_migrations", viewportModule});
+        if (selection.includeOpenTelemetry) {
+            host.dependencies.push_back(
+                ModuleDependency{.module = ModuleId{"horo.observability.opentelemetry"}, .minimumVersion = kContractVersion});
+        }
+        modules.push_back(std::move(host));
         return Result<std::vector<ModuleDescriptor>>::Success(std::move(modules));
     }
 

--- a/apps/common/HostModuleComposition.cpp
+++ b/apps/common/HostModuleComposition.cpp
@@ -11,6 +11,12 @@ namespace Horo::Application::Internal {
     namespace {
         constexpr ModuleContractVersion kContractVersion{1, 0, 0};
 
+        /**
+         * @brief Builds inert metadata for one module and its required dependencies.
+         * @param id Canonical module identity.
+         * @param dependencies Canonical identities of required provider modules.
+         * @return Complete inert descriptor using the current internal contract version.
+         */
         [[nodiscard]] ModuleDescriptor Describe(std::string id, const std::initializer_list<std::string_view> dependencies = {}) {
             ModuleDescriptor descriptor{.id = ModuleId{std::move(id)}, .version = kContractVersion};
             descriptor.dependencies.reserve(dependencies.size());
@@ -21,6 +27,12 @@ namespace Horo::Application::Internal {
             return descriptor;
         }
 
+        /**
+         * @brief Creates a typed failure for an unsupported host composition selection.
+         * @tparam T Success value type expected by the caller.
+         * @param message Actionable explanation of the invalid selection.
+         * @return Failed result in the application host error domain.
+         */
         template <typename T> [[nodiscard]] Result<T> InvalidSelection(std::string message) {
             return Result<T>::Failure(Error{.code = ErrorCode{"application.host.invalid_module_selection"},
                                             .domain = ErrorDomainId{"horo.application.host"},
@@ -28,7 +40,10 @@ namespace Horo::Application::Internal {
                                             .message = std::move(message)});
         }
 
-        /** @brief Describes the renderer-independent modules linked into the editor host. */
+        /**
+         * @brief Describes the renderer-independent modules linked into the editor host.
+         * @return Inert descriptors for the editor's shared module closure.
+         */
         [[nodiscard]] std::vector<ModuleDescriptor> DescribeEditorCoreModules() {
             return {
                 Describe("horo.foundation"),
@@ -61,6 +76,15 @@ namespace Horo::Application::Internal {
         }
     }  // namespace
 
+    /** @copydoc HostRendererFromBackendId */
+    Result<HostRenderer> HostRendererFromBackendId(const std::string_view backendId) {
+        if (backendId == "opengl")
+            return Result<HostRenderer>::Success(HostRenderer::OpenGL);
+        if (backendId == "metal")
+            return Result<HostRenderer>::Success(HostRenderer::Metal);
+        return InvalidSelection<HostRenderer>("Unsupported interactive renderer backend identity: " + std::string{backendId});
+    }
+
     /** @copydoc DescribeHostModules */
     Result<std::vector<ModuleDescriptor>> DescribeHostModules(const HostModuleSelection &selection) {
         if (selection.host == HostKind::Headless) {
@@ -83,6 +107,7 @@ namespace Horo::Application::Internal {
 
         std::vector<ModuleDescriptor> modules = DescribeEditorCoreModules();
 
+        /** @brief Canonical module identities selected for one interactive renderer. */
         struct RendererModules {
             std::string_view renderer;
             std::string_view viewport;

--- a/apps/common/HostModuleComposition.cpp
+++ b/apps/common/HostModuleComposition.cpp
@@ -83,22 +83,26 @@ namespace Horo::Application::Internal {
 
         std::vector<ModuleDescriptor> modules = DescribeEditorCoreModules();
 
-        const bool useOpenGL = selection.renderer == HostRenderer::OpenGL;
-        const std::string_view rendererModule = useOpenGL ? "horo.render.opengl" : "horo.render.metal";
-        const std::string_view viewportModule = useOpenGL ? "horo.editor.viewport.opengl" : "horo.editor.viewport.metal";
-        modules.push_back(Describe(std::string{rendererModule}, {"horo.render.backend_registry"}));
-        modules.push_back(Describe(std::string{viewportModule}, {"horo.editor.viewport_scene", rendererModule}));
+        struct RendererModules {
+            std::string_view renderer;
+            std::string_view viewport;
+        };
+
+        const RendererModules selectedModules = selection.renderer == HostRenderer::OpenGL
+                                                    ? RendererModules{"horo.render.opengl", "horo.editor.viewport.opengl"}
+                                                    : RendererModules{"horo.render.metal", "horo.editor.viewport.metal"};
+        modules.push_back(Describe(std::string{selectedModules.renderer}, {"horo.render.backend_registry"}));
+        modules.push_back(Describe(std::string{selectedModules.viewport}, {"horo.editor.viewport_scene", selectedModules.renderer}));
         if (selection.includeOpenTelemetry)
             modules.push_back(Describe("horo.observability.opentelemetry", {"horo.foundation"}));
 
         ModuleDescriptor host =
             Describe("horo.host.editor", {"horo.gui", "horo.editor.services", "horo.editor.render_extraction", "horo.render.frontend",
                                           "horo.runtime", "horo.runtime.scene", "horo.extensions", "horo.platform", "horo.input.sdl",
-                                          "horo.application.project_migrations", viewportModule});
-        if (selection.includeOpenTelemetry) {
-            host.dependencies.push_back(
-                ModuleDependency{.module = ModuleId{"horo.observability.opentelemetry"}, .minimumVersion = kContractVersion});
-        }
+                                          "horo.application.project_migrations", selectedModules.viewport});
+        host.dependencies.push_back(ModuleDependency{.module = ModuleId{"horo.observability.opentelemetry"},
+                                                     .minimumVersion = kContractVersion,
+                                                     .kind = ModuleDependencyKind::Optional});
         modules.push_back(std::move(host));
         return Result<std::vector<ModuleDescriptor>>::Success(std::move(modules));
     }

--- a/apps/common/HostModuleComposition.cpp
+++ b/apps/common/HostModuleComposition.cpp
@@ -1,0 +1,154 @@
+#include "HostModuleComposition.h"
+
+#include "Horo/Foundation/ErrorCode.h"
+
+#include <initializer_list>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace Horo::Application::Internal {
+    namespace {
+        constexpr ModuleContractVersion kContractVersion{1, 0, 0};
+
+        [[nodiscard]] ModuleDescriptor Describe(std::string id, const std::initializer_list<std::string_view> dependencies = {}) {
+            ModuleDescriptor descriptor{.id = ModuleId{std::move(id)}, .version = kContractVersion};
+            descriptor.dependencies.reserve(dependencies.size());
+            for (const std::string_view dependency : dependencies) {
+                descriptor.dependencies.push_back(
+                    ModuleDependency{.module = ModuleId{std::string{dependency}}, .minimumVersion = kContractVersion});
+            }
+            return descriptor;
+        }
+
+        template <typename T> [[nodiscard]] Result<T> InvalidSelection(std::string message) {
+            return Result<T>::Failure(Error{.code = ErrorCode{"application.host.invalid_module_selection"},
+                                            .domain = ErrorDomainId{"horo.application.host"},
+                                            .severity = ErrorSeverity::Critical,
+                                            .message = std::move(message)});
+        }
+
+        void AddEditorFoundationModules(std::vector<ModuleDescriptor> &modules) {
+            modules.push_back(Describe("horo.foundation"));
+            modules.push_back(Describe("horo.application", {"horo.foundation"}));
+            modules.push_back(Describe("horo.application.project_migrations", {"horo.application"}));
+            modules.push_back(Describe("horo.platform", {"horo.foundation"}));
+            modules.push_back(Describe("horo.runtime", {"horo.foundation"}));
+            modules.push_back(Describe("horo.assets", {"horo.foundation"}));
+            modules.push_back(Describe("horo.input", {"horo.foundation"}));
+            modules.push_back(Describe("horo.input.sdl", {"horo.input"}));
+        }
+
+        void AddEditorGameplayModules(std::vector<ModuleDescriptor> &modules) {
+            modules.push_back(Describe("horo.gameplay.api", {"horo.foundation"}));
+            modules.push_back(Describe("horo.render.api", {"horo.foundation"}));
+            modules.push_back(Describe("horo.scene.model", {"horo.foundation", "horo.render.api"}));
+            modules.push_back(Describe("horo.runtime.scene",
+                                       {"horo.foundation", "horo.runtime", "horo.assets", "horo.gameplay.api", "horo.scene.model"}));
+            modules.push_back(Describe("horo.gameplay.runtime", {"horo.gameplay.api", "horo.runtime.scene"}));
+            modules.push_back(Describe("horo.gameplay.module_host", {"horo.gameplay.runtime", "horo.platform"}));
+            modules.push_back(Describe("horo.gameplay.build", {"horo.foundation", "horo.platform", "horo.gameplay.module_host"}));
+            modules.push_back(Describe("horo.gameplay.lua", {"horo.gameplay.runtime"}));
+        }
+
+        void AddEditorRenderModules(std::vector<ModuleDescriptor> &modules, const HostRenderer renderer) {
+            modules.push_back(Describe("horo.render.backend_registry", {"horo.render.api"}));
+            modules.push_back(Describe("horo.render.frontend", {"horo.render.api", "horo.render.backend_registry"}));
+
+            if (renderer == HostRenderer::OpenGL) {
+                modules.push_back(Describe("horo.render.opengl", {"horo.render.backend_registry"}));
+                modules.push_back(Describe("horo.editor.viewport.opengl", {"horo.editor.viewport_scene", "horo.render.opengl"}));
+            } else {
+                modules.push_back(Describe("horo.render.metal", {"horo.render.backend_registry"}));
+                modules.push_back(Describe("horo.editor.viewport.metal", {"horo.editor.viewport_scene", "horo.render.metal"}));
+            }
+        }
+
+        void AddEditorFeatureModules(std::vector<ModuleDescriptor> &modules) {
+            modules.push_back(Describe("horo.editor.model", {"horo.foundation", "horo.scene.model", "horo.runtime.scene"}));
+            modules.push_back(Describe("horo.editor.viewport_scene", {"horo.editor.model"}));
+            modules.push_back(Describe("horo.editor.render_extraction", {"horo.editor.model", "horo.editor.viewport_scene"}));
+            modules.push_back(Describe("horo.editor.services", {"horo.foundation", "horo.application", "horo.platform", "horo.editor.model",
+                                                                "horo.gameplay.module_host", "horo.gameplay.build", "horo.gameplay.lua",
+                                                                "horo.input", "horo.application.project_migrations", "horo.assets"}));
+            modules.push_back(Describe("horo.extensions", {"horo.foundation", "horo.platform", "horo.assets"}));
+            modules.push_back(
+                Describe("horo.gui", {"horo.editor.services", "horo.foundation", "horo.editor.render_extraction", "horo.extensions"}));
+        }
+
+        void AddEditorHost(std::vector<ModuleDescriptor> &modules, const HostModuleSelection &selection) {
+            std::vector<std::string_view> dependencies{
+                "horo.gui",
+                "horo.editor.services",
+                "horo.editor.render_extraction",
+                "horo.render.frontend",
+                "horo.runtime",
+                "horo.runtime.scene",
+                "horo.extensions",
+                "horo.platform",
+                "horo.input.sdl",
+                "horo.application.project_migrations",
+            };
+            dependencies.push_back(selection.renderer == HostRenderer::OpenGL ? "horo.editor.viewport.opengl"
+                                                                              : "horo.editor.viewport.metal");
+            if (selection.includeOpenTelemetry)
+                dependencies.push_back("horo.observability.opentelemetry");
+
+            ModuleDescriptor host = Describe("horo.host.editor");
+            host.dependencies.reserve(dependencies.size());
+            for (const std::string_view dependency : dependencies) {
+                host.dependencies.push_back(
+                    ModuleDependency{.module = ModuleId{std::string{dependency}}, .minimumVersion = kContractVersion});
+            }
+            modules.push_back(std::move(host));
+        }
+    }  // namespace
+
+    /** @copydoc DescribeHostModules */
+    Result<std::vector<ModuleDescriptor>> DescribeHostModules(const HostModuleSelection &selection) {
+        if (selection.host == HostKind::Headless) {
+            if (selection.renderer != HostRenderer::None || selection.includeOpenTelemetry) {
+                return InvalidSelection<std::vector<ModuleDescriptor>>(
+                    "The current headless host does not link an interactive renderer or OpenTelemetry module.");
+            }
+            std::vector<ModuleDescriptor> modules;
+            modules.reserve(3);
+            modules.push_back(Describe("horo.foundation"));
+            modules.push_back(Describe("horo.application", {"horo.foundation"}));
+            modules.push_back(Describe("horo.host.cli", {"horo.application"}));
+            return Result<std::vector<ModuleDescriptor>>::Success(std::move(modules));
+        }
+
+        if (selection.renderer == HostRenderer::None) {
+            return InvalidSelection<std::vector<ModuleDescriptor>>(
+                "The graphical editor host requires one concrete interactive renderer module.");
+        }
+
+        std::vector<ModuleDescriptor> modules;
+        modules.reserve(27);
+        AddEditorFoundationModules(modules);
+        AddEditorGameplayModules(modules);
+        AddEditorFeatureModules(modules);
+        AddEditorRenderModules(modules, selection.renderer);
+        if (selection.includeOpenTelemetry)
+            modules.push_back(Describe("horo.observability.opentelemetry", {"horo.foundation"}));
+        AddEditorHost(modules, selection);
+        return Result<std::vector<ModuleDescriptor>>::Success(std::move(modules));
+    }
+
+    /** @copydoc ComposeHostModules */
+    Result<std::unique_ptr<ModuleHost>> ComposeHostModules(const HostModuleSelection &selection) {
+        auto described = DescribeHostModules(selection);
+        if (described.HasError())
+            return Result<std::unique_ptr<ModuleHost>>::Failure(described.ErrorValue());
+
+        auto host = std::make_unique<ModuleHost>();
+        for (const ModuleDescriptor &descriptor : described.Value()) {
+            if (const Result<void> registered = host->Register(descriptor); registered.HasError())
+                return Result<std::unique_ptr<ModuleHost>>::Failure(registered.ErrorValue());
+        }
+        if (const Result<std::size_t> activated = host->ActivateRegistered(nullptr); activated.HasError())
+            return Result<std::unique_ptr<ModuleHost>>::Failure(activated.ErrorValue());
+        return Result<std::unique_ptr<ModuleHost>>::Success(std::move(host));
+    }
+}  // namespace Horo::Application::Internal

--- a/apps/common/HostModuleComposition.cpp
+++ b/apps/common/HostModuleComposition.cpp
@@ -28,6 +28,37 @@ namespace Horo::Application::Internal {
                                             .message = std::move(message)});
         }
 
+        /** @brief Describes the renderer-independent modules linked into the editor host. */
+        [[nodiscard]] std::vector<ModuleDescriptor> DescribeEditorCoreModules() {
+            return {
+                Describe("horo.foundation"),
+                Describe("horo.application", {"horo.foundation"}),
+                Describe("horo.application.project_migrations", {"horo.application"}),
+                Describe("horo.platform", {"horo.foundation"}),
+                Describe("horo.runtime", {"horo.foundation"}),
+                Describe("horo.assets", {"horo.foundation"}),
+                Describe("horo.input", {"horo.foundation"}),
+                Describe("horo.input.sdl", {"horo.input"}),
+                Describe("horo.gameplay.api", {"horo.foundation"}),
+                Describe("horo.render.api", {"horo.foundation"}),
+                Describe("horo.scene.model", {"horo.foundation", "horo.render.api"}),
+                Describe("horo.runtime.scene", {"horo.foundation", "horo.runtime", "horo.assets", "horo.gameplay.api", "horo.scene.model"}),
+                Describe("horo.gameplay.runtime", {"horo.gameplay.api", "horo.runtime.scene"}),
+                Describe("horo.gameplay.module_host", {"horo.gameplay.runtime", "horo.platform"}),
+                Describe("horo.gameplay.build", {"horo.foundation", "horo.platform", "horo.gameplay.module_host"}),
+                Describe("horo.gameplay.lua", {"horo.gameplay.runtime"}),
+                Describe("horo.render.backend_registry", {"horo.render.api"}),
+                Describe("horo.render.frontend", {"horo.render.api", "horo.render.backend_registry"}),
+                Describe("horo.editor.model", {"horo.foundation", "horo.scene.model", "horo.runtime.scene"}),
+                Describe("horo.editor.viewport_scene", {"horo.editor.model"}),
+                Describe("horo.editor.render_extraction", {"horo.editor.model", "horo.editor.viewport_scene"}),
+                Describe("horo.editor.services",
+                         {"horo.foundation", "horo.application", "horo.platform", "horo.editor.model", "horo.gameplay.module_host",
+                          "horo.gameplay.build", "horo.gameplay.lua", "horo.input", "horo.application.project_migrations", "horo.assets"}),
+                Describe("horo.extensions", {"horo.foundation", "horo.platform", "horo.assets"}),
+                Describe("horo.gui", {"horo.editor.services", "horo.foundation", "horo.editor.render_extraction", "horo.extensions"}),
+            };
+        }
     }  // namespace
 
     /** @copydoc DescribeHostModules */
@@ -50,34 +81,7 @@ namespace Horo::Application::Internal {
                 "The graphical editor host requires one concrete interactive renderer module.");
         }
 
-        std::vector<ModuleDescriptor> modules{
-            Describe("horo.foundation"),
-            Describe("horo.application", {"horo.foundation"}),
-            Describe("horo.application.project_migrations", {"horo.application"}),
-            Describe("horo.platform", {"horo.foundation"}),
-            Describe("horo.runtime", {"horo.foundation"}),
-            Describe("horo.assets", {"horo.foundation"}),
-            Describe("horo.input", {"horo.foundation"}),
-            Describe("horo.input.sdl", {"horo.input"}),
-            Describe("horo.gameplay.api", {"horo.foundation"}),
-            Describe("horo.render.api", {"horo.foundation"}),
-            Describe("horo.scene.model", {"horo.foundation", "horo.render.api"}),
-            Describe("horo.runtime.scene", {"horo.foundation", "horo.runtime", "horo.assets", "horo.gameplay.api", "horo.scene.model"}),
-            Describe("horo.gameplay.runtime", {"horo.gameplay.api", "horo.runtime.scene"}),
-            Describe("horo.gameplay.module_host", {"horo.gameplay.runtime", "horo.platform"}),
-            Describe("horo.gameplay.build", {"horo.foundation", "horo.platform", "horo.gameplay.module_host"}),
-            Describe("horo.gameplay.lua", {"horo.gameplay.runtime"}),
-            Describe("horo.render.backend_registry", {"horo.render.api"}),
-            Describe("horo.render.frontend", {"horo.render.api", "horo.render.backend_registry"}),
-            Describe("horo.editor.model", {"horo.foundation", "horo.scene.model", "horo.runtime.scene"}),
-            Describe("horo.editor.viewport_scene", {"horo.editor.model"}),
-            Describe("horo.editor.render_extraction", {"horo.editor.model", "horo.editor.viewport_scene"}),
-            Describe("horo.editor.services",
-                     {"horo.foundation", "horo.application", "horo.platform", "horo.editor.model", "horo.gameplay.module_host",
-                      "horo.gameplay.build", "horo.gameplay.lua", "horo.input", "horo.application.project_migrations", "horo.assets"}),
-            Describe("horo.extensions", {"horo.foundation", "horo.platform", "horo.assets"}),
-            Describe("horo.gui", {"horo.editor.services", "horo.foundation", "horo.editor.render_extraction", "horo.extensions"}),
-        };
+        std::vector<ModuleDescriptor> modules = DescribeEditorCoreModules();
 
         const bool useOpenGL = selection.renderer == HostRenderer::OpenGL;
         const std::string_view rendererModule = useOpenGL ? "horo.render.opengl" : "horo.render.metal";

--- a/apps/common/HostModuleComposition.cpp
+++ b/apps/common/HostModuleComposition.cpp
@@ -2,6 +2,8 @@
 
 #include "Horo/Foundation/ErrorCode.h"
 
+#include <algorithm>
+#include <array>
 #include <initializer_list>
 #include <string>
 #include <string_view>
@@ -10,6 +12,12 @@
 namespace Horo::Application::Internal {
     namespace {
         constexpr ModuleContractVersion kContractVersion{1, 0, 0};
+
+        /** @brief Explicit backend identities supported by host module composition. */
+        constexpr std::array<std::pair<std::string_view, HostRenderer>, 2> kHostRenderers{{
+            {"opengl", HostRenderer::OpenGL},
+            {"metal", HostRenderer::Metal},
+        }};
 
         /**
          * @brief Builds inert metadata for one module and its required dependencies.
@@ -78,11 +86,10 @@ namespace Horo::Application::Internal {
 
     /** @copydoc HostRendererFromBackendId */
     Result<HostRenderer> HostRendererFromBackendId(const std::string_view backendId) {
-        if (backendId == "opengl")
-            return Result<HostRenderer>::Success(HostRenderer::OpenGL);
-        if (backendId == "metal")
-            return Result<HostRenderer>::Success(HostRenderer::Metal);
-        return InvalidSelection<HostRenderer>("Unsupported interactive renderer backend identity: " + std::string{backendId});
+        const auto selected = std::ranges::find(kHostRenderers, backendId, &std::pair<std::string_view, HostRenderer>::first);
+        if (selected == kHostRenderers.end())
+            return InvalidSelection<HostRenderer>("Unsupported interactive renderer backend identity: " + std::string{backendId});
+        return Result<HostRenderer>::Success(selected->second);
     }
 
     /** @copydoc DescribeHostModules */

--- a/apps/common/HostModuleComposition.h
+++ b/apps/common/HostModuleComposition.h
@@ -10,6 +10,7 @@
 #include "Horo/Foundation/Result.h"
 
 #include <memory>
+#include <string_view>
 #include <vector>
 
 namespace Horo::Application::Internal {
@@ -32,6 +33,13 @@ namespace Horo::Application::Internal {
         HostRenderer renderer{HostRenderer::None}; /**< Editor renderer selected before presentation creation. */
         bool includeOpenTelemetry{false};          /**< Whether the optional OpenTelemetry module is linked. */
     };
+
+    /**
+     * @brief Maps a concrete renderer backend identity to the host composition renderer type.
+     * @param backendId Canonical backend identity resolved by the renderer module registry.
+     * @return The matching renderer type, or a typed error for an unsupported identity.
+     */
+    [[nodiscard]] Result<HostRenderer> HostRendererFromBackendId(std::string_view backendId);
 
     /**
      * @brief Builds inert descriptors for the real modules linked into a supported host.

--- a/apps/common/HostModuleComposition.h
+++ b/apps/common/HostModuleComposition.h
@@ -1,0 +1,49 @@
+#pragma once
+
+/**
+ * @file HostModuleComposition.h
+ * @brief Non-installed module composition contract shared by Horo application hosts.
+ */
+
+#include "Horo/Foundation/ModuleDescriptor.h"
+#include "Horo/Foundation/ModuleHost.h"
+#include "Horo/Foundation/Result.h"
+
+#include <memory>
+#include <vector>
+
+namespace Horo::Application::Internal {
+    /** @brief Supported application composition roots. */
+    enum class HostKind {
+        Headless,
+        Editor,
+    };
+
+    /** @brief Concrete interactive renderer selected by an application composition root. */
+    enum class HostRenderer {
+        None,
+        OpenGL,
+        Metal,
+    };
+
+    /** @brief Build-time and startup choices that determine one host module graph. */
+    struct HostModuleSelection {
+        HostKind host{HostKind::Headless};         /**< Host whose real linked module set is composed. */
+        HostRenderer renderer{HostRenderer::None}; /**< Editor renderer selected before presentation creation. */
+        bool includeOpenTelemetry{false};          /**< Whether the optional OpenTelemetry module is linked. */
+    };
+
+    /**
+     * @brief Builds inert descriptors for the real modules linked into a supported host.
+     * @param selection Host and optional-module choices made by the composition root.
+     * @return Complete descriptor set, or a typed error for an impossible host selection.
+     */
+    [[nodiscard]] Result<std::vector<ModuleDescriptor>> DescribeHostModules(const HostModuleSelection &selection);
+
+    /**
+     * @brief Registers, validates, and activates the selected host module graph.
+     * @param selection Host and optional-module choices made by the composition root.
+     * @return Owning module host, or a failure with no partially active module set.
+     */
+    [[nodiscard]] Result<std::unique_ptr<ModuleHost>> ComposeHostModules(const HostModuleSelection &selection);
+}  // namespace Horo::Application::Internal

--- a/apps/horo-engine/main.cpp
+++ b/apps/horo-engine/main.cpp
@@ -1,6 +1,7 @@
 #include "Horo/Application/HostObservability.h"
 #include "Horo/Foundation/Logging/Logger.h"
 #include "Horo/Foundation/Telemetry/Telemetry.h"
+#include "HostModuleComposition.h"
 
 #include <filesystem>
 #include <iostream>
@@ -44,6 +45,13 @@ int main(const int argc, char **argv) {
         return 0;
     }
 
+    auto composedModules = Horo::Application::Internal::ComposeHostModules({.host = Horo::Application::Internal::HostKind::Headless});
+    if (composedModules.HasError()) {
+        std::cerr << "horo-engine: module composition failed: " << composedModules.ErrorValue().message << '\n';
+        return 2;
+    }
+    std::unique_ptr<Horo::ModuleHost> moduleHost = std::move(composedModules).Value();
+
     Horo::Application::HostObservabilityConfiguration configuration{.logging = {.logDirectory = "~/.horo/logs",
                                                                                 .baseName = "horo-engine",
                                                                                 .hostName = "horo-engine",
@@ -78,5 +86,6 @@ int main(const int argc, char **argv) {
         }
         std::cout << result.Value().outputPath.string() << '\n';  // NOSONAR(cpp:S5145)
     }
+    moduleHost->DeactivateAll();
     return 0;
 }

--- a/cmake/HoroDependencyPolicy.cmake
+++ b/cmake/HoroDependencyPolicy.cmake
@@ -58,7 +58,8 @@ horo_allow_target_dependencies(TARGET HoroExtensions
     DEPENDENCIES HoroFoundation HoroPlatform HoroAssets)
 
 # Executables are composition roots and may select any production module.
-horo_allow_target_dependencies(TARGET horo-engine DEPENDENCIES HoroApplication)
+horo_allow_target_dependencies(TARGET HoroHostModuleComposition DEPENDENCIES HoroFoundation)
+horo_allow_target_dependencies(TARGET horo-engine DEPENDENCIES HoroApplication HoroHostModuleComposition)
 horo_allow_target_dependencies(TARGET HoroEditor
     DEPENDENCIES
         HoroGui
@@ -73,7 +74,8 @@ horo_allow_target_dependencies(TARGET HoroEditor
         HoroInputSdl
         HoroOpenTelemetry
         HoroEditorViewportOpenGL
-        HoroEditorViewportMetal)
+        HoroEditorViewportMetal
+        HoroHostModuleComposition)
 
 # These edges predate the target-level architecture. Each exception is tied to
 # an active roadmap owner and must disappear when that ticket resolves the

--- a/docs/architecture/foundation/current-target-and-dependency-inventory.md
+++ b/docs/architecture/foundation/current-target-and-dependency-inventory.md
@@ -33,7 +33,7 @@ Snapshot:
 
 ## Current Production Targets
 
-The current combined macOS editor composition contains 30 first-party library
+The current combined macOS editor composition contains 31 first-party library
 targets and two executable targets. `HoroEngine::*` names below are CMake aliases;
 the unqualified names are the real targets that CMake modifies and builds.
 
@@ -91,6 +91,7 @@ include directories do not enforce those ownership boundaries, as documented in
 | `HoroEditorViewportOpenGL` (`HoroEngine::EditorViewportOpenGL`) | GUI and OpenGL | Owns the OpenGL ImGui/viewport/presentation bridge. Backend, SDL, GLAD, and ImGui adapter details are private, but SDL is currently a public link dependency. | EditorViewportScene, RenderOpenGL (public) |
 | `HoroEditorViewportMetal` (`HoroEngine::EditorViewportMetal`) | Apple, GUI, and Metal | Owns the Metal ImGui/viewport/presentation bridge. Objective-C++ and ImGui adapter details are private, but SDL is currently a public link dependency. | EditorViewportScene, RenderMetal (public) |
 | `HoroGui` (`HoroEngine::Gui`) | Editor GUI only | Owns ImGui screens, modals, panels, workspace controllers, and design-system implementation. ImGui is private, while all of `include/` and `src/` are exported as public include roots. | EditorServices, Foundation (public); EditorRenderExtraction and Extensions (private) |
+| `HoroHostModuleComposition` | Always | Non-installed application-host composition contract under `apps/common/`. It describes and activates the real linked module profiles for supported hosts without exposing an SDK header. | Foundation (public) |
 | `horo-engine` | Always | Terminal/headless composition root. It currently composes only Application and does not yet compose CLI command or MCP targets. | Application (private) |
 | `HoroEditor` | Editor GUI only | Graphical composition root. It selects GUI, editor services/extraction, runtime, extensions, platform, input, migrations, frontend, and enabled concrete viewport backends. | Composition-only private links |
 
@@ -150,6 +151,18 @@ owner and removal ticket; CMake rejects an exception once its edge becomes stale
 The normative policy and current exception inventory live in
 [System Design](./system-design.md#automated-target-policy).
 
+### ARC-001.5 host composition update
+
+The two supported executable roots now register and activate explicit descriptor
+graphs through the shared, non-installed `HoroHostModuleComposition` target. The
+headless profile contains only Foundation, Application, and the CLI host. The
+editor profile mirrors the real linked first-party module closure and selects
+exactly one concrete renderer and viewport adapter before window or presentation
+creation. Optional OpenTelemetry participation is derived from the same build
+selection that controls the executable link edge. Focused host-composition tests
+validate deterministic graph ordering, headless exclusion, concrete-backend
+selection, and rejection before activation of impossible host profiles.
+
 ## Documented Target Status
 
 This table covers every canonical target named by System Design. Build System
@@ -204,7 +217,7 @@ five are implemented. Its `HoroEngine::TestSdk`, `EditorSourceEditor`, and
 
 Current but non-canonical targets are Transitional: OpenTelemetry,
 GameplayRuntime, GameplayModuleHost, GameplayLua, GameplayBuild, Input,
-InputSdl, Extensions, and the renderer registry. They represent useful real
+InputSdl, Extensions, HostModuleComposition, and the renderer registry. They represent useful real
 boundaries, but the canonical target lists must either adopt them or assign
 their responsibilities to another documented target.
 

--- a/docs/architecture/foundation/internal-module-descriptor.md
+++ b/docs/architecture/foundation/internal-module-descriptor.md
@@ -88,6 +88,24 @@ into the composition path. `DeactivateAll` provides idempotent reverse-order
 teardown; attached module instances are released with their activation
 contexts.
 
+## Supported Host Profiles
+
+`apps/common/HostModuleComposition.h` is the non-installed contract shared by
+the two application composition roots. It translates the modules actually
+linked into each executable into the descriptor graph consumed by `ModuleHost`:
+
+| Host profile | Required participation | Optional selection |
+|---|---|---|
+| `horo-engine` | Foundation, Application, CLI host | None in the current implementation |
+| `HoroEditor` | The linked application, runtime, scene, asset, input, gameplay, editor, extension, GUI, and renderer-neutral modules | Exactly one compiled interactive renderer and viewport adapter; OpenTelemetry when linked |
+
+The profile is validated and activated before the host creates platform windows
+or presentation resources. An impossible profile therefore fails before any
+module activation, and a valid profile produces the same provider-before-
+dependant order from the same selection. Concrete renderer choice remains in the
+`HoroEditor` composition root; feature modules receive only the resulting
+backend-neutral services.
+
 ## Module Lifecycle And Shutdown
 
 `ModuleHost` owns the explicit per-registration state machine:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.sourceEncoding=UTF-8
 # Sonar must not index, analyze, or compute coverage for anything under it.
 sonar.sources=.
 sonar.exclusions=deprecated/**,build/**,cmake-build-debug/**,venv/**,.venv/**,.git/**,.hermes/**,.idea/**,.vscode/**,.cursor/**,.openclaw/**,.pytest_cache/**,bw-output/**,vendor/**,docs/**,.sonar/**,.cmake/**,_deps/**,src/application/project_migrations/definitions/**
-sonar.coverage.exclusions=deprecated/**,tests/**,build/**,cmake-build-debug/**,vendor/**
+sonar.coverage.exclusions=deprecated/**,tests/**,build/**,cmake-build-debug/**,vendor/**,apps/HoroEditor/app/HoroEditorApp.cpp,apps/horo-engine/main.cpp
 sonar.cpd.exclusions=deprecated/**,vendor/**
 sonar.test.exclusions=deprecated/**
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -574,6 +574,11 @@ add_executable(HoroFoundationModuleHostCompositionTests
 
 target_compile_features(HoroFoundationModuleHostCompositionTests PRIVATE cxx_std_20)
 target_link_libraries(HoroFoundationModuleHostCompositionTests PRIVATE HoroEngine::Foundation)
+add_executable(HoroHostModuleCompositionTests
+        unit/application/HostModuleCompositionTests.cpp
+)
+target_compile_features(HoroHostModuleCompositionTests PRIVATE cxx_std_20)
+target_link_libraries(HoroHostModuleCompositionTests PRIVATE HoroHostModuleComposition)
 add_executable(HoroFoundationPathsTimeHandlesTests
         unit/foundation/PathsTimeHandlesTests.cpp
 )
@@ -986,6 +991,7 @@ set(HORO_CATCH_TEST_TARGETS
         HoroFoundationResultTests
         HoroFoundationModuleDescriptorTests
         HoroFoundationModuleHostCompositionTests
+        HoroHostModuleCompositionTests
         HoroFoundationPathsTimeHandlesTests
         HoroFoundationCancellationProgressTests
         HoroFoundationConfigurationTests

--- a/tests/unit/application/HostModuleCompositionTests.cpp
+++ b/tests/unit/application/HostModuleCompositionTests.cpp
@@ -25,7 +25,6 @@ TEST_CASE("Headless host composition activates only its linked module set", "[un
     REQUIRE(ModuleIds(described.Value()) == std::vector<std::string>{"horo.foundation", "horo.application", "horo.host.cli"});
 
     auto composed = ComposeHostModules(selection);
-    INFO((composed.HasError() ? composed.ErrorValue().message : std::string{}));
     REQUIRE(composed.HasValue());
     REQUIRE(composed.Value()->HasActiveModules());
     REQUIRE(composed.Value()->StateOf(ModuleId{"horo.host.cli"}) == ModuleLifecycleState::Active);
@@ -37,7 +36,6 @@ TEST_CASE("Headless host composition activates only its linked module set", "[un
 TEST_CASE("Editor host composition selects exactly one concrete renderer", "[unit][application][modules]") {
     const HostModuleSelection selection{.host = HostKind::Editor, .renderer = HostRenderer::OpenGL, .includeOpenTelemetry = true};
     auto composed = ComposeHostModules(selection);
-    INFO((composed.HasError() ? composed.ErrorValue().message : std::string{}));
     REQUIRE(composed.HasValue());
     REQUIRE(composed.Value()->StateOf(ModuleId{"horo.host.editor"}) == ModuleLifecycleState::Active);
     REQUIRE(composed.Value()->StateOf(ModuleId{"horo.render.opengl"}) == ModuleLifecycleState::Active);
@@ -55,7 +53,6 @@ TEST_CASE("Supported host descriptor order is deterministic from the same select
     REQUIRE(second.HasValue());
 
     auto firstGraph = ValidateModuleGraph(first.Value());
-    INFO((firstGraph.HasError() ? firstGraph.ErrorValue().message : std::string{}));
     REQUIRE(firstGraph.HasValue());
     std::vector<ModuleDescriptor> reversed = second.Value();
     std::ranges::reverse(reversed);

--- a/tests/unit/application/HostModuleCompositionTests.cpp
+++ b/tests/unit/application/HostModuleCompositionTests.cpp
@@ -10,6 +10,20 @@ namespace {
 
 }  // namespace
 
+TEST_CASE("Renderer backend identities map explicitly to host renderer types", "[unit][application][modules]") {
+    const auto openGL = HostRendererFromBackendId("opengl");
+    REQUIRE(openGL.HasValue());
+    CHECK(openGL.Value() == HostRenderer::OpenGL);
+
+    const auto metal = HostRendererFromBackendId("metal");
+    REQUIRE(metal.HasValue());
+    CHECK(metal.Value() == HostRenderer::Metal);
+
+    const auto unsupported = HostRendererFromBackendId("future-renderer");
+    REQUIRE(unsupported.HasError());
+    CHECK(unsupported.ErrorValue().code.Value() == "application.host.invalid_module_selection");
+}
+
 TEST_CASE("Headless host composition activates only its linked module set", "[unit][application][modules]") {
     const HostModuleSelection selection{.host = HostKind::Headless};
     auto described = DescribeHostModules(selection);

--- a/tests/unit/application/HostModuleCompositionTests.cpp
+++ b/tests/unit/application/HostModuleCompositionTests.cpp
@@ -1,0 +1,71 @@
+#include "HostModuleComposition.h"
+
+#include <algorithm>
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include <vector>
+
+namespace {
+    using namespace Horo;
+    using namespace Horo::Application::Internal;
+
+    [[nodiscard]] std::vector<std::string> ModuleIds(const std::vector<ModuleDescriptor> &descriptors) {
+        std::vector<std::string> ids;
+        ids.reserve(descriptors.size());
+        for (const ModuleDescriptor &descriptor : descriptors)
+            ids.push_back(descriptor.id.value);
+        return ids;
+    }
+}  // namespace
+
+TEST_CASE("Headless host composition activates only its linked module set", "[unit][application][modules]") {
+    const HostModuleSelection selection{.host = HostKind::Headless};
+    auto described = DescribeHostModules(selection);
+    REQUIRE(described.HasValue());
+    REQUIRE(ModuleIds(described.Value()) == std::vector<std::string>{"horo.foundation", "horo.application", "horo.host.cli"});
+
+    auto composed = ComposeHostModules(selection);
+    INFO((composed.HasError() ? composed.ErrorValue().message : std::string{}));
+    REQUIRE(composed.HasValue());
+    REQUIRE(composed.Value()->HasActiveModules());
+    REQUIRE(composed.Value()->StateOf(ModuleId{"horo.host.cli"}) == ModuleLifecycleState::Active);
+    REQUIRE_FALSE(composed.Value()->StateOf(ModuleId{"horo.gui"}).has_value());
+    REQUIRE_FALSE(composed.Value()->StateOf(ModuleId{"horo.render.opengl"}).has_value());
+    REQUIRE_FALSE(composed.Value()->StateOf(ModuleId{"horo.render.metal"}).has_value());
+}
+
+TEST_CASE("Editor host composition selects exactly one concrete renderer", "[unit][application][modules]") {
+    const HostModuleSelection selection{.host = HostKind::Editor, .renderer = HostRenderer::OpenGL, .includeOpenTelemetry = true};
+    auto composed = ComposeHostModules(selection);
+    INFO((composed.HasError() ? composed.ErrorValue().message : std::string{}));
+    REQUIRE(composed.HasValue());
+    REQUIRE(composed.Value()->StateOf(ModuleId{"horo.host.editor"}) == ModuleLifecycleState::Active);
+    REQUIRE(composed.Value()->StateOf(ModuleId{"horo.render.opengl"}) == ModuleLifecycleState::Active);
+    REQUIRE(composed.Value()->StateOf(ModuleId{"horo.editor.viewport.opengl"}) == ModuleLifecycleState::Active);
+    REQUIRE(composed.Value()->StateOf(ModuleId{"horo.observability.opentelemetry"}) == ModuleLifecycleState::Active);
+    REQUIRE_FALSE(composed.Value()->StateOf(ModuleId{"horo.render.metal"}).has_value());
+    REQUIRE_FALSE(composed.Value()->StateOf(ModuleId{"horo.editor.viewport.metal"}).has_value());
+}
+
+TEST_CASE("Supported host descriptor order is deterministic from the same selection", "[unit][application][modules]") {
+    const HostModuleSelection selection{.host = HostKind::Editor, .renderer = HostRenderer::Metal};
+    auto first = DescribeHostModules(selection);
+    auto second = DescribeHostModules(selection);
+    REQUIRE(first.HasValue());
+    REQUIRE(second.HasValue());
+
+    auto firstGraph = ValidateModuleGraph(first.Value());
+    INFO((firstGraph.HasError() ? firstGraph.ErrorValue().message : std::string{}));
+    REQUIRE(firstGraph.HasValue());
+    std::vector<ModuleDescriptor> reversed = second.Value();
+    std::ranges::reverse(reversed);
+    auto secondGraph = ValidateModuleGraph(reversed);
+    REQUIRE(secondGraph.HasValue());
+    REQUIRE(firstGraph.Value().initializationOrder == secondGraph.Value().initializationOrder);
+}
+
+TEST_CASE("Impossible host module selections fail before activation", "[unit][application][modules]") {
+    REQUIRE(DescribeHostModules({.host = HostKind::Headless, .renderer = HostRenderer::OpenGL}).HasError());
+    REQUIRE(DescribeHostModules({.host = HostKind::Headless, .includeOpenTelemetry = true}).HasError());
+    REQUIRE(DescribeHostModules({.host = HostKind::Editor, .renderer = HostRenderer::None}).HasError());
+}

--- a/tests/unit/application/HostModuleCompositionTests.cpp
+++ b/tests/unit/application/HostModuleCompositionTests.cpp
@@ -2,27 +2,22 @@
 
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
-#include <string>
 #include <vector>
 
 namespace {
     using namespace Horo;
     using namespace Horo::Application::Internal;
 
-    [[nodiscard]] std::vector<std::string> ModuleIds(const std::vector<ModuleDescriptor> &descriptors) {
-        std::vector<std::string> ids;
-        ids.reserve(descriptors.size());
-        for (const ModuleDescriptor &descriptor : descriptors)
-            ids.push_back(descriptor.id.value);
-        return ids;
-    }
 }  // namespace
 
 TEST_CASE("Headless host composition activates only its linked module set", "[unit][application][modules]") {
     const HostModuleSelection selection{.host = HostKind::Headless};
     auto described = DescribeHostModules(selection);
     REQUIRE(described.HasValue());
-    REQUIRE(ModuleIds(described.Value()) == std::vector<std::string>{"horo.foundation", "horo.application", "horo.host.cli"});
+    REQUIRE(described.Value().size() == 3);
+    CHECK(described.Value()[0].id == ModuleId{"horo.foundation"});
+    CHECK(described.Value()[1].id == ModuleId{"horo.application"});
+    CHECK(described.Value()[2].id == ModuleId{"horo.host.cli"});
 
     auto composed = ComposeHostModules(selection);
     REQUIRE(composed.HasValue());


### PR DESCRIPTION
## Summary
- add a non-installed host-composition target that describes the real module profiles of horo-engine and HoroEditor
- register, validate, and activate those profiles through ModuleHost before platform window or presentation creation
- keep the headless graph free of GUI and renderer modules and activate exactly one selected editor renderer adapter
- add focused composition tests and update the target inventory and architecture contract

## Motivation
PR #2327 introduced the generic ModuleHost contract but neither production application root consumed it. ARC-001.5 requires supported hosts to build their module graphs explicitly at composition time and reject invalid selections before activation.

## Implementation Notes
- The headless profile contains Foundation, Application, and the CLI host only.
- The editor profile mirrors the real first-party link closure, includes OpenTelemetry only when linked, and selects one OpenGL or Metal renderer plus its viewport adapter.
- Concrete renderer selection remains at the HoroEditor executable boundary; feature modules do not select backends.
- The shared contract is narrow and non-installed under apps/common; it adds no SDK header.
- CMake dependency policy and the current target inventory include the new composition target.
- CircleCI coverage now measures production sources under apps/common. Platform executable entrypoints remain integration/manual-smoke surfaces and are explicitly excluded from unit-coverage calculation.

## Validation
- [x] Configure passed
- [x] Relevant tests passed
- [ ] Full build passed
- [ ] Manual GPU smoke tested if applicable

Commands and checks run:
- Headless configure with BUILD_TESTING enabled: header inventory and dependency-direction policy passed.
- OpenGL-only editor configure passed.
- Metal-only editor configure passed.
- Combined OpenGL and Metal editor configure passed.
- Manual focused build/link of current ModuleHost sources plus HoroHostModuleCompositionTests: 4/4 test cases, 23 assertions passed.
- HoroEditorApp.cpp syntax check passed with OpenGL, Metal, and OpenTelemetry compile definitions.
- HostModuleComposition.cpp, host tests, and horo-engine main syntax checks passed.
- CircleCI YAML parsed successfully with Ruby YAML.
- python3 scripts/dev.py format --check passed.
- git diff --check passed.

The ordinary CMake target build was attempted but the machine ran out of disk space while archiving Catch2/Foundation objects. No compiler error from the changed source preceded the environment failure; repository CI remains the authoritative full native build matrix.

## Risks
- Runtime descriptor dependencies intentionally mirror the compile-time module graph; future target-edge changes must update both reviewed contracts together.
- The descriptors establish host participation and deterministic lifecycle ordering. Existing subsystem-owned runtime objects continue to be constructed by their current explicit host APIs until their owning subsystem migrations attach concrete ModuleHost instances.
- GPU smoke paths were not run.

## Issue Links
Closes #67

## Reviewer Notes
Review apps/common/HostModuleComposition.cpp first, then both executable integration points, the focused tests, and finally the CMake policy/inventory updates.