### PR TITLE
docs(config): ratify schema, precedence and secret boundary HORO-1777 [CFG-001.1]

### DIFF
--- a/docs/adr/009-configuration-schema-precedence-and-secret-boundary.md
+++ b/docs/adr/009-configuration-schema-precedence-and-secret-boundary.md
@@ -1,0 +1,131 @@
+# ADR-009: Configuration Schema, Precedence and Secret Boundary
+
+- **Status**: Proposed
+- **Date**: 2026-08-28
+- **Supersedes**: None
+- **Scope**: Foundation configuration schema, domain ownership, source precedence, environment indirection and credential references
+- **Issue**: [#1821](https://github.com/abdullahbodur/horo-engine/issues/1821) ([CFG-001.1])
+- **JIRA**: HORO-1777
+- **Normative document**: [Configuration System](../architecture/foundation/configuration-system.md)
+
+## Context
+
+`docs/architecture/foundation/configuration-system.md` defines one typed configuration contract shared by the editor, runtime, CLI, MCP, Python, build and release hosts. Settings are declared before composition, resolved from explicitly ordered sources, exposed through immutable snapshots and never used to carry credential values.
+
+The current implementation provides a useful typed baseline, but it is a single-layer draft/commit service rather than the documented multi-source resolver:
+
+- `include/Horo/Foundation/Configuration.h` exposes `SettingKey`, `SettingDescriptor`, `ConfigurationSchema`, immutable shared `ConfigurationSnapshot` handles, `ConfigurationDraft` and `ConfigurationService` from the `HoroFoundation` target.
+- `SettingDescriptor` carries key, type, default, one `SettingScope`, reload policy and sensitivity. It does not carry an owning module/domain, a validation rule, legal source set, explicit environment binding or the `sessionOverride` policy.
+- `ConfigurationSchema::Register()` rejects duplicate keys and default/type mismatches, and `Seal()` prevents later registration. It does not validate dotted-key syntax, namespace ownership, source legality, environment collisions or module contributions.
+- `ConfigurationService` starts from schema defaults and atomically replaces a shared immutable value map after validating a revision and primitive value type. It does not retain `ConfigurationSource` provenance or resolve multiple source layers.
+- `LoadJson()` silently ignores unknown keys. `SaveFile()` truncates the destination directly and snapshot serialization iterates an unordered map. These behaviors do not meet the normative diagnostic, deterministic-write or atomic-replacement contracts.
+- `ConfigurationChangedEvent` is published after the service lock is released and carries bounded revision/key metadata, but its domain remains `All`, changed-key ordering is not deterministic and reload policy is not enforced.
+- Editor settings remain authoritative in `EditorSettingsService` and `EditorSettingsStore`; four appearance values are projected into Foundation configuration. This is a temporary adapter, not a complete shared configuration authority.
+- `SettingSensitivity::SecretReference` exists, but the schema cannot validate reference syntax or prevent a caller from supplying a credential value as an ordinary string. No configuration-owned credential resolution path exists.
+- Configuration values are not resolved from environment bindings. Direct environment reads that exist elsewhere are host/platform bootstrap behavior and must not become a second settings resolver.
+
+[CFG-001.1] requires a ratify-or-revise decision for this baseline, an explicit ownership map, one precedence contract shared by all hosts and a strict boundary between configuration and credentials.
+
+## Decision
+
+**Foundation owns inert configuration types, schema validation, source-resolution contracts and immutable snapshots. Modules own their setting descriptors and stable namespaces. The application composition root collects and validates contributions, captures host inputs once and constructs the active resolver. Credential providers own secret values; configuration carries only bounded opaque references.**
+
+### Ratify-or-revise outcomes
+
+| Area | Current state | Outcome |
+|---|---|---|
+| `SettingKey`, primitive `SettingValue` and type checking | Typed Foundation values exist | **Ratified for the current value set.** New value kinds require typed schema additions, not string parsing at call sites. |
+| `ConfigurationSchema` registration and sealing | Explicit builder; duplicate keys and invalid defaults fail | **Ratified as the inert Foundation baseline.** Registration remains side-effect free and sealing precedes resolution. |
+| Descriptor ownership and validation | No module owner, validation rule, legal-source set or environment binding | **Revised.** Module-owned contributions and composition-time namespace/source validation are implemented by [CFG-001.3]. |
+| `SettingScope` | One enum mixes ownership/persistence concepts and cannot express legal source sets | **Revised.** It remains a compatibility field until the typed source-policy contract in [CFG-001.2]/[CFG-001.3] replaces it; it is not the authoritative domain owner. |
+| Immutable shared snapshots | `shared_ptr<const Data>` preserves captured revisions | **Ratified.** Readers continue to observe one complete revision and never a partially applied update. |
+| Resolution and provenance | Defaults plus successive draft commits; no `ConfigurationSource` | **Revised.** [CFG-001.2] adds the single resolver and per-value provenance. Direct `LoadJson()` commits are not the final resolution model. |
+| Unknown and malformed inputs | Unknown JSON keys are ignored; primitive parse/type errors fail fast | **Revised.** Unknown, illegal-source and malformed values produce typed deterministic diagnostics through the resolution pipeline. |
+| Persistence | Direct truncating write and unordered serialization | **Revised.** [CFG-001.2] owns versioned deterministic documents, temporary same-filesystem writes, durable flush and atomic replacement. |
+| Reload and notifications | Immutable commit and post-lock event exist; reload policy/domain projection are not enforced | **Ratified as a starting mechanism, revised as a lifecycle contract.** [CFG-001.4] owns synchronization-point activation, rollback and one deterministic committed-change notification. |
+| Editor settings adapter | Editor model is authoritative; four values are projected into Foundation configuration | **Ratified only as migration compatibility.** [CFG-001.5] moves the Settings modal to the shared authority without preserving two independently mutable sources of truth. |
+| `SecretReference` sensitivity | Marker exists; reference validation and credential-provider boundary do not | **Revised.** [CFG-001.6] introduces bounded typed references and operation-local credential resolution; raw secrets remain forbidden. |
+
+### Ownership map
+
+Ownership has three independent dimensions and must not be inferred from persistence location:
+
+| Concern | Owner | Rule |
+|---|---|---|
+| Setting identity and descriptor | Declaring built-in or extension module | Stable dotted key lives under the module's registered namespace; descriptors are inert. |
+| Schema/contribution validation | Application composition root using Foundation contracts | Collect all selected contributions, reject duplicates/collisions and seal once before resolution. |
+| Resolution algorithm and immutable snapshot representation | `HoroFoundation` | Apply the canonical source order, retain provenance and publish complete revisions. |
+| Engine defaults | Declaring module descriptor | Default is always present and type-correct before registration succeeds. |
+| Packaged profile/preset | Distribution/application composition | Supplies signed or packaged policy input; it does not redefine descriptors. |
+| User configuration | Host user-settings adapter | Persists user preferences in the platform user-config location. |
+| Project configuration | Project/application layer | Owns portable project settings and project extension requests; requests never grant trust. |
+| Workspace configuration | Editor workspace owner | Owns local presentation/layout state and never becomes portable project authority. |
+| Session overrides | Active host/session owner | Memory-only, bounded by descriptor policy and discarded with the session. |
+| Invocation/environment inputs | GUI/CLI/MCP host adapter | Capture once at startup/request boundary and translate into typed source maps. |
+| Credential values | Platform/release credential provider | Resolve only inside the consuming operation; never enter configuration snapshots, events, files, logs or diagnostics. |
+
+`ConfigurationDomain` remains a notification/query projection during migration. It does not assign schema ownership. Module identity plus the validated key namespace is the authoritative ownership contract.
+
+The current production schema has no orphan descriptors: `editor.theme.active`, `editor.appearance.accent_color`, `editor.appearance.ui_scale_percent` and `editor.appearance.code_font_size_px` are all owned by the Editor module, use the `editor.*` namespace and are user-persisted preferences. Test-only descriptors remain owned by their test composition roots. Every new production descriptor must enter through the module-contribution validation path; adding a key directly to a host-local parser does not establish ownership.
+
+### Canonical source precedence
+
+All hosts use this order from highest to lowest:
+
+1. explicit invocation arguments;
+2. environment bindings captured by the host;
+3. session overrides;
+4. project configuration;
+5. user configuration;
+6. packaged profile or preset;
+7. schema default.
+
+The resolver evaluates only sources permitted by the descriptor. Environment variables are not discovered from dotted keys: each mapping is explicitly declared by the owning module, uses the `HORO_` prefix and is collision-checked at composition.
+
+The documented `sessionOverride` exception is retained: a session value may override a captured environment value only when the descriptor explicitly permits it. Otherwise the environment-derived value is locked for the process lifetime. This exception is part of resolution, not an alternate host-specific precedence list.
+
+Foundation and feature modules never call `getenv()` to obtain setting values. A host/platform adapter captures the environment once and passes a bounded input map into composition. CLI, GUI, MCP and test hosts use the same resolver API; they may provide different source maps, but not different precedence rules.
+
+Each resolved value records its winning source and optional safe source location. Presentation surfaces may explain shadowed values from this provenance, but callers branch only on typed results and setting identities.
+
+### Secret and credential boundary
+
+`SecretReference` means an opaque identifier for a credential-provider entry, not a secret string with a sensitive label.
+
+- descriptors explicitly declare whether a setting accepts a credential reference;
+- reference syntax and size are validated before activation;
+- configuration files and snapshots may contain the reference identity only;
+- the consuming operation resolves the reference through an explicitly injected credential provider;
+- the resolved value is owning, short-lived and excluded from snapshots, events, serialization, logs, diagnostics and support bundles;
+- missing credential capability or reference resolution returns a typed error at the operation boundary;
+- environment variables containing credential values are operation inputs owned by the host adapter and are never copied into the configuration snapshot.
+
+Marking a plain `std::string` as `SecretReference` does not make an arbitrary value safe. [CFG-001.6] owns the typed reference and provider integration; until then, production descriptors must not accept credential values through `ConfigurationService`.
+
+### Migration boundaries
+
+- [CFG-001.2] adds source maps, provenance, the resolver and durable persistence without changing the public precedence order decided here.
+- [CFG-001.3] adds module contribution descriptors, namespace ownership and environment-binding validation without ambient registration.
+- [CFG-001.4] enforces reload policies, synchronization points, rollback and deterministic notification.
+- [CFG-001.5] migrates editor settings/modal persistence to the shared authority and removes the temporary dual-model projection.
+- [CFG-001.6] adds credential-reference validation and provider-backed resolution.
+
+No follow-up may introduce a host-local precedence list, direct module environment lookup, process-global schema registry or raw credential value in configuration as a compatibility shortcut.
+
+## Consequences
+
+- The current schema and immutable snapshot code remain valid foundations rather than being replaced wholesale.
+- Current `ConfigurationService` file loading is explicitly a prototype ingress, preventing new callers from treating last-write order as canonical precedence.
+- Domain ownership is derived from validated module identity and key namespace, while persistence/source policy remains independently typed.
+- GUI, CLI, MCP, Python and tests converge on one resolver contract and can explain the same winning value through provenance.
+- Editor settings migration must end with one authoritative commit path; persistence and activation failures cannot leave two committed revisions.
+- Credential references can be portable where policy permits, while credential values remain provider-owned and short-lived.
+
+## Rejected Alternatives
+
+- **Treat `SettingScope` as both module ownership and source precedence.** Rejected: one enum cannot express namespace ownership, legal source sets and the environment/session exception without conflating independent contracts.
+- **Let each host merge configuration in its own startup code.** Rejected: precedence and validation would drift across GUI, CLI, MCP, Python and tests.
+- **Derive environment variable names mechanically from dotted keys.** Rejected: aliases, collisions and compatibility become implicit and cannot be validated before activation.
+- **Keep editor settings and Foundation configuration as permanent peer authorities.** Rejected: cross-surface commits can diverge or partially succeed, leaving no single committed revision.
+- **Store raw credentials in a sensitive `SettingValue`.** Rejected: a sensitivity marker does not provide secure lifetime, redaction or provider isolation.
+- **Implement the complete resolver in this M0 decision.** Rejected: the focused follow-up tickets own implementation and regression coverage; this ADR fixes their shared contract first.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ to the replacement.
 | [006](006-lua-5-4-gameplay-runtime.md) | Lua 5.4 Gameplay Runtime             | accepted | 2026-08-02 |
 | [007](007-cross-engine-project-interchange.md) | Cross-Engine Project Interchange | proposed | 2026-08-26 |
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
+| [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 
 ## Conventions
 


### PR DESCRIPTION
## Summary
- Adds ADR-009 to ratify the existing typed configuration schema and immutable snapshot baseline.
- Defines module, composition-root, source-layer and credential-provider ownership.
- Fixes one canonical precedence order, including explicit environment bindings and the bounded session-override exception.
- Records current deviations and assigns implementation to CFG-001.2 through CFG-001.6 without creating a second configuration authority.

## Motivation
- The current ConfigurationService is a typed single-layer draft/commit service, while the normative architecture requires multi-source resolution, provenance, module contributions and credential references.
- CFG-001.1 requires the shared decision before dependent configuration implementation begins.

## Implementation Notes
- Ratifies SettingKey, primitive SettingValue, explicit schema sealing and immutable shared snapshots.
- Treats SettingScope as a compatibility field rather than authoritative ownership or source precedence.
- Confirms the four current production descriptors are Editor-owned and that no production descriptor is orphaned.
- Keeps raw credential values outside configuration; only bounded opaque references may enter configuration state.
- Intentionally defers resolver, contribution, reload, modal migration and credential-provider implementation to CFG-001.2–CFG-001.6.

## Validation
- [ ] Build passed (not required; documentation-only change)
- [x] Relevant checks passed
- [x] Manual smoke tested if applicable (n/a)

Commands run:
```bash
git diff --check
# validated every relative Markdown link target in ADR-009
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risks
- Follow-up implementations must not preserve host-local precedence lists or the temporary Editor/Foundation dual-authority projection.
- ConfigurationService file loading remains a prototype ingress until CFG-001.2 supplies source resolution and durable persistence.

## Issue Links
Closes #1821
HORO-1777

## Reviewer Notes
- Review ADR-009 in order: ratify-or-revise table, ownership map, precedence, then secret boundary.
- Compare the audit against include/Horo/Foundation/Configuration.h, src/foundation/config/Configuration.cpp and src/editor/settings/EditorSettingsService.cpp.