### PR TITLE
docs(vfx): effect ownership, simulation domain policy and renderer boundary decision HORO-1706 #1749 [VFX-001.1]

### DIFF
--- a/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
+++ b/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
@@ -183,7 +183,7 @@ not a claim of unlimited capacity or a benchmark result.
 | Admitted cosmetic emitter reaches cap | Drop new births, retain existing particles, record a counter |
 | Required gameplay capacity unavailable | Typed failure requiring explicit owner handling; no silent clamp/drop |
 
-TryEnqueueSpawn returns Result<VfxRequestId> and copies bounded schema-typed parameters.
+TryEnqueueSpawn returns `Result<VfxRequestId>` and copies bounded schema-typed parameters.
 The scene owner serializes acceptance; authoritative producer inputs have stable
 ordering before admission. Each clock domain has its own queue/cutoff under the aggregate budget;
 no request is drained once per emitter or on both clocks. Freeze the accepted queue

--- a/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
+++ b/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
@@ -92,17 +92,33 @@ Domain selection is **policy-driven, asset-declared, and feature-tier constraine
 
 #### Domain Selection Criteria
 
+Domain resolution applies constraints in the following order. A CPU-mandatory
+criterion always takes precedence over an explicit or automatically selected GPU
+domain, including for systems above the particle-count threshold.
+
 1. **`SimulationDomain::CPU`** is mandatory when:
-   - Particles require two-way gameplay interaction (e.g., triggering game logic, modifying gameplay physics bodies, collecting pickup items).
+   - Particles require two-way gameplay interaction (e.g., triggering game logic,
+     modifying gameplay physics bodies, collecting pickup items).
    - High-precision CPU raycast/geometry collision response is required.
-   - System particle count is low-to-medium (≤ 2,048 particles).
-   - Running on low-spec hardware tiers (e.g., `es3`) or in headless/null environments.
-2. **`SimulationDomain::GPU`** is selected when:
-   - System particle count is high (> 2,048 particles).
-   - Complex vector fields, curl noise, or GPU depth-buffer collisions are utilized.
-   - Effects are purely cosmetic (visual-only, no synchronous gameplay CPU readback).
-3. **`SimulationDomain::Automatic`** (Asset Default):
-   - Resolved at asset cook/load time. High-count visual-only systems select GPU compute when supported by the active feature tier; otherwise, they degrade to CPU simulation.
+   - Running on low-spec hardware tiers (e.g., `es3`) or in headless/null
+     environments.
+2. **Explicit domain requests** are considered after mandatory constraints:
+   - Explicit `CPU` remains on CPU, subject to the active tier's capacity budget.
+   - Explicit `GPU` is valid only for visual-only effects on a
+     GPU-compute-capable tier. Otherwise, resolution falls back deterministically
+     to CPU and records a typed cook/load diagnostic.
+3. **`SimulationDomain::Automatic`** (Asset Default) uses the particle-count
+   heuristic:
+   - Visual-only systems with `maxParticles > 2,048` select GPU when the active
+     tier supports GPU compute.
+   - Systems with `maxParticles <= 2,048`, or systems on tiers without GPU
+     compute, select CPU.
+   - Complex vector fields, curl noise, or GPU depth-buffer collision may prefer
+     GPU only after the CPU-mandatory checks above pass.
+
+The `2,048` value is a domain-selection heuristic, not a universal capacity
+limit. Feature-tier capacity limits are applied after domain resolution and may
+clamp a system below this threshold.
 
 #### Coexistence Rules
 
@@ -115,7 +131,7 @@ Domain selection is **policy-driven, asset-declared, and feature-tier constraine
 | Feature Tier / Platform | Primary Domain | GPU Compute Particles | GPU Radix / Bitonic Sort | Volumetrics & Curl Noise | Fallback Behavior |
 |---|---|---|---|---|---|
 | **Headless / Null** (`null`) | `CPU` (Null Simulator) | Disabled | Disabled | Disabled | Full deterministic CPU dummy simulation; no GPU allocations or draw dispatches. |
-| **Mobile / Low-Spec** (`es3`) | `CPU` | Disabled | Disabled | Disabled | GPU particle assets automatically fall back to CPU simulation with clamped particle caps (e.g., max 512). Complex noise disabled. |
+| **Mobile / Low-Spec** (`es3`) | `CPU` | Disabled | Disabled | Disabled | GPU requests fall back to CPU. The tier clamps each system to its configured CPU cap (`512` by default), overriding the general `2,048` domain heuristic. Complex noise is disabled. |
 | **Desktop Baseline** (`dx11` / `opengl4`) | `CPU` & `GPU` | Supported (Compute) | Supported (Bitonic) | Basic 3D Textures | Over-budget GPU systems throttle spawn rates or drop lowest-priority sub-emitters. |
 | **High-End Desktop / Console** (`dx12_vulkan` / `metal`) | `CPU` & `GPU` | Full Compute | Full Radix/Bitonic | Full Curl Noise & Vector Fields | Unrestricted simulation with GPU indirect draw and GPU culling. |
 

--- a/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
+++ b/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
@@ -192,7 +192,7 @@ struct VfxRenderBatch {
 ### Pass Placement, Material Pipeline, and Sorting
 
 1. **Standard Material Pipeline Integration**:
-   - Particle and decal shaders are authored and compiled via the engine's standard material system (refer to [Material And Shader Model](./material-and-shader-model.md)).
+   - Particle and decal shaders are authored and compiled via the engine's standard material system (refer to [Material And Shader Model](../architecture/runtime/material-and-shader-model.md)).
    - Shading models supported: `Unlit`, `DefaultPBR` (lit particles/mesh particles), and `DecalEmissive`/`DecalPBR`.
    - Blend modes: `Opaque`, `Masked`, `Translucent` (alpha blend), and `Additive`.
    - Soft particles: Translucent particle shaders consume the scene depth buffer texture to evaluate soft-intersection depth fading.

--- a/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
+++ b/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
@@ -3,252 +3,277 @@
 - **Status**: Proposed
 - **Date**: 2026-08-28
 - **Supersedes**: None
-- **Scope**: Runtime VFX subsystem ownership, simulation domain selection policy, platform fallback matrix, render extraction boundary, pass placement and sorting
+- **Scope**: Runtime VFX ownership, per-emitter domain policy, bounded admission, immutable extraction, GPU scheduling, retirement and per-view sorting
 - **Issue**: [#1749](https://github.com/abdullahbodur/horo-engine/issues/1749) ([VFX-001.1])
 - **JIRA**: HORO-1706
 - **Normative document**: [VFX And Particles Architecture](../architecture/runtime/vfx-and-particles-architecture.md)
 
 ## Context
 
-Visual effects (particle systems, ribbon emitters, mesh particles, decals, and volumetric effects) span gameplay simulation, physics interaction, compute dispatching, and graphics presentation. Without explicit architectural boundaries, effects tend to introduce severe architectural debt:
+Particles, ribbons, decals and volumetric effects cross simulation and rendering
+boundaries. The previous proposal assigned compute encoding and Render Graph
+submission to scene-owned components while also requiring backend neutrality and
+immutable snapshots. It promised synchronous GPU reclamation and zero allocations
+without defining overflow. Its Null and GPU-to-CPU fallback rules could change
+headless gameplay or move an unaffordable visual effect onto the CPU.
 
-1. **Immediate-mode rendering anti-patterns**: Gameplay or effect scripts issuing immediate-mode draw calls directly into graphics contexts, breaking render graph scheduling, pass reordering, and multi-threaded rendering.
-2. **Ambiguous subsystem ownership**: Effects persisting across scene transitions or living in global singletons, leading to memory leaks, dangling scene references, and non-deterministic state.
-3. **Ad hoc simulation domains**: Simulation code branching dynamically on loose flags at call sites, making CPU versus GPU particle behavior non-reproducible and error-prone across hardware tiers.
-4. **Backend-leaking abstractions**: Exposing native GPU buffer handles or API-specific compute shaders directly to gameplay and scene systems.
-
-Ticket [#1749](https://github.com/abdullahbodur/horo-engine/issues/1749) ([VFX-001.1]) requires a definitive architecture decision that establishes:
-
-- The authoritative owner and deterministic lifecycle of `VfxWorld` and its subsystem components.
-- A policy-driven, reproducible simulation domain selection model with explicit hardware/platform fallback matrices.
-- A backend-neutral render-extraction contract that integrates with the standard material and Render Graph pass system.
+The decision must separate logical scene state from renderer-owned native work,
+resolve domain intent per compiled emitter, and specify capacity and timing outcomes.
+It must reconcile ADR-010/018 owner dispatch and ADR-012 cell retirement, rather than
+add a separate asynchronous execution or streaming model. This record remains
+Proposed; merging this documentation is not a claim of acceptance or implementation.
 
 ## Decision
 
-**`VfxWorld` is owned exclusively by the active `SceneRuntime`, initialized at scene startup, ticked during the scene simulation phase, and deterministically reset/destroyed on scene unload or replacement. Simulation domain selection (CPU vs. GPU compute) is policy-driven, asset-defined, and feature-tier constrained. Visual effects never use immediate-mode rendering; `VfxWorld` extracts typed, backend-neutral render primitives (`VfxRenderBatch`, `ParticleBufferView`, `DynamicInstanceTransform`) during the Render Extraction phase for submission to standard Render Graph passes.**
+**SceneRuntime owns VfxWorld and logical effect state. SimulationDomainResolver
+selects one domain per compiled emitter using gameplay constraints, asset intent,
+actual capabilities and admitted budgets. VfxRenderExtractor writes immutable,
+backend-neutral work/render descriptors into RenderWorldSnapshot. RenderFrontend
+owns GPU compute/sort/cull/draw scheduling and physical resource retirement. VFX
+never submits immediate-mode calls or Render Graph passes.**
 
-### Ratify-or-revise outcomes
+### Ownership And Execution
 
-| Area | Prior / Baseline State | Outcome |
+| Component | Owner | Contract |
 |---|---|---|
-| **VFX World Ownership** | Loosely placed under Scene Runtime | **Ratified and Formalized.** `VfxWorld` is strictly owned by `SceneRuntime`. Its lifetime is bounded exactly by the scene lifecycle. |
-| **Lifecycle & Teardown** | Implicit teardown on scene change | **Ratified.** Reset and teardown are deterministic; pools, queues, and compute allocations are reclaimed synchronously on scene replacement. |
-| **Simulation Domain** | Ad hoc CPU/GPU distinction | **Revised to Policy-Driven.** Domain is determined by asset descriptor rules, gameplay coupling requirements, and platform feature tiers with deterministic fallback. |
-| **Headless / Null Simulation** | Undefined headless behavior | **Formalized.** Headless and test environments use deterministic, allocation-free `NullParticleSimulator` / CPU simulation without GPU dependencies. |
-| **Renderer Boundary** | Conceptually separated | **Ratified and Strictly Enforced.** Zero immediate-mode rendering. `VfxRenderExtractor` emits immutable backend-neutral render batches during the Render Extraction phase. |
-| **Material & Shader Pipeline** | Mixed custom/standard shader models | **Ratified.** Particles and decals use the standard PBR and unlit material model compiled via the shared shader pipeline. |
-| **Sorting & Transparency** | Described in high-level terms | **Formalized.** Camera-relative distance sorting is CPU-radix for CPU systems and GPU bitonic/radix compute for GPU systems; additive particles skip sorting. |
+| VfxWorld | SceneRuntime | Logical scene-scoped effects, CPU state, bounded queues and extraction |
+| EffectSystem / SimulationDomainResolver | VfxWorld | Lifecycle, compiled graph bindings and per-emitter resolution |
+| CpuParticleSimulator | VfxWorld | Real CPU kernels, including gameplay-coupled headless execution |
+| GpuParticleSimulator | VfxWorld | Produces GpuVfxSimulationWork with logical step/resource IDs, never native dispatch |
+| NullParticleSimulator | VfxWorld | Permitted visual suppression, preserving queue/tick/lifecycle contracts |
+| DecalManager | VfxWorld | Logical projection/fade/atlas requests; no physical texture ownership |
+| EffectInstancePool / VfxEventQueue | VfxWorld | Preallocated storage, explicit admission and overflow outcomes |
+| VfxRenderExtractor | VfxWorld | Immutable frame packing; no graph submission or simulation mutation |
+| RenderFrontend / renderer resource manager | Renderer | Upload, graph construction, native resource leases and deferred retirement |
 
----
+Host composition provides inert descriptors, capability snapshots and adapters.
+It never makes a concrete graphics backend discoverable from gameplay/VFX code.
+Scene-owned logical GPU state does not imply ownership of native buffers or commands.
 
-### Authoritative Ownership & Component Breakdown
-
-Every component within the runtime effects ecosystem has a single, unambiguous owner:
+### Simulation, Snapshot And Graph Phases
 
 ```text
-SceneRuntime
-  └── VfxWorld
-        ├── EffectSystem
-        ├── CpuParticleSimulator
-        ├── GpuParticleSimulator
-        ├── NullParticleSimulator
-        ├── DecalManager
-        ├── EffectInstancePool
-        ├── VfxEventQueue
-        └── VfxRenderExtractor
+Scene simulation owner
+    CPU SoA update + backend-neutral GpuVfxSimulationWork
+        -> VfxRenderExtractor
+        -> immutable RenderWorldSnapshot
+        -> RenderFrontend
+        -> VFX Compute (once per step)
+        -> per-view Sort/Cull
+        -> standard Shadow/Depth/Opaque/Decal/Volume/Translucent passes
+        -> fence-based renderer retirement
 ```
 
-| Component | Owner | Responsibility |
-|---|---|---|
-| `SceneRuntime` | Application / Host | Owns `VfxWorld` as a major scene subsystem. Controls creation, fixed/variable simulation ticking, and destruction. |
-| `VfxWorld` | `SceneRuntime` | Subsystem composition root. Coordinates simulators, decal manager, instance pools, event queues, and render extraction. |
-| `EffectSystem` | `VfxWorld` | Manages effect instance life cycles, template instantiation, parameter bindings, and spatial hierarchy tracking. |
-| `CpuParticleSimulator` | `VfxWorld` | Flat Structure-of-Arrays (SoA) SIMD-accelerated particle updater for gameplay-interactive, collision-coupled, or CPU-bound effects. |
-| `GpuParticleSimulator` | `VfxWorld` | Manages compute dispatch generation, indirect draw arguments, and compute buffer references for high-density particle volumes. |
-| `NullParticleSimulator` | `VfxWorld` | Deterministic, allocation-free simulation path for headless testing, CI, and server execution where GPU rendering is disabled. |
-| `DecalManager` | `VfxWorld` | Manages active decal projection volumes, fading envelopes, dynamic bounds, and decal atlas allocations. |
-| `EffectInstancePool` | `VfxWorld` | Preallocated memory pools for particle buffers, emitter states, and effect instances to guarantee zero frame-time allocations. |
-| `VfxEventQueue` | `VfxWorld` | Bounded FIFO queue capturing gameplay and animation spawn events (e.g., footsteps, impacts, explosions). |
-| `VfxRenderExtractor` | `VfxWorld` | Extracts immutable, backend-neutral render primitives (`VfxRenderBatch`) and submits them to the Render Graph during extraction. |
+The existing Scene scheduler declares access/dependency edges. Gameplay-coupled CPU
+emitters use the owning fixed simulation tick after required physics results; their
+gameplay outputs reach a declared later owner safe point. Cosmetic work uses
+Presentation before RenderExtraction. A unit is not advanced on both schedules.
+Scene clock/seed policy controls pause and replay, not wall time or view count.
 
-#### Lifecycle and Scene Transition Rules
+VfxWorld::Update drains a bounded accepted-event prefix and advances CPU/logical
+state. GpuParticleSimulator only writes typed work descriptors. Extraction publishes
+stable data and leases; it does not encode compute, write mapped GPU buffers or
+submit passes. At render frame synchronization, RenderFrontend validates the
+snapshot, uploads CPU slices and constructs the graph. The selected backend owns
+native encoding and resource/queue barriers on its permitted execution roles.
 
-1. **Initialization**: `VfxWorld` is instantiated when `SceneRuntime` activates. Preallocated instance and particle buffer pools are established according to scene/project quality configurations.
-2. **Simulation Phase**: `VfxWorld::Update(DeltaTime)` executes within the scene simulation loop:
-   - Processes all queued `VfxEventQueue` events.
-   - Updates CPU particle systems and decal timers.
-   - Encodes GPU compute simulation dispatches for compute-backed systems.
-3. **Extraction Phase**: `VfxWorld::ExtractRenderData(RenderWorldSnapshot&, const SceneView&)` is called strictly during the Render Extraction phase. No simulation state is mutated during extraction.
-4. **Teardown & Scene Replacement**: When a scene is unloaded or replaced:
-   - All active effect instances, emitters, and decals are stopped immediately.
-   - All pooled buffers, GPU compute resources, and event queues are deterministically reset/released.
-   - No effect instance, GPU handle, or callback reference may leak into the replacement scene or host runtime.
+[ADR-010](010-job-waiting-and-operation-store-ownership.md) JobSystem/JobId and
+non-blocking completion ownership apply to CPU preparation. Workers cannot mutate
+live scene state or wait on nested work. Required CPU progress uses the host's
+non-blocking scheduling policy rather than stale gameplay data. Long user-visible
+operations use the application OperationStore, not a VFX-owned replacement service.
+[ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md)
+WorkerJob does not authorize native GPU encoding; RenderSafePoint commands enter
+the same render frame synchronization seam. No ordinary owner/render frame waits
+on workers or GPU fences.
 
----
+GPU work is keyed by scene incarnation, effect/emitter generation and simulation
+step. Multiple views or snapshot reuse must not submit that step twice. Output versions
+remain leased, so later steps cannot overwrite data needed by old snapshots. Bounded
+pending work retains leases until renderer acknowledgement; submission is not
+retirement. Backpressure stops new cosmetic GPU work and reports it, with an authored
+bounded restart/reset policy, not unlimited catch-up or automatic CPU migration.
+Uncertain submission uses renderer recovery rather than blindly replaying the step.
 
-### Simulation Domain Selection Policy and Fallback Matrix
+GPU depth collision uses one declared cosmetic collision view's previous completed,
+generation-valid depth snapshot. Missing depth follows authored fallback/disable
+policy. It cannot create a cycle through the current VFX-dependent depth pass or
+advance a simulation once per view. GPU readback cannot drive authoritative gameplay.
 
-Domain selection is **policy-driven, asset-declared, and feature-tier constrained**. Individual gameplay call sites cannot arbitrarily override simulation rules via raw backend branching.
+### Per-Emitter Domain Policy
 
-#### Domain Selection Criteria
+A compiled emitter simulation unit owns one particle state and one resolved domain.
+Any gameplay interaction or required CPU geometry query makes that entire unit
+CPU-mandatory, regardless of particle count. A composite graph may contain separate
+CPU and GPU units; an individual unit is never partly CPU and partly GPU. Synchronous
+state/gameplay dependencies propagate CPU requirements through connected units or
+fail cook if incompatible. CPU-to-GPU visual child events use bounded next-tick
+requests; synchronous authoritative GPU-to-CPU feedback is prohibited.
 
-Domain resolution applies constraints in the following order. A CPU-mandatory
-criterion always takes precedence over an explicit or automatically selected GPU
-domain, including for systems above the particle-count threshold.
+The normative contract separates SimulationPreference (Automatic, RequireCPU,
+PreferCPU, PreferGPU, RequireGPU) from ResolvedSimulationDomain (CPU, GPU, Null).
+Resolve in this order:
 
-1. **`SimulationDomain::CPU`** is mandatory when:
-   - Particles require two-way gameplay interaction (e.g., triggering game logic,
-     modifying gameplay physics bodies, collecting pickup items).
-   - High-precision CPU raycast/geometry collision response is required.
-   - Running on low-spec hardware tiers (e.g., `es3`) or in headless/null
-     environments.
-2. **Explicit domain requests** are considered after mandatory constraints:
-   - Explicit `CPU` remains on CPU, subject to the active tier's capacity budget.
-   - Explicit `GPU` is valid only for visual-only effects on a
-     GPU-compute-capable tier. Otherwise, resolution falls back deterministically
-     to CPU and records a typed cook/load diagnostic.
-3. **`SimulationDomain::Automatic`** (Asset Default) uses the particle-count
-   heuristic:
-   - Visual-only systems with `maxParticles > 2,048` select GPU when the active
-     tier supports GPU compute.
-   - Systems with `maxParticles <= 2,048`, or systems on tiers without GPU
-     compute, select CPU.
-   - Complex vector fields, curl noise, or GPU depth-buffer collision may prefer
-     GPU only after the CPU-mandatory checks above pass.
+1. Validate CPU-mandatory behavior. RequireGPU conflicts are typed asset errors;
+   otherwise use real CPU simulation, with a required compatible CPU kernel.
+2. Apply explicit intent and host mode. RequireCPU cannot become GPU. RequireGPU
+   needs the capabilities or a separately authored fallback effect; otherwise it
+   is unavailable. Headless visual suppression through Null is permitted only by
+   authored policy and cannot replace gameplay behavior.
+3. Preferences try the preferred compatible/admitted path, then an explicitly
+   permitted fallback. CPU fallback needs a cooked CPU kernel and CPU memory/work
+   admission. Unsupported required noise/collision behavior is not silently erased.
+4. Automatic uses VfxQualityPolicy.autoGpuParticleThreshold: eligible visual emitters
+   above desktop default 2048 prefer GPU; at/below it prefer CPU. Authored kernel/cost
+   needs can prefer GPU below it only after mandatory checks. The same admission and
+   fallback rules apply.
 
-The `2,048` value is a domain-selection heuristic, not a universal capacity
-limit. Feature-tier capacity limits are applied after domain resolution and may
-clamp a system below this threshold.
+2048 is a configurable heuristic, not a cap. Per-emitter and aggregate budgets always
+apply, including high-end profiles. The default low-budget cosmetic CPU fallback cap
+is 512. Only authored valid cosmetic reductions may clamp counts; required gameplay
+capacity failure returns a typed rejection to its owner. No 500k GPU effect becomes
+an unbounded CPU workload by fallback.
 
-#### Coexistence Rules
+Cooked descriptors record supported kernels, required capabilities, dependencies,
+fallbacks and peak costs. Load resolves against a captured host policy/capability
+revision. Changing domain requires safe re-admission/restart, not live state migration.
+The prior proposed SimulationDomain field migrates with descriptor versioning:
+Automatic -> Automatic, CPU -> RequireCPU, GPU -> PreferGPU, with diagnostics. Do not
+retain competing selectors or silently reinterpret stored asset intent.
 
-- CPU and GPU particle systems can coexist seamlessly within the same scene and within the same composite VFX graph asset.
-- Synchronization is governed by shared scene simulation time and camera transforms.
-- CPU particles write to CPU-mapped dynamic vertex/instance buffers. GPU particles simulate in GPU compute buffers and emit indirect draw calls.
+### Capabilities, Profiles And Null Semantics
 
-#### Platform & Feature Tier Fallback Matrix
+VfxCapabilities reports actual compute, indirect draw, GPU sorting, volume textures,
+vector fields and device limits. VfxQualityPolicy provides validated finite budgets,
+heuristics and authored degradation rules. Backend/API names do not imply support.
 
-| Feature Tier / Platform | Primary Domain | GPU Compute Particles | GPU Radix / Bitonic Sort | Volumetrics & Curl Noise | Fallback Behavior |
-|---|---|---|---|---|---|
-| **Headless / Null** (`null`) | `CPU` (Null Simulator) | Disabled | Disabled | Disabled | Full deterministic CPU dummy simulation; no GPU allocations or draw dispatches. |
-| **Mobile / Low-Spec** (`es3`) | `CPU` | Disabled | Disabled | Disabled | GPU requests fall back to CPU. The tier clamps each system to its configured CPU cap (`512` by default), overriding the general `2,048` domain heuristic. Complex noise is disabled. |
-| **Desktop Baseline** (`dx11` / `opengl4`) | `CPU` & `GPU` | Supported (Compute) | Supported (Bitonic) | Basic 3D Textures | Over-budget GPU systems throttle spawn rates or drop lowest-priority sub-emitters. |
-| **High-End Desktop / Console** (`dx12_vulkan` / `metal`) | `CPU` & `GPU` | Full Compute | Full Radix/Bitonic | Full Curl Noise & Vector Fields | Unrestricted simulation with GPU indirect draw and GPU culling. |
+| Profile | Execution and fallback |
+|---|---|
+| Headless/test | Real CPU gameplay; permitted visual Null; same queue/tick/lifecycle timing, zero GPU dependency |
+| Low visual budget | Admitted CPU or explicitly supported GPU; default cosmetic CPU fallback cap 512; authored substitute or rejection |
+| Desktop baseline | CPU/GPU by intent/capability/cost; finite work, memory and spawn limits |
+| High visual budget | Larger finite budgets; optional advanced paths still require actual capabilities |
 
----
+Legacy es3/dx11/opengl4/dx12_vulkan/metal labels are not VFX capability enums.
+The renderer parity and availability contracts remain authoritative: VFX fallback
+cannot silently select another renderer or switch an interactive host to RenderNull.
+Reproducible resolution does not claim bitwise visual CPU/GPU parity across devices.
 
-### Renderer Boundary and Render Extraction Contract
+Null keeps accepted FIFO order, drain cutoff/limit, next-tick result delivery,
+logical lifetime, pause and cancellation timing. It cannot complete submission inline.
+It suppresses visual kernels; it does not fabricate per-particle collision/death
+results. Gameplay, audio or other required nonvisual events use real CPU simulation
+or an authored deterministic CPU event source. Headless gameplay uses the same CPU
+kernels, seed/tick inputs and admission rules as graphical hosts. Tests needing GPU
+latency use delayed fake completions; Null does not guarantee device timing equivalence.
 
-Visual effects adhere strictly to Horo Engine's decoupled rendering architecture. **VFX code is strictly prohibited from invoking immediate-mode draw calls or holding backend graphics contexts.**
+### Capacity And Overflow
 
-#### Render Extraction Pipeline
+Preallocate or admit pools, particle/scratch slices, frame copies, per-view sort data,
+GPU work, completion and retirement records before activation. Never grow those pools
+during Update, spawn or extraction. Resizing requires explicit preparation and peak
+old/new reservation. Zero steady-state allocation is a qualification requirement,
+not a claim of unlimited capacity or a benchmark result.
 
-```text
-  [ VfxWorld (Scene Simulation) ]
-                 │
-                 ▼
-  [ VfxRenderExtractor ]  (ExtractRenderData phase)
-                 │
-                 ├─► VfxRenderBatch (Translucent Billboard / Ribbon / Mesh)
-                 ├─► VfxRenderBatch (Opaque / Masked Mesh Particles)
-                 ├─► DecalRenderBatch (Deferred / Clustered Decals)
-                 └─► ParticleBufferView & DynamicInstanceTransforms
-                 │
-                 ▼
-  [ Render Graph Execution ]
-         ├── G-Buffer / Depth Pre-Pass (Opaque Mesh Particles)
-         ├── Decal Pass (Projected Decals)
-         ├── Forward / Translucent Pass (Sorted Particles & Ribbons)
-         └── Volumetric Accumulation Pass
-```
+| Condition | Outcome |
+|---|---|
+| Event queue full | Reject incoming/newest with EventQueueFull; never overwrite accepted entries |
+| Instance/particle capacity exhausted | Reject new request with EffectCapacityExceeded; do not implicitly evict an existing effect |
+| Renderer/memory/work budget exhausted | ResourceBudgetExceeded or declared cosmetic reduction at admission |
+| Admitted cosmetic emitter reaches cap | Drop new births, retain existing particles, record a counter |
+| Required gameplay capacity unavailable | Typed failure requiring explicit owner handling; no silent clamp/drop |
 
-#### Typed Render Primitives
+TryEnqueueSpawn returns Result<VfxRequestId> and copies bounded schema-typed parameters.
+The scene owner serializes acceptance; authoritative producer inputs have stable
+ordering before admission. Each clock domain has its own queue/cutoff under the aggregate budget;
+no request is drained once per emitter or on both clocks. Freeze the accepted queue
+prefix at tick start, drain at
+most maxEventsPerTick, and defer requests generated during that update until the next
+tick. Result/cancellation/retirement capacity is reserved before acceptance. Cosmetic
+requests cannot consume configured gameplay reserves. All paths, including Null,
+follow those rules and report rate-limited diagnostics; callers do not spin or block.
 
-```cpp
-enum class VfxPassKind : uint8_t {
-    OpaqueMesh,
-    MaskedMesh,
-    TranslucentForward,
-    AdditiveForward,
-    DeferredDecal,
-    ForwardDecal,
-    VolumetricAccumulation
-};
+CPU, GPU, upload/sort copies and frames in flight count toward admitted peak memory.
+ADR-012 cell reservations are slices of the host ledger, not an extra allowance.
+Logical cancellation does not return credits for memory still used by readers/GPU.
 
-enum class VfxPrimitiveTopology : uint8_t {
-    CameraFacingBillboard,
-    RibbonStrip,
-    InstancedMesh,
-    DecalBox
-};
+### Scene, Streaming Cell And GPU Retirement
 
-struct ParticleBufferView {
-    BufferHandle bufferHandle;
-    uint32_t byteOffset;
-    uint32_t particleCount;
-    uint32_t stride;
-};
+Scene/effect/request handles carry incarnation and slot generation; checked exhaustion
+retires identities instead of wrapping. Scene replacement closes admission and
+invalidates old handles at the owner safe point. Logical stopping is immediate;
+physical memory reclamation is not. CPU jobs and snapshots retain their slices;
+renderer resources retire only after frame readers and GPU fences finish. Retirement
+records retain no raw VfxWorld/ECS pointers and cannot publish into a replacement scene.
 
-struct VfxRenderBatch {
-    VfxPassKind passKind;
-    VfxPrimitiveTopology topology;
-    MaterialId material;
-    MeshHandle mesh;                      // Valid for InstancedMesh
-    ParticleBufferView instanceData;      // Position, size, rotation, color, UV
-    BufferHandle indirectArgsBuffer;       // Optional, for GPU indirect draw
-    uint32_t indirectArgsOffset;
-    AABB worldBounds;
-    float sortDistance;                   // Key for translucent back-to-front sorting
-    bool isCastShadowEnabled;
-};
-```
+[ADR-012](012-world-streaming-partition-authority-and-subsystem-boundaries.md) cell-bound
+effects additionally capture StreamingFence with PartitionEpoch and cell generation.
+An IFeatureStreamingProvider adapter reports admitted cost, Ready/Prepared and Retired.
+Prepared publication attaches already admitted resources without allocation or new
+recoverable work. Required/Optional/Degradable behavior follows the cell contract.
 
----
+Partial eviction retires only cell-owned effects, rejects late fenced spawns, and
+acknowledges Retired only after CPU/asset/snapshot/device leases finish. Shared caches
+have separate charged ownership; persistent/network effects are not evicted by position.
+Whole-scene teardown retires every remaining scope using the same registered dependency
+DAG and Scene safe points. There is no synchronous GPU free or ordinary device-idle wait.
 
-### Pass Placement, Material Pipeline, and Sorting
+ADR-010 bounded teardown and ADR-012 timeout behavior apply: report incomplete retirement
+and retain outstanding module/resource/asset dependencies safely. Never detach work
+referencing freed state or claim a clean unload. Old retirement remains charged during
+new-scene admission. Cancellation prevents stale publication, not guaranteed physical
+interruption of I/O or GPU work.
 
-1. **Standard Material Pipeline Integration**:
-   - Particle and decal shaders are authored and compiled via the engine's standard material system (refer to [Material And Shader Model](../architecture/runtime/material-and-shader-model.md)).
-   - Shading models supported: `Unlit`, `DefaultPBR` (lit particles/mesh particles), and `DecalEmissive`/`DecalPBR`.
-   - Blend modes: `Opaque`, `Masked`, `Translucent` (alpha blend), and `Additive`.
-   - Soft particles: Translucent particle shaders consume the scene depth buffer texture to evaluate soft-intersection depth fading.
+### Render Primitives, Passes And Sorting
 
-2. **Pass Placement**:
-   - **Opaque / Masked Mesh Particles**: Inserted into the standard G-Buffer (deferred) or Depth Pre-Pass / Opaque Forward pass. Writes depth.
-   - **Deferred Decals**: Rendered into the G-Buffer during the decal pass (modifying Albedo, Roughness/Metallic, and Normal attachments).
-   - **Forward Decals**: Rendered in the forward lighting pass for forward-only tiers.
-   - **Translucent Particles & Ribbons**: Inserted into the Translucent Forward Pass. Depth-tested against scene depth, no depth write.
-   - **Additive Particles**: Inserted into the Additive Forward Pass. Depth-tested, no depth write, order-independent.
+The normative document owns the schematic typed contracts: GpuVfxSimulationWork,
+ParticleDataSource (CPU frame slices or GPU logical resource views), VfxRenderBatch,
+DynamicInstanceTransform, DecalRenderBatch, VolumetricVfxBatch and VfxViewSortKey.
+They carry frame/resource leases, checked layouts/bounds and scene/origin identity;
+they never expose mutable simulation spans, native handles or backend contexts.
+CPU simulation writes private SoA; extraction packs immutable CPU frame data and the
+renderer performs uploads. Volumes have an explicit volume-grid contract separate
+from particle topology; decals and light outputs use their own typed render contracts.
 
-3. **Sorting Policy**:
-   - **Translucent Systems**: Sorted back-to-front relative to the active camera.
-     - **CPU Simulated**: Sorted on the CPU using multi-threaded radix sort over camera distance keys before writing into the extraction buffer.
-     - **GPU Simulated**: Sorted via GPU bitonic or radix sort compute kernels prior to indirect dispatch.
-   - **Additive Systems**: Sorting is skipped entirely, eliminating sorting overhead for additive glows and sparks.
-   - **Opaque Systems**: Sorted front-to-back by the Render Frontend alongside standard static/dynamic scene meshes to maximize early-Z rejection.
+Shared PBR/unlit material compilation remains authoritative. RenderFrontend schedules
+compute before dependent sort/cull and draw passes, with declared barriers. Opaque/
+masked mesh particles use standard depth/opaque and permitted shadow caster passes.
+Translucent/ribbon and additive paths depth-test without depth writes; additive skips
+sorting. Decals and volumetric accumulation use capability-validated dedicated paths.
+Shadow casting in this contract is opaque/masked mesh only; unsupported combinations
+require an authored substitute or typed rejection, not a silently ignored boolean.
 
----
+Sort/cull is per RenderViewId, covering editor/game, split screen, XR and reflections.
+CPU radix sorting writes packed-frame index/key data; GPU sorting writes per-view
+indices after simulation. sortDistance is a render key, never particle state. Neither
+path reorders the simulation SoA. Equal keys use stable batch/particle IDs; nonfinite
+keys fail validation. A pending CPU sort cannot block the frame: omit/report the
+cosmetic batch under the declared view fallback rather than falsely submit sorted alpha.
 
 ## Consequences
 
-### Positive
-
-- **Architectural Purity**: Elimination of immediate-mode draw calls guarantees compatibility with multi-threaded rendering and future render graphs.
-- **Backend Neutrality**: `VfxWorld` operates with zero knowledge of concrete graphics APIs (Vulkan, Metal, OpenGL, D3D12, Null).
-- **Deterministic Lifecycles**: Subsystem ownership by `SceneRuntime` guarantees clean teardown, eliminating cross-scene leaks.
-- **Predictable Performance**: Memory pooling guarantees zero heap allocations during steady-state gameplay updates and particle spawning.
-- **Cross-Platform Scalability**: Explicit feature tier matrices allow high-end platforms to utilize massive compute particle simulations while ensuring graceful degradation to CPU simulation on lower tiers and headless servers.
-
-### Negative / Tradeoffs
-
-- Render extraction introduces a lightweight data-packing step to format instance buffers into backend-neutral views.
-- GPU particle simulation requires compute shader support; platforms lacking compute capability must adhere to CPU particle budget limits.
-
----
+- Scene ownership, logical GPU intent and renderer-native work have separate lifetimes.
+- Bounded admission and failure outcomes make bursts/overload implementable without
+  hidden heap growth, gameplay loss or unsafe resource reclamation.
+- Domain fallback requires authored compatibility and budgets; some effects will be
+  explicitly unavailable on unsupported hosts.
+- Multi-view extraction requires extra admitted frame/index storage but leaves
+  simulation state camera-independent except declared cosmetic depth input.
+- Implementation qualification must cover overload, delayed completion, partial cell
+  eviction, headless gameplay, graph dependencies and all supported renderer profiles.
+  This documentation change does not implement those tests or runtime paths.
 
 ## Rejected Alternatives
 
-- **Immediate-Mode Rendering from Gameplay / Effect Components**: Rejected because it violates pass ordering, prevents multi-threaded extraction, breaks render graph compilation, and couples gameplay code to the active graphics backend.
-- **Renderer-Owned VFX Systems**: Rejected because particle simulation requires access to scene transforms, gameplay physics, and spatial queries. The renderer must remain a consumer of immutable snapshots.
-- **Ad Hoc Per-Emitter Backend / Domain Switching**: Rejected because call-site branching produces non-reproducible visual artifacts, race conditions, and unmaintainable platform code.
-- **Dedicated Proprietary Particle Shading System**: Rejected in favor of the standard PBR / unlit material pipeline to ensure consistent lighting, shadows, and asset pipeline integration across the engine.
+- **Scene-owned native dispatch or direct extractor-to-graph submission**: Violates
+  immutable snapshot consumption, resource scheduling and backend isolation.
+- **Renderer-owned logical VFX world**: Moves gameplay/physics/scene ownership into
+  a renderer that should consume values and typed work.
+- **Synchronous GPU destruction on scene unload**: Releasing a logical handle does
+  not prove frames in flight have completed; waits also stall ordinary frames.
+- **Dummy headless gameplay or unconditional GPU-to-CPU fallback**: Changes behavior
+  or admits unaffordable work without an authored compatible substitute.
+- **Implicit pool growth, old-entry overwrite or silent required-event loss**: Breaks
+  bounded capacity, reproducibility and observable admission failure.
+- **Per-call backend branching or a proprietary VFX shading stack**: Duplicates
+  capability policy and the standard material/render pipeline.

--- a/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
+++ b/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
@@ -1,0 +1,235 @@
+# ADR-011: Effect Ownership, Simulation Domain Policy and Renderer Boundary
+
+- **Status**: Proposed
+- **Date**: 2026-08-28
+- **Supersedes**: None
+- **Scope**: Runtime VFX subsystem ownership, simulation domain selection policy, platform fallback matrix, render extraction boundary, pass placement and sorting
+- **Issue**: [#1749](https://github.com/abdullahbodur/horo-engine/issues/1749) ([VFX-001.1])
+- **Normative document**: [VFX And Particles Architecture](../architecture/runtime/vfx-and-particles-architecture.md)
+
+## Context
+
+Visual effects (particle systems, ribbon emitters, mesh particles, decals, and volumetric effects) span gameplay simulation, physics interaction, compute dispatching, and graphics presentation. Without explicit architectural boundaries, effects tend to introduce severe architectural debt:
+1. **Immediate-mode rendering anti-patterns**: Gameplay or effect scripts issuing immediate-mode draw calls directly into graphics contexts, breaking render graph scheduling, pass reordering, and multi-threaded rendering.
+2. **Ambiguous subsystem ownership**: Effects persisting across scene transitions or living in global singletons, leading to memory leaks, dangling scene references, and non-deterministic state.
+3. **Ad hoc simulation domains**: Simulation code branching dynamically on loose flags at call sites, making CPU versus GPU particle behavior non-reproducible and error-prone across hardware tiers.
+4. **Backend-leaking abstractions**: Exposing native GPU buffer handles or API-specific compute shaders directly to gameplay and scene systems.
+
+Ticket [#1749](https://github.com/abdullahbodur/horo-engine/issues/1749) ([VFX-001.1]) requires a definitive architecture decision that establishes:
+- The authoritative owner and deterministic lifecycle of `VfxWorld` and its subsystem components.
+- A policy-driven, reproducible simulation domain selection model with explicit hardware/platform fallback matrices.
+- A backend-neutral render-extraction contract that integrates with the standard material and Render Graph pass system.
+
+## Decision
+
+**`VfxWorld` is owned exclusively by the active `SceneRuntime`, initialized at scene startup, ticked during the scene simulation phase, and deterministically reset/destroyed on scene unload or replacement. Simulation domain selection (CPU vs. GPU compute) is policy-driven, asset-defined, and feature-tier constrained. Visual effects never use immediate-mode rendering; `VfxWorld` extracts typed, backend-neutral render primitives (`VfxRenderBatch`, `ParticleBufferView`, `DynamicInstanceTransform`) during the Render Extraction phase for submission to standard Render Graph passes.**
+
+### Ratify-or-revise outcomes
+
+| Area | Prior / Baseline State | Outcome |
+|---|---|---|
+| **VFX World Ownership** | Loosely placed under Scene Runtime | **Ratified and Formalized.** `VfxWorld` is strictly owned by `SceneRuntime`. Its lifetime is bounded exactly by the scene lifecycle. |
+| **Lifecycle & Teardown** | Implicit teardown on scene change | **Ratified.** Reset and teardown are deterministic; pools, queues, and compute allocations are reclaimed synchronously on scene replacement. |
+| **Simulation Domain** | Ad hoc CPU/GPU distinction | **Revised to Policy-Driven.** Domain is determined by asset descriptor rules, gameplay coupling requirements, and platform feature tiers with deterministic fallback. |
+| **Headless / Null Simulation** | Undefined headless behavior | **Formalized.** Headless and test environments use deterministic, allocation-free `NullParticleSimulator` / CPU simulation without GPU dependencies. |
+| **Renderer Boundary** | Conceptually separated | **Ratified and Strictly Enforced.** Zero immediate-mode rendering. `VfxRenderExtractor` emits immutable backend-neutral render batches during the Render Extraction phase. |
+| **Material & Shader Pipeline** | Mixed custom/standard shader models | **Ratified.** Particles and decals use the standard PBR and unlit material model compiled via the shared shader pipeline. |
+| **Sorting & Transparency** | Described in high-level terms | **Formalized.** Camera-relative distance sorting is CPU-radix for CPU systems and GPU bitonic/radix compute for GPU systems; additive particles skip sorting. |
+
+---
+
+### Authoritative Ownership & Component Breakdown
+
+Every component within the runtime effects ecosystem has a single, unambiguous owner:
+
+```text
+SceneRuntime
+  └── VfxWorld
+        ├── EffectSystem
+        ├── CpuParticleSimulator
+        ├── GpuParticleSimulator
+        ├── NullParticleSimulator
+        ├── DecalManager
+        ├── EffectInstancePool
+        ├── VfxEventQueue
+        └── VfxRenderExtractor
+```
+
+| Component | Owner | Responsibility |
+|---|---|---|
+| `SceneRuntime` | Application / Host | Owns `VfxWorld` as a major scene subsystem. Controls creation, fixed/variable simulation ticking, and destruction. |
+| `VfxWorld` | `SceneRuntime` | Subsystem composition root. Coordinates simulators, decal manager, instance pools, event queues, and render extraction. |
+| `EffectSystem` | `VfxWorld` | Manages effect instance life cycles, template instantiation, parameter bindings, and spatial hierarchy tracking. |
+| `CpuParticleSimulator` | `VfxWorld` | Flat Structure-of-Arrays (SoA) SIMD-accelerated particle updater for gameplay-interactive, collision-coupled, or CPU-bound effects. |
+| `GpuParticleSimulator` | `VfxWorld` | Manages compute dispatch generation, indirect draw arguments, and compute buffer references for high-density particle volumes. |
+| `NullParticleSimulator` | `VfxWorld` | Deterministic, allocation-free simulation path for headless testing, CI, and server execution where GPU rendering is disabled. |
+| `DecalManager` | `VfxWorld` | Manages active decal projection volumes, fading envelopes, dynamic bounds, and decal atlas allocations. |
+| `EffectInstancePool` | `VfxWorld` | Preallocated memory pools for particle buffers, emitter states, and effect instances to guarantee zero frame-time allocations. |
+| `VfxEventQueue` | `VfxWorld` | Bounded FIFO queue capturing gameplay and animation spawn events (e.g., footsteps, impacts, explosions). |
+| `VfxRenderExtractor` | `VfxWorld` | Extracts immutable, backend-neutral render primitives (`VfxRenderBatch`) and submits them to the Render Graph during extraction. |
+
+#### Lifecycle and Scene Transition Rules
+
+1. **Initialization**: `VfxWorld` is instantiated when `SceneRuntime` activates. Preallocated instance and particle buffer pools are established according to scene/project quality configurations.
+2. **Simulation Phase**: `VfxWorld::Update(DeltaTime)` executes within the scene simulation loop:
+   - Processes all queued `VfxEventQueue` events.
+   - Updates CPU particle systems and decal timers.
+   - Encodes GPU compute simulation dispatches for compute-backed systems.
+3. **Extraction Phase**: `VfxWorld::ExtractRenderData(RenderWorldSnapshot&, const SceneView&)` is called strictly during the Render Extraction phase. No simulation state is mutated during extraction.
+4. **Teardown & Scene Replacement**: When a scene is unloaded or replaced:
+   - All active effect instances, emitters, and decals are stopped immediately.
+   - All pooled buffers, GPU compute resources, and event queues are deterministically reset/released.
+   - No effect instance, GPU handle, or callback reference may leak into the replacement scene or host runtime.
+
+---
+
+### Simulation Domain Selection Policy and Fallback Matrix
+
+Domain selection is **policy-driven, asset-declared, and feature-tier constrained**. Individual gameplay call sites cannot arbitrarily override simulation rules via raw backend branching.
+
+#### Domain Selection Criteria
+
+1. **`SimulationDomain::CPU`** is mandatory when:
+   - Particles require two-way gameplay interaction (e.g., triggering game logic, modifying gameplay physics bodies, collecting pickup items).
+   - High-precision CPU raycast/geometry collision response is required.
+   - System particle count is low-to-medium (≤ 2,048 particles).
+   - Running on low-spec hardware tiers (e.g., `es3`) or in headless/null environments.
+2. **`SimulationDomain::GPU`** is selected when:
+   - System particle count is high (2,048 to 1,000,000+ particles).
+   - Complex vector fields, curl noise, or GPU depth-buffer collisions are utilized.
+   - Effects are purely cosmetic (visual-only, no synchronous gameplay CPU readback).
+3. **`SimulationDomain::Automatic`** (Asset Default):
+   - Resolved at asset cook/load time. High-count visual-only systems select GPU compute when supported by the active feature tier; otherwise, they degrade to CPU simulation.
+
+#### Coexistence Rules
+
+- CPU and GPU particle systems can coexist seamlessly within the same scene and within the same composite VFX graph asset.
+- Synchronization is governed by shared scene simulation time and camera transforms.
+- CPU particles write to CPU-mapped dynamic vertex/instance buffers. GPU particles simulate in GPU compute buffers and emit indirect draw calls.
+
+#### Platform & Feature Tier Fallback Matrix
+
+| Feature Tier / Platform | Primary Domain | GPU Compute Particles | GPU Radix / Bitonic Sort | Volumetrics & Curl Noise | Fallback Behavior |
+|---|---|---|---|---|---|
+| **Headless / Null** (`null`) | `CPU` (Null Simulator) | Disabled | Disabled | Disabled | Full deterministic CPU dummy simulation; no GPU allocations or draw dispatches. |
+| **Mobile / Low-Spec** (`es3`) | `CPU` | Disabled | Disabled | Disabled | GPU particle assets automatically fall back to CPU simulation with clamped particle caps (e.g., max 512). Complex noise disabled. |
+| **Desktop Baseline** (`dx11` / `opengl4`) | `CPU` & `GPU` | Supported (Compute) | Supported (Bitonic) | Basic 3D Textures | Over-budget GPU systems throttle spawn rates or drop lowest-priority sub-emitters. |
+| **High-End Desktop / Console** (`dx12_vulkan` / `metal`) | `CPU` & `GPU` | Full Compute | Full Radix/Bitonic | Full Curl Noise & Vector Fields | Unrestricted simulation with GPU indirect draw and GPU culling. |
+
+---
+
+### Renderer Boundary and Render Extraction Contract
+
+Visual effects adhere strictly to Horo Engine's decoupled rendering architecture. **VFX code is strictly prohibited from invoking immediate-mode draw calls or holding backend graphics contexts.**
+
+#### Render Extraction Pipeline
+
+```text
+  [ VfxWorld (Scene Simulation) ]
+                 │
+                 ▼
+  [ VfxRenderExtractor ]  (ExtractRenderData phase)
+                 │
+                 ├─► VfxRenderBatch (Translucent Billboard / Ribbon / Mesh)
+                 ├─► VfxRenderBatch (Opaque / Masked Mesh Particles)
+                 ├─► DecalRenderBatch (Deferred / Clustered Decals)
+                 └─► ParticleBufferView & DynamicInstanceTransforms
+                 │
+                 ▼
+  [ Render Graph Execution ]
+         ├── G-Buffer / Depth Pre-Pass (Opaque Mesh Particles)
+         ├── Decal Pass (Projected Decals)
+         ├── Forward / Translucent Pass (Sorted Particles & Ribbons)
+         └── Volumetric Accumulation Pass
+```
+
+#### Typed Render Primitives
+
+```cpp
+enum class VfxPassKind : uint8_t {
+    OpaqueMesh,
+    MaskedMesh,
+    TranslucentForward,
+    AdditiveForward,
+    DeferredDecal,
+    ForwardDecal,
+    VolumetricAccumulation
+};
+
+enum class VfxPrimitiveTopology : uint8_t {
+    CameraFacingBillboard,
+    RibbonStrip,
+    InstancedMesh,
+    DecalBox
+};
+
+struct ParticleBufferView {
+    BufferHandle bufferHandle;
+    uint32_t byteOffset;
+    uint32_t particleCount;
+    uint32_t stride;
+};
+
+struct VfxRenderBatch {
+    VfxPassKind passKind;
+    VfxPrimitiveTopology topology;
+    MaterialId material;
+    MeshHandle mesh;                      // Valid for InstancedMesh
+    ParticleBufferView instanceData;      // Position, size, rotation, color, UV
+    BufferHandle indirectArgsBuffer;       // Optional, for GPU indirect draw
+    uint32_t indirectArgsOffset;
+    AABB worldBounds;
+    float sortDistance;                   // Key for translucent back-to-front sorting
+    bool isCastShadowEnabled;
+};
+```
+
+---
+
+### Pass Placement, Material Pipeline, and Sorting
+
+1. **Standard Material Pipeline Integration**:
+   - Particle and decal shaders are authored and compiled via the engine's standard material system (refer to [Material And Shader Model](./material-and-shader-model.md)).
+   - Shading models supported: `Unlit`, `DefaultPBR` (lit particles/mesh particles), and `DecalEmissive`/`DecalPBR`.
+   - Blend modes: `Opaque`, `Masked`, `Translucent` (alpha blend), and `Additive`.
+   - Soft particles: Translucent particle shaders consume the scene depth buffer texture to evaluate soft-intersection depth fading.
+
+2. **Pass Placement**:
+   - **Opaque / Masked Mesh Particles**: Inserted into the standard G-Buffer (deferred) or Depth Pre-Pass / Opaque Forward pass. Writes depth.
+   - **Deferred Decals**: Rendered into the G-Buffer during the decal pass (modifying Albedo, Roughness/Metallic, and Normal attachments).
+   - **Forward Decals**: Rendered in the forward lighting pass for forward-only tiers.
+   - **Translucent Particles & Ribbons**: Inserted into the Translucent Forward Pass. Depth-tested against scene depth, no depth write.
+   - **Additive Particles**: Inserted into the Additive Forward Pass. Depth-tested, no depth write, order-independent.
+
+3. **Sorting Policy**:
+   - **Translucent Systems**: Sorted back-to-front relative to the active camera.
+     - **CPU Simulated**: Sorted on the CPU using multi-threaded radix sort over camera distance keys before writing into the extraction buffer.
+     - **GPU Simulated**: Sorted via GPU bitonic or radix sort compute kernels prior to indirect dispatch.
+   - **Additive Systems**: Sorting is skipped entirely, eliminating sorting overhead for additive glows and sparks.
+   - **Opaque Systems**: Sorted front-to-back by the Render Frontend alongside standard static/dynamic scene meshes to maximize early-Z rejection.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Architectural Purity**: Elimination of immediate-mode draw calls guarantees compatibility with multi-threaded rendering and future render graphs.
+- **Backend Neutrality**: `VfxWorld` operates with zero knowledge of concrete graphics APIs (Vulkan, Metal, OpenGL, D3D12, Null).
+- **Deterministic Lifecycles**: Subsystem ownership by `SceneRuntime` guarantees clean teardown, eliminating cross-scene leaks.
+- **Predictable Performance**: Memory pooling guarantees zero heap allocations during steady-state gameplay updates and particle spawning.
+- **Cross-Platform Scalability**: Explicit feature tier matrices allow high-end platforms to utilize massive compute particle simulations while ensuring graceful degradation to CPU simulation on lower tiers and headless servers.
+
+### Negative / Tradeoffs
+
+- Render extraction introduces a lightweight data-packing step to format instance buffers into backend-neutral views.
+- GPU particle simulation requires compute shader support; platforms lacking compute capability must adhere to CPU particle budget limits.
+
+---
+
+## Rejected Alternatives
+
+- **Immediate-Mode Rendering from Gameplay / Effect Components**: Rejected because it violates pass ordering, prevents multi-threaded extraction, breaks render graph compilation, and couples gameplay code to the active graphics backend.
+- **Renderer-Owned VFX Systems**: Rejected because particle simulation requires access to scene transforms, gameplay physics, and spatial queries. The renderer must remain a consumer of immutable snapshots.
+- **Ad Hoc Per-Emitter Backend / Domain Switching**: Rejected because call-site branching produces non-reproducible visual artifacts, race conditions, and unmaintainable platform code.
+- **Dedicated Proprietary Particle Shading System**: Rejected in favor of the standard PBR / unlit material pipeline to ensure consistent lighting, shadows, and asset pipeline integration across the engine.

--- a/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
+++ b/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
@@ -10,12 +10,14 @@
 ## Context
 
 Visual effects (particle systems, ribbon emitters, mesh particles, decals, and volumetric effects) span gameplay simulation, physics interaction, compute dispatching, and graphics presentation. Without explicit architectural boundaries, effects tend to introduce severe architectural debt:
+
 1. **Immediate-mode rendering anti-patterns**: Gameplay or effect scripts issuing immediate-mode draw calls directly into graphics contexts, breaking render graph scheduling, pass reordering, and multi-threaded rendering.
 2. **Ambiguous subsystem ownership**: Effects persisting across scene transitions or living in global singletons, leading to memory leaks, dangling scene references, and non-deterministic state.
 3. **Ad hoc simulation domains**: Simulation code branching dynamically on loose flags at call sites, making CPU versus GPU particle behavior non-reproducible and error-prone across hardware tiers.
 4. **Backend-leaking abstractions**: Exposing native GPU buffer handles or API-specific compute shaders directly to gameplay and scene systems.
 
 Ticket [#1749](https://github.com/abdullahbodur/horo-engine/issues/1749) ([VFX-001.1]) requires a definitive architecture decision that establishes:
+
 - The authoritative owner and deterministic lifecycle of `VfxWorld` and its subsystem components.
 - A policy-driven, reproducible simulation domain selection model with explicit hardware/platform fallback matrices.
 - A backend-neutral render-extraction contract that integrates with the standard material and Render Graph pass system.

--- a/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
+++ b/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
@@ -95,7 +95,7 @@ Domain selection is **policy-driven, asset-declared, and feature-tier constraine
    - System particle count is low-to-medium (≤ 2,048 particles).
    - Running on low-spec hardware tiers (e.g., `es3`) or in headless/null environments.
 2. **`SimulationDomain::GPU`** is selected when:
-   - System particle count is high (2,048 to 1,000,000+ particles).
+   - System particle count is high (> 2,048 particles).
    - Complex vector fields, curl noise, or GPU depth-buffer collisions are utilized.
    - Effects are purely cosmetic (visual-only, no synchronous gameplay CPU readback).
 3. **`SimulationDomain::Automatic`** (Asset Default):

--- a/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
+++ b/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
@@ -5,6 +5,7 @@
 - **Supersedes**: None
 - **Scope**: Runtime VFX subsystem ownership, simulation domain selection policy, platform fallback matrix, render extraction boundary, pass placement and sorting
 - **Issue**: [#1749](https://github.com/abdullahbodur/horo-engine/issues/1749) ([VFX-001.1])
+- **JIRA**: HORO-1706
 - **Normative document**: [VFX And Particles Architecture](../architecture/runtime/vfx-and-particles-architecture.md)
 
 ## Context

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
+| [011](011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md) | Effect Ownership, Simulation Domain Policy and Renderer Boundary | proposed | 2026-08-28 |
 | [012](012-world-streaming-partition-authority-and-subsystem-boundaries.md) | World Streaming Partition Authority and Subsystem Boundaries | proposed | 2026-08-28 |
 | [013](013-environment-query-ownership-item-and-scoring-model.md) | Environment Query Ownership, Item and Scoring Model | proposed | 2026-08-28 |
 | [014](014-sequencer-ownership-clock-authority-and-binding-boundary.md) | Sequencer Ownership, Clock Authority and Binding Boundary | proposed | 2026-08-28 |

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -450,6 +450,16 @@ component pools, editor widgets, or backend objects.
 Multiple views, including game, scene viewport, thumbnails, and previews, use
 separate `RenderView` descriptors over compatible snapshots.
 
+The [VFX contract](./vfx-and-particles-architecture.md) extends the snapshot with
+bounded immutable GPU simulation work, CPU/GPU particle sources, decals and volume
+batches. VfxRenderExtractor never submits graph passes or writes mapped GPU buffers.
+RenderFrontend admits/uploads CPU frame slices, schedules VFX Compute once per
+scene/emitter step, then per-view Sort/Cull and dependent rendering passes. Multiple
+views or reusing a snapshot cannot advance the same simulation step twice. Native
+encoding, graph resource barriers and fence-based deferred retirement remain renderer
+responsibilities. Retained snapshot and GPU leases may outlive logical scene teardown
+but cannot reference destroyed scene storage or publish into a new incarnation.
+
 ## XR Views And External Presentation Targets
 
 XR supplies a bounded runtime-driven set of view descriptors and

--- a/docs/architecture/runtime/vfx-and-particles-architecture.md
+++ b/docs/architecture/runtime/vfx-and-particles-architecture.md
@@ -134,7 +134,7 @@ enum class SimulationDomain : uint8_t {
    - System particle count is low-to-medium (≤ 2,048 particles).
    - Running on low-spec hardware tiers (e.g., `es3`) or in headless/null environments.
 2. **`SimulationDomain::GPU`** is selected when:
-   - System particle count is high (2,048 to 1,000,000+ particles).
+   - System particle count is high (> 2,048 particles).
    - Complex vector fields, curl noise, or GPU depth-buffer collisions are utilized.
    - Effects are purely cosmetic (visual-only, no synchronous gameplay CPU readback).
 3. **`SimulationDomain::Automatic`** (Asset Default):

--- a/docs/architecture/runtime/vfx-and-particles-architecture.md
+++ b/docs/architecture/runtime/vfx-and-particles-architecture.md
@@ -127,19 +127,31 @@ enum class SimulationDomain : uint8_t {
 
 ### Domain Selection Criteria
 
+Domain resolution applies constraints in the following order. A CPU-mandatory
+criterion always takes precedence over an explicit or automatically selected GPU
+domain, including for systems above the particle-count threshold.
+
 1. **`SimulationDomain::CPU`** is mandatory when:
    - Particles require two-way gameplay interaction (e.g., triggering game logic,
      modifying gameplay physics bodies, collecting pickup items).
    - High-precision CPU raycast or complex geometry collision response is required.
-   - System particle count is low-to-medium (≤ 2,048 particles).
    - Running on low-spec hardware tiers (e.g., `es3`) or in headless/null environments.
-2. **`SimulationDomain::GPU`** is selected when:
-   - System particle count is high (> 2,048 particles).
-   - Complex vector fields, curl noise, or GPU depth-buffer collisions are utilized.
-   - Effects are purely cosmetic (visual-only, no synchronous gameplay CPU readback).
-3. **`SimulationDomain::Automatic`** (Asset Default):
-   - Resolved at asset cook/load time. High-count visual-only systems select GPU compute
-     when supported by the active feature tier; otherwise, they degrade to CPU simulation.
+2. **Explicit domain requests** are considered after mandatory constraints:
+   - Explicit `CPU` remains on CPU, subject to the active tier's capacity budget.
+   - Explicit `GPU` is valid only for visual-only effects on a GPU-compute-capable
+     tier. Otherwise, resolution falls back deterministically to CPU and records a
+     typed cook/load diagnostic.
+3. **`SimulationDomain::Automatic`** (Asset Default) uses the particle-count heuristic:
+   - Visual-only systems with `maxParticles > 2,048` select GPU when the active tier
+     supports GPU compute.
+   - Systems with `maxParticles <= 2,048`, or systems on tiers without GPU compute,
+     select CPU.
+   - Complex vector fields, curl noise, or GPU depth-buffer collision may prefer GPU
+     only after the CPU-mandatory checks above pass.
+
+The `2,048` value is a domain-selection heuristic, not a universal capacity
+limit. Feature-tier capacity limits are applied after domain resolution and may
+clamp a system below this threshold.
 
 ### Coexistence and Synchronization Rules
 
@@ -156,7 +168,7 @@ enum class SimulationDomain : uint8_t {
 | Feature Tier / Platform | Primary Domain | GPU Compute Particles | GPU Radix / Bitonic Sort | Volumetrics & Curl Noise | Fallback Behavior |
 |---|---|---|---|---|---|
 | **Headless / Null** (`null`) | `CPU` (Null Simulator) | Disabled | Disabled | Disabled | Full deterministic CPU dummy simulation; no GPU allocations or draw dispatches. |
-| **Mobile / Low-Spec** (`es3`) | `CPU` | Disabled | Disabled | Disabled | GPU particle assets automatically fall back to CPU simulation with clamped particle caps (e.g., max 512). Complex noise disabled. |
+| **Mobile / Low-Spec** (`es3`) | `CPU` | Disabled | Disabled | Disabled | GPU requests fall back to CPU. The tier clamps each system to its configured CPU cap (`512` by default), overriding the general `2,048` domain heuristic. Complex noise is disabled. |
 | **Desktop Baseline** (`dx11` / `opengl4`) | `CPU` & `GPU` | Supported (Compute) | Supported (Bitonic) | Basic 3D Textures | Over-budget GPU systems throttle spawn rates or drop lowest-priority sub-emitters. |
 | **High-End Desktop / Console** (`dx12_vulkan` / `metal`) | `CPU` & `GPU` | Full Compute | Full Radix/Bitonic | Full Curl Noise & Vector Fields | Unrestricted simulation with GPU indirect draw and GPU culling. |
 
@@ -438,7 +450,9 @@ and emit structured diagnostics according to the observability system.
 - **Ownership & Lifecycle Tests**: Verify `VfxWorld` construction, tick, and complete
   destruction on `SceneRuntime` unload without leaking memory or GPU handles.
 - **Domain Selection Policy Tests**: Verify deterministic domain resolution across
-  all feature tiers (`null`, `es3`, `dx11`, `dx12_vulkan`, `metal`).
+  all feature tiers (`null`, `es3`, `dx11`, `dx12_vulkan`, `metal`), including a
+  gameplay-interactive system above 2,048 particles, both sides of the Automatic
+  threshold, and the `es3` tier-cap override.
 - **Null / Headless Simulation Tests**: Verify `NullParticleSimulator` produces
   deterministic, zero-graphics simulation ticks in headless test environments.
 - **Render Extraction Tests**: Verify `VfxRenderExtractor` emits valid, typed

--- a/docs/architecture/runtime/vfx-and-particles-architecture.md
+++ b/docs/architecture/runtime/vfx-and-particles-architecture.md
@@ -202,7 +202,7 @@ transaction with peak old/new memory admitted; old readers/fences must retire be
 reuse. Zero steady-state heap allocation is a requirement to verify for these paths,
 not an unlimited-capacity or measured performance claim.
 
-TryEnqueueSpawn returns Result<VfxRequestId> and copies a bounded typed parameter
+TryEnqueueSpawn returns `Result<VfxRequestId>` and copies a bounded typed parameter
 block, never an arbitrary heap-allocating VariantMap. The scene owner serializes
 accepted requests; external producers submit typed commands through declared owner
 seams. Authoritative producers have stable tick/producer/sequence ordering before

--- a/docs/architecture/runtime/vfx-and-particles-architecture.md
+++ b/docs/architecture/runtime/vfx-and-particles-architecture.md
@@ -3,68 +3,278 @@
 ## Purpose
 
 This document defines Horo Engine's visual effects runtime: particle systems,
-decals, GPU particles, VFX graphs, and volumetric effects. It specifies how
-effects are authored, simulated, rendered, and integrated with gameplay, audio,
-and the render graph.
+ribbons, mesh particles, decals, GPU compute particles, VFX graphs, and
+volumetric effects. It specifies how effects are authored, simulated, rendered,
+and integrated with scene lifecycles, gameplay, audio, and the render graph.
 
-The goal is to provide a scalable effects architecture that supports everything
-from simple one-shot bursts to large GPU-driven environmental effects, without
-forcing the renderer to treat every effect as a special case.
+The goal is to provide a scalable, deterministic, and modular visual effects
+architecture that supports everything from simple one-shot gameplay bursts to
+large GPU-driven environmental volumes, without allowing immediate-mode rendering
+leaks or coupling scene simulation to concrete graphics backends.
 
 ## Scope
 
 Covered:
 
-- particle system data model and components
-- CPU and GPU simulation paths
-- VFX graph authoring and runtime evaluation
-- decal projection and lifetime
-- effect instancing, pooling, and culling
-- sorting and transparency
-- event-driven spawning
-- integration with scene runtime, render graph, audio, and gameplay
+- runtime subsystem ownership, component hierarchy, and deterministic lifecycle
+- simulation domain selection policy (CPU, GPU Compute, Headless/Null)
+- platform and feature tier fallback matrix
+- decoupled renderer boundary and typed render extraction contracts
+- pass placement, standard material pipeline integration, and camera-relative sorting
+- particle system data model and emitter stages
+- VFX graph asset compilation and runtime evaluation
+- decal projection, lifetime, and atlas management
+- event-driven spawning, pooling, and audio routing
+- performance budgets, diagnostics, and regression test requirements
 
 Not covered:
 
-- specific DCC tools or texture authoring
-- fluid simulation (future document; not currently in scope)
-- full atmospheric scattering model (only the VFX boundary is covered here; see
+- DCC tools and texture authoring workflows
+- full fluid dynamics / Navier-Stokes solvers (future subsystem)
+- atmospheric scattering and sky atmosphere simulation (see
   [Advanced Rendering Architecture](./advanced-rendering-architecture.md))
-- post-processing effects (see [Advanced Rendering Architecture](./advanced-rendering-architecture.md))
+- screen-space post-processing effects (see
+  [Advanced Rendering Architecture](./advanced-rendering-architecture.md))
 
 ## Core Decisions
 
-- Effects are runtime objects owned by the scene runtime, not by the renderer.
-- Particle simulation may run on CPU or GPU depending on complexity, platform,
-  and feature tier.
-- VFX graphs are authored assets that compile into a runtime effect descriptor.
-  They are not interpreted per particle.
-- Decals are first-class scene objects with a defined projection volume and
-  lifetime.
-- Effects use the same material and render pass system as meshes; no hidden
-  immediate-mode rendering from gameplay code.
-- Particle spawn is event-driven or continuous. Gameplay fires events; the VFX
-  system decides how to translate them into spawned instances.
-- Effects are pooled. Allocation during gameplay should be avoided except during
-  initial load.
+- **Subsystem Ownership**: `VfxWorld` is owned strictly by the active `SceneRuntime`.
+  It is initialized at scene startup and torn down/reset deterministically on scene
+  replacement or unload. No effect instances or GPU resources outlive their scene.
+- **Zero Immediate-Mode Rendering**: Effects are strictly prohibited from issuing
+  immediate-mode draw calls or touching graphics contexts directly. `VfxWorld`
+  extracts backend-neutral render primitives during the Render Extraction phase.
+- **Policy-Driven Simulation Domain**: Particle simulation domain (CPU vs. GPU Compute)
+  is determined by asset configuration, gameplay interaction requirements, and active
+  hardware feature tiers. Call-site ad hoc branching is forbidden.
+- **Deterministic Headless Execution**: Headless servers and CI test suites use
+  `NullParticleSimulator` / deterministic CPU simulation without GPU allocations or
+  graphics dependencies.
+- **Standard Material & Pass Integration**: Particles and decals use the standard
+  PBR and unlit material model compiled via the shared material pipeline, executing
+  in standard Render Graph passes (G-Buffer, Decal, Translucent Forward, Additive).
+- **Camera-Relative Sorting**: Translucent particles are sorted back-to-front
+  (CPU radix sort for CPU particles, GPU bitonic/radix compute for GPU particles);
+  additive particles skip sorting.
+- **Zero Allocation Steady State**: All particle buffers, emitter states, and effect
+  instances are preallocated in pools during scene initialization, guaranteeing zero
+  heap allocations during active gameplay.
 
-## Effect System Ownership
+## Subsystem Ownership and Lifecycle
 
 ```text
-Scene Runtime
-  +-- VfxWorld
-      +-- EffectSystem
-      +-- ParticleSimulators (CPU and GPU)
-      +-- DecalManager
-      +-- EffectInstancePool
-      +-- VfxEventQueue
-      +-- VfxRenderExtractor
+SceneRuntime
+  └── VfxWorld
+        ├── EffectSystem
+        ├── CpuParticleSimulator
+        ├── GpuParticleSimulator
+        ├── NullParticleSimulator
+        ├── DecalManager
+        ├── EffectInstancePool
+        ├── VfxEventQueue
+        └── VfxRenderExtractor
 ```
 
-`VfxWorld` is owned by the active scene runtime. It lives across gameplay frames
-and communicates with the renderer through extracted render instances.
+### Component Breakdown
 
-## Particle System
+Every component within the runtime effects ecosystem has a single, unambiguous owner:
+
+| Component | Owner | Responsibility |
+|---|---|---|
+| `SceneRuntime` | Application / Host | Owns `VfxWorld` as a major scene subsystem. Controls creation, fixed/variable simulation ticking, and destruction. |
+| `VfxWorld` | `SceneRuntime` | Subsystem composition root. Coordinates simulators, decal manager, instance pools, event queues, and render extraction. |
+| `EffectSystem` | `VfxWorld` | Manages effect instance life cycles, template instantiation, parameter bindings, and spatial hierarchy tracking. |
+| `CpuParticleSimulator` | `VfxWorld` | Flat Structure-of-Arrays (SoA) SIMD-accelerated particle updater for gameplay-interactive, collision-coupled, or CPU-bound effects. |
+| `GpuParticleSimulator` | `VfxWorld` | Manages compute dispatch generation, indirect draw arguments, and compute buffer references for high-density particle volumes. |
+| `NullParticleSimulator` | `VfxWorld` | Deterministic, allocation-free simulation path for headless testing, CI, and server execution where GPU rendering is disabled. |
+| `DecalManager` | `VfxWorld` | Manages active decal projection volumes, fading envelopes, dynamic bounds, and decal atlas allocations. |
+| `EffectInstancePool` | `VfxWorld` | Preallocated memory pools for particle buffers, emitter states, and effect instances to guarantee zero frame-time allocations. |
+| `VfxEventQueue` | `VfxWorld` | Bounded FIFO queue capturing gameplay and animation spawn events (e.g., footsteps, impacts, explosions). |
+| `VfxRenderExtractor` | `VfxWorld` | Extracts immutable, backend-neutral render primitives (`VfxRenderBatch`) and submits them to the Render Graph during extraction. |
+
+### Lifecycle and Scene Transition Invariants
+
+1. **Initialization**: `VfxWorld` is instantiated synchronously when `SceneRuntime`
+   activates. Buffer pools, emitter slots, and decal capacities are allocated based on
+   the active project and feature tier settings.
+2. **Simulation Phase (`Update`)**: `VfxWorld::Update(DeltaTime)` executes within
+   the scene simulation loop:
+   - Drains and processes pending spawn requests from `VfxEventQueue`.
+   - Advances active CPU particle systems and updates decal lifetimes.
+   - Generates GPU compute simulation dispatches for compute-backed systems.
+3. **Extraction Phase (`ExtractRenderData`)**: Called by the renderer frontend
+   strictly during the Render Extraction phase. Generates immutable snapshots of
+   visible particle batches, decal volumes, and instance transforms. Simulation
+   state is never modified during this phase.
+4. **Teardown & Scene Replacement**: When a scene is unloaded or replaced:
+   - All active effect instances, emitters, and decals are stopped immediately.
+   - All pooled CPU buffers and GPU compute buffers are deterministically reset or released.
+   - No effect instance, GPU handle, or callback reference may leak across the scene boundary.
+
+## Simulation Domain Selection Policy
+
+Domain selection is **policy-driven, asset-declared, and feature-tier constrained**.
+Individual gameplay call sites cannot arbitrarily override simulation rules via raw
+backend branching.
+
+```cpp
+enum class SimulationDomain : uint8_t {
+    Automatic,  ///< Resolved at cook/load time based on emitter parameters and tier
+    CPU,        ///< Guaranteed CPU execution; supports gameplay queries and collisions
+    GPU         ///< GPU compute execution; visual-only high-density particle simulation
+};
+```
+
+### Domain Selection Criteria
+
+1. **`SimulationDomain::CPU`** is mandatory when:
+   - Particles require two-way gameplay interaction (e.g., triggering game logic,
+     modifying gameplay physics bodies, collecting pickup items).
+   - High-precision CPU raycast or complex geometry collision response is required.
+   - System particle count is low-to-medium (≤ 2,048 particles).
+   - Running on low-spec hardware tiers (e.g., `es3`) or in headless/null environments.
+2. **`SimulationDomain::GPU`** is selected when:
+   - System particle count is high (2,048 to 1,000,000+ particles).
+   - Complex vector fields, curl noise, or GPU depth-buffer collisions are utilized.
+   - Effects are purely cosmetic (visual-only, no synchronous gameplay CPU readback).
+3. **`SimulationDomain::Automatic`** (Asset Default):
+   - Resolved at asset cook/load time. High-count visual-only systems select GPU compute
+     when supported by the active feature tier; otherwise, they degrade to CPU simulation.
+
+### Coexistence and Synchronization Rules
+
+- CPU and GPU particle systems can coexist seamlessly within the same scene and within
+  the same composite VFX graph asset.
+- Synchronization is governed by shared scene simulation time and camera transforms.
+- CPU particles write to CPU-mapped dynamic vertex/instance buffers. GPU particles simulate
+  in GPU compute buffers and emit indirect draw calls.
+- Readback from GPU particles to CPU is prohibited in standard frame loops; gameplay
+  requiring particle positional data must use CPU simulation.
+
+### Platform & Feature Tier Fallback Matrix
+
+| Feature Tier / Platform | Primary Domain | GPU Compute Particles | GPU Radix / Bitonic Sort | Volumetrics & Curl Noise | Fallback Behavior |
+|---|---|---|---|---|---|
+| **Headless / Null** (`null`) | `CPU` (Null Simulator) | Disabled | Disabled | Disabled | Full deterministic CPU dummy simulation; no GPU allocations or draw dispatches. |
+| **Mobile / Low-Spec** (`es3`) | `CPU` | Disabled | Disabled | Disabled | GPU particle assets automatically fall back to CPU simulation with clamped particle caps (e.g., max 512). Complex noise disabled. |
+| **Desktop Baseline** (`dx11` / `opengl4`) | `CPU` & `GPU` | Supported (Compute) | Supported (Bitonic) | Basic 3D Textures | Over-budget GPU systems throttle spawn rates or drop lowest-priority sub-emitters. |
+| **High-End Desktop / Console** (`dx12_vulkan` / `metal`) | `CPU` & `GPU` | Full Compute | Full Radix/Bitonic | Full Curl Noise & Vector Fields | Unrestricted simulation with GPU indirect draw and GPU culling. |
+
+## Renderer Boundary & Render Extraction Contract
+
+Visual effects adhere strictly to Horo Engine's decoupled rendering architecture.
+**VFX code is strictly prohibited from invoking immediate-mode draw calls or holding
+backend graphics contexts.**
+
+### Extraction Pipeline
+
+```text
+  [ VfxWorld (Scene Simulation) ]
+                 │
+                 ▼
+  [ VfxRenderExtractor ]  (ExtractRenderData phase)
+                 │
+                 ├─► VfxRenderBatch (Translucent Billboard / Ribbon / Mesh)
+                 ├─► VfxRenderBatch (Opaque / Masked Mesh Particles)
+                 ├─► DecalRenderBatch (Deferred / Clustered Decals)
+                 └─► ParticleBufferView & DynamicInstanceTransforms
+                 │
+                 ▼
+  [ Render Graph Execution ]
+         ├── G-Buffer / Depth Pre-Pass (Opaque Mesh Particles)
+         ├── Decal Pass (Projected Decals)
+         ├── Forward / Translucent Pass (Sorted Particles & Ribbons)
+         └── Volumetric Accumulation Pass
+```
+
+### Typed Backend-Neutral Render Primitives
+
+```cpp
+enum class VfxPassKind : uint8_t {
+    OpaqueMesh,
+    MaskedMesh,
+    TranslucentForward,
+    AdditiveForward,
+    DeferredDecal,
+    ForwardDecal,
+    VolumetricAccumulation
+};
+
+enum class VfxPrimitiveTopology : uint8_t {
+    CameraFacingBillboard,
+    RibbonStrip,
+    InstancedMesh,
+    DecalBox
+};
+
+struct ParticleBufferView {
+    BufferHandle bufferHandle;
+    uint32_t byteOffset;
+    uint32_t particleCount;
+    uint32_t stride;
+};
+
+struct VfxRenderBatch {
+    VfxPassKind passKind;
+    VfxPrimitiveTopology topology;
+    MaterialId material;
+    MeshHandle mesh;                      // Valid for InstancedMesh topology
+    ParticleBufferView instanceData;      // Position, size, rotation, color, UV
+    BufferHandle indirectArgsBuffer;       // Optional, for GPU indirect draw dispatches
+    uint32_t indirectArgsOffset;
+    AABB worldBounds;
+    float sortDistance;                   // Key for translucent back-to-front sorting
+    bool isCastShadowEnabled;
+};
+
+struct DecalRenderBatch {
+    MaterialId material;
+    Transform worldTransform;
+    Vec3 halfSize;
+    float fadeFactor;
+    AABB worldBounds;
+};
+```
+
+## Pass Placement, Material Integration, and Sorting
+
+### Material & Shader Pipeline Integration
+
+Particles and decals use the standard material system (see
+[Material And Shader Model](./material-and-shader-model.md)):
+
+- **Shading Models**: `Unlit`, `DefaultPBR` (lit particles/mesh particles), and
+  `DecalPBR` / `DecalEmissive`.
+- **Blend Modes**: `Opaque`, `Masked`, `Translucent` (alpha blend), and `Additive`.
+- **Soft Particles**: Translucent particle shaders consume the scene depth buffer
+  texture to evaluate soft-intersection depth fading against background geometry.
+- **Flipbook Animation**: Packed sub-UV grids animated by normalized particle age.
+
+### Pass Placement
+
+| Primitive Type | Target Pass | Blend Mode | Depth Write | Depth Test |
+|---|---|---|---|---|
+| **Opaque Mesh Particles** | G-Buffer / Opaque Forward | `Opaque` | Yes | Yes |
+| **Masked Mesh Particles** | Depth Pre-Pass + G-Buffer | `Masked` | Yes | Yes |
+| **Deferred Decals** | Decal Pass (G-Buffer) | `Translucent` / `Decal` | No | Yes (Read-Only) |
+| **Forward Decals** | Forward Lighting Pass | `Translucent` | No | Yes (Read-Only) |
+| **Translucent Particles** | Translucent Forward Pass | `Translucent` | No | Yes (Read-Only) |
+| **Additive Particles** | Additive Forward Pass | `Additive` | No | Yes (Read-Only) |
+| **Volumetric VFX** | Volumetric Accumulation Pass | Custom Blend | No | Yes (Read-Only) |
+
+### Camera-Relative Sorting Policy
+
+- **Translucent Systems**: Sorted strictly back-to-front relative to the active camera.
+  - **CPU Simulated**: Sorted on the CPU using multi-threaded radix sort over camera
+    distance keys before writing into the extraction buffer.
+  - **GPU Simulated**: Sorted via GPU bitonic or radix sort compute passes prior to
+    indirect draw submission.
+- **Additive Systems**: Sorting is skipped entirely, eliminating sorting overhead
+  for additive glows, sparks, and energy beams.
+- **Opaque Systems**: Sorted front-to-back by the Render Frontend alongside standard
+  static/dynamic scene meshes to maximize early-Z rejection.
+
+## Particle System Data Model
 
 A particle system is a template that describes how particles are spawned,
 simulated, rendered, and destroyed.
@@ -73,7 +283,7 @@ simulated, rendered, and destroyed.
 struct ParticleSystemDescriptor {
     ParticleSystemId id;
     SimulationDomain domain;      // CPU or GPU
-    MaxParticleCount maxParticles;
+    uint32_t maxParticles;
     EmitterShape shape;
     SpawnRate spawnRate;
     LifetimeRange lifetime;
@@ -81,72 +291,63 @@ struct ParticleSystemDescriptor {
     InitialSizeRange size;
     InitialColorRange color;
     MaterialId material;
-    RenderMode renderMode;        // Billboard, Mesh, Ribbon, Trail
+    VfxPrimitiveTopology renderMode;
     SortMode sortMode;            // None, ByDistance, OldestFirst
     CollisionMode collisionMode;  // None, Planes, SceneDepth, PhysicsWorld
 };
 ```
 
-### Simulation Stages
+### CPU Simulation Layout (Structure of Arrays)
 
-Each particle has:
+To maximize SIMD vectorization and cache locality, CPU particle memory is stored
+as flat arrays:
 
-- position, velocity, acceleration
-- size, rotation, angular velocity
-- color and opacity
-- lifetime and age
-- custom payload (for gameplay-defined modules)
+```cpp
+struct CpuParticleBufferSoA {
+    std::vector<float> posX, posY, posZ;
+    std::vector<float> velX, velY, velZ;
+    std::vector<float> scaleX, scaleY;
+    std::vector<float> rotZ, rotVelZ;
+    std::vector<uint32_t> packedColor;
+    std::vector<float> age, maxAge;
+    std::vector<uint32_t> customFlags;
+    uint32_t activeCount{0};
+    uint32_t capacity{0};
+};
+```
 
-Per-frame stages:
+### GPU Compute Simulation Layout
 
-1. Spawn
-2. Initialize new particles
-3. Apply forces (gravity, wind, attraction, noise)
-4. Update position/rotation/size/color
-5. Collision response
-6. Kill expired particles
-7. Extract render instances
+GPU particles reside in device compute buffers and are updated via compute kernels:
 
-### CPU Simulation
+```hlsl
+struct GpuParticleData {
+    float3 position;
+    float  age;
+    float3 velocity;
+    float  maxAge;
+    float2 size;
+    float  rotation;
+    float  rotationVelocity;
+    uint   packedColor;
+    uint   flags;
+};
 
-CPU simulation uses a flat SoA buffer. It is the default for:
+// Ping-pong buffers:
+StructuredBuffer<GpuParticleData>   CurrentParticles : register(t0);
+RWStructuredBuffer<GpuParticleData> NextParticles    : register(u0);
+```
 
-- low particle counts
-- complex gameplay interactions
-- platforms without compute support
-- effects that need tight gameplay coupling
+## VFX Graph Asset & Compilation
 
-### GPU Simulation
-
-GPU simulation uses compute shaders. It is the default for:
-
-- high particle counts
-- effects with simple local forces
-- platforms with compute support
-
-Rules:
-
-- GPU particles may fall back to CPU if the feature tier lacks compute.
-- CPU and GPU particle systems may coexist in the same scene.
-- Gameplay reads from CPU particles; GPU particles are visual-only unless a
-  read-back path is explicitly declared.
-
-## VFX Graph
-
-A VFX graph is an authored node graph that defines a complex effect made of
-multiple emitters, forces, events, and render outputs.
+A VFX graph is an authored node graph that defines a complex effect composed of
+emitters, forces, turbulence, events, and render outputs.
 
 ```text
 VFXGraph
-  +-- Update Context
-  |     +-- Spawn Event Handler
-  |     +-- Force Field
-  |     +-- Kill Condition
-  +-- Output Context
-        +-- Particle Renderer
-        +-- Ribbon Renderer
-        +-- Mesh Renderer
-        +-- Decal Spawner
+  +-- Spawn Context (Rates, Bursts, Triggers)
+  +-- Update Context (Forces, Turbulence, Drag, Collision, Age)
+  +-- Output Context (Billboard, Ribbon, Mesh, Decal, Light, Audio)
 ```
 
 Graph nodes:
@@ -155,22 +356,22 @@ Graph nodes:
 |---|---|
 | `Emitter` | Spawns particles continuously or on event. |
 | `Force` | Applies gravity, wind, vortex, attraction. |
-| `Noise` | Adds turbulent displacement. |
-| `Collision` | Bounce or die on collision. |
-| `ColorOverLife` | Animates color/opacity by normalized age. |
-| `SizeOverLife` | Animates size by normalized age. |
-| `SubEmitter` | Spawns child particles on birth/death/collision. |
+| `Noise` | Adds turbulent displacement (simplex, Perlin, curl noise). |
+| `Collision` | Bounce or die on collision with planes, depth, or physics geometry. |
+| `ColorOverLife` | Animates color and opacity curves by normalized particle age. |
+| `SizeOverLife` | Animates size curves by normalized particle age. |
+| `SubEmitter` | Spawns child particles on birth, death, or collision. |
 | `Decal` | Projects a decal at particle position or collision point. |
 | `Light` | Spawns a temporary point light (bounded, tier-aware). |
-| `Audio` | Triggers an audio event on spawn/collision. |
+| `Audio` | Triggers an audio event on spawn or collision. |
 
-Graphs compile to a runtime descriptor. The runtime evaluates update contexts
-and extracts outputs. The graph does not interpret arbitrary scripts at runtime.
+Graphs compile ahead-of-time (or at asset cook time) into runtime descriptors and
+optimized compute/CPU kernels. The graph runtime never interprets arbitrary scripts
+per particle.
 
 ## Decals
 
-A decal is a projected texture applied to scene geometry within a bounded
-volume.
+A decal is a projected texture applied to scene geometry within an oriented bounding box.
 
 ```cpp
 struct DecalDescriptor {
@@ -181,209 +382,81 @@ struct DecalDescriptor {
     float fadeAngle;
     float fadeOutDistance;
     float lifetimeSeconds;
-    bool affectedByTimeOfDay;
+    bool isPermanent;
 };
 ```
 
-Decals are placed as scene objects. They are rendered as part of the deferred or
-forward decal pass using the standard material model.
+- **Projection Mode**: Default is deferred projection writing to the G-Buffer.
+  Forward decals use clustered/tiled decal lists on forward feature tiers.
+- **Lifetime**: Supports permanent environmental decals, timed fading decals
+  (e.g., bullet holes, blood splatters), and event-driven removal.
+- **Atlas Management**: `DecalManager` pools and batches decal textures to minimize
+  descriptor and texture switches.
 
-Lifetime options:
+## Event-Driven Spawning & Audio Coupling
 
-- permanent until explicitly removed
-- timed with optional fade
-- event-driven removal
-
-Decal atlas and deferred projection are the default. Forward decals are a
-fallback for forward-only feature tiers.
-
-## Render Modes
-
-| Mode | Description |
-|---|---|
-| `Billboard` | Camera-facing quad. |
-| `Mesh` | Instanced mesh particles. |
-| `Ribbon` | Connected segments forming a ribbon. |
-| `Trail` | Trail following a moving emitter. |
-| `Decal` | Projected decal. |
-| `Light` | Temporary light spawned by effect (limited, tier-aware). |
-
-## Sorting And Transparency
-
-Translucent particles are sorted back-to-front per camera.
-
-- CPU particles may be sorted on CPU.
-- GPU particles use GPU bitonic or radix sort.
-- Additive particles do not require strict sorting.
-- Opaque/masked particles participate in the opaque pass and depth testing.
-
-Sorting must not dominate frame time. Budgets are enforced and reported.
-
-## Culling
-
-Effects are culled using:
-
-- view frustum
-- distance-based LOD
-- screen-size thresholds
-- occlusion (when available)
-
-GPU particle systems are still budgeted even when culled; inactive systems may
-sleep and skip simulation.
-
-## Event-Driven Spawning
-
-Gameplay spawns effects by firing events to the VFX world.
+Gameplay spawns effects by submitting requests to `VfxEventQueue`:
 
 ```cpp
 struct VfxSpawnRequest {
     AssetId effectAsset;
     Transform worldTransform;
     std::optional<Vec3> impactNormal;
-    float scale;
+    float scale{1.0f};
     VariantMap parameters;
 };
 ```
 
-Common events:
+### Audio Routing
 
-- `Footstep` — dust or splash at foot position
-- `BulletImpact` — spark, debris, decal
-- `Explosion` — fireball, smoke, shockwave
-- `MuzzleFlash` — flash and smoke
-- `AbilityCast` — gameplay-specific visual
+VFX graphs trigger audio events on spawn, collision, or sub-emitter creation. Audio
+events are dispatched to `AudioWorld` via typed IDs and world positions; the VFX
+subsystem never plays sounds directly, preserving the mixing and spatialization
+pipeline.
 
-The VFX system maps events to effect assets through a gameplay-defined table or
-effect tags. It does not hardcode gameplay semantics.
+## Performance Budgets and Diagnostics
 
-## Audio Coupling
+### Per-Effect Budgets
 
-VFX graphs may trigger audio events:
+- Maximum particle count per emitter.
+- Maximum concurrent active instances per effect asset.
+- Maximum transient point lights spawned (e.g., max 4 lights per scene effect).
+- Maximum active decals per volume.
 
-- on spawn
-- on collision
-- on death
-- on sub-emitter spawn
+### Global World Budgets
 
-Audio events are sent to the audio world, not played directly. This preserves
-the audio mixing and spatialization pipeline.
+- Total active CPU particles (default limit: 16,384 across all CPU systems).
+- Total active GPU particles (default limit: 1,000,000 across all GPU systems).
+- Total active decals (default limit: 256).
+- Maximum render extraction time budget per frame.
 
-## Material Integration
+Over-budget conditions drop oldest/farthest cosmetic particles, clamp spawn counts,
+and emit structured diagnostics according to the observability system.
 
-Particles and decals use the same material system as meshes (see
-[Material And Shader Model](./material-and-shader-model.md)).
+## Testing and Verification Requirements
 
-Particle materials typically use:
-
-- `Unlit` or `Lit` shading model
-- `Translucent` or `Additive` blend mode
-- flipbook/texture atlas animation
-- soft particle depth fading
-- vertex color modulation
-
-Decal materials use:
-
-- `Lit` or `Unlit`
-- `Translucent` or `Masked`
-- deferred projection shader
-
-## Performance Budgets
-
-Per effect:
-
-- max particle count
-- max active instances
-- max lights spawned
-- max decals spawned
-- max simulation time per frame
-
-Global budgets:
-
-- total live particles across all CPU systems
-- total live particles across all GPU systems
-- total decals
-- total effect draw calls
-- effect GPU time
-
-Exceeding a budget drops oldest/farthest particles or delays spawn. Diagnostics
-report over-budget events.
-
-## Feature Tier Behavior
-
-| Tier | Behavior |
-|---|---|
-| `es3` | CPU particles only, no GPU simulation, limited lights, no volumetrics. |
-| `dx11` | GPU particles supported, limited decals, simple volumetrics. |
-| `dx12_vulkan` | Full GPU particles, many decals, compute-driven effects. |
-| `high_end` | GPU events, large-scale simulations, advanced volumetrics. |
-
-Effects must degrade gracefully: fewer particles, simpler shaders, CPU fallback.
-
-## Asset Formats
-
-### Particle System Asset
-
-```json
-{
-  "schemaVersion": 1,
-  "assetType": "particle_system",
-  "simulationDomain": "CPU",
-  "maxParticles": 256,
-  "emitterShape": { "type": "Cone", "angle": 30, "radius": 0.1 },
-  "spawnRate": { "type": "Burst", "count": 32 },
-  "lifetime": { "min": 0.5, "max": 1.2 },
-  "velocity": { "min": [0, 1, 0], "max": [0, 3, 0] },
-  "material": "material_spark_001",
-  "renderMode": "Billboard"
-}
-```
-
-### VFX Graph Asset
-
-```json
-{
-  "schemaVersion": 1,
-  "assetType": "vfx_graph",
-  "contexts": [
-    {
-      "name": "Update",
-      "nodes": [...]
-    },
-    {
-      "name": "Output",
-      "nodes": [...]
-    }
-  ]
-}
-```
-
-## Diagnostics And Validation
-
-- Missing materials or textures are reported at import time.
-- GPU particle systems on compute-less tiers produce a warning and fallback.
-- Over-budget effects are logged with the offending asset ID.
-- Infinite-lifetime particles without kill conditions are rejected.
-- Decal count and light-spawn limits are enforced at runtime.
-
-## Testing Requirements
-
-- Unit tests for particle spawn/kill bookkeeping.
-- CPU vs GPU simulation equivalence tests for simple forces.
-- Sort correctness tests.
-- Culling tests for off-screen and far-away effects.
-- Event-to-spawn mapping tests.
-- Visual regression tests for representative effects.
-- Performance tests measuring particle count vs frame time.
+- **Ownership & Lifecycle Tests**: Verify `VfxWorld` construction, tick, and complete
+  destruction on `SceneRuntime` unload without leaking memory or GPU handles.
+- **Domain Selection Policy Tests**: Verify deterministic domain resolution across
+  all feature tiers (`null`, `es3`, `dx11`, `dx12_vulkan`, `metal`).
+- **Null / Headless Simulation Tests**: Verify `NullParticleSimulator` produces
+  deterministic, zero-graphics simulation ticks in headless test environments.
+- **Render Extraction Tests**: Verify `VfxRenderExtractor` emits valid, typed
+  `VfxRenderBatch` primitives with correct sort distances and bounding boxes.
+- **Sorting Correctness Tests**: Verify translucent particle back-to-front sorting
+  and additive sort-skipping invariants.
+- **Memory Pooling Invariants**: Assert zero heap allocations during steady-state
+  particle updates and burst spawning.
 
 ## Related Documents
 
-- [Particle Editor UI Reference](./particle-editor.html): emitter stack, module parameters, curve editing, and live preview panel.
-
-- [Material And Shader Model](./material-and-shader-model.md): particle and
-  decal materials.
-- [Rendering Architecture](./rendering-architecture.md): render graph and pass
-  extraction.
-- [Advanced Rendering Architecture](./advanced-rendering-architecture.md):
-  post-processing, volumetrics, and high-end feature tiers.
-- [Audio Architecture](./audio-architecture.md): audio event routing.
-- [Asset Pipeline](./asset-pipeline.md): effect import and cook.
+- [ADR-011: Effect Ownership, Simulation Domain Policy and Renderer Boundary](../../adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md):
+  Authoritative M0 architecture decision.
+- [Particle Editor UI Reference](./particle-editor.html): Emitter stack, curve editing,
+  and live preview panel.
+- [Material And Shader Model](./material-and-shader-model.md): Particle and decal materials.
+- [Rendering Architecture](./rendering-architecture.md): Render graph and pass extraction.
+- [Scene Runtime Architecture](./scene-runtime.md): Scene runtime lifecycle and ownership.
+- [Advanced Rendering Architecture](./advanced-rendering-architecture.md): Volumetrics and post-processing.
+- [Audio Architecture](./audio-architecture.md): Audio event routing.
+- [Asset Pipeline](./asset-pipeline.md): Effect compilation and cooking.

--- a/docs/architecture/runtime/vfx-and-particles-architecture.md
+++ b/docs/architecture/runtime/vfx-and-particles-architecture.md
@@ -1,300 +1,428 @@
 # VFX And Particles Architecture
 
-## Purpose
+## Purpose And Scope
 
-This document defines Horo Engine's visual effects runtime: particle systems,
-ribbons, mesh particles, decals, GPU compute particles, VFX graphs, and
-volumetric effects. It specifies how effects are authored, simulated, rendered,
-and integrated with scene lifecycles, gameplay, audio, and the render graph.
+This document defines runtime particles, ribbons, mesh particles, decals and
+volumetric VFX: scene ownership, emitter domain policy, bounded admission, immutable
+extraction and renderer scheduling. [ADR-011](../../adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md)
+records the proposed decision. These are implementation contracts, not claims that
+all paths or qualification tests already exist.
 
-The goal is to provide a scalable, deterministic, and modular visual effects
-architecture that supports everything from simple one-shot gameplay bursts to
-large GPU-driven environmental volumes, without allowing immediate-mode rendering
-leaks or coupling scene simulation to concrete graphics backends.
+DCC workflows, full fluid solvers, atmospheric scattering and screen-space
+post-processing remain outside this subsystem; see
+[Advanced Rendering Architecture](./advanced-rendering-architecture.md).
 
-## Scope
+## Ownership And Renderer Boundary
 
-Covered:
-
-- runtime subsystem ownership, component hierarchy, and deterministic lifecycle
-- simulation domain selection policy (CPU, GPU Compute, Headless/Null)
-- platform and feature tier fallback matrix
-- decoupled renderer boundary and typed render extraction contracts
-- pass placement, standard material pipeline integration, and camera-relative sorting
-- particle system data model and emitter stages
-- VFX graph asset compilation and runtime evaluation
-- decal projection, lifetime, and atlas management
-- event-driven spawning, pooling, and audio routing
-- performance budgets, diagnostics, and regression test requirements
-
-Not covered:
-
-- DCC tools and texture authoring workflows
-- full fluid dynamics / Navier-Stokes solvers (future subsystem)
-- atmospheric scattering and sky atmosphere simulation (see
-  [Advanced Rendering Architecture](./advanced-rendering-architecture.md))
-- screen-space post-processing effects (see
-  [Advanced Rendering Architecture](./advanced-rendering-architecture.md))
-
-## Core Decisions
-
-- **Subsystem Ownership**: `VfxWorld` is owned strictly by the active `SceneRuntime`.
-  It is initialized at scene startup and torn down/reset deterministically on scene
-  replacement or unload. No effect instances or GPU resources outlive their scene.
-- **Zero Immediate-Mode Rendering**: Effects are strictly prohibited from issuing
-  immediate-mode draw calls or touching graphics contexts directly. `VfxWorld`
-  extracts backend-neutral render primitives during the Render Extraction phase.
-- **Policy-Driven Simulation Domain**: Particle simulation domain (CPU vs. GPU Compute)
-  is determined by asset configuration, gameplay interaction requirements, and active
-  hardware feature tiers. Call-site ad hoc branching is forbidden.
-- **Deterministic Headless Execution**: Headless servers and CI test suites use
-  `NullParticleSimulator` / deterministic CPU simulation without GPU allocations or
-  graphics dependencies.
-- **Standard Material & Pass Integration**: Particles and decals use the standard
-  PBR and unlit material model compiled via the shared material pipeline, executing
-  in standard Render Graph passes (G-Buffer, Decal, Translucent Forward, Additive).
-- **Camera-Relative Sorting**: Translucent particles are sorted back-to-front
-  (CPU radix sort for CPU particles, GPU bitonic/radix compute for GPU particles);
-  additive particles skip sorting.
-- **Zero Allocation Steady State**: All particle buffers, emitter states, and effect
-  instances are preallocated in pools during scene initialization, guaranteeing zero
-  heap allocations during active gameplay.
-
-## Subsystem Ownership and Lifecycle
-
-```text
-SceneRuntime
-  └── VfxWorld
-        ├── EffectSystem
-        ├── CpuParticleSimulator
-        ├── GpuParticleSimulator
-        ├── NullParticleSimulator
-        ├── DecalManager
-        ├── EffectInstancePool
-        ├── VfxEventQueue
-        └── VfxRenderExtractor
-```
-
-### Component Breakdown
-
-Every component within the runtime effects ecosystem has a single, unambiguous owner:
+VfxWorld belongs to one SceneRuntime incarnation. It owns logical effect state,
+CPU particle storage and bounded requests; it never owns a native graphics context,
+encodes a command buffer, writes mapped GPU memory or submits Render Graph passes.
+Host composition selects capabilities/adapters explicitly; inert descriptors do not
+register services or discover a backend. No immediate-mode drawing is permitted.
 
 | Component | Owner | Responsibility |
 |---|---|---|
-| `SceneRuntime` | Application / Host | Owns `VfxWorld` as a major scene subsystem. Controls creation, fixed/variable simulation ticking, and destruction. |
-| `VfxWorld` | `SceneRuntime` | Subsystem composition root. Coordinates simulators, decal manager, instance pools, event queues, and render extraction. |
-| `EffectSystem` | `VfxWorld` | Manages effect instance life cycles, template instantiation, parameter bindings, and spatial hierarchy tracking. |
-| `CpuParticleSimulator` | `VfxWorld` | Flat Structure-of-Arrays (SoA) SIMD-accelerated particle updater for gameplay-interactive, collision-coupled, or CPU-bound effects. |
-| `GpuParticleSimulator` | `VfxWorld` | Manages compute dispatch generation, indirect draw arguments, and compute buffer references for high-density particle volumes. |
-| `NullParticleSimulator` | `VfxWorld` | Deterministic, allocation-free simulation path for headless testing, CI, and server execution where GPU rendering is disabled. |
-| `DecalManager` | `VfxWorld` | Manages active decal projection volumes, fading envelopes, dynamic bounds, and decal atlas allocations. |
-| `EffectInstancePool` | `VfxWorld` | Preallocated memory pools for particle buffers, emitter states, and effect instances to guarantee zero frame-time allocations. |
-| `VfxEventQueue` | `VfxWorld` | Bounded FIFO queue capturing gameplay and animation spawn events (e.g., footsteps, impacts, explosions). |
-| `VfxRenderExtractor` | `VfxWorld` | Extracts immutable, backend-neutral render primitives (`VfxRenderBatch`) and submits them to the Render Graph during extraction. |
+| VfxWorld | SceneRuntime | Coordinates effect state and admitted work for this scene incarnation |
+| EffectSystem | VfxWorld | Instance lifecycle, compiled emitter descriptors, parameter bindings and ownership |
+| SimulationDomainResolver | VfxWorld | Resolves each compiled emitter using validated asset intent and host policy |
+| CpuParticleSimulator | VfxWorld | CPU SoA updates, including real gameplay-coupled simulation in headless hosts |
+| GpuParticleSimulator | VfxWorld | Produces backend-neutral GpuVfxSimulationWork; tracks logical step/resource identities, never dispatches |
+| NullParticleSimulator | VfxWorld | Visual-only suppression with normal admission, tick and lifecycle timing; no gameplay simulation substitute |
+| DecalManager | VfxWorld | Logical projection volumes, fades and atlas requests; renderer owns physical atlas storage |
+| EffectInstancePool | VfxWorld | Preallocated instance/emitter/CPU storage and explicit capacity admission |
+| VfxEventQueue | VfxWorld | Bounded FIFO of admitted typed requests with deterministic drain and overflow outcomes |
+| VfxRenderExtractor | VfxWorld | Writes immutable simulation/render descriptors into RenderWorldSnapshot; no graph submission |
+| RenderFrontend / resource manager | Renderer | Validates snapshots, admits renderer storage, schedules compute/sort/cull/draw and retires resources |
+| Concrete render backend | Renderer composition | Native allocation, upload, command encoding, barriers and completion fences |
 
-### Lifecycle and Scene Transition Invariants
+Physical renderer allocations and retained snapshot leases may outlive logical
+scene shutdown while retiring. They cannot retain raw VfxWorld/ECS pointers or gain
+access to the replacement scene. This is deferred ownership, not a live old effect.
 
-1. **Initialization**: `VfxWorld` is instantiated synchronously when `SceneRuntime`
-   activates. Buffer pools, emitter slots, and decal capacities are allocated based on
-   the active project and feature tier settings.
-2. **Simulation Phase (`Update`)**: `VfxWorld::Update(DeltaTime)` executes within
-   the scene simulation loop:
-   - Drains and processes pending spawn requests from `VfxEventQueue`.
-   - Advances active CPU particle systems and updates decal lifetimes.
-   - Generates GPU compute simulation dispatches for compute-backed systems.
-3. **Extraction Phase (`ExtractRenderData`)**: Called by the renderer frontend
-   strictly during the Render Extraction phase. Generates immutable snapshots of
-   visible particle batches, decal volumes, and instance transforms. Simulation
-   state is never modified during this phase.
-4. **Teardown & Scene Replacement**: When a scene is unloaded or replaced:
-   - All active effect instances, emitters, and decals are stopped immediately.
-   - All pooled CPU buffers and GPU compute buffers are deterministically reset or released.
-   - No effect instance, GPU handle, or callback reference may leak across the scene boundary.
+## Frame, Thread And Timing Contract
 
-## Simulation Domain Selection Policy
+Scene composition declares VFX access/dependency edges in the existing scheduler.
+Gameplay-coupled CPU emitters use the owning fixed simulation tick after their
+required physics results, with typed gameplay results consumed at a declared later
+safe point. Cosmetic updates use Presentation before RenderExtraction. A compiled
+emitter selects one clock/tick schedule; it is not advanced on both schedules.
+Scene time/seed policy controls pause, delta and replay; VFX does not read wall time
+or independently tick gameplay when presentation runs. Each VfxEventQueue belongs
+to one clock domain; fixed and presentation queues have separate cutoffs and share
+the admitted aggregate budget. FIFO is defined within that queue, never by draining
+the same request once for each emitter or clock.
 
-Domain selection is **policy-driven, asset-declared, and feature-tier constrained**.
-Individual gameplay call sites cannot arbitrarily override simulation rules via raw
-backend branching.
+1. On the scene simulation owner, freeze each queue cutoff once at the start of
+   its declared clock update. Drain at most maxEventsPerTick accepted requests in
+   FIFO order; requests produced during the drain/update become eligible next tick.
+   No backend invokes a spawn completion inline from submission.
+2. Advance CPU state and logical decal/effect timers. CPU work may use Foundation
+   JobSystem/JobId over exclusive staging slices. Completion records are applied
+   on the declared owner phase, never by worker callbacks mutating live ECS.
+3. GPU emitters produce bounded GpuVfxSimulationWork with scene/effect/emitter
+   generation, step ID, delta/seed, parameters and typed input/output resource IDs.
+   They do not encode GPU dispatches during VfxWorld::Update.
+4. Extract immutable CPU frame data, GPU work and render descriptors into a
+   frame-owned RenderWorldSnapshot. Extraction reads stable state; no particle
+   lifetime, simulation order, seed or emitter state is modified.
+5. At render frame synchronization, RenderFrontend consumes that snapshot, uploads
+   bounded CPU data, and builds the graph: VFX Compute -> per-view Sort/Cull ->
+   consuming depth/shadow/opaque/decal/volume/translucent passes. Backend encoding
+   and native synchronization stay on the renderer's permitted execution roles.
+
+[ADR-010](../../adr/010-job-waiting-and-operation-store-ownership.md) governs jobs,
+operation tracking and allowed teardown drains. No ordinary owner/render/transport
+path waits on workers or GPU completion, and workers do not wait on nested jobs.
+A pending required CPU update holds dependent simulation progress through the host's
+non-blocking scheduling/loading policy; it cannot silently use stale gameplay
+results. Cosmetic work may use a documented skip/reset outcome under budget.
+
+[ADR-018](../../adr/018-command-registration-permissions-threading-and-packaged-build-policy.md)
+WorkerJob is for CPU preparation, not permission to encode native GPU commands.
+RenderSafePoint debug mutations enter the same render frame synchronization seam;
+normal simulation descriptors are renderer inputs, not console commands. Long
+user-visible preload/export tasks use the application-owned OperationStore; per-tick
+VFX work does not create a second operation service.
+
+GPU step submission is keyed by scene incarnation, emitter generation and step ID.
+A snapshot may be used by multiple views/frames, but a GPU step is submitted once,
+not once per view. The frontend tracks ordered submitted steps and returns bounded
+admission/submission status records to the scene owner. Submission acknowledgement
+is not GPU retirement. Pending work and frames in flight stay leased and charged.
+A failed/uncertain submission follows renderer recovery, never blind step replay.
+When the pending-work cap is reached, stop accepting cosmetic GPU steps/spawns and
+report backpressure; no unbounded catch-up queue or automatic huge CPU migration.
+Resume using the authored bounded restart/reset policy, not a giant accumulated delta.
+
+GPU depth collision uses one explicitly selected cosmetic collision view and its
+previous completed depth snapshot (with matching scene/view/origin generation).
+Missing or stale depth uses the authored no-collision/substitute/disable policy.
+It cannot require the current depth pass that itself depends on VFX Compute, or
+advance the same emitter separately for each eye/view. No GPU particle readback
+may drive authoritative gameplay in the ordinary frame loop.
+
+## Domain Selection And Asset Intent
+
+Resolution is **per compiled emitter simulation unit**, not per composite graph.
+A unit has one particle state and one resolved domain. Any gameplay interaction or
+CPU geometry-query requirement makes the whole unit CPU-mandatory, even above the
+count heuristic. It cannot be partly CPU and partly GPU. Graphs may contain separate
+CPU and GPU units only with explicit typed boundaries. A dependency requiring
+synchronous particle state or gameplay results propagates CPU requirements through
+that connected dependency; unsupported cycles/contracts fail cook. A CPU event may
+trigger a visual GPU child through a bounded next-tick request. A GPU child cannot
+feed synchronous authoritative state back to the CPU parent.
 
 ```cpp
-enum class SimulationDomain : uint8_t {
-    Automatic,  ///< Resolved at cook/load time based on emitter parameters and tier
-    CPU,        ///< Guaranteed CPU execution; supports gameplay queries and collisions
-    GPU         ///< GPU compute execution; visual-only high-density particle simulation
+enum class SimulationPreference : uint8_t {
+    Automatic, RequireCPU, PreferCPU, PreferGPU, RequireGPU
 };
+enum class ResolvedSimulationDomain : uint8_t { CPU, GPU, Null };
 ```
 
-### Domain Selection Criteria
+Cook records supported kernels, gameplay dependencies, authored fallback assets,
+required capabilities and cost bounds. Load/admission resolves against a captured
+host capability/quality-policy revision. Call sites do not select concrete backends.
+Changing policy requires re-admission/restart at a safe point, not live CPU/GPU state
+migration. Migrate the previous proposed SimulationDomain field in cooked descriptor
+versioning: Automatic -> Automatic, CPU -> RequireCPU, GPU -> PreferGPU, with a
+migration diagnostic. There are not two parallel domain selectors.
 
-Domain resolution applies constraints in the following order. A CPU-mandatory
-criterion always takes precedence over an explicit or automatically selected GPU
-domain, including for systems above the particle-count threshold.
+Resolution order:
 
-1. **`SimulationDomain::CPU`** is mandatory when:
-   - Particles require two-way gameplay interaction (e.g., triggering game logic,
-     modifying gameplay physics bodies, collecting pickup items).
-   - High-precision CPU raycast or complex geometry collision response is required.
-   - Running on low-spec hardware tiers (e.g., `es3`) or in headless/null environments.
-2. **Explicit domain requests** are considered after mandatory constraints:
-   - Explicit `CPU` remains on CPU, subject to the active tier's capacity budget.
-   - Explicit `GPU` is valid only for visual-only effects on a GPU-compute-capable
-     tier. Otherwise, resolution falls back deterministically to CPU and records a
-     typed cook/load diagnostic.
-3. **`SimulationDomain::Automatic`** (Asset Default) uses the particle-count heuristic:
-   - Visual-only systems with `maxParticles > 2,048` select GPU when the active tier
-     supports GPU compute.
-   - Systems with `maxParticles <= 2,048`, or systems on tiers without GPU compute,
-     select CPU.
-   - Complex vector fields, curl noise, or GPU depth-buffer collision may prefer GPU
-     only after the CPU-mandatory checks above pass.
+1. Validate CPU-mandatory dependencies. RequireGPU plus a CPU-mandatory unit is a
+   typed incompatible-asset error; all other preferences resolve that unit to real
+   CPU simulation. A missing CPU kernel is an error, never dummy gameplay.
+2. Apply host mode and explicit intent. Headless visual-only units may use Null only
+   when their authored policy permits visual suppression; gameplay units still use
+   CpuParticleSimulator. RequireGPU needs its capabilities or a separately authored
+   fallback effect; otherwise the effect is unavailable. Null suppression is an
+   explicit authored headless fallback, never an implicit override of RequireGPU.
+   RequireCPU never becomes GPU.
+3. PreferCPU selects a supported admitted CPU path, then an explicitly permitted GPU
+   path; PreferGPU does the reverse. A CPU fallback requires a compatible cooked CPU
+   kernel and admitted CPU work/memory. GPU-only noise/depth features are substituted
+   only by an authored fallback, never silently deleted from required behavior.
+4. Automatic prefers GPU for eligible visual units above
+   VfxQualityPolicy.autoGpuParticleThreshold (desktop default 2048), CPU at/below it.
+   Authored cost/kernel requirements may prefer GPU even below it, after step 1.
+   It uses the same supported, budget-admitted fallback rules as a preference.
 
-The `2,048` value is a domain-selection heuristic, not a universal capacity
-limit. Feature-tier capacity limits are applied after domain resolution and may
-clamp a system below this threshold.
+The threshold is a configurable heuristic, not a capacity limit. Per-emitter caps
+and aggregate CPU/GPU/memory/work budgets apply to **every** profile. Cosmetic counts
+may be clamped only where the asset declares a valid reduced-count result. Required
+gameplay counts are never silently clamped: reject admission and let the gameplay
+owner use its explicit safe fallback/loading/failure policy. A 500k-particle GPU
+asset is not automatically run as 500k CPU particles when GPU support is missing.
 
-### Coexistence and Synchronization Rules
+### Capabilities And Fallback Matrix
 
-- CPU and GPU particle systems can coexist seamlessly within the same scene and within
-  the same composite VFX graph asset.
-- Synchronization is governed by shared scene simulation time and camera transforms.
-- CPU particles write to CPU-mapped dynamic vertex/instance buffers. GPU particles simulate
-  in GPU compute buffers and emit indirect draw calls.
-- Readback from GPU particles to CPU is prohibited in standard frame loops; gameplay
-  requiring particle positional data must use CPU simulation.
+VfxCapabilities is a typed snapshot of actual selected-device capabilities, including
+compute, indirectDraw, gpuSorting, volumeTextures, vectorFields and resource/work
+limits. VfxQualityPolicy adds validated positive finite budgets, CPU fallback caps,
+autoGpuParticleThreshold and permitted cosmetic degradation. Backend names do not
+imply any capability. The renderer parity/availability contracts remain authoritative;
+VFX fallback never silently switches the selected renderer or an interactive host to
+RenderNull.
 
-### Platform & Feature Tier Fallback Matrix
+| Host policy profile | Domain behavior | Unsupported/budget outcome |
+|---|---|---|
+| Headless/test | Real CPU for gameplay; permitted visual suppression through Null | Same queue/tick/lifecycle contract; no GPU allocations; incompatible required visuals reported unavailable |
+| Low visual budget | Admitted CPU, GPU only if actual capabilities and policy permit | Default cosmetic CPU fallback cap 512 per emitter; authored substitute or typed rejection for unsupported kernels/RequireGPU |
+| Desktop baseline | CPU/GPU according to intent, actual capabilities and costs | Finite per-emitter and aggregate caps; reject new work or apply authored cosmetic reduction |
+| High visual budget | Larger admitted CPU/GPU budgets and optional sort/volume/field paths | Still bounded; missing capabilities use authored fallback or typed unavailability, never unrestricted simulation |
 
-| Feature Tier / Platform | Primary Domain | GPU Compute Particles | GPU Radix / Bitonic Sort | Volumetrics & Curl Noise | Fallback Behavior |
-|---|---|---|---|---|---|
-| **Headless / Null** (`null`) | `CPU` (Null Simulator) | Disabled | Disabled | Disabled | Full deterministic CPU dummy simulation; no GPU allocations or draw dispatches. |
-| **Mobile / Low-Spec** (`es3`) | `CPU` | Disabled | Disabled | Disabled | GPU requests fall back to CPU. The tier clamps each system to its configured CPU cap (`512` by default), overriding the general `2,048` domain heuristic. Complex noise is disabled. |
-| **Desktop Baseline** (`dx11` / `opengl4`) | `CPU` & `GPU` | Supported (Compute) | Supported (Bitonic) | Basic 3D Textures | Over-budget GPU systems throttle spawn rates or drop lowest-priority sub-emitters. |
-| **High-End Desktop / Console** (`dx12_vulkan` / `metal`) | `CPU` & `GPU` | Full Compute | Full Radix/Bitonic | Full Curl Noise & Vector Fields | Unrestricted simulation with GPU indirect draw and GPU culling. |
+Legacy labels es3, dx11/opengl4 and dx12_vulkan/metal are not VFX capability enums.
+They may identify external product presets, but must resolve through typed capability
+facts and quality policy. Identical inputs resolve deterministically; this does not
+promise bitwise-identical visual CPU/GPU algorithms across devices.
 
-## Renderer Boundary & Render Extraction Contract
+### Null Timing And Gameplay Parity
 
-Visual effects adhere strictly to Horo Engine's decoupled rendering architecture.
-**VFX code is strictly prohibited from invoking immediate-mode draw calls or holding
-backend graphics contexts.**
+Null suppresses visual particle kernels/draws, not scheduler semantics. It obeys the
+same submission cutoff, FIFO drain limit, next-tick spawn/result delivery, owner phase,
+logical lifetime and cancellation rules as the real paths. Completion is queued,
+never inline merely because there is no GPU. Device timing is not simulated: tests
+requiring delayed completion/retirement use controllable bounded fake completions.
 
-### Extraction Pipeline
+Particle collision/death-derived gameplay, audio or other externally observable
+nonvisual events cannot rely on Null dummy particles. Such dependencies require the
+real CPU implementation or a separately authored deterministic CPU event source.
+Visual-only Null units emit only declared logical lifecycle outcomes and do not
+fabricate per-particle collisions. Headless gameplay uses the same CPU kernels,
+seeds, fixed ticks and admission requirements as graphical execution.
+
+## Capacity, Pool Exhaustion And Event Overflow
+
+Pool sizes, particle slices, scratch, packed frame data, per-view sort indices,
+pending GPU work, completion records and retirement entries are preallocated or
+admitted during bounded preparation before activation. No pool grows on Update,
+spawn, queue drain or extraction. Resizing is an explicit asynchronous preparation
+transaction with peak old/new memory admitted; old readers/fences must retire before
+reuse. Zero steady-state heap allocation is a requirement to verify for these paths,
+not an unlimited-capacity or measured performance claim.
+
+TryEnqueueSpawn returns Result<VfxRequestId> and copies a bounded typed parameter
+block, never an arbitrary heap-allocating VariantMap. The scene owner serializes
+accepted requests; external producers submit typed commands through declared owner
+seams. Authoritative producers have stable tick/producer/sequence ordering before
+admission, so OS worker arrival races are not gameplay order. FIFO means this
+accepted owner order. Retrying failed submission is explicit, not hidden recursion.
+
+- Queue full: reject the **incoming/newest** request with EventQueueFull. Never
+  overwrite accepted entries or silently drop the oldest. Preserve reserved gameplay
+  capacity; cosmetic requests cannot consume the configured gameplay reserve.
+- Pool/particle/renderer reservation exhausted: reject the new request with
+  EffectCapacityExceeded or ResourceBudgetExceeded; existing effects are not evicted
+  implicitly. A queued request that fails later receives a next-phase typed result
+  from reserved result capacity. Failed admission leaves no partial live effect.
+- An admitted emitter reaching its particle cap drops **new cosmetic births**, not
+  existing particles, and records a counter. Gameplay emitters must reserve their
+  authored worst case; inability to satisfy it reports a gameplay failure rather
+  than silently changing the simulation.
+- Rejections/degradation increment structured counters and rate-limited diagnostics.
+  Callers may discard a cosmetic request only after receiving that outcome. A required
+  caller must handle rejection with its declared safe policy; it may not block/spin.
+
+Drain work is bounded by maxEventsPerTick and admitted per-request cost. Remaining
+entries retain FIFO order for later ticks. Results, cancellation and retirement have
+reserved capacity so overload cannot prevent cleanup. Configuration validates queue,
+result and gameplay-reserve limits together. Null follows the same capacity policy;
+a separate reduced visual resource budget cannot consume the gameplay reserve.
+
+## Scene And Cell Teardown
+
+Effect/request handles include scene incarnation, slot generation and owner identity.
+Zero is invalid; checked exhaustion retires a slot/incarnation rather than wrapping.
+Scene replacement closes admission, invalidates the old incarnation and logically
+stops effects at the owner safe point. It cancels pending requests and detaches
+bindings before destroying entities they depend on. CPU jobs, frame-data readers,
+asset leases and GPU submissions retain their own immutable retirement records.
+
+The renderer resource manager owns deferred GPU destruction after all frame readers
+and completion fences release resources. Snapshot/job-owned CPU slices also cannot
+be reused early. Old allocations remain charged; no normal-frame device-idle wait,
+forced free or raw pointer callback into a destroyed VfxWorld is permitted. Only
+logical deactivation is immediate; physical retirement can span frames.
+
+Cell-bound effects additionally capture ADR-012 StreamingFence (partition identity,
+PartitionEpoch, cell and StreamingGeneration). An IFeatureStreamingProvider adapter
+participates in estimate/reserve, Ready/Prepared publication and Retired barriers.
+Its prepared publication attaches already admitted effects without allocation or
+recoverable work. Required/Optional/Degradable behavior follows that cell's validated
+policy; ambient visuals are not automatically Required or automatically Optional.
+
+On partial cell eviction, reject late spawns/publication for that fence and retire
+only the cell-owned effects. Retired is acknowledged after CPU readers/jobs and
+renderer fences release all cell-owned resources, not when the stop command is queued.
+Shared asset caches keep separate charged leases. Persistent or network-owned effects
+are not removed merely because their positions lie within the cell. Normal cell
+eviction, whole-scene replacement and shutdown use the same registered dependency
+DAG and Scene safe points; whole-scene shutdown retires all remaining ownership scopes.
+
+ADR-010's bounded teardown drain and ADR-012's timeout safety apply: on timeout return
+a typed incomplete-retirement diagnostic and retain outstanding resource/module/
+asset dependencies in a retirement owner. Never detach work referencing freed state
+or report a clean unload before retirement. New scene admission accounts for retained
+old resources. Cancellation fences publication but cannot promise physical I/O/GPU abort.
+
+## Immutable Extraction And Typed Contracts
 
 ```text
-  [ VfxWorld (Scene Simulation) ]
-                 │
-                 ▼
-  [ VfxRenderExtractor ]  (ExtractRenderData phase)
-                 │
-                 ├─► VfxRenderBatch (Translucent Billboard / Ribbon / Mesh)
-                 ├─► VfxRenderBatch (Opaque / Masked Mesh Particles)
-                 ├─► DecalRenderBatch (Deferred / Clustered Decals)
-                 └─► ParticleBufferView & DynamicInstanceTransforms
-                 │
-                 ▼
-  [ Render Graph Execution ]
-         ├── G-Buffer / Depth Pre-Pass (Opaque Mesh Particles)
-         ├── Decal Pass (Projected Decals)
-         ├── Forward / Translucent Pass (Sorted Particles & Ribbons)
-         └── Volumetric Accumulation Pass
+Scene simulation: CPU SoA + logical GPU work
+    -> VfxRenderExtractor
+    -> RenderWorldSnapshot (frame-owned immutable values and leases)
+    -> RenderFrontend (validation, bounded CPU upload, graph construction)
+    -> VFX Compute (once per step)
+    -> per-view Sort/Cull
+    -> standard Shadow/Depth/Opaque/Decal/Volume/Translucent passes
+    -> renderer deferred retirement
 ```
 
-### Typed Backend-Neutral Render Primitives
+CPU simulation writes only its private SoA. Extraction copies/packs CPU data into
+frame-owned slices; only the renderer uploads those slices to GPU buffers. GPU
+identities below are Horo-owned generation-safe logical resource leases resolved by
+the renderer, not native handles. Every slice is bounds/layout checked against its
+retained storage, with checked offset/count/stride arithmetic. GPU buffers and
+indirect arguments require correct admitted usage/size and current resource generation.
+
+The shapes below are schematic contracts, not installed public headers. FrameSlice
+refers to immutable frame-owned storage, not an unowned span into simulation memory.
+GpuVfxStateHandle identifies a renderer-owned state bundle (particle ping-pong,
+count/indirect and scratch resources); it exposes no allocation or encoding API.
+Each work/output step pins its resource version until all consumers retire. Later
+steps cannot overwrite storage still referenced by an older snapshot; a full version
+ring causes the documented backpressure. Reusing a snapshot renders its retained
+output version, not whichever mutable GPU buffer happens to be current.
 
 ```cpp
-enum class VfxPassKind : uint8_t {
-    OpaqueMesh,
-    MaskedMesh,
-    TranslucentForward,
-    AdditiveForward,
-    DeferredDecal,
-    ForwardDecal,
-    VolumetricAccumulation
-};
-
-enum class VfxPrimitiveTopology : uint8_t {
-    CameraFacingBillboard,
-    RibbonStrip,
-    InstancedMesh,
-    DecalBox
-};
-
-struct ParticleBufferView {
-    BufferHandle bufferHandle;
-    uint32_t byteOffset;
+struct CpuParticleView {
+    FrameSlice packedParticles;
+    ParticleLayoutId layout;
     uint32_t particleCount;
-    uint32_t stride;
+};
+struct GpuParticleView {
+    GpuVfxStateHandle state;
+    VfxStepKey step;                // retained output version consumed by this view
+    ParticleLayoutId layout;
+    uint32_t maxParticles;
+};
+using ParticleDataSource = std::variant<CpuParticleView, GpuParticleView>;
+
+struct GpuVfxSimulationWork {
+    VfxStepKey key;                 // scene + effect/emitter generations + step
+    GpuVfxStateHandle state;
+    VfxKernelId kernel;
+    FrameSlice parameters;         // delta, seed, bounded typed kernel inputs
+    OptionalDepthSnapshot collisionDepth;
 };
 
+enum class VfxParticlePass : uint8_t {
+    Opaque, Masked, Translucent, Additive
+};
+enum class VfxPrimitiveTopology : uint8_t {
+    CameraFacingBillboard, RibbonStrip, InstancedMesh
+};
+enum class VfxShadowPolicy : uint8_t { Disabled, OpaqueMaskedCaster };
+struct DynamicInstanceTransform {
+    Mat4 localToRenderOrigin;
+};
 struct VfxRenderBatch {
-    VfxPassKind passKind;
+    VfxBatchId id;
+    VfxParticlePass pass;
     VfxPrimitiveTopology topology;
     MaterialId material;
-    MeshHandle mesh;                      // Valid for InstancedMesh topology
-    ParticleBufferView instanceData;      // Position, size, rotation, color, UV
-    BufferHandle indirectArgsBuffer;       // Optional, for GPU indirect draw dispatches
-    uint32_t indirectArgsOffset;
-    AABB worldBounds;
-    float sortDistance;                   // Key for translucent back-to-front sorting
-    bool isCastShadowEnabled;
+    OptionalMeshHandle mesh;        // required for InstancedMesh
+    ParticleDataSource instances;
+    FrameSlice instanceTransforms;  // DynamicInstanceTransform layout
+    RenderRelativeBounds bounds;
+    VfxShadowPolicy shadows;
 };
-
 struct DecalRenderBatch {
+    DecalId id;
     MaterialId material;
-    Transform worldTransform;
+    DecalProjectionPath path;       // deferred or forward, validated capability
+    DynamicInstanceTransform transform;
     Vec3 halfSize;
     float fadeFactor;
-    AABB worldBounds;
+    RenderRelativeBounds bounds;
+};
+struct VolumetricVfxBatch {
+    VfxBatchId id;
+    MaterialId material;
+    VolumeGridView density;         // typed retained volume resource + dimensions
+    DynamicInstanceTransform transform;
+    RenderRelativeBounds bounds;
+};
+struct VfxViewSortKey {
+    RenderViewId view;
+    VfxBatchId batch;
+    float sortDistance;             // render-origin-relative key, never particle state
 };
 ```
 
-## Pass Placement, Material Integration, and Sorting
+VolumetricVfxBatch is a separate volume-grid contract, not a DecalBox particle topology.
+Density dimensions/format, sample usage and lifetime are validated; unsupported volumes
+use authored fallback/unavailability. Light outputs use the renderer's existing typed
+LightData contract and admitted light budget. Shading/layout/pass combinations,
+transform count and topology are validated before publication, not inferred from
+optional native pointers. The proposed ParticleBufferView-only model is replaced by
+ParticleDataSource; renderer-owned upload makes CPU/GPU storage roles explicit.
 
-### Material & Shader Pipeline Integration
+Spatial extraction follows ADR-026 canonical world coordinates and a captured render
+origin/revision. Per-view keys and packed transforms use that same origin; rebasing
+cannot change durable emitter identity or race extraction. RenderWorldSnapshot carries
+bounded arrays of GPU work, particle batches, decals and volumes alongside scene data,
+with scene/origin revision and all leases needed until the final consumer retires.
 
-Particles and decals use the standard material system (see
-[Material And Shader Model](./material-and-shader-model.md)):
+## Pass Placement, Materials And Per-View Sorting
 
-- **Shading Models**: `Unlit`, `DefaultPBR` (lit particles/mesh particles), and
-  `DecalPBR` / `DecalEmissive`.
-- **Blend Modes**: `Opaque`, `Masked`, `Translucent` (alpha blend), and `Additive`.
-- **Soft Particles**: Translucent particle shaders consume the scene depth buffer
-  texture to evaluate soft-intersection depth fading against background geometry.
-- **Flipbook Animation**: Packed sub-UV grids animated by normalized particle age.
+[Material And Shader Model](./material-and-shader-model.md) owns shared PBR/unlit
+compilation. Particles/decals use Unlit, DefaultPBR, DecalPBR or DecalEmissive with
+validated opaque/masked/translucent/additive blend modes. Flipbooks use normalized
+particle age. Soft-particle fading samples declared scene depth in the draw pass.
 
-### Pass Placement
+| Output | Graph placement |
+|---|---|
+| CPU particle data | Bounded renderer upload before consuming passes |
+| GPU particle state | Compute update before every dependent sort/cull/draw; graph declares read/write and queue barriers |
+| Opaque/masked mesh particles | Depth prepass and G-Buffer or opaque forward path; depth writes enabled |
+| OpaqueMaskedCaster | Standard shadow caster pass with matching material alpha test; consumes the same completed simulation state |
+| Deferred/forward decals | Supported decal/G-Buffer or forward-lighting path; no particle topology workaround |
+| VolumetricVfxBatch | Volume injection/accumulation and composite with declared depth/light dependencies |
+| Translucent/ribbons | Per-view sort then translucent forward; depth test, no depth write |
+| Additive | Additive forward; depth test, no depth write, no distance sort |
 
-| Primitive Type | Target Pass | Blend Mode | Depth Write | Depth Test |
-|---|---|---|---|---|
-| **Opaque Mesh Particles** | G-Buffer / Opaque Forward | `Opaque` | Yes | Yes |
-| **Masked Mesh Particles** | Depth Pre-Pass + G-Buffer | `Masked` | Yes | Yes |
-| **Deferred Decals** | Decal Pass (G-Buffer) | `Translucent` / `Decal` | No | Yes (Read-Only) |
-| **Forward Decals** | Forward Lighting Pass | `Translucent` | No | Yes (Read-Only) |
-| **Translucent Particles** | Translucent Forward Pass | `Translucent` | No | Yes (Read-Only) |
-| **Additive Particles** | Additive Forward Pass | `Additive` | No | Yes (Read-Only) |
-| **Volumetric VFX** | Volumetric Accumulation Pass | Custom Blend | No | Yes (Read-Only) |
+Shadow casting is supported here only for opaque/masked mesh particles. Requesting
+OpaqueMaskedCaster on ribbons, translucent/additive particles, decals or volumes is
+an unsupported combination requiring authored substitute or typed rejection. It is
+not a bool that silently inserts arbitrary shadow passes.
 
-### Camera-Relative Sorting Policy
+Each RenderViewId (game, editor, split screen, XR or reflection) gets its own sort/cull
+indices and keys over compatible immutable data. CPU radix sorting operates on packed
+frame data or an index copy in extraction/render preparation, never reorders the
+simulation SoA or writes particle distance fields. sortDistance lives only in
+VfxViewSortKey. Equal distances use stable batch/particle identity; reject nonfinite
+keys. GPU sort likewise writes separate per-view index buffers after simulation.
+Sorting one view cannot change another view or advance the emitter again.
 
-- **Translucent Systems**: Sorted strictly back-to-front relative to the active camera.
-  - **CPU Simulated**: Sorted on the CPU using multi-threaded radix sort over camera
-    distance keys before writing into the extraction buffer.
-  - **GPU Simulated**: Sorted via GPU bitonic or radix sort compute passes prior to
-    indirect draw submission.
-- **Additive Systems**: Sorting is skipped entirely, eliminating sorting overhead
-  for additive glows, sparks, and energy beams.
-- **Opaque Systems**: Sorted front-to-back by the Render Frontend alongside standard
-  static/dynamic scene meshes to maximize early-Z rejection.
+CPU sorting may use JobSystem staging with completion published before consuming the
+view. It cannot block extraction/render on a pending worker. If its bounded work is
+not ready, the declared cosmetic view fallback omits that batch and reports it; it
+does not submit unsorted alpha as though sorting succeeded. The frontend sorts opaque
+batches front-to-back alongside ordinary meshes. Additive sorting is skipped.
 
 ## Particle System Data Model
 
 A particle system is a template that describes how particles are spawned,
-simulated, rendered, and destroyed.
+simulated, rendered, and destroyed. The sortMode is validated against its output
+material: None/OldestFirst cannot override required back-to-front alpha ordering.
+Authored age order is allowed only for an output whose blend contract permits it.
 
 ```cpp
 struct ParticleSystemDescriptor {
     ParticleSystemId id;
-    SimulationDomain domain;      // CPU or GPU
+    SimulationPreference preference; // resolved once per admitted emitter unit
     uint32_t maxParticles;
     EmitterShape shape;
     SpawnRate spawnRate;
@@ -312,17 +440,21 @@ struct ParticleSystemDescriptor {
 ### CPU Simulation Layout (Structure of Arrays)
 
 To maximize SIMD vectorization and cache locality, CPU particle memory is stored
-as flat arrays:
+as aligned slices of one pool-owned allocation. The spans below are mutable only
+by the owning simulation/staging job; extraction never retains them. Capacity is
+fixed at admission, and activeCount never exceeds it. Float positions are bounded
+emitter-local coordinates with a canonical WorldCoordinate64 origin; large-world
+rebasing uses versioned staging rather than treating floats as durable world identity:
 
 ```cpp
 struct CpuParticleBufferSoA {
-    std::vector<float> posX, posY, posZ;
-    std::vector<float> velX, velY, velZ;
-    std::vector<float> scaleX, scaleY;
-    std::vector<float> rotZ, rotVelZ;
-    std::vector<uint32_t> packedColor;
-    std::vector<float> age, maxAge;
-    std::vector<uint32_t> customFlags;
+    std::span<float> posX, posY, posZ;
+    std::span<float> velX, velY, velZ;
+    std::span<float> scaleX, scaleY;
+    std::span<float> rotZ, rotVelZ;
+    std::span<uint32_t> packedColor;
+    std::span<float> age, maxAge;
+    std::span<uint32_t> customFlags;
     uint32_t activeCount{0};
     uint32_t capacity{0};
 };
@@ -330,7 +462,9 @@ struct CpuParticleBufferSoA {
 
 ### GPU Compute Simulation Layout
 
-GPU particles reside in device compute buffers and are updated via compute kernels:
+The renderer owns GPU device buffers and runs the cooked kernels in declared graph
+passes. This shader example is backend-private, not a public VFX API or permission
+for VfxWorld to allocate/dispatch:
 
 ```hlsl
 struct GpuParticleData {
@@ -378,8 +512,11 @@ Graph nodes:
 | `Audio` | Triggers an audio event on spawn or collision. |
 
 Graphs compile ahead-of-time (or at asset cook time) into runtime descriptors and
-optimized compute/CPU kernels. The graph runtime never interprets arbitrary scripts
-per particle.
+optimized compute/CPU kernels. Compilation validates emitter dependency closure,
+CPU-mandatory conflicts, fallback compatibility, bounded parameters and peak cost.
+Asset versions migrate the previous domain field explicitly; cook diagnoses required
+unsupported nodes rather than silently dropping gameplay behavior. The graph runtime
+never interprets arbitrary scripts per particle.
 
 ## Decals
 
@@ -402,12 +539,13 @@ struct DecalDescriptor {
   Forward decals use clustered/tiled decal lists on forward feature tiers.
 - **Lifetime**: Supports permanent environmental decals, timed fading decals
   (e.g., bullet holes, blood splatters), and event-driven removal.
-- **Atlas Management**: `DecalManager` pools and batches decal textures to minimize
-  descriptor and texture switches.
+- **Atlas Management**: `DecalManager` groups logical atlas requests; the renderer
+  owns texture packing/upload and deferred atlas retirement under the admitted budget.
 
 ## Event-Driven Spawning & Audio Coupling
 
-Gameplay spawns effects by submitting requests to `VfxEventQueue`:
+Gameplay requests effects through fallible bounded admission to VfxEventQueue;
+this schematic payload is copied into queue-owned storage:
 
 ```cpp
 struct VfxSpawnRequest {
@@ -415,57 +553,88 @@ struct VfxSpawnRequest {
     Transform worldTransform;
     std::optional<Vec3> impactNormal;
     float scale{1.0f};
-    VariantMap parameters;
+    VfxParameterBlock parameters; // fixed-capacity, schema-typed values
+    VfxOwnershipScope ownership;  // scene, cell fence, or explicit persistent owner
+    VfxRequestClass requestClass; // gameplay-required or cosmetic
 };
 ```
 
 ### Audio Routing
 
 VFX graphs trigger audio events on spawn, collision, or sub-emitter creation. Audio
-events are dispatched to `AudioWorld` via typed IDs and world positions; the VFX
-subsystem never plays sounds directly, preserving the mixing and spatialization
-pipeline.
+events are bounded typed requests to AudioWorld with asset/event IDs, owner fence
+and world position; VFX never plays sounds directly. Queue rejection remains visible
+and follows the same required/cosmetic failure distinction. Gameplay-relevant or
+headless-required audio is driven by CPU/logical events, not GPU readback or Null
+fabricated collisions. Renderer completion never calls audio from a native GPU thread.
 
-## Performance Budgets and Diagnostics
+## Performance Budgets And Diagnostics
 
-### Per-Effect Budgets
+Budgets cover maximum particles per emitter, concurrent instances per asset, emitter
+slots, decals, pending events/results, worker scratch, per-view packing/sorting,
+GPU work and every frame/retirement lease. Baseline configurable defaults remain
+16,384 aggregate CPU particles, 1,000,000 GPU particles, 256 decals and four transient
+lights per effect. They are ceilings, not guaranteed allocations. Device byte/work
+limits, host aggregate budgets and required gameplay reservations may lower usable
+capacity. Every count/byte product is checked before allocation or admission.
 
-- Maximum particle count per emitter.
-- Maximum concurrent active instances per effect asset.
-- Maximum transient point lights spawned (e.g., max 4 lights per scene effect).
-- Maximum active decals per volume.
+Admission includes all simultaneous CPU/GPU/upload/sort copies and frames in flight;
+old scene/cell retirement stays charged. Streaming cell reservations are slices of
+ADR-012's aggregate ledger, not an extra VFX allowance. Resource growth needs prior
+reservation; GPU completion, not logical release, returns credits. Bounded extraction
+work prevents starting excess work, not preempts native calls or guarantees frame time.
 
-### Global World Budgets
+The single overflow policy above rejects incoming requests/new cosmetic births.
+There is no separate implicit oldest/farthest eviction policy. Authored quality
+reductions are selected during admission/restart and reported with the resolved
+cap, capability/policy revision, emitter identity and reason. Diagnostics expose
+queue/pool use, rejected requests, deferred steps, gameplay failures, sort omissions,
+retired bytes and timeout causes through the observability system.
 
-- Total active CPU particles (default limit: 16,384 across all CPU systems).
-- Total active GPU particles (default limit: 1,000,000 across all GPU systems).
-- Total active decals (default limit: 256).
-- Maximum render extraction time budget per frame.
+## Typed Failure Contract
 
-Over-budget conditions drop oldest/farthest cosmetic particles, clamp spawn counts,
-and emit structured diagnostics according to the observability system.
+Follow [ADR-008](../../adr/008-error-model-exception-boundary-and-registry.md) Result/Error.
+Failures retain scene/emitter/request identity, policy/capability revision and the
+underlying asset/renderer/job cause. DomainConflict, UnsupportedCapability or
+MissingKernel rejects incompatible admission. EventQueueFull, EffectCapacityExceeded
+and ResourceBudgetExceeded preserve existing state and require explicit caller
+handling. Cancelled/StaleGeneration suppress publication but still route matching
+retirement acknowledgements. RetirementIncomplete keeps resources/dependencies
+charged and alive; it is never translated into successful shutdown.
 
-## Testing and Verification Requirements
+## Testing And Verification Requirements
 
-- **Ownership & Lifecycle Tests**: Verify `VfxWorld` construction, tick, and complete
-  destruction on `SceneRuntime` unload without leaking memory or GPU handles.
-- **Domain Selection Policy Tests**: Verify deterministic domain resolution across
-  all feature tiers (`null`, `es3`, `dx11`, `dx12_vulkan`, `metal`), including a
-  gameplay-interactive system above 2,048 particles, both sides of the Automatic
-  threshold, and the `es3` tier-cap override.
-- **Null / Headless Simulation Tests**: Verify `NullParticleSimulator` produces
-  deterministic, zero-graphics simulation ticks in headless test environments.
-- **Render Extraction Tests**: Verify `VfxRenderExtractor` emits valid, typed
-  `VfxRenderBatch` primitives with correct sort distances and bounding boxes.
-- **Sorting Correctness Tests**: Verify translucent particle back-to-front sorting
-  and additive sort-skipping invariants.
-- **Memory Pooling Invariants**: Assert zero heap allocations during steady-state
-  particle updates and burst spawning.
+These are qualification scenarios for implementation, not tests delivered by this
+architecture-only change:
+
+- Resolve a mixed CPU/GPU graph per emitter; force a high-count gameplay emitter to
+  CPU; reject RequireGPU conflicts and invalid synchronous cross-domain dependencies.
+- Exercise 2048/2049 default heuristic, configured thresholds, 512 cosmetic fallback,
+  missing kernels/capabilities, RequireGPU authored fallback/unavailability, and no
+  silent gameplay count clamp or concrete renderer switch.
+- Run gameplay CPU kernels with identical seed/tick inputs in graphical and headless
+  hosts; verify Null's accepted FIFO, next-tick results, pause/cancel/lifetime timing.
+  Fake delayed submission/fences rather than assuming Null matches device latency.
+- Fill instance/particle/event/result/frame pools. Verify incoming rejection, gameplay
+  reserve, stable ordering, no old-entry overwrite, cleanup progress and zero hot-path
+  heap growth, including bounded typed parameter copying and diagnostics.
+- Verify extraction never submits passes, writes mapped GPU buffers or mutates SoA;
+  validate CPU/GPU source layouts, slice bounds, generations and retained ownership.
+- Render one snapshot in multiple views/frames: submit each GPU step once; sort each
+  view independently; preserve SoA and stable ties; reject nonfinite keys and invalid
+  shadow/volume/decal combinations. Exercise a missing previous-depth snapshot.
+- Verify graph compute/read/write/sort/draw dependencies and native affinity on each
+  supported backend/capability profile, including an explicit no-compute composition.
+- Delay workers, GPU fences and snapshot readers across cell eviction and scene
+  replacement. No early free/slot reuse, stale publication or lost accounting;
+  Retired remains pending and teardown timeout retains dependencies safely.
+- Verify provider Ready/Prepared/Retired barriers, authored optional/fallback behavior,
+  typed failures, and partial cell eviction without stopping unrelated effects.
 
 ## Related Documents
 
 - [ADR-011: Effect Ownership, Simulation Domain Policy and Renderer Boundary](../../adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md):
-  Authoritative M0 architecture decision.
+  Proposed ownership, simulation and renderer-boundary decision.
 - [Particle Editor UI Reference](./particle-editor.html): Emitter stack, curve editing,
   and live preview panel.
 - [Material And Shader Model](./material-and-shader-model.md): Particle and decal materials.
@@ -474,3 +643,6 @@ and emit structured diagnostics according to the observability system.
 - [Advanced Rendering Architecture](./advanced-rendering-architecture.md): Volumetrics and post-processing.
 - [Audio Architecture](./audio-architecture.md): Audio event routing.
 - [Asset Pipeline](./asset-pipeline.md): Effect compilation and cooking.
+- [World Streaming Architecture](./world-streaming-architecture.md): Provider barriers and cell ownership.
+- [Render Backend Parity Contract](./render-backend-parity-contract.md): Typed capabilities and equal backends.
+- [Renderer Distribution And Availability](./renderer-distribution-and-availability.md): Explicit renderer selection.


### PR DESCRIPTION
## Summary

Propose ADR-011 for VFX ownership, per-emitter simulation domains and renderer boundaries, incorporating the supplied VFX reviews. ADR-011 remains **Proposed**; this documentation change does not claim formal acceptance or runtime implementation.

- Separate logical VfxWorld state and GPU work descriptors from renderer-owned command encoding, graph scheduling and native resources. Extraction writes immutable snapshots; RenderFrontend schedules compute, per-view sort/cull and standard draw passes.
- Resolve CPU-mandatory behavior per compiled emitter, including mixed graphs. Add explicit RequireCPU/PreferCPU/PreferGPU/RequireGPU intent, authored fallbacks, typed capabilities and finite budgets instead of backend-name assumptions.
- Keep real CPU gameplay simulation in headless hosts. Null only suppresses permitted visuals and preserves queue/tick/lifecycle timing.
- Define incoming-request rejection for pool/queue exhaustion, reserved gameplay/result/cleanup capacity, bounded typed parameters and no hot-path pool growth.
- Reconcile ADR-012 cell Ready/Prepared/Retired barriers with scene teardown and renderer fence-based retirement. Distinguish immediate logical stopping from deferred physical release.
- Define CPU frame slices versus GPU state views, volume/decal/shadow contracts, per-view sort data and once-per-step GPU submission across snapshot reuse.
- Rebase onto main after #2341, preserve the existing ADR index and add the corresponding renderer snapshot boundary clarification. The first attachment repeats the already-resolved streaming review; its relevant integration rules are applied here.

## Validation

- `git diff --check`.
- Relative Markdown links, balanced fences, one document title per file and preservation of existing ADR index records.
- Manual reconciliation against both VFX reviews and ADR-010/012/018 plus the rendering/Scene contracts.
- Documentation only: runtime/build/GPU tests were not run. The listed qualification scenarios are implementation requirements, not tests added in this PR.
- Latest-commit Codacy/Gitar results and review comments are checked before merge.

## Risks

Implementation must supply bounded admission, compatible cooked fallback kernels, graph resource versions and delayed retirement. These contracts are specified here, not claimed as implemented.

## Issue Links

Closes #1749. HORO-1706 [VFX-001.1].
