### PR TITLE
feat(input): action mapping conflict validation on typed bindings HORO-1791 #1835 [INP-001.2]

### DIFF
--- a/include/Horo/Runtime/Input.h
+++ b/include/Horo/Runtime/Input.h
@@ -384,6 +384,8 @@ namespace Horo::Input {
         InvalidDeadzone,
         InvalidSchema,
         MalformedProfile,
+        DeviceExclusivityViolation,
+        AmbiguousContext,
     };
 
     /** @brief One actionable profile validation diagnostic. */

--- a/src/runtime/input/Input.cpp
+++ b/src/runtime/input/Input.cpp
@@ -493,9 +493,9 @@ namespace Horo::Input {
                     continue;
                 }
                 if (!actionIds.insert(action.id.Value()).second) {
-                    report.diagnostics.emplace_back(
-                        InvalidAction, action.id,
-                        std::format("Action map contains more than one descriptor for action ID '{}'.", action.id.Value()));
+                    report.diagnostics.emplace_back(InvalidAction, action.id,
+                                                    std::format("Action map contains more than one descriptor for action ID '{}'.",
+                                                                action.id.Value()));
                     continue;
                 }
                 if (!action.context.IsValid()) {

--- a/src/runtime/input/Input.cpp
+++ b/src/runtime/input/Input.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <format>
 #include <fstream>
 #include <limits>
 #include <nlohmann/json.hpp>
@@ -103,6 +104,19 @@ namespace Horo::Input {
                 });
             };
             return contains(left, right) || contains(right, left);
+        }
+
+        bool SameAnalogAxis(const InputBinding &left, const InputBinding &right) noexcept {
+            if (left.kind != right.kind || left.requiredModifiers != right.requiredModifiers || left.chordSize != 0 || right.chordSize != 0)
+                return false;
+            using enum BindingControlKind;
+            if (left.kind == GamepadAxis)
+                return left.gamepadAxis == right.gamepadAxis;
+            if (left.kind == RawGamepadAxis)
+                return left.rawControl == right.rawControl;
+            if (left.kind == PointerWheelX || left.kind == PointerWheelY)
+                return true;
+            return false;
         }
 
         struct BindingEvaluationResult {
@@ -418,7 +432,7 @@ namespace Horo::Input {
 
         template <typename Bindings>
         void ReportDuplicateTransitions(BindingValidationReport &report, const ActionId &action, const Bindings &bindings,
-                                        const char *message) {
+                                        const std::string &message) {
             for (std::size_t i = 0; i + 1 < bindings.size(); ++i)
                 for (std::size_t j = i + 1; j < bindings.size(); ++j)
                     if (SameTransition(bindings[i], bindings[j]))
@@ -431,17 +445,21 @@ namespace Horo::Input {
             std::unordered_set<std::string, StringViewHash, std::equal_to<>> overriddenActions;
             for (const BindingOverride &overrideValue : profile.overrides) {
                 if (const auto action = std::ranges::find(actions, overrideValue.action, &ActionDescriptor::id); action == actions.end()) {
-                    report.diagnostics.emplace_back(InvalidAction, overrideValue.action, "Binding override references an unknown action.");
+                    report.diagnostics.emplace_back(InvalidAction, overrideValue.action,
+                                                    std::format("Binding override references unknown action '{}'.",
+                                                                overrideValue.action.Value()));
                     continue;
                 }
                 if (!overriddenActions.insert(overrideValue.action.Value()).second)
                     report.diagnostics.emplace_back(DuplicateBinding, overrideValue.action,
-                                                    "The profile contains more than one override for the action.");
+                                                    std::format("The profile contains more than one override for action '{}'.",
+                                                                overrideValue.action.Value()));
                 for (const InputBinding &binding : overrideValue.bindings)
                     ValidateBinding(report, overrideValue.action, binding, "Binding deadzone must be in [0, 1).",
                                     "Binding references an unsupported control.", "Binding is reserved by the operating system.");
                 ReportDuplicateTransitions(report, overrideValue.action, overrideValue.bindings,
-                                           "The action contains a duplicate binding.");
+                                           std::format("Action '{}' override contains a duplicate binding on the same trigger.",
+                                                       overrideValue.action.Value()));
             }
         }
 
@@ -455,15 +473,33 @@ namespace Horo::Input {
             using enum BindingDiagnosticCode;
             std::vector<EffectiveBinding> effective;
             for (const ActionDescriptor &action : actions) {
+                if (!action.id.IsValid()) {
+                    report.diagnostics.emplace_back(InvalidAction, action.id, "Action descriptor contains an empty action ID.");
+                    continue;
+                }
+                if (!action.context.IsValid())
+                    report.diagnostics.emplace_back(AmbiguousContext, action.id,
+                                                    std::format("Action '{}' has an invalid or empty context ID.", action.id.Value()));
+
                 const auto overrideValue = std::ranges::find(profile.overrides, action.id, &BindingOverride::action);
                 const std::vector<InputBinding> &bindings =
                     overrideValue == profile.overrides.end() ? action.defaultBindings : overrideValue->bindings;
                 if (action.required && bindings.empty())
-                    report.diagnostics.emplace_back(RequiredActionUnbound, action.id, "A required action has no binding.");
-                for (const InputBinding &binding : bindings)
+                    report.diagnostics.emplace_back(RequiredActionUnbound, action.id,
+                                                    std::format("Required action '{}' has no binding in context '{}'.", action.id.Value(),
+                                                                action.context.Value()));
+                for (const InputBinding &binding : bindings) {
                     ValidateBinding(report, action.id, binding, "Action binding deadzone must be in [0, 1).",
                                     "Action references an unsupported control.", "Action uses an operating-system-reserved shortcut.");
-                ReportDuplicateTransitions(report, action.id, bindings, "Action contains a duplicate binding.");
+                    if ((action.valueType == ActionValueType::Digital || action.valueType == ActionValueType::Axis1D) &&
+                        binding.component != 0)
+                        report.diagnostics.emplace_back(DeviceExclusivityViolation, action.id,
+                                                        std::format("Binding on action '{}' specifies component {}, but digital and 1D "
+                                                                    "actions require component 0.",
+                                                                    action.id.Value(), binding.component));
+                }
+                ReportDuplicateTransitions(report, action.id, bindings,
+                                           std::format("Action '{}' contains a duplicate binding on the same trigger.", action.id.Value()));
                 effective.reserve(bindings.size());
                 for (const InputBinding &binding : bindings)
                     effective.push_back({&action, &binding});
@@ -472,12 +508,29 @@ namespace Horo::Input {
                 for (std::size_t j = i + 1; j < effective.size(); ++j) {
                     if (effective[i].action->id == effective[j].action->id || effective[i].action->context != effective[j].action->context)
                         continue;
-                    if (SameTransition(*effective[i].binding, *effective[j].binding))
-                        report.diagnostics.emplace_back(DuplicateBinding, effective[j].action->id,
-                                                        "Binding conflicts with another action in the same context.");
-                    else if (ChordsOverlap(*effective[i].binding, *effective[j].binding))
+                    if (effective[i].binding->kind == BindingControlKind::GamepadAxis ||
+                        effective[i].binding->kind == BindingControlKind::RawGamepadAxis ||
+                        effective[i].binding->kind == BindingControlKind::PointerWheelX ||
+                        effective[i].binding->kind == BindingControlKind::PointerWheelY) {
+                        if (SameAnalogAxis(*effective[i].binding, *effective[j].binding)) {
+                            report.diagnostics.emplace_back(DeviceExclusivityViolation, effective[j].action->id,
+                                                            std::format("Action '{}' and action '{}' in context '{}' have an exclusive "
+                                                                        "device binding conflict on the same axis.",
+                                                                        effective[j].action->id.Value(), effective[i].action->id.Value(),
+                                                                        effective[j].action->context.Value()));
+                        }
+                    } else if (SameTransition(*effective[i].binding, *effective[j].binding)) {
+                        report.diagnostics
+                            .emplace_back(DuplicateBinding, effective[j].action->id,
+                                          std::format("Action '{}' conflicts with action '{}' in context '{}' on the same trigger.",
+                                                      effective[j].action->id.Value(), effective[i].action->id.Value(),
+                                                      effective[j].action->context.Value()));
+                    } else if (ChordsOverlap(*effective[i].binding, *effective[j].binding)) {
                         report.diagnostics.emplace_back(AmbiguousChord, effective[j].action->id,
-                                                        "Chord overlaps another action in the same context.");
+                                                        std::format("Action '{}' chord overlaps action '{}' in context '{}'.",
+                                                                    effective[j].action->id.Value(), effective[i].action->id.Value(),
+                                                                    effective[j].action->context.Value()));
+                    }
                 }
             }
         }

--- a/src/runtime/input/Input.cpp
+++ b/src/runtime/input/Input.cpp
@@ -85,7 +85,13 @@ namespace Horo::Input {
                    (mods.alt && binding.key == F4) || (mods.control && mods.alt && binding.key == Delete);
         }
 
+        bool HasValidChordSize(const InputBinding &binding) noexcept {
+            return binding.chordSize <= binding.chord.size();
+        }
+
         bool SameTransition(const InputBinding &left, const InputBinding &right) noexcept {
+            if (!HasValidChordSize(left) || !HasValidChordSize(right))
+                return false;
             return left.kind == right.kind && left.key == right.key && left.pointerButton == right.pointerButton &&
                    left.gamepadButton == right.gamepadButton && left.gamepadAxis == right.gamepadAxis &&
                    left.rawControl == right.rawControl && left.requiredModifiers == right.requiredModifiers &&
@@ -94,6 +100,8 @@ namespace Horo::Input {
         }
 
         bool ChordsOverlap(const InputBinding &left, const InputBinding &right) noexcept {
+            if (!HasValidChordSize(left) || !HasValidChordSize(right))
+                return false;
             if (left.kind != right.kind || left.key != right.key || left.pointerButton != right.pointerButton ||
                 left.gamepadButton != right.gamepadButton || left.gamepadAxis != right.gamepadAxis || left.rawControl != right.rawControl ||
                 left.requiredModifiers != right.requiredModifiers)
@@ -478,9 +486,16 @@ namespace Horo::Input {
                                        const std::span<const ActionDescriptor> actions) {
             using enum BindingDiagnosticCode;
             std::vector<EffectiveBinding> effective;
+            std::unordered_set<std::string, StringViewHash, std::equal_to<>> actionIds;
             for (const ActionDescriptor &action : actions) {
                 if (!action.id.IsValid()) {
                     report.diagnostics.emplace_back(InvalidAction, action.id, "Action descriptor contains an empty action ID.");
+                    continue;
+                }
+                if (!actionIds.insert(action.id.Value()).second) {
+                    report.diagnostics.emplace_back(
+                        InvalidAction, action.id,
+                        std::format("Action map contains more than one descriptor for action ID '{}'.", action.id.Value()));
                     continue;
                 }
                 if (!action.context.IsValid()) {

--- a/src/runtime/input/Input.cpp
+++ b/src/runtime/input/Input.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <limits>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <unordered_set>
 #include <utility>
 
@@ -430,13 +431,17 @@ namespace Horo::Input {
                 report.diagnostics.emplace_back(UnsupportedControl, action, "Binding scale, threshold, or component is invalid.");
         }
 
-        template <typename Bindings>
+        template <typename Bindings, typename MessageFn>
         void ReportDuplicateTransitions(BindingValidationReport &report, const ActionId &action, const Bindings &bindings,
-                                        const std::string &message) {
+                                        MessageFn &&makeMessage) {
+            std::optional<std::string> message;
             for (std::size_t i = 0; i + 1 < bindings.size(); ++i)
                 for (std::size_t j = i + 1; j < bindings.size(); ++j)
-                    if (SameTransition(bindings[i], bindings[j]))
-                        report.diagnostics.emplace_back(BindingDiagnosticCode::DuplicateBinding, action, message);
+                    if (SameTransition(bindings[i], bindings[j])) {
+                        if (!message)
+                            message = std::forward<MessageFn>(makeMessage)();
+                        report.diagnostics.emplace_back(BindingDiagnosticCode::DuplicateBinding, action, *message);
+                    }
         }
 
         void ValidateOverrides(BindingValidationReport &report, const InputBindingProfile &profile,
@@ -457,9 +462,10 @@ namespace Horo::Input {
                 for (const InputBinding &binding : overrideValue.bindings)
                     ValidateBinding(report, overrideValue.action, binding, "Binding deadzone must be in [0, 1).",
                                     "Binding references an unsupported control.", "Binding is reserved by the operating system.");
-                ReportDuplicateTransitions(report, overrideValue.action, overrideValue.bindings,
-                                           std::format("Action '{}' override contains a duplicate binding on the same trigger.",
-                                                       overrideValue.action.Value()));
+                ReportDuplicateTransitions(report, overrideValue.action, overrideValue.bindings, [&overrideValue] {
+                    return std::format("Action '{}' override contains a duplicate binding on the same trigger.",
+                                       overrideValue.action.Value());
+                });
             }
         }
 
@@ -477,9 +483,11 @@ namespace Horo::Input {
                     report.diagnostics.emplace_back(InvalidAction, action.id, "Action descriptor contains an empty action ID.");
                     continue;
                 }
-                if (!action.context.IsValid())
+                if (!action.context.IsValid()) {
                     report.diagnostics.emplace_back(AmbiguousContext, action.id,
                                                     std::format("Action '{}' has an invalid or empty context ID.", action.id.Value()));
+                    continue;
+                }
 
                 const auto overrideValue = std::ranges::find(profile.overrides, action.id, &BindingOverride::action);
                 const std::vector<InputBinding> &bindings =
@@ -498,9 +506,10 @@ namespace Horo::Input {
                                                                     "actions require component 0.",
                                                                     action.id.Value(), binding.component));
                 }
-                ReportDuplicateTransitions(report, action.id, bindings,
-                                           std::format("Action '{}' contains a duplicate binding on the same trigger.", action.id.Value()));
-                effective.reserve(bindings.size());
+                ReportDuplicateTransitions(report, action.id, bindings, [&action] {
+                    return std::format("Action '{}' contains a duplicate binding on the same trigger.", action.id.Value());
+                });
+                effective.reserve(effective.size() + bindings.size());
                 for (const InputBinding &binding : bindings)
                     effective.push_back({&action, &binding});
             }

--- a/tests/unit/runtime/input/InputTests.cpp
+++ b/tests/unit/runtime/input/InputTests.cpp
@@ -225,92 +225,204 @@ namespace {
         const InputContextId workspace{"workspace"};
         const InputContextId gameplay{"gameplay"};
 
-        // 1. Same trigger in different contexts does not conflict
-        const std::array crossContextActions{ActionDescriptor{ActionId{"editor.interact"},
-                                                              ActionValueType::Digital,
-                                                              workspace,
-                                                              false,
-                                                              {KeyBinding(Key::E)}},
-                                             ActionDescriptor{ActionId{"gameplay.use"},
-                                                              ActionValueType::Digital,
-                                                              gameplay,
-                                                              false,
-                                                              {KeyBinding(Key::E)}}};
-        const BindingValidationReport crossContextReport = ValidateBindingProfile(crossContextActions, InputBindingProfile{});
-        REQUIRE((crossContextReport.IsValid()));
+        SECTION("Same trigger in different contexts does not conflict") {
+            const std::array crossContextActions{ActionDescriptor{ActionId{"editor.interact"},
+                                                                  ActionValueType::Digital,
+                                                                  workspace,
+                                                                  false,
+                                                                  {KeyBinding(Key::E)}},
+                                                 ActionDescriptor{ActionId{"gameplay.use"},
+                                                                  ActionValueType::Digital,
+                                                                  gameplay,
+                                                                  false,
+                                                                  {KeyBinding(Key::E)}}};
+            const BindingValidationReport crossContextReport = ValidateBindingProfile(crossContextActions, InputBindingProfile{});
+            REQUIRE((crossContextReport.IsValid()));
+        }
 
-        // 2. Same trigger in same context produces DuplicateBinding with actionable message
-        const std::array
-            sameContextActions{ActionDescriptor{ActionId{"action.first"}, ActionValueType::Digital, workspace, false, {KeyBinding(Key::E)}},
-                               ActionDescriptor{ActionId{"action.second"},
-                                                ActionValueType::Digital,
-                                                workspace,
-                                                false,
-                                                {KeyBinding(Key::E)}}};
-        const BindingValidationReport sameContextReport = ValidateBindingProfile(sameContextActions, InputBindingProfile{});
-        REQUIRE((!sameContextReport.IsValid()));
-        const auto dupDiag =
-            std::ranges::find(sameContextReport.diagnostics, BindingDiagnosticCode::DuplicateBinding, &BindingDiagnostic::code);
-        REQUIRE((dupDiag != sameContextReport.diagnostics.end()));
-        REQUIRE((dupDiag->message.find("action.second") != std::string::npos));
-        REQUIRE((dupDiag->message.find("action.first") != std::string::npos));
-        REQUIRE((dupDiag->message.find("workspace") != std::string::npos));
+        SECTION("Same trigger in same context produces DuplicateBinding with actionable message") {
+            const std::array sameContextActions{ActionDescriptor{ActionId{"action.first"},
+                                                                 ActionValueType::Digital,
+                                                                 workspace,
+                                                                 false,
+                                                                 {KeyBinding(Key::E)}},
+                                                ActionDescriptor{ActionId{"action.second"},
+                                                                 ActionValueType::Digital,
+                                                                 workspace,
+                                                                 false,
+                                                                 {KeyBinding(Key::E)}}};
+            const BindingValidationReport sameContextReport = ValidateBindingProfile(sameContextActions, InputBindingProfile{});
+            REQUIRE((!sameContextReport.IsValid()));
+            const auto dupDiag =
+                std::ranges::find(sameContextReport.diagnostics, BindingDiagnosticCode::DuplicateBinding, &BindingDiagnostic::code);
+            REQUIRE((dupDiag != sameContextReport.diagnostics.end()));
+            REQUIRE((dupDiag->message.find("action.second") != std::string::npos));
+            REQUIRE((dupDiag->message.find("action.first") != std::string::npos));
+            REQUIRE((dupDiag->message.find("workspace") != std::string::npos));
+        }
 
-        // 3. Chord overlap in same context produces AmbiguousChord with actionable message
-        InputBinding baseChord = KeyBinding(Key::K);
-        InputBinding subChord = KeyBinding(Key::K);
-        subChord.chord[0] = Key::L;
-        subChord.chordSize = 1;
-        const std::array chordActions{ActionDescriptor{ActionId{"chord.base"}, ActionValueType::Digital, workspace, false, {baseChord}},
-                                      ActionDescriptor{ActionId{"chord.sub"}, ActionValueType::Digital, workspace, false, {subChord}}};
-        const BindingValidationReport chordReport = ValidateBindingProfile(chordActions, InputBindingProfile{});
-        REQUIRE((!chordReport.IsValid()));
-        const auto chordDiag = std::ranges::find(chordReport.diagnostics, BindingDiagnosticCode::AmbiguousChord, &BindingDiagnostic::code);
-        REQUIRE((chordDiag != chordReport.diagnostics.end()));
-        REQUIRE((chordDiag->message.find("chord.sub") != std::string::npos));
-        REQUIRE((chordDiag->message.find("chord.base") != std::string::npos));
+        SECTION("Chord overlap in same context produces AmbiguousChord with actionable message") {
+            InputBinding baseChord = KeyBinding(Key::K);
+            InputBinding subChord = KeyBinding(Key::K);
+            subChord.chord[0] = Key::L;
+            subChord.chordSize = 1;
+            const std::array chordActions{ActionDescriptor{ActionId{"chord.base"}, ActionValueType::Digital, workspace, false, {baseChord}},
+                                          ActionDescriptor{ActionId{"chord.sub"}, ActionValueType::Digital, workspace, false, {subChord}}};
+            const BindingValidationReport chordReport = ValidateBindingProfile(chordActions, InputBindingProfile{});
+            REQUIRE((!chordReport.IsValid()));
+            const auto chordDiag =
+                std::ranges::find(chordReport.diagnostics, BindingDiagnosticCode::AmbiguousChord, &BindingDiagnostic::code);
+            REQUIRE((chordDiag != chordReport.diagnostics.end()));
+            REQUIRE((chordDiag->message.find("chord.sub") != std::string::npos));
+            REQUIRE((chordDiag->message.find("chord.base") != std::string::npos));
+        }
 
-        // 4. Device exclusivity violation: analog axis conflict in same context
-        InputBinding axisA{.kind = BindingControlKind::GamepadAxis, .gamepadAxis = GamepadAxis::LeftX, .scale = 1.0F};
-        InputBinding axisB{.kind = BindingControlKind::GamepadAxis, .gamepadAxis = GamepadAxis::LeftX, .scale = -1.0F};
-        const std::array axisActions{ActionDescriptor{ActionId{"steer.left"}, ActionValueType::Axis1D, gameplay, false, {axisA}},
-                                     ActionDescriptor{ActionId{"steer.right"}, ActionValueType::Axis1D, gameplay, false, {axisB}}};
-        const BindingValidationReport axisReport = ValidateBindingProfile(axisActions, InputBindingProfile{});
-        REQUIRE((!axisReport.IsValid()));
-        const auto axisDiag =
-            std::ranges::find(axisReport.diagnostics, BindingDiagnosticCode::DeviceExclusivityViolation, &BindingDiagnostic::code);
-        REQUIRE((axisDiag != axisReport.diagnostics.end()));
-        REQUIRE((axisDiag->message.find("gameplay") != std::string::npos));
+        SECTION("Device exclusivity violation: analog axis conflict in same context") {
+            InputBinding axisA{.kind = BindingControlKind::GamepadAxis, .gamepadAxis = GamepadAxis::LeftX, .scale = 1.0F};
+            InputBinding axisB{.kind = BindingControlKind::GamepadAxis, .gamepadAxis = GamepadAxis::LeftX, .scale = -1.0F};
+            const std::array axisActions{ActionDescriptor{ActionId{"steer.left"}, ActionValueType::Axis1D, gameplay, false, {axisA}},
+                                         ActionDescriptor{ActionId{"steer.right"}, ActionValueType::Axis1D, gameplay, false, {axisB}}};
+            const BindingValidationReport axisReport = ValidateBindingProfile(axisActions, InputBindingProfile{});
+            REQUIRE((!axisReport.IsValid()));
+            const auto axisDiag =
+                std::ranges::find(axisReport.diagnostics, BindingDiagnosticCode::DeviceExclusivityViolation, &BindingDiagnostic::code);
+            REQUIRE((axisDiag != axisReport.diagnostics.end()));
+            REQUIRE((axisDiag->message.find("gameplay") != std::string::npos));
+        }
 
-        // 5. Device exclusivity violation: invalid component index on 1D/Digital action
-        InputBinding invalidComponent = KeyBinding(Key::Space);
-        invalidComponent.component = 1;
-        const std::array componentActions{
-            ActionDescriptor{ActionId{"jump"}, ActionValueType::Digital, gameplay, false, {invalidComponent}}};
-        const BindingValidationReport componentReport = ValidateBindingProfile(componentActions, InputBindingProfile{});
-        REQUIRE((!componentReport.IsValid()));
-        REQUIRE((std::ranges::any_of(componentReport.diagnostics, [](const BindingDiagnostic &d) {
-            return d.code == BindingDiagnosticCode::DeviceExclusivityViolation;
-        })));
+        SECTION("Device exclusivity violation: raw gamepad axis and pointer wheel in same context") {
+            InputBinding rawA{.kind = BindingControlKind::RawGamepadAxis, .rawControl = 3, .scale = 1.0F};
+            InputBinding rawB{.kind = BindingControlKind::RawGamepadAxis, .rawControl = 3, .scale = -1.0F};
+            const std::array rawActions{ActionDescriptor{ActionId{"raw.left"}, ActionValueType::Axis1D, gameplay, false, {rawA}},
+                                        ActionDescriptor{ActionId{"raw.right"}, ActionValueType::Axis1D, gameplay, false, {rawB}}};
+            const BindingValidationReport rawReport = ValidateBindingProfile(rawActions, InputBindingProfile{});
+            REQUIRE((!rawReport.IsValid()));
+            REQUIRE((std::ranges::any_of(rawReport.diagnostics, [](const BindingDiagnostic &d) {
+                return d.code == BindingDiagnosticCode::DeviceExclusivityViolation;
+            })));
 
-        // 6. Ambiguous context detection
-        const std::array invalidContextActions{
-            ActionDescriptor{ActionId{"valid.action"}, ActionValueType::Digital, InputContextId{""}, false, {KeyBinding(Key::Space)}}};
-        const BindingValidationReport contextReport = ValidateBindingProfile(invalidContextActions, InputBindingProfile{});
-        REQUIRE((!contextReport.IsValid()));
-        REQUIRE((std::ranges::any_of(contextReport.diagnostics, [](const BindingDiagnostic &d) {
-            return d.code == BindingDiagnosticCode::AmbiguousContext;
-        })));
+            InputBinding wheelA{.kind = BindingControlKind::PointerWheelX, .scale = 1.0F};
+            InputBinding wheelB{.kind = BindingControlKind::PointerWheelX, .scale = -1.0F};
+            const std::array wheelActions{ActionDescriptor{ActionId{"look.x"}, ActionValueType::Axis1D, gameplay, false, {wheelA}},
+                                          ActionDescriptor{ActionId{"zoom.x"}, ActionValueType::Axis1D, gameplay, false, {wheelB}}};
+            const BindingValidationReport wheelReport = ValidateBindingProfile(wheelActions, InputBindingProfile{});
+            REQUIRE((!wheelReport.IsValid()));
+            REQUIRE((std::ranges::any_of(wheelReport.diagnostics, [](const BindingDiagnostic &d) {
+                return d.code == BindingDiagnosticCode::DeviceExclusivityViolation;
+            })));
 
-        // 7. InputRouter atomic rejection on invalid profile
-        InputRouter router;
-        REQUIRE(
-            (router.SetActionMap({ActionDescriptor{ActionId{"test.act"}, ActionValueType::Digital, workspace, false, {KeyBinding(Key::Z)}}})
-                 .HasValue()));
-        InputBindingProfile badProfile{.profileId = "bad", .overrides = {BindingOverride{ActionId{"unknown.act"}, {KeyBinding(Key::X)}}}};
-        const Horo::Result<void> setRes = router.SetProfile(badProfile);
-        REQUIRE((setRes.HasError()));
-        REQUIRE((router.Profile().profileId == "default"));
+            InputBinding wheelYA{.kind = BindingControlKind::PointerWheelY, .scale = 1.0F};
+            InputBinding wheelYB{.kind = BindingControlKind::PointerWheelY, .scale = -1.0F};
+            const std::array wheelYActions{ActionDescriptor{ActionId{"look.y"}, ActionValueType::Axis1D, gameplay, false, {wheelYA}},
+                                           ActionDescriptor{ActionId{"zoom.y"}, ActionValueType::Axis1D, gameplay, false, {wheelYB}}};
+            const BindingValidationReport wheelYReport = ValidateBindingProfile(wheelYActions, InputBindingProfile{});
+            REQUIRE((!wheelYReport.IsValid()));
+            REQUIRE((std::ranges::any_of(wheelYReport.diagnostics, [](const BindingDiagnostic &d) {
+                return d.code == BindingDiagnosticCode::DeviceExclusivityViolation;
+            })));
+        }
+
+        SECTION("Device exclusivity violation: invalid component index on 1D/Digital action") {
+            InputBinding invalidComponent = KeyBinding(Key::Space);
+            invalidComponent.component = 1;
+            const std::array componentActions{
+                ActionDescriptor{ActionId{"jump"}, ActionValueType::Digital, gameplay, false, {invalidComponent}}};
+            const BindingValidationReport componentReport = ValidateBindingProfile(componentActions, InputBindingProfile{});
+            REQUIRE((!componentReport.IsValid()));
+            REQUIRE((std::ranges::any_of(componentReport.diagnostics, [](const BindingDiagnostic &d) {
+                return d.code == BindingDiagnosticCode::DeviceExclusivityViolation;
+            })));
+
+            InputBinding invalidAxisComponent{.kind = BindingControlKind::GamepadAxis, .gamepadAxis = GamepadAxis::LeftX, .component = 1};
+            const std::array axisComponentActions{
+                ActionDescriptor{ActionId{"move.x"}, ActionValueType::Axis1D, gameplay, false, {invalidAxisComponent}}};
+            const BindingValidationReport axisComponentReport = ValidateBindingProfile(axisComponentActions, InputBindingProfile{});
+            REQUIRE((!axisComponentReport.IsValid()));
+            REQUIRE((std::ranges::any_of(axisComponentReport.diagnostics, [](const BindingDiagnostic &d) {
+                return d.code == BindingDiagnosticCode::DeviceExclusivityViolation;
+            })));
+        }
+
+        SECTION("Ambiguous context skips further binding validation for that action") {
+            InputBinding invalidDeadzone = KeyBinding(Key::Space);
+            invalidDeadzone.deadzone = 2.0F;
+            const std::array invalidContextActions{ActionDescriptor{ActionId{"valid.action"},
+                                                                    ActionValueType::Digital,
+                                                                    InputContextId{""},
+                                                                    false,
+                                                                    {invalidDeadzone}},
+                                                   ActionDescriptor{ActionId{"other.action"},
+                                                                    ActionValueType::Digital,
+                                                                    gameplay,
+                                                                    false,
+                                                                    {KeyBinding(Key::Space)}}};
+            const BindingValidationReport contextReport = ValidateBindingProfile(invalidContextActions, InputBindingProfile{});
+            REQUIRE((!contextReport.IsValid()));
+            REQUIRE((std::ranges::count_if(contextReport.diagnostics, [](const BindingDiagnostic &d) {
+                return d.code == BindingDiagnosticCode::AmbiguousContext;
+            }) == 1));
+            REQUIRE((std::ranges::none_of(contextReport.diagnostics, [](const BindingDiagnostic &d) {
+                return d.action.Value() == "valid.action" && d.code != BindingDiagnosticCode::AmbiguousContext;
+            })));
+        }
+
+        SECTION("Empty action ID is reported as InvalidAction") {
+            const std::array emptyIdActions{
+                ActionDescriptor{ActionId{""}, ActionValueType::Digital, gameplay, false, {KeyBinding(Key::Space)}}};
+            const BindingValidationReport emptyIdReport = ValidateBindingProfile(emptyIdActions, InputBindingProfile{});
+            REQUIRE((!emptyIdReport.IsValid()));
+            REQUIRE((std::ranges::any_of(emptyIdReport.diagnostics, [](const BindingDiagnostic &d) {
+                return d.code == BindingDiagnosticCode::InvalidAction;
+            })));
+        }
+
+        SECTION("Duplicate override for the same action is reported") {
+            const std::array actions{
+                ActionDescriptor{ActionId{"jump"}, ActionValueType::Digital, gameplay, false, {KeyBinding(Key::Space)}}};
+            const InputBindingProfile profile{.profileId = "dup-override",
+                                              .overrides = {BindingOverride{ActionId{"jump"}, {KeyBinding(Key::A)}},
+                                                            BindingOverride{ActionId{"jump"}, {KeyBinding(Key::B)}}}};
+            const BindingValidationReport report = ValidateBindingProfile(actions, profile);
+            REQUIRE((!report.IsValid()));
+            REQUIRE((std::ranges::any_of(report.diagnostics, [](const BindingDiagnostic &d) {
+                return d.code == BindingDiagnosticCode::DuplicateBinding && d.message.find("jump") != std::string::npos;
+            })));
+        }
+
+        SECTION("Duplicate trigger within a single action binding list is reported") {
+            const std::array actions{ActionDescriptor{ActionId{"jump"},
+                                                      ActionValueType::Digital,
+                                                      gameplay,
+                                                      false,
+                                                      {KeyBinding(Key::Space), KeyBinding(Key::Space)}}};
+            const BindingValidationReport defaultReport = ValidateBindingProfile(actions, InputBindingProfile{});
+            REQUIRE((!defaultReport.IsValid()));
+            REQUIRE((std::ranges::any_of(defaultReport.diagnostics, [](const BindingDiagnostic &d) {
+                return d.code == BindingDiagnosticCode::DuplicateBinding && d.message.find("jump") != std::string::npos;
+            })));
+
+            const InputBindingProfile overrideProfile{.profileId = "dup-binding",
+                                                      .overrides = {
+                                                          BindingOverride{ActionId{"jump"}, {KeyBinding(Key::A), KeyBinding(Key::A)}}}};
+            const BindingValidationReport overrideReport = ValidateBindingProfile(actions, overrideProfile);
+            REQUIRE((!overrideReport.IsValid()));
+            REQUIRE((std::ranges::any_of(overrideReport.diagnostics, [](const BindingDiagnostic &d) {
+                return d.code == BindingDiagnosticCode::DuplicateBinding && d.message.find("override") != std::string::npos;
+            })));
+        }
+
+        SECTION("InputRouter rejects an invalid profile without mutating live state") {
+            InputRouter router;
+            REQUIRE((router
+                         .SetActionMap(
+                             {ActionDescriptor{ActionId{"test.act"}, ActionValueType::Digital, workspace, false, {KeyBinding(Key::Z)}}})
+                         .HasValue()));
+            InputBindingProfile badProfile{.profileId = "bad",
+                                           .overrides = {BindingOverride{ActionId{"unknown.act"}, {KeyBinding(Key::X)}}}};
+            const Horo::Result<void> setRes = router.SetProfile(badProfile);
+            REQUIRE((setRes.HasError()));
+            REQUIRE((router.Profile().profileId == "default"));
+        }
     }
 
     TEST_CASE("Action Transitions Are Consumed And Gamepad Axes Have Edges", "[unit][runtime][input]") {

--- a/tests/unit/runtime/input/InputTests.cpp
+++ b/tests/unit/runtime/input/InputTests.cpp
@@ -221,6 +221,98 @@ namespace {
         REQUIRE((merged.Value().overrides.front().bindings.front().key == Key::D));
     }
 
+    TEST_CASE("Conflict Validation Detects Declared Conflict Classes With Source Context", "[unit][runtime][input]") {
+        const InputContextId workspace{"workspace"};
+        const InputContextId gameplay{"gameplay"};
+
+        // 1. Same trigger in different contexts does not conflict
+        const std::array crossContextActions{ActionDescriptor{ActionId{"editor.interact"},
+                                                              ActionValueType::Digital,
+                                                              workspace,
+                                                              false,
+                                                              {KeyBinding(Key::E)}},
+                                             ActionDescriptor{ActionId{"gameplay.use"},
+                                                              ActionValueType::Digital,
+                                                              gameplay,
+                                                              false,
+                                                              {KeyBinding(Key::E)}}};
+        const BindingValidationReport crossContextReport = ValidateBindingProfile(crossContextActions, InputBindingProfile{});
+        REQUIRE((crossContextReport.IsValid()));
+
+        // 2. Same trigger in same context produces DuplicateBinding with actionable message
+        const std::array
+            sameContextActions{ActionDescriptor{ActionId{"action.first"}, ActionValueType::Digital, workspace, false, {KeyBinding(Key::E)}},
+                               ActionDescriptor{ActionId{"action.second"},
+                                                ActionValueType::Digital,
+                                                workspace,
+                                                false,
+                                                {KeyBinding(Key::E)}}};
+        const BindingValidationReport sameContextReport = ValidateBindingProfile(sameContextActions, InputBindingProfile{});
+        REQUIRE((!sameContextReport.IsValid()));
+        const auto dupDiag =
+            std::ranges::find(sameContextReport.diagnostics, BindingDiagnosticCode::DuplicateBinding, &BindingDiagnostic::code);
+        REQUIRE((dupDiag != sameContextReport.diagnostics.end()));
+        REQUIRE((dupDiag->message.find("action.second") != std::string::npos));
+        REQUIRE((dupDiag->message.find("action.first") != std::string::npos));
+        REQUIRE((dupDiag->message.find("workspace") != std::string::npos));
+
+        // 3. Chord overlap in same context produces AmbiguousChord with actionable message
+        InputBinding baseChord = KeyBinding(Key::K);
+        InputBinding subChord = KeyBinding(Key::K);
+        subChord.chord[0] = Key::L;
+        subChord.chordSize = 1;
+        const std::array chordActions{ActionDescriptor{ActionId{"chord.base"}, ActionValueType::Digital, workspace, false, {baseChord}},
+                                      ActionDescriptor{ActionId{"chord.sub"}, ActionValueType::Digital, workspace, false, {subChord}}};
+        const BindingValidationReport chordReport = ValidateBindingProfile(chordActions, InputBindingProfile{});
+        REQUIRE((!chordReport.IsValid()));
+        const auto chordDiag = std::ranges::find(chordReport.diagnostics, BindingDiagnosticCode::AmbiguousChord, &BindingDiagnostic::code);
+        REQUIRE((chordDiag != chordReport.diagnostics.end()));
+        REQUIRE((chordDiag->message.find("chord.sub") != std::string::npos));
+        REQUIRE((chordDiag->message.find("chord.base") != std::string::npos));
+
+        // 4. Device exclusivity violation: analog axis conflict in same context
+        InputBinding axisA{.kind = BindingControlKind::GamepadAxis, .gamepadAxis = GamepadAxis::LeftX, .scale = 1.0F};
+        InputBinding axisB{.kind = BindingControlKind::GamepadAxis, .gamepadAxis = GamepadAxis::LeftX, .scale = -1.0F};
+        const std::array axisActions{ActionDescriptor{ActionId{"steer.left"}, ActionValueType::Axis1D, gameplay, false, {axisA}},
+                                     ActionDescriptor{ActionId{"steer.right"}, ActionValueType::Axis1D, gameplay, false, {axisB}}};
+        const BindingValidationReport axisReport = ValidateBindingProfile(axisActions, InputBindingProfile{});
+        REQUIRE((!axisReport.IsValid()));
+        const auto axisDiag =
+            std::ranges::find(axisReport.diagnostics, BindingDiagnosticCode::DeviceExclusivityViolation, &BindingDiagnostic::code);
+        REQUIRE((axisDiag != axisReport.diagnostics.end()));
+        REQUIRE((axisDiag->message.find("gameplay") != std::string::npos));
+
+        // 5. Device exclusivity violation: invalid component index on 1D/Digital action
+        InputBinding invalidComponent = KeyBinding(Key::Space);
+        invalidComponent.component = 1;
+        const std::array componentActions{
+            ActionDescriptor{ActionId{"jump"}, ActionValueType::Digital, gameplay, false, {invalidComponent}}};
+        const BindingValidationReport componentReport = ValidateBindingProfile(componentActions, InputBindingProfile{});
+        REQUIRE((!componentReport.IsValid()));
+        REQUIRE((std::ranges::any_of(componentReport.diagnostics, [](const BindingDiagnostic &d) {
+            return d.code == BindingDiagnosticCode::DeviceExclusivityViolation;
+        })));
+
+        // 6. Ambiguous context detection
+        const std::array invalidContextActions{
+            ActionDescriptor{ActionId{"valid.action"}, ActionValueType::Digital, InputContextId{""}, false, {KeyBinding(Key::Space)}}};
+        const BindingValidationReport contextReport = ValidateBindingProfile(invalidContextActions, InputBindingProfile{});
+        REQUIRE((!contextReport.IsValid()));
+        REQUIRE((std::ranges::any_of(contextReport.diagnostics, [](const BindingDiagnostic &d) {
+            return d.code == BindingDiagnosticCode::AmbiguousContext;
+        })));
+
+        // 7. InputRouter atomic rejection on invalid profile
+        InputRouter router;
+        REQUIRE(
+            (router.SetActionMap({ActionDescriptor{ActionId{"test.act"}, ActionValueType::Digital, workspace, false, {KeyBinding(Key::Z)}}})
+                 .HasValue()));
+        InputBindingProfile badProfile{.profileId = "bad", .overrides = {BindingOverride{ActionId{"unknown.act"}, {KeyBinding(Key::X)}}}};
+        const Horo::Result<void> setRes = router.SetProfile(badProfile);
+        REQUIRE((setRes.HasError()));
+        REQUIRE((router.Profile().profileId == "default"));
+    }
+
     TEST_CASE("Action Transitions Are Consumed And Gamepad Axes Have Edges", "[unit][runtime][input]") {
         RawInputCollector collector;
         collector.BeginFrame(1);

--- a/tests/unit/runtime/input/InputTests.cpp
+++ b/tests/unit/runtime/input/InputTests.cpp
@@ -340,6 +340,35 @@ namespace {
         })));
     }
 
+    TEST_CASE("Conflict Validation Rejects Duplicate Action Ids", "[unit][runtime][input]") {
+        const InputContextId workspace{"workspace"};
+        const InputContextId gameplay{"gameplay"};
+        const std::array
+            actions{ActionDescriptor{ActionId{"shared.action"}, ActionValueType::Digital, workspace, false, {KeyBinding(Key::A)}},
+                    ActionDescriptor{ActionId{"shared.action"}, ActionValueType::Digital, gameplay, false, {KeyBinding(Key::B)}}};
+        const BindingValidationReport report = ValidateBindingProfile(actions, InputBindingProfile{});
+        REQUIRE((!report.IsValid()));
+        REQUIRE((std::ranges::any_of(report.diagnostics, [](const BindingDiagnostic &diagnostic) {
+            return diagnostic.code == BindingDiagnosticCode::InvalidAction &&
+                   diagnostic.message.find("shared.action") != std::string::npos;
+        })));
+    }
+
+    TEST_CASE("Conflict Validation Rejects Oversized Chords Without Inspecting Past Storage", "[unit][runtime][input]") {
+        const InputContextId gameplay{"gameplay"};
+        InputBinding malformed = KeyBinding(Key::K);
+        malformed.chordSize = static_cast<std::uint8_t>(malformed.chord.size() + 1);
+        const std::array
+            actions{ActionDescriptor{ActionId{"malformed.chord"}, ActionValueType::Digital, gameplay, false, {malformed}},
+                    ActionDescriptor{ActionId{"valid.chord"}, ActionValueType::Digital, gameplay, false, {KeyBinding(Key::K)}}};
+        const BindingValidationReport report = ValidateBindingProfile(actions, InputBindingProfile{});
+        REQUIRE((!report.IsValid()));
+        REQUIRE((std::ranges::any_of(report.diagnostics, [](const BindingDiagnostic &diagnostic) {
+            return diagnostic.action.Value() == "malformed.chord" &&
+                   diagnostic.code == BindingDiagnosticCode::AmbiguousChord;
+        })));
+    }
+
     TEST_CASE("Conflict Validation Reports Duplicate Overrides For One Action", "[unit][runtime][input]") {
         const InputContextId gameplay{"gameplay"};
         const std::array actions{ActionDescriptor{ActionId{"jump"}, ActionValueType::Digital, gameplay, false, {KeyBinding(Key::Space)}}};

--- a/tests/unit/runtime/input/InputTests.cpp
+++ b/tests/unit/runtime/input/InputTests.cpp
@@ -221,208 +221,170 @@ namespace {
         REQUIRE((merged.Value().overrides.front().bindings.front().key == Key::D));
     }
 
-    TEST_CASE("Conflict Validation Detects Declared Conflict Classes With Source Context", "[unit][runtime][input]") {
+    TEST_CASE("Conflict Validation Allows Same Trigger Across Contexts", "[unit][runtime][input]") {
         const InputContextId workspace{"workspace"};
         const InputContextId gameplay{"gameplay"};
+        const std::array
+            actions{ActionDescriptor{ActionId{"editor.interact"}, ActionValueType::Digital, workspace, false, {KeyBinding(Key::E)}},
+                    ActionDescriptor{ActionId{"gameplay.use"}, ActionValueType::Digital, gameplay, false, {KeyBinding(Key::E)}}};
+        const BindingValidationReport report = ValidateBindingProfile(actions, InputBindingProfile{});
+        REQUIRE((report.IsValid()));
+    }
 
-        SECTION("Same trigger in different contexts does not conflict") {
-            const std::array crossContextActions{ActionDescriptor{ActionId{"editor.interact"},
-                                                                  ActionValueType::Digital,
-                                                                  workspace,
-                                                                  false,
-                                                                  {KeyBinding(Key::E)}},
-                                                 ActionDescriptor{ActionId{"gameplay.use"},
-                                                                  ActionValueType::Digital,
-                                                                  gameplay,
-                                                                  false,
-                                                                  {KeyBinding(Key::E)}}};
-            const BindingValidationReport crossContextReport = ValidateBindingProfile(crossContextActions, InputBindingProfile{});
-            REQUIRE((crossContextReport.IsValid()));
-        }
+    TEST_CASE("Conflict Validation Reports DuplicateBinding In The Same Context", "[unit][runtime][input]") {
+        const InputContextId workspace{"workspace"};
+        const std::array
+            actions{ActionDescriptor{ActionId{"action.first"}, ActionValueType::Digital, workspace, false, {KeyBinding(Key::E)}},
+                    ActionDescriptor{ActionId{"action.second"}, ActionValueType::Digital, workspace, false, {KeyBinding(Key::E)}}};
+        const BindingValidationReport report = ValidateBindingProfile(actions, InputBindingProfile{});
+        REQUIRE((!report.IsValid()));
+        const auto dupDiag = std::ranges::find(report.diagnostics, BindingDiagnosticCode::DuplicateBinding, &BindingDiagnostic::code);
+        REQUIRE((dupDiag != report.diagnostics.end()));
+        REQUIRE((dupDiag->message.find("action.second") != std::string::npos));
+        REQUIRE((dupDiag->message.find("action.first") != std::string::npos));
+        REQUIRE((dupDiag->message.find("workspace") != std::string::npos));
+    }
 
-        SECTION("Same trigger in same context produces DuplicateBinding with actionable message") {
-            const std::array sameContextActions{ActionDescriptor{ActionId{"action.first"},
-                                                                 ActionValueType::Digital,
-                                                                 workspace,
-                                                                 false,
-                                                                 {KeyBinding(Key::E)}},
-                                                ActionDescriptor{ActionId{"action.second"},
-                                                                 ActionValueType::Digital,
-                                                                 workspace,
-                                                                 false,
-                                                                 {KeyBinding(Key::E)}}};
-            const BindingValidationReport sameContextReport = ValidateBindingProfile(sameContextActions, InputBindingProfile{});
-            REQUIRE((!sameContextReport.IsValid()));
-            const auto dupDiag =
-                std::ranges::find(sameContextReport.diagnostics, BindingDiagnosticCode::DuplicateBinding, &BindingDiagnostic::code);
-            REQUIRE((dupDiag != sameContextReport.diagnostics.end()));
-            REQUIRE((dupDiag->message.find("action.second") != std::string::npos));
-            REQUIRE((dupDiag->message.find("action.first") != std::string::npos));
-            REQUIRE((dupDiag->message.find("workspace") != std::string::npos));
-        }
+    TEST_CASE("Conflict Validation Reports AmbiguousChord Overlap", "[unit][runtime][input]") {
+        const InputContextId workspace{"workspace"};
+        InputBinding baseChord = KeyBinding(Key::K);
+        InputBinding subChord = KeyBinding(Key::K);
+        subChord.chord[0] = Key::L;
+        subChord.chordSize = 1;
+        const std::array actions{ActionDescriptor{ActionId{"chord.base"}, ActionValueType::Digital, workspace, false, {baseChord}},
+                                 ActionDescriptor{ActionId{"chord.sub"}, ActionValueType::Digital, workspace, false, {subChord}}};
+        const BindingValidationReport report = ValidateBindingProfile(actions, InputBindingProfile{});
+        REQUIRE((!report.IsValid()));
+        const auto chordDiag = std::ranges::find(report.diagnostics, BindingDiagnosticCode::AmbiguousChord, &BindingDiagnostic::code);
+        REQUIRE((chordDiag != report.diagnostics.end()));
+        REQUIRE((chordDiag->message.find("chord.sub") != std::string::npos));
+        REQUIRE((chordDiag->message.find("chord.base") != std::string::npos));
+    }
 
-        SECTION("Chord overlap in same context produces AmbiguousChord with actionable message") {
-            InputBinding baseChord = KeyBinding(Key::K);
-            InputBinding subChord = KeyBinding(Key::K);
-            subChord.chord[0] = Key::L;
-            subChord.chordSize = 1;
-            const std::array chordActions{ActionDescriptor{ActionId{"chord.base"}, ActionValueType::Digital, workspace, false, {baseChord}},
-                                          ActionDescriptor{ActionId{"chord.sub"}, ActionValueType::Digital, workspace, false, {subChord}}};
-            const BindingValidationReport chordReport = ValidateBindingProfile(chordActions, InputBindingProfile{});
-            REQUIRE((!chordReport.IsValid()));
-            const auto chordDiag =
-                std::ranges::find(chordReport.diagnostics, BindingDiagnosticCode::AmbiguousChord, &BindingDiagnostic::code);
-            REQUIRE((chordDiag != chordReport.diagnostics.end()));
-            REQUIRE((chordDiag->message.find("chord.sub") != std::string::npos));
-            REQUIRE((chordDiag->message.find("chord.base") != std::string::npos));
-        }
+    TEST_CASE("Conflict Validation Reports Gamepad Axis Exclusivity", "[unit][runtime][input]") {
+        const InputContextId gameplay{"gameplay"};
+        InputBinding axisA{.kind = BindingControlKind::GamepadAxis, .gamepadAxis = GamepadAxis::LeftX, .scale = 1.0F};
+        InputBinding axisB{.kind = BindingControlKind::GamepadAxis, .gamepadAxis = GamepadAxis::LeftX, .scale = -1.0F};
+        const std::array actions{ActionDescriptor{ActionId{"steer.left"}, ActionValueType::Axis1D, gameplay, false, {axisA}},
+                                 ActionDescriptor{ActionId{"steer.right"}, ActionValueType::Axis1D, gameplay, false, {axisB}}};
+        const BindingValidationReport report = ValidateBindingProfile(actions, InputBindingProfile{});
+        REQUIRE((!report.IsValid()));
+        const auto axisDiag =
+            std::ranges::find(report.diagnostics, BindingDiagnosticCode::DeviceExclusivityViolation, &BindingDiagnostic::code);
+        REQUIRE((axisDiag != report.diagnostics.end()));
+        REQUIRE((axisDiag->message.find("gameplay") != std::string::npos));
+    }
 
-        SECTION("Device exclusivity violation: analog axis conflict in same context") {
-            InputBinding axisA{.kind = BindingControlKind::GamepadAxis, .gamepadAxis = GamepadAxis::LeftX, .scale = 1.0F};
-            InputBinding axisB{.kind = BindingControlKind::GamepadAxis, .gamepadAxis = GamepadAxis::LeftX, .scale = -1.0F};
-            const std::array axisActions{ActionDescriptor{ActionId{"steer.left"}, ActionValueType::Axis1D, gameplay, false, {axisA}},
-                                         ActionDescriptor{ActionId{"steer.right"}, ActionValueType::Axis1D, gameplay, false, {axisB}}};
-            const BindingValidationReport axisReport = ValidateBindingProfile(axisActions, InputBindingProfile{});
-            REQUIRE((!axisReport.IsValid()));
-            const auto axisDiag =
-                std::ranges::find(axisReport.diagnostics, BindingDiagnosticCode::DeviceExclusivityViolation, &BindingDiagnostic::code);
-            REQUIRE((axisDiag != axisReport.diagnostics.end()));
-            REQUIRE((axisDiag->message.find("gameplay") != std::string::npos));
-        }
+    TEST_CASE("Conflict Validation Reports Raw Axis Exclusivity", "[unit][runtime][input]") {
+        const InputContextId gameplay{"gameplay"};
+        InputBinding rawA{.kind = BindingControlKind::RawGamepadAxis, .rawControl = 3, .scale = 1.0F};
+        InputBinding rawB{.kind = BindingControlKind::RawGamepadAxis, .rawControl = 3, .scale = -1.0F};
+        const std::array actions{ActionDescriptor{ActionId{"raw.left"}, ActionValueType::Axis1D, gameplay, false, {rawA}},
+                                 ActionDescriptor{ActionId{"raw.right"}, ActionValueType::Axis1D, gameplay, false, {rawB}}};
+        const BindingValidationReport report = ValidateBindingProfile(actions, InputBindingProfile{});
+        REQUIRE((!report.IsValid()));
+        REQUIRE((std::ranges::any_of(report.diagnostics, [](const BindingDiagnostic &d) {
+            return d.code == BindingDiagnosticCode::DeviceExclusivityViolation;
+        })));
+    }
 
-        SECTION("Device exclusivity violation: raw gamepad axis and pointer wheel in same context") {
-            InputBinding rawA{.kind = BindingControlKind::RawGamepadAxis, .rawControl = 3, .scale = 1.0F};
-            InputBinding rawB{.kind = BindingControlKind::RawGamepadAxis, .rawControl = 3, .scale = -1.0F};
-            const std::array rawActions{ActionDescriptor{ActionId{"raw.left"}, ActionValueType::Axis1D, gameplay, false, {rawA}},
-                                        ActionDescriptor{ActionId{"raw.right"}, ActionValueType::Axis1D, gameplay, false, {rawB}}};
-            const BindingValidationReport rawReport = ValidateBindingProfile(rawActions, InputBindingProfile{});
-            REQUIRE((!rawReport.IsValid()));
-            REQUIRE((std::ranges::any_of(rawReport.diagnostics, [](const BindingDiagnostic &d) {
-                return d.code == BindingDiagnosticCode::DeviceExclusivityViolation;
-            })));
+    TEST_CASE("Conflict Validation Reports Pointer Wheel Exclusivity", "[unit][runtime][input]") {
+        const InputContextId gameplay{"gameplay"};
+        InputBinding wheelA{.kind = BindingControlKind::PointerWheelX, .scale = 1.0F};
+        InputBinding wheelB{.kind = BindingControlKind::PointerWheelX, .scale = -1.0F};
+        const std::array xActions{ActionDescriptor{ActionId{"look.x"}, ActionValueType::Axis1D, gameplay, false, {wheelA}},
+                                  ActionDescriptor{ActionId{"zoom.x"}, ActionValueType::Axis1D, gameplay, false, {wheelB}}};
+        REQUIRE((!ValidateBindingProfile(xActions, InputBindingProfile{}).IsValid()));
+        InputBinding wheelYA{.kind = BindingControlKind::PointerWheelY, .scale = 1.0F};
+        InputBinding wheelYB{.kind = BindingControlKind::PointerWheelY, .scale = -1.0F};
+        const std::array yActions{ActionDescriptor{ActionId{"look.y"}, ActionValueType::Axis1D, gameplay, false, {wheelYA}},
+                                  ActionDescriptor{ActionId{"zoom.y"}, ActionValueType::Axis1D, gameplay, false, {wheelYB}}};
+        REQUIRE((!ValidateBindingProfile(yActions, InputBindingProfile{}).IsValid()));
+    }
 
-            InputBinding wheelA{.kind = BindingControlKind::PointerWheelX, .scale = 1.0F};
-            InputBinding wheelB{.kind = BindingControlKind::PointerWheelX, .scale = -1.0F};
-            const std::array wheelActions{ActionDescriptor{ActionId{"look.x"}, ActionValueType::Axis1D, gameplay, false, {wheelA}},
-                                          ActionDescriptor{ActionId{"zoom.x"}, ActionValueType::Axis1D, gameplay, false, {wheelB}}};
-            const BindingValidationReport wheelReport = ValidateBindingProfile(wheelActions, InputBindingProfile{});
-            REQUIRE((!wheelReport.IsValid()));
-            REQUIRE((std::ranges::any_of(wheelReport.diagnostics, [](const BindingDiagnostic &d) {
-                return d.code == BindingDiagnosticCode::DeviceExclusivityViolation;
-            })));
+    TEST_CASE("Conflict Validation Rejects Invalid Component On Digital And Axis1D", "[unit][runtime][input]") {
+        const InputContextId gameplay{"gameplay"};
+        InputBinding invalidComponent = KeyBinding(Key::Space);
+        invalidComponent.component = 1;
+        const std::array digital{ActionDescriptor{ActionId{"jump"}, ActionValueType::Digital, gameplay, false, {invalidComponent}}};
+        REQUIRE((!ValidateBindingProfile(digital, InputBindingProfile{}).IsValid()));
+        InputBinding invalidAxis{.kind = BindingControlKind::GamepadAxis, .gamepadAxis = GamepadAxis::LeftX, .component = 1};
+        const std::array axis{ActionDescriptor{ActionId{"move.x"}, ActionValueType::Axis1D, gameplay, false, {invalidAxis}}};
+        REQUIRE((!ValidateBindingProfile(axis, InputBindingProfile{}).IsValid()));
+    }
 
-            InputBinding wheelYA{.kind = BindingControlKind::PointerWheelY, .scale = 1.0F};
-            InputBinding wheelYB{.kind = BindingControlKind::PointerWheelY, .scale = -1.0F};
-            const std::array wheelYActions{ActionDescriptor{ActionId{"look.y"}, ActionValueType::Axis1D, gameplay, false, {wheelYA}},
-                                           ActionDescriptor{ActionId{"zoom.y"}, ActionValueType::Axis1D, gameplay, false, {wheelYB}}};
-            const BindingValidationReport wheelYReport = ValidateBindingProfile(wheelYActions, InputBindingProfile{});
-            REQUIRE((!wheelYReport.IsValid()));
-            REQUIRE((std::ranges::any_of(wheelYReport.diagnostics, [](const BindingDiagnostic &d) {
-                return d.code == BindingDiagnosticCode::DeviceExclusivityViolation;
-            })));
-        }
+    TEST_CASE("Conflict Validation Skips Bindings When Context Is Invalid", "[unit][runtime][input]") {
+        const InputContextId gameplay{"gameplay"};
+        InputBinding invalidDeadzone = KeyBinding(Key::Space);
+        invalidDeadzone.deadzone = 2.0F;
+        const std::array
+            actions{ActionDescriptor{ActionId{"valid.action"}, ActionValueType::Digital, InputContextId{""}, false, {invalidDeadzone}},
+                    ActionDescriptor{ActionId{"other.action"}, ActionValueType::Digital, gameplay, false, {KeyBinding(Key::Space)}}};
+        const BindingValidationReport report = ValidateBindingProfile(actions, InputBindingProfile{});
+        REQUIRE((!report.IsValid()));
+        REQUIRE((std::ranges::count_if(report.diagnostics, [](const BindingDiagnostic &d) {
+            return d.code == BindingDiagnosticCode::AmbiguousContext;
+        }) == 1));
+        REQUIRE((std::ranges::none_of(report.diagnostics, [](const BindingDiagnostic &d) {
+            return d.action.Value() == "valid.action" && d.code != BindingDiagnosticCode::AmbiguousContext;
+        })));
+    }
 
-        SECTION("Device exclusivity violation: invalid component index on 1D/Digital action") {
-            InputBinding invalidComponent = KeyBinding(Key::Space);
-            invalidComponent.component = 1;
-            const std::array componentActions{
-                ActionDescriptor{ActionId{"jump"}, ActionValueType::Digital, gameplay, false, {invalidComponent}}};
-            const BindingValidationReport componentReport = ValidateBindingProfile(componentActions, InputBindingProfile{});
-            REQUIRE((!componentReport.IsValid()));
-            REQUIRE((std::ranges::any_of(componentReport.diagnostics, [](const BindingDiagnostic &d) {
-                return d.code == BindingDiagnosticCode::DeviceExclusivityViolation;
-            })));
+    TEST_CASE("Conflict Validation Reports Empty Action Id", "[unit][runtime][input]") {
+        const InputContextId gameplay{"gameplay"};
+        const std::array actions{ActionDescriptor{ActionId{""}, ActionValueType::Digital, gameplay, false, {KeyBinding(Key::Space)}}};
+        const BindingValidationReport report = ValidateBindingProfile(actions, InputBindingProfile{});
+        REQUIRE((!report.IsValid()));
+        REQUIRE((std::ranges::any_of(report.diagnostics, [](const BindingDiagnostic &d) {
+            return d.code == BindingDiagnosticCode::InvalidAction;
+        })));
+    }
 
-            InputBinding invalidAxisComponent{.kind = BindingControlKind::GamepadAxis, .gamepadAxis = GamepadAxis::LeftX, .component = 1};
-            const std::array axisComponentActions{
-                ActionDescriptor{ActionId{"move.x"}, ActionValueType::Axis1D, gameplay, false, {invalidAxisComponent}}};
-            const BindingValidationReport axisComponentReport = ValidateBindingProfile(axisComponentActions, InputBindingProfile{});
-            REQUIRE((!axisComponentReport.IsValid()));
-            REQUIRE((std::ranges::any_of(axisComponentReport.diagnostics, [](const BindingDiagnostic &d) {
-                return d.code == BindingDiagnosticCode::DeviceExclusivityViolation;
-            })));
-        }
+    TEST_CASE("Conflict Validation Reports Duplicate Overrides For One Action", "[unit][runtime][input]") {
+        const InputContextId gameplay{"gameplay"};
+        const std::array actions{ActionDescriptor{ActionId{"jump"}, ActionValueType::Digital, gameplay, false, {KeyBinding(Key::Space)}}};
+        const InputBindingProfile profile{.profileId = "dup-override",
+                                          .overrides = {BindingOverride{ActionId{"jump"}, {KeyBinding(Key::A)}},
+                                                        BindingOverride{ActionId{"jump"}, {KeyBinding(Key::B)}}}};
+        const BindingValidationReport report = ValidateBindingProfile(actions, profile);
+        REQUIRE((!report.IsValid()));
+        REQUIRE((std::ranges::any_of(report.diagnostics, [](const BindingDiagnostic &d) {
+            return d.code == BindingDiagnosticCode::DuplicateBinding && d.message.find("jump") != std::string::npos;
+        })));
+    }
 
-        SECTION("Ambiguous context skips further binding validation for that action") {
-            InputBinding invalidDeadzone = KeyBinding(Key::Space);
-            invalidDeadzone.deadzone = 2.0F;
-            const std::array invalidContextActions{ActionDescriptor{ActionId{"valid.action"},
-                                                                    ActionValueType::Digital,
-                                                                    InputContextId{""},
-                                                                    false,
-                                                                    {invalidDeadzone}},
-                                                   ActionDescriptor{ActionId{"other.action"},
-                                                                    ActionValueType::Digital,
-                                                                    gameplay,
-                                                                    false,
-                                                                    {KeyBinding(Key::Space)}}};
-            const BindingValidationReport contextReport = ValidateBindingProfile(invalidContextActions, InputBindingProfile{});
-            REQUIRE((!contextReport.IsValid()));
-            REQUIRE((std::ranges::count_if(contextReport.diagnostics, [](const BindingDiagnostic &d) {
-                return d.code == BindingDiagnosticCode::AmbiguousContext;
-            }) == 1));
-            REQUIRE((std::ranges::none_of(contextReport.diagnostics, [](const BindingDiagnostic &d) {
-                return d.action.Value() == "valid.action" && d.code != BindingDiagnosticCode::AmbiguousContext;
-            })));
-        }
+    TEST_CASE("Conflict Validation Reports Duplicate Triggers Inside One Action", "[unit][runtime][input]") {
+        const InputContextId gameplay{"gameplay"};
+        const std::array actions{ActionDescriptor{ActionId{"jump"},
+                                                  ActionValueType::Digital,
+                                                  gameplay,
+                                                  false,
+                                                  {KeyBinding(Key::Space), KeyBinding(Key::Space)}}};
+        const BindingValidationReport defaultReport = ValidateBindingProfile(actions, InputBindingProfile{});
+        REQUIRE((!defaultReport.IsValid()));
+        REQUIRE((std::ranges::any_of(defaultReport.diagnostics, [](const BindingDiagnostic &d) {
+            return d.code == BindingDiagnosticCode::DuplicateBinding && d.message.find("jump") != std::string::npos;
+        })));
+        const InputBindingProfile overrideProfile{.profileId = "dup-binding",
+                                                  .overrides = {
+                                                      BindingOverride{ActionId{"jump"}, {KeyBinding(Key::A), KeyBinding(Key::A)}}}};
+        const BindingValidationReport overrideReport = ValidateBindingProfile(actions, overrideProfile);
+        REQUIRE((!overrideReport.IsValid()));
+        REQUIRE((std::ranges::any_of(overrideReport.diagnostics, [](const BindingDiagnostic &d) {
+            return d.code == BindingDiagnosticCode::DuplicateBinding && d.message.find("override") != std::string::npos;
+        })));
+    }
 
-        SECTION("Empty action ID is reported as InvalidAction") {
-            const std::array emptyIdActions{
-                ActionDescriptor{ActionId{""}, ActionValueType::Digital, gameplay, false, {KeyBinding(Key::Space)}}};
-            const BindingValidationReport emptyIdReport = ValidateBindingProfile(emptyIdActions, InputBindingProfile{});
-            REQUIRE((!emptyIdReport.IsValid()));
-            REQUIRE((std::ranges::any_of(emptyIdReport.diagnostics, [](const BindingDiagnostic &d) {
-                return d.code == BindingDiagnosticCode::InvalidAction;
-            })));
-        }
-
-        SECTION("Duplicate override for the same action is reported") {
-            const std::array actions{
-                ActionDescriptor{ActionId{"jump"}, ActionValueType::Digital, gameplay, false, {KeyBinding(Key::Space)}}};
-            const InputBindingProfile profile{.profileId = "dup-override",
-                                              .overrides = {BindingOverride{ActionId{"jump"}, {KeyBinding(Key::A)}},
-                                                            BindingOverride{ActionId{"jump"}, {KeyBinding(Key::B)}}}};
-            const BindingValidationReport report = ValidateBindingProfile(actions, profile);
-            REQUIRE((!report.IsValid()));
-            REQUIRE((std::ranges::any_of(report.diagnostics, [](const BindingDiagnostic &d) {
-                return d.code == BindingDiagnosticCode::DuplicateBinding && d.message.find("jump") != std::string::npos;
-            })));
-        }
-
-        SECTION("Duplicate trigger within a single action binding list is reported") {
-            const std::array actions{ActionDescriptor{ActionId{"jump"},
-                                                      ActionValueType::Digital,
-                                                      gameplay,
-                                                      false,
-                                                      {KeyBinding(Key::Space), KeyBinding(Key::Space)}}};
-            const BindingValidationReport defaultReport = ValidateBindingProfile(actions, InputBindingProfile{});
-            REQUIRE((!defaultReport.IsValid()));
-            REQUIRE((std::ranges::any_of(defaultReport.diagnostics, [](const BindingDiagnostic &d) {
-                return d.code == BindingDiagnosticCode::DuplicateBinding && d.message.find("jump") != std::string::npos;
-            })));
-
-            const InputBindingProfile overrideProfile{.profileId = "dup-binding",
-                                                      .overrides = {
-                                                          BindingOverride{ActionId{"jump"}, {KeyBinding(Key::A), KeyBinding(Key::A)}}}};
-            const BindingValidationReport overrideReport = ValidateBindingProfile(actions, overrideProfile);
-            REQUIRE((!overrideReport.IsValid()));
-            REQUIRE((std::ranges::any_of(overrideReport.diagnostics, [](const BindingDiagnostic &d) {
-                return d.code == BindingDiagnosticCode::DuplicateBinding && d.message.find("override") != std::string::npos;
-            })));
-        }
-
-        SECTION("InputRouter rejects an invalid profile without mutating live state") {
-            InputRouter router;
-            REQUIRE((router
-                         .SetActionMap(
-                             {ActionDescriptor{ActionId{"test.act"}, ActionValueType::Digital, workspace, false, {KeyBinding(Key::Z)}}})
-                         .HasValue()));
-            InputBindingProfile badProfile{.profileId = "bad",
-                                           .overrides = {BindingOverride{ActionId{"unknown.act"}, {KeyBinding(Key::X)}}}};
-            const Horo::Result<void> setRes = router.SetProfile(badProfile);
-            REQUIRE((setRes.HasError()));
-            REQUIRE((router.Profile().profileId == "default"));
-        }
+    TEST_CASE("InputRouter Rejects Invalid Profile Without Mutating Live State", "[unit][runtime][input]") {
+        const InputContextId workspace{"workspace"};
+        InputRouter router;
+        REQUIRE(
+            (router.SetActionMap({ActionDescriptor{ActionId{"test.act"}, ActionValueType::Digital, workspace, false, {KeyBinding(Key::Z)}}})
+                 .HasValue()));
+        InputBindingProfile badProfile{.profileId = "bad", .overrides = {BindingOverride{ActionId{"unknown.act"}, {KeyBinding(Key::X)}}}};
+        const Horo::Result<void> setRes = router.SetProfile(badProfile);
+        REQUIRE((setRes.HasError()));
+        REQUIRE((router.Profile().profileId == "default"));
     }
 
     TEST_CASE("Action Transitions Are Consumed And Gamepad Axes Have Edges", "[unit][runtime][input]") {

--- a/tests/unit/runtime/input/InputTests.cpp
+++ b/tests/unit/runtime/input/InputTests.cpp
@@ -349,8 +349,7 @@ namespace {
         const BindingValidationReport report = ValidateBindingProfile(actions, InputBindingProfile{});
         REQUIRE((!report.IsValid()));
         REQUIRE((std::ranges::any_of(report.diagnostics, [](const BindingDiagnostic &diagnostic) {
-            return diagnostic.code == BindingDiagnosticCode::InvalidAction &&
-                   diagnostic.message.find("shared.action") != std::string::npos;
+            return diagnostic.code == BindingDiagnosticCode::InvalidAction && diagnostic.message.find("shared.action") != std::string::npos;
         })));
     }
 
@@ -364,8 +363,7 @@ namespace {
         const BindingValidationReport report = ValidateBindingProfile(actions, InputBindingProfile{});
         REQUIRE((!report.IsValid()));
         REQUIRE((std::ranges::any_of(report.diagnostics, [](const BindingDiagnostic &diagnostic) {
-            return diagnostic.action.Value() == "malformed.chord" &&
-                   diagnostic.code == BindingDiagnosticCode::AmbiguousChord;
+            return diagnostic.action.Value() == "malformed.chord" && diagnostic.code == BindingDiagnosticCode::AmbiguousChord;
         })));
     }
 


### PR DESCRIPTION
## Summary
- Implements comprehensive authoring-time conflict validation for typed action mappings and binding profiles.
- Detects declared conflict classes: same trigger within the same context, chord overlap ambiguity, device exclusivity violations on composite axes/controls, and ambiguous context identifiers.
- Delivers actionable diagnostics containing source action ID, conflicting action ID, and target context ID.

## Motivation
- Fulfills **[INP-001.2]** (#1835): Ensures runtime never receives conflicting or invalid binding configurations by detecting and rejecting them at authoring/profile-application time.

## Implementation Notes
- Added `DeviceExclusivityViolation` and `AmbiguousContext` enumerators to `BindingDiagnosticCode`.
- Extended `ValidateEffectiveBindings` in `src/runtime/input/Input.cpp` with typed conflict checks:
  - Same trigger conflict across actions in the same context (`DuplicateBinding`) with source and conflicting action details.
  - Chord overlap/shadowing on the same primary key within the same context (`AmbiguousChord`).
  - Exclusive continuous axis stream conflicts (`DeviceExclusivityViolation`) for gamepad and pointer wheel controls.
  - Component index validation for digital and 1D actions vs 2D actions (`DeviceExclusivityViolation`).
- Rejects duplicate action IDs before effective-map construction, preventing first-match ambiguity.
- Guards chord comparisons against oversized chord counts so malformed typed inputs cannot read past bounded storage.
- Maintained atomicity: `InputRouter::SetActionMap` and `InputRouter::SetProfile` reject any invalid map/profile without mutating live state.

## Validation
- [x] Build passed (`HoroInputTests`)
- [x] Relevant unit tests passed (25/25 tests passed)
- [x] Pre-commit hooks passed (`horo clang-format staged`, `horo-engine layout configure`)

Commands run:
```bash
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
cmake --build build/skeleton --target HoroInputTests --parallel
ctest --test-dir build/skeleton -R "HoroInputTests" --output-on-failure
```

## Risks
- Low risk. Only affects validation of binding profiles and action map registrations; existing valid profiles pass unchanged.

## Issue Links
- GitHub: Closes #1835

## Reviewer Notes
- Review order: `include/Horo/Runtime/Input.h` -> `src/runtime/input/Input.cpp` -> `tests/unit/runtime/input/InputTests.cpp`.