### PR TITLE
docs(ai): environment query ownership, item and scoring model decision HORO-1346 #1346 [GAI-004.1]

### DIFF
--- a/docs/adr/011-environment-query-ownership-item-and-scoring-model.md
+++ b/docs/adr/011-environment-query-ownership-item-and-scoring-model.md
@@ -1,0 +1,162 @@
+# ADR-011: Environment Query Ownership, Item and Scoring Model
+
+- **Status**: Proposed
+- **Date**: 2026-08-28
+- **Supersedes**: None
+- **Scope**: Environment Query System (EQS), query templates/plans, item types, contexts, generators, tests, score normalization, subsystem provider boundaries, time-budgeted execution, caching, determinism, and cancellation
+- **Issue**: [#1346](https://github.com/abdullahbodur/horo-engine/issues/1346) ([GAI-004.1])
+- **JIRA**: HORO-1785
+- **Normative document**: [Navigation And AI Architecture](../architecture/runtime/navigation-and-ai-architecture.md)
+
+## Context
+
+Tactical AI agents require spatial reasoning to select positions in the world (such as finding cover, establishing flanking angles, maintaining line of sight to a target, or choosing patrol vantage points). Without a formal tactical query framework, gameplay code tends to embed ad hoc physics raycasts, NavMesh traversability checks, perception scans, and scoring heuristics directly inside behavior trees, state machines, or tick callbacks. This causes:
+
+1. **Distributed and competing ownership**: Navigation, Physics, and Perception systems are polled ad hoc without unified scheduling or lifecycle tracking.
+2. **Fixed-tick stalls and unbounded frame overhead**: Synchronous world queries (e.g. dozens of line-of-sight raycasts and NavMesh path computations) stall the simulation thread when multiple agents make tactical decisions simultaneously.
+3. **Inconsistent and non-deterministic scoring**: Ad hoc scoring formulas produce non-normalized values, suffer from arithmetic anomalies (NaN/Inf), and lack deterministic tie-breaking.
+4. **Lifecycle and memory leaks**: When an agent or target entity is destroyed during an in-flight query, callbacks access dangling pointers or leave background work orphaned.
+5. **Lack of caching and deduplication**: Identical tactical queries (e.g. multiple squad members searching for cover near the same anchor point) duplicate expensive geometric tests across ticks.
+
+[GAI-004.1] requires an authoritative architecture decision freezing the tactical query model, defining query templates, items, contexts, generators, tests, score normalization, provider separation, asynchronous time-budgeted execution, deterministic replay, caching, and lifecycle cancellation before subsequent GAI-004 implementation tickets proceed.
+
+## Decision
+
+**The Gameplay AI subsystem (`HoroAI` / `EnvironmentQueryManager`) is the sole authority owning query orchestration, stage scheduling, test evaluation, score normalization, result aggregation, and terminal outcomes. Navigation, Physics, and Perception systems act strictly as read-only snapshot providers. Behavior trees and decision graphs consume query results asynchronously via typed handles without blocking fixed-tick simulation. All scoring is normalized to `[0.0, 1.0]` with strict deterministic tie-breaking cascades, and queries execute under per-tick time budgets with cooperative cancellation on entity or scene destruction.**
+
+### 1. Subsystem Ownership and Separation of Concerns
+
+| Subsystem / Authority | Role in Environment Queries | Forbidden Actions |
+|---|---|---|
+| **`EnvironmentQueryManager` (GAI)** | **Single authority** owning query lifecycle, query plans, stage scheduling, candidate generation, test execution, scoring normalization, cache management, and terminal outcome delivery. | Does not own collision geometry, NavMesh geometry, or sensory stimulus stores. |
+| **`NavigationSystem`** | **Read-only provider** for NavMesh surface projection, polygon containment, traversability, and pathfinding distance/cost calculation. | Does not execute query plans, score candidates, or manage tactical decision state. |
+| **`PhysicsSystem`** | **Read-only provider** for geometric raycasts, shape sweeps, line-of-sight checks, and scene collision overlap queries. | Does not orchestrate multi-stage AI queries or rank items. |
+| **`PerceptionSystem`** | **Read-only provider** for perceived entities, stimulus locations, sensory memory records, and visibility states. | Does not generate spatial grids or evaluate navigation costs. |
+| **Decision Graphs / Behavior Trees** | **Consumers** requesting query execution via asynchronous task nodes and reading immutable `QueryResult` snapshots. | Never synchronously wait on queries or mutate query execution state during fixed ticks. |
+
+### 2. Query Asset, Template, and Item Model
+
+1. **Query Template (`EnvironmentQueryTemplate` / `EnvironmentQueryPlan`)**:
+   - Immutable, versioned compiled data assets.
+   - Declares primary item type, input context requirements, generator stages, ordered test/filter stages, normalization rules, and time budgets.
+   - Stages possess stable unique `StageId`s independent of editor ordering.
+2. **Item Types (`EnvQueryItemType`)**:
+   - `Point` (`WorldCoordinate`): 3D spatial points (cover positions, tactical vantage points, ambush locations).
+   - `Actor` / `Entity` (`EntityId`): Scene entities (potential targets, allies, cover obstacles, interactive items).
+   - `DirectionalRay` (`Ray` / `Direction`): Vectors or bearings (flanking trajectories, escape angles, aim vectors).
+   - `Custom`: Extensible payload with explicit schema for game-specific tactical constructs.
+3. **Query Contexts (`EnvQueryContext`)**:
+   - Built-in contexts: `Querier` (requesting agent), `Target` (primary focus/adversary), `QuerierLocation`, `TargetLocation`, `WorldOrigin`.
+   - Pluggable custom contexts: resolved by registered context providers (e.g. `SquadLeaderContext`, `CombatAnchorContext`, `LastKnownEnemyLocationContext`).
+   - Context values are snapshotted into an immutable `QueryContextSnapshot` at query start. Contexts never expose raw mutable scene pointers.
+
+### 3. Generators and Tests
+
+1. **Generators (`EnvQueryGenerator`)**:
+   - Produce candidate items bounded by explicit configuration parameters.
+   - Built-in generators:
+     - `GridGenerator`: 2D/3D regular lattice around context with defined radius, density/spacing, and layer masks.
+     - `DonutRingGenerator`: Concentric radial rings around context with inner radius, outer radius, and radial step counts.
+     - `ConeGenerator`: Wedge/cone oriented along context forward vector with radius, angle, and angular steps.
+     - `NavMeshProjectionGenerator`: Projects spatial candidate points onto valid NavMesh surfaces, filtering unreachable geometry.
+     - `PerceivedEntitiesGenerator`: Populates candidate items from agent perception memory matching filter criteria.
+   - All generators enforce strict maximum item limits (`maxItems`) to prevent unbounded memory allocation and CPU spikes.
+2. **Tests and Filters (`EnvQueryTest`)**:
+   - `LineOfSightTest`: Raycast or shape sweep between candidate item and target/querier context using Physics traces.
+   - `DistanceTest`: Euclidean, Chebyshev, Manhattan, or NavMesh path distance between item and context.
+   - `DotProductTest`: Directional alignment (facing angle, field of view, flanking angle).
+   - `PathfindingCostTest`: NavMesh path length, travel cost, or reachability.
+   - `CoverExposureTest`: Obstacle height, stance clearance, and exposure angle relative to threat positions.
+   - Test Modes:
+     - `FilterOnly`: Discards items failing a boolean threshold (e.g. must have line of sight).
+     - `ScoreOnly`: Assigns normalized continuous score `[0.0, 1.0]` without discarding.
+     - `FilterAndScore`: Discards non-qualifying items and scores survivors.
+
+### 4. Scoring Normalization and Deterministic Tie-Breaking
+
+1. **Score Normalization**:
+   - Every scoring test normalizes raw values to `[0.0, 1.0]` using explicit scoring functions:
+     - `Linear`: `(val - min) / (max - min)`
+     - `InverseLinear`: `1.0 - (val - min) / (max - min)`
+     - `Sigmoid` / `SCurve`: Smooth progression emphasizing mid-ranges.
+     - `ThresholdStep`: Step function returning `0.0` or `1.0`.
+   - Arithmetic Safety: Non-finite scores (`NaN`, `+Inf`, `-Inf`) and division-by-zero are trapped; offending items are assigned `0.0` with diagnostic reporting and cannot rank as winning candidates.
+2. **Total Score Aggregation**:
+   - Weighted linear combination:
+     $$\text{TotalScore} = \frac{\sum_{i=1}^{N} w_i \cdot s_i}{\sum_{i=1}^{N} w_i}$$
+     where $w_i \ge 0$ is the stage weight and $s_i \in [0.0, 1.0]$ is the normalized test score.
+3. **Deterministic Tie-Breaking Cascade**:
+   - Candidate ranking must be 100% deterministic and independent of worker thread scheduling or memory address order.
+   - Ranking order:
+     1. Primary: Highest `TotalScore`.
+     2. Secondary: Configured tie-breaker test score (e.g. closest distance to Querier).
+     3. Tertiary: Stable item generation sequence index (`item_index`), ensuring zero jitter across replay runs.
+
+### 5. Time-Budgeted Asynchronous Execution and Lifecycles
+
+```text
++-------------------------------------------------------------------------+
+|                       EnvironmentQueryManager                           |
+|  +-------------------------------------------------------------------+  |
+|  | Tick (Time-Sliced Budget: e.g. 1.5ms / max N items per frame)      |  |
+|  +-------------------------------------------------------------------+  |
+|         |                     |                      |                  |
+|  +--------------+     +----------------+     +------------------+       |
+|  | Query State: |     | Query State:   |     | Query State:     |       |
+|  | Resolving    | --> | Generating /   | --> | Scoring /        |       |
+|  | Context      |     | Nav Projection |     | Physics Traces   |       |
+|  +--------------+     +----------------+     +------------------+       |
+|                                                      |                  |
+|                                              +------------------+       |
+|                                              | Query State:     |       |
+|                                              | Completed /      |       |
+|                                              | PartialSuccess   |       |
+|                                              +------------------+       |
++-------------------------------------------------------------------------+
+```
+
+1. **Asynchronous Multi-Frame Staging**:
+   - Queries execute across multiple frames using cooperative time-slicing under a configured global/per-tick time budget (e.g. `1.5ms` per simulation tick).
+   - High-load queries yield at stage boundaries or item batch boundaries and resume on subsequent ticks.
+2. **Terminal States**:
+   - `Completed`: Query evaluated all stages and returned ranked items.
+   - `PartialSuccess`: Budget exhausted or early exit requested; returns best-ranked valid candidate evaluated so far.
+   - `Cancelled`: Query cancelled cooperatively by caller token or owning task.
+   - `TimedOut`: Query exceeded maximum allowed elapsed frames without finding a valid candidate.
+   - `Aborted`: Querier, target entity, or scene was destroyed during in-flight evaluation.
+3. **Lifecycle Safety and Cancellation**:
+   - Queries hold weak `EntityId` handles and scene generation counters.
+   - On entity destruction or scene transition, in-flight queries transition to `Aborted` immediately; outstanding asynchronous jobs, raycasts, and pathfinding requests are cancelled.
+   - Result callbacks and decision nodes observe typed failure rather than executing against invalid entities.
+4. **Caching and Invalidation**:
+   - Immutable query results may be cached using a composite key:
+     $$\text{CacheKey} = (\text{QueryTemplateId}, \text{ContextSnapshotHash}, \text{NavMeshRevision}, \text{PhysicsRevision})$$
+   - Bounded LRU cache with time-to-live (TTL).
+   - Cache eviction never invalidates caller-owned `QueryResult` snapshots.
+
+## Ratify-or-Revise Outcomes
+
+| Area | Current Baseline | Outcome |
+|---|---|---|
+| Query orchestration authority | Ad hoc raycasts and navigation queries scattered in gameplay code | **Revised.** `EnvironmentQueryManager` is established as the sole orchestration authority. |
+| Subsystem boundaries | Direct synchronous physics/navmesh calls | **Ratified separation.** Navigation, Physics, and Perception provide read-only data snapshots; GAI executes queries. |
+| Item types | Implicit spatial coordinates only | **Revised.** Explicit typed items (`Point`, `Actor`/`Entity`, `DirectionalRay`, `Custom`). |
+| Scoring normalization | Unbounded raw values, potential division by zero | **Revised.** Mandatory normalization to `[0.0, 1.0]`, NaN/Inf traps, and deterministic tie-breaking cascades. |
+| Execution threading | Synchronous single-tick queries risking frame drops | **Revised.** Asynchronous time-budgeted multi-frame staging with cooperative cancellation. |
+| Lifecycle safety | Unchecked raw entity handles | **Revised.** Weak entity tracking, scene generation counters, and automatic abortion on destruction. |
+
+## Consequences
+
+- AI tactical decision making is decoupled from low-level physics and navigation details.
+- Frame rates remain stable under heavy AI load due to strict time budgeting and asynchronous staging.
+- Tactical queries produce 100% deterministic results across replay runs.
+- Behavior trees and decision graphs interact through clean, non-blocking async task nodes.
+- Memory and entity lifetimes are protected against dangling references and orphaned background jobs.
+
+## Rejected Alternatives
+
+- **Let Physics or Navigation subsystem own tactical queries.** Rejected: violates single responsibility and couples world geometry to gameplay decision logic.
+- **Run all queries synchronously in a single frame.** Rejected: causes catastrophic simulation frame drops when multiple agents query simultaneously.
+- **Use unbounded floating-point scores without normalization.** Rejected: leads to weighted combination imbalances, arithmetic overflow, and non-deterministic behavior.
+- **Rely on memory address or hash map iteration order for candidate ranking.** Rejected: creates non-deterministic simulation divergence across different platforms and runs.
+- **Allow queries to hold direct scene pointers.** Rejected: leads to use-after-free crashes when entities or components are removed during query execution.

--- a/docs/adr/011-environment-query-ownership-item-and-scoring-model.md
+++ b/docs/adr/011-environment-query-ownership-item-and-scoring-model.md
@@ -130,7 +130,7 @@ Tactical AI agents require spatial reasoning to select positions in the world (s
    - Result callbacks and decision nodes observe typed failure rather than executing against invalid entities.
 4. **Caching and Invalidation**:
    - Immutable query results may be cached using a composite key:
-     $$\text{CacheKey} = (\text{QueryTemplateId}, \text{ContextSnapshotHash}, \text{NavMeshRevision}, \text{PhysicsRevision})$$
+     $$\text{CacheKey} = (\text{QueryTemplateId}, \text{ContextSnapshotHash (querier/target positions quantized to integer millimeters)}, \text{NavMeshRevision}, \text{PhysicsRevision})$$
    - Bounded LRU cache with time-to-live (TTL).
    - Cache eviction never invalidates caller-owned `QueryResult` snapshots.
 

--- a/docs/adr/013-environment-query-ownership-item-and-scoring-model.md
+++ b/docs/adr/013-environment-query-ownership-item-and-scoring-model.md
@@ -1,4 +1,4 @@
-# ADR-011: Environment Query Ownership, Item and Scoring Model
+# ADR-013: Environment Query Ownership, Item and Scoring Model
 
 - **Status**: Proposed
 - **Date**: 2026-08-28

--- a/docs/adr/013-environment-query-ownership-item-and-scoring-model.md
+++ b/docs/adr/013-environment-query-ownership-item-and-scoring-model.md
@@ -5,7 +5,7 @@
 - **Supersedes**: None
 - **Scope**: Environment Query System (EQS), query templates/plans, item types, contexts, generators, tests, score normalization, subsystem provider boundaries, time-budgeted execution, caching, determinism, and cancellation
 - **Issue**: [#1346](https://github.com/abdullahbodur/horo-engine/issues/1346) ([GAI-004.1])
-- **JIRA**: HORO-1785
+- **JIRA**: HORO-1346
 - **Normative document**: [Navigation And AI Architecture](../architecture/runtime/navigation-and-ai-architecture.md)
 
 ## Context

--- a/docs/adr/013-environment-query-ownership-item-and-scoring-model.md
+++ b/docs/adr/013-environment-query-ownership-item-and-scoring-model.md
@@ -3,160 +3,230 @@
 - **Status**: Proposed
 - **Date**: 2026-08-28
 - **Supersedes**: None
-- **Scope**: Environment Query System (EQS), query templates/plans, item types, contexts, generators, tests, score normalization, subsystem provider boundaries, time-budgeted execution, caching, determinism, and cancellation
+- **Scope**: EQS orchestration, typed providers, plans/items/contexts, scoring, safe points, deterministic/adaptive budgets, cache identity and cancellation
 - **Issue**: [#1346](https://github.com/abdullahbodur/horo-engine/issues/1346) ([GAI-004.1])
 - **JIRA**: HORO-1346
-- **Normative document**: [Navigation And AI Architecture](../architecture/runtime/navigation-and-ai-architecture.md)
+- **Normative document**: [Navigation And AI Architecture — EQS](../architecture/runtime/navigation-and-ai-architecture.md#environment-query-system-eqs)
 
 ## Context
 
-Tactical AI agents require spatial reasoning to select positions in the world (such as finding cover, establishing flanking angles, maintaining line of sight to a target, or choosing patrol vantage points). Without a formal tactical query framework, gameplay code tends to embed ad hoc physics raycasts, NavMesh traversability checks, perception scans, and scoring heuristics directly inside behavior trees, state machines, or tick callbacks. This causes:
-
-1. **Distributed and competing ownership**: Navigation, Physics, and Perception systems are polled ad hoc without unified scheduling or lifecycle tracking.
-2. **Fixed-tick stalls and unbounded frame overhead**: Synchronous world queries (e.g. dozens of line-of-sight raycasts and NavMesh path computations) stall the simulation thread when multiple agents make tactical decisions simultaneously.
-3. **Inconsistent and non-deterministic scoring**: Ad hoc scoring formulas produce non-normalized values, suffer from arithmetic anomalies (NaN/Inf), and lack deterministic tie-breaking.
-4. **Lifecycle and memory leaks**: When an agent or target entity is destroyed during an in-flight query, callbacks access dangling pointers or leave background work orphaned.
-5. **Lack of caching and deduplication**: Identical tactical queries (e.g. multiple squad members searching for cover near the same anchor point) duplicate expensive geometric tests across ticks.
-
-[GAI-004.1] requires an authoritative architecture decision freezing the tactical query model, defining query templates, items, contexts, generators, tests, score normalization, provider separation, asynchronous time-budgeted execution, deterministic replay, caching, and lifecycle cancellation before subsequent GAI-004 implementation tickets proceed.
+Tactical AI queries compose candidate generation, geometric/navigation tests and
+ranking to find cover, targets or vantage points. The previous proposal described
+active query execution as passive snapshot provision, combined millisecond cutoffs
+with unconditional replay determinism, and treated ordinary slice exhaustion as a
+terminal partial result. Its cache omitted dependencies such as Perception and its
+cancellation wording implied that every running provider job could be stopped.
+These contracts need explicit authority, timing, identity and lifetime rules.
 
 ## Decision
 
-**The Gameplay AI subsystem (`HoroAI` / `EnvironmentQueryManager`) is the sole authority owning query orchestration, stage scheduling, test evaluation, score normalization, result aggregation, and terminal outcomes. Navigation, Physics, and Perception systems act strictly as read-only snapshot providers. Behavior trees and decision graphs consume query results asynchronously via typed handles without blocking fixed-tick simulation. All scoring is normalized to `[0.0, 1.0]` with strict deterministic tie-breaking cascades, and queries execute under per-tick time budgets with cooperative cancellation on entity or scene destruction.**
+**Gameplay AI owns tactical orchestration and scoring. Navigation, Physics and
+Perception own both their domain data and query execution; EQS submits bounded
+typed read-only requests. Immutable submission inputs govern an accepted query.
+Deterministic execution uses work units and declared-tick provider publication;
+adaptive execution may use wall-time targets with weaker timing guarantees.
+Ordinary yielding is nonterminal. Cache correctness requires complete input and
+provider identities. Cancellation suppresses late results while safely retiring
+work that cannot be interrupted.**
 
-### 1. Subsystem Ownership and Separation of Concerns
+### Ownership And Composition
 
-| Subsystem / Authority | Role in Environment Queries | Forbidden Actions |
+| Responsibility | Authority |
+|---|---|
+| Admission, query handles, lifecycle, scheduling and terminal publication | EnvironmentQueryManager within Gameplay AI |
+| Candidate/test stages | Internal QueryExecutor |
+| Normalization/aggregation/ranking | Internal QueryScoring |
+| Result entries and bounded eviction | Internal QueryCache |
+| Navigation projection, containment and path/cost kernels | NavigationCoordinator / NavigationApi under ADR-016 |
+| Collision ray/sweep/overlap kernels | Physics owner or its read-only query adapter |
+| Agent-specific sensed state and memory | Perception domain |
+| Decisions using immutable results | Behavior trees / decision graphs |
+
+Sole authority is a **subsystem** rule, not a mandate for one concrete manager class
+to implement every operation. Internal roles do not create independent schedulers,
+thread pools or OperationStores. EQS never implements pathfinding from borrowed
+NavMesh data, mutates provider state or gives clients access to server-private
+perception. Host composition injects domain adapters; no runtime editor dependency
+or provider discovery through global services is introduced.
+
+### Assets, Inputs And Extensions
+
+EnvironmentQueryTemplate has a stable AssetId registered in AssetRegistry;
+EnvironmentQueryPlan is its immutable cooked artifact, published through CookCatalog.
+Stable StageIds survive renaming/reordering. The plan records complete stage/context
+schemas, dependencies, result policy, scores and budgets. Runtime pins its artifact
+digest for the query lifetime rather than changing plans on hot reload.
+
+Follow the [Asset Pipeline](../architecture/runtime/asset-pipeline.md) and
+[ADR-017](017-prefab-role-ownership-and-capability-tiers.md): preserve every canonical
+cook-key field and use the dependency-aware extension for referenced assets and
+provider/schema artifacts. ProjectVersion authoring migration precedes cook;
+cooked-format/schema compatibility is independently checked at runtime. Unsupported
+versions, broken dependencies and bounds errors fail before activation. This is a
+required implementation contract, not a claim of a completed EQS cooker.
+
+Point uses canonical WorldCoordinate64; Actor carries a non-owning EntityRef with
+scene and entity generation; DirectionalRay includes an origin and finite direction.
+Custom items carry a stable type/schema ID and bounded immutable canonical bytes
+(maximum 64 inline bytes). No pointers, borrowed transient views, native C++ object
+layouts or callbacks enter payloads. Context data uses bounded retained storage.
+
+Required contexts, positions, identities, parameters, tags/team/faction/stance,
+seed and provider read versions are captured at successful submission. Contexts
+remain unchanged across ticks: consumers requiring fresher state cancel/reissue.
+Results expose as-of ticks and revisions; they are not promises of current state.
+Provider reads use retained immutable versions or validate the captured revision;
+inability to honor it yields StaleInputs, never a silent context refresh.
+
+Custom item/context/stage descriptors are inert metadata, following
+[ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md).
+They declare unique namespaced IDs, schema versions, size/alignment, dependencies,
+owner thread/safe point, mode capabilities and canonical serialization/hash/equality.
+Host composition rejects duplicates, missing dependencies, cycles and incompatible
+schemas. A provider without complete deterministic cache identity makes the query
+uncacheable, not partially keyed.
+
+### Generators, Tests And Scoring
+
+Grid, donut-ring and cone generators have checked dimensions and maxItems.
+NavMeshProjectionGenerator submits Navigation-owned work; PerceivedEntitiesGenerator
+reads an authorized perception snapshot. Stable item indices are assigned before
+async dispatch using canonical generation/entity order.
+
+GeometryLineOfSightTest measures physical obstruction through Physics.
+PerceivedVisibilityTest asks what an agent senses/remembers through Perception.
+Distance, dot-product, path-cost and cover-exposure tests declare all actual provider
+and context dependencies. Geometric visibility and perception are not synonyms.
+
+Each test filters, scores, or both. Scores normalize to [0,1] using declared fixed
+ranges. Scored plans use `sum(weight * score) / sum(weight)`; cook/admission require
+finite nonnegative weights and a finite positive total, and reject invalid ranges
+and statically reproducible arithmetic failures. Explicit filter-only plans bypass
+the formula and use stable selection ordering.
+
+Runtime NaN/Inf or overflow marks a candidate InvalidScore, excludes it from winning,
+and produces a bounded diagnostic; a displayed zero does not make invalid data
+eligible. Validation tests surface reproducible authoring errors. Ranking compares
+plan-versioned fixed-point ScoreKeys, then the configured tie-breaker and stable
+item index, with explicit precision/rounding and StageId aggregation order. No
+hash-map/pointer order or non-transitive epsilon comparator is permitted.
+
+### Threading, Safe Points And Modes
+
+EQS runs on the simulation owner using existing ADR-021/022 phases. BlackboardSync
+drains eligible results and publishes immutable terminal records before blackboards
+freeze. At the start of AiDecisionEvaluate, previously admitted queries advance;
+behavior nodes then submit requests or consume published results. New admissions
+never execute or callback inline. Navigation retains NavIntentCommit publication;
+Physics retains its owner-thread/outside-Step or leased-snapshot query contract.
+Provider completions feed a later BlackboardSync, not a reentrant decision callback.
+
+EQS accounts for stage/item work and provider admissions; providers own their own
+kernel/scratch/queue budgets. Backpressure yields before acceptance; an accepted
+request is not resubmitted each tick. Host composition intersects budgets, so EQS
+cannot reset provider quotas or gain capacity by nesting jobs. Background work uses
+Foundation JobSystem/JobId. Owner paths never Wait/Join; workers never wait on nested
+provider jobs. Only user-facing tooling gets OperationId through the application
+coordinator's shared OperationStore under [ADR-010](010-job-waiting-and-operation-store-ownership.md).
+
+| Mode | Authoritative budget | Replay guarantee |
 |---|---|---|
-| **`EnvironmentQueryManager` (GAI)** | **Single authority** owning query lifecycle, query plans, stage scheduling, candidate generation, test execution, scoring normalization, cache management, and terminal outcome delivery. | Does not own collision geometry, NavMesh geometry, or sensory stimulus stores. |
-| **`NavigationSystem`** | **Read-only provider** for NavMesh surface projection, polygon containment, traversability, and pathfinding distance/cost calculation. | Does not execute query plans, score candidates, or manage tactical decision state. |
-| **`PhysicsSystem`** | **Read-only provider** for geometric raycasts, shape sweeps, line-of-sight checks, and scene collision overlap queries. | Does not orchestrate multi-stage AI queries or rank items. |
-| **`PerceptionSystem`** | **Read-only provider** for perceived entities, stimulus locations, sensory memory records, and visibility states. | Does not generate spatial grids or evaluate navigation costs. |
-| **Decision Graphs / Behavior Trees** | **Consumers** requesting query execution via asynchronous task nodes and reading immutable `QueryResult` snapshots. | Never synchronously wait on queries or mutate query execution state during fixed ticks. |
+| DeterministicWorkUnits | Bounded item/stage/provider units, stable order and declared tick deadlines | Same semantic result and publication tick for identical input/revision histories and declared provider/numeric contract |
+| AdaptiveRealtime | Same hard caps plus optional wall-time targets at yield boundaries | No guarantee of identical completion timing or partial candidate populations |
 
-### 2. Query Asset, Template, and Item Model
+Deterministic providers execute bounded kernels on their declared owning executor,
+following ADR-016, instead of selecting whichever worker finished first. Unsupported
+mode, unavailable pinned inputs or unreservable quotas cause explicit rejection;
+there is no synchronous wait fallback. Result caching is disabled in deterministic
+mode to prevent cache state changing work allocation and completion timing.
+Adaptive decisions require recorded outcomes/timing for replay. Neither mode claims
+unverified cross-platform physics or floating-point bit identity.
 
-1. **Query Template (`EnvironmentQueryTemplate` / `EnvironmentQueryPlan`)**:
-   - Immutable, versioned compiled data assets.
-   - Declares primary item type, input context requirements, generator stages, ordered test/filter stages, normalization rules, and time budgets.
-   - Stages possess stable unique `StageId`s independent of editor ordering.
-2. **Item Types (`EnvQueryItemType`)**:
-   - `Point` (`WorldCoordinate`): 3D spatial points (cover positions, tactical vantage points, ambush locations).
-   - `Actor` / `Entity` (`EntityId`): Scene entities (potential targets, allies, cover obstacles, interactive items).
-   - `DirectionalRay` (`Ray` / `Direction`): Vectors or bearings (flanking trajectories, escape angles, aim vectors).
-   - `Custom`: Extensible payload with explicit schema for game-specific tactical constructs.
-3. **Query Contexts (`EnvQueryContext`)**:
-   - Built-in contexts: `Querier` (requesting agent), `Target` (primary focus/adversary), `QuerierLocation`, `TargetLocation`, `WorldOrigin`.
-   - Pluggable custom contexts: resolved by registered context providers (e.g. `SquadLeaderContext`, `CombatAnchorContext`, `LastKnownEnemyLocationContext`).
-   - Context values are snapshotted into an immutable `QueryContextSnapshot` at query start. Contexts never expose raw mutable scene pointers.
+### Yielding, Partial Results And Deadlines
 
-### 3. Generators and Tests
+Running, Yielded, AwaitingAdmission and AwaitingProvider are nonterminal. A per-tick
+budget cutoff retains state and resumes later; it never creates PartialSuccess.
 
-1. **Generators (`EnvQueryGenerator`)**:
-   - Produce candidate items bounded by explicit configuration parameters.
-   - Built-in generators:
-     - `GridGenerator`: 2D/3D regular lattice around context with defined radius, density/spacing, and layer masks.
-     - `DonutRingGenerator`: Concentric radial rings around context with inner radius, outer radius, and radial step counts.
-     - `ConeGenerator`: Wedge/cone oriented along context forward vector with radius, angle, and angular steps.
-     - `NavMeshProjectionGenerator`: Projects spatial candidate points onto valid NavMesh surfaces, filtering unreachable geometry.
-     - `PerceivedEntitiesGenerator`: Populates candidate items from agent perception memory matching filter criteria.
-   - All generators enforce strict maximum item limits (`maxItems`) to prevent unbounded memory allocation and CPU spikes.
-2. **Tests and Filters (`EnvQueryTest`)**:
-   - `LineOfSightTest`: Raycast or shape sweep between candidate item and target/querier context using Physics traces.
-   - `DistanceTest`: Euclidean, Chebyshev, Manhattan, or NavMesh path distance between item and context.
-   - `DotProductTest`: Directional alignment (facing angle, field of view, flanking angle).
-   - `PathfindingCostTest`: NavMesh path length, travel cost, or reachability.
-   - `CoverExposureTest`: Obstacle height, stance clearance, and exposure angle relative to threat positions.
-   - Test Modes:
-     - `FilterOnly`: Discards items failing a boolean threshold (e.g. must have line of sight).
-     - `ScoreOnly`: Assigns normalized continuous score `[0.0, 1.0]` without discarding.
-     - `FilterAndScore`: Discards non-qualifying items and scores survivors.
+| Terminal outcome | Meaning |
+|---|---|
+| Completed | All stages finished; empty eligible set is a valid result with no winner |
+| PartialSuccess | Caller opted in; hard deadline or explicit FinishEarly ends the query with at least one fully filtered/scored candidate |
+| TimedOut | Hard deadline reached without an allowed partial result, even if some candidates exist but complete results were required |
+| Failed | Typed provider/schema/scoring failure or explicit early finish with no eligible partial candidate |
+| StaleInputs | A required captured provider version can no longer be honored |
+| Cancelled / Aborted | Caller cancellation / required entity or scene invalidation; no tactical winner |
 
-### 4. Scoring Normalization and Deterministic Tie-Breaking
+Deadlines count simulation ticks from accepted submission; pause freezes tick-age.
+Lifecycle invalidation/cancellation wins over completion, then eligible completions
+(including on the deadline tick) precede deadline evaluation. Partial results include
+coverage and snapshot provenance and never enter the result cache. Population-based
+normalization cannot publish partial ranks before its required full-stage barrier.
 
-1. **Score Normalization**:
-   - Every scoring test normalizes raw values to `[0.0, 1.0]` using explicit scoring functions:
-     - `Linear`: `(val - min) / (max - min)`
-     - `InverseLinear`: `1.0 - (val - min) / (max - min)`
-     - `Sigmoid` / `SCurve`: Smooth progression emphasizing mid-ranges.
-     - `ThresholdStep`: Step function returning `0.0` or `1.0`.
-   - Arithmetic Safety: Non-finite scores (`NaN`, `+Inf`, `-Inf`) and division-by-zero are trapped; offending items are assigned `0.0` with diagnostic reporting and cannot rank as winning candidates.
-2. **Total Score Aggregation**:
-   - Weighted linear combination:
-     $$\text{TotalScore} = \frac{\sum_{i=1}^{N} w_i \cdot s_i}{\sum_{i=1}^{N} w_i}$$
-     where $w_i \ge 0$ is the stage weight and $s_i \in [0.0, 1.0]$ is the normalized test score.
-3. **Deterministic Tie-Breaking Cascade**:
-   - Candidate ranking must be 100% deterministic and independent of worker thread scheduling or memory address order.
-   - Ranking order:
-     1. Primary: Highest `TotalScore`.
-     2. Secondary: Configured tie-breaker test score (e.g. closest distance to Querier).
-     3. Tertiary: Stable item generation sequence index (`item_index`), ensuring zero jitter across replay runs.
+### Cache Correctness And Quantization
 
-### 5. Time-Budgeted Asynchronous Execution and Lifecycles
+Adaptive cache identity contains template AssetId/artifact digest, full canonical
+inputs and effective settings, extension/numeric versions, and the sorted revision
+set of every generator/context/filter/score/tie-breaker dependency. Include Navigation,
+Physics, Perception, entity lifecycle, team/tag and custom-provider revisions whenever
+read. Tokens identify provider instance, incarnation, revision and global/spatial scope.
+Unknown reads disable caching; TTL never replaces revision validation. Hash matches
+must also compare canonical key data. Scoped tokens are allowed only when the entire
+read footprint is known; otherwise use a conservative global token.
 
-```text
-+-------------------------------------------------------------------------+
-|                       EnvironmentQueryManager                           |
-|  +-------------------------------------------------------------------+  |
-|  | Tick (Time-Sliced Budget: e.g. 1.5ms / max N items per frame)      |  |
-|  +-------------------------------------------------------------------+  |
-|         |                     |                      |                  |
-|  +--------------+     +----------------+     +------------------+       |
-|  | Query State: |     | Query State:   |     | Query State:     |       |
-|  | Resolving    | --> | Generating /   | --> | Scoring /        |       |
-|  | Context      |     | Nav Projection |     | Physics Traces   |       |
-|  +--------------+     +----------------+     +------------------+       |
-|                                                      |                  |
-|                                              +------------------+       |
-|                                              | Query State:     |       |
-|                                              | Completed /      |       |
-|                                              | PartialSuccess   |       |
-|                                              +------------------+       |
-+-------------------------------------------------------------------------+
-```
+ContextQuantizationPolicy defaults to Exact. Explicit spatial grids declare positive
+size, rounding and accepted error tolerance. Canonical millimeter position storage
+is not a mandatory cache cell size. Approximate plans evaluate the same quantized
+context they hash and report that provenance; quantizing only the key would return
+incorrect results. Other inputs remain exact unless their schema explicitly defines
+an equally valid approximation policy. Consumers revalidate live eligibility before
+acting on historical/approximate results.
 
-1. **Asynchronous Multi-Frame Staging**:
-   - Queries execute across multiple frames using cooperative time-slicing under a configured global/per-tick time budget (e.g. `1.5ms` per simulation tick).
-   - High-load queries yield at stage boundaries or item batch boundaries and resume on subsequent ticks.
-2. **Terminal States**:
-   - `Completed`: Query evaluated all stages and returned ranked items.
-   - `PartialSuccess`: Budget exhausted or early exit requested; returns best-ranked valid candidate evaluated so far.
-   - `Cancelled`: Query cancelled cooperatively by caller token or owning task.
-   - `TimedOut`: Query exceeded maximum allowed elapsed frames without finding a valid candidate.
-   - `Aborted`: Querier, target entity, or scene was destroyed during in-flight evaluation.
-3. **Lifecycle Safety and Cancellation**:
-   - Queries hold weak `EntityId` handles and scene generation counters.
-   - On entity destruction or scene transition, in-flight queries transition to `Aborted` immediately; outstanding asynchronous jobs, raycasts, and pathfinding requests are cancelled.
-   - Result callbacks and decision nodes observe typed failure rather than executing against invalid entities.
-4. **Caching and Invalidation**:
-   - Immutable query results may be cached using a composite key:
-     $$\text{CacheKey} = (\text{QueryTemplateId}, \text{ContextSnapshotHash (querier/target positions quantized to integer millimeters)}, \text{NavMeshRevision}, \text{PhysicsRevision})$$
-   - Bounded LRU cache with time-to-live (TTL).
-   - Cache eviction never invalidates caller-owned `QueryResult` snapshots.
+Only complete successful immutable snapshots are cached. Lookup validates current
+provider revisions, scene/owner authority and every entity generation/identity.
+Dead entities cause a miss rather than silent filtering/re-ranking. Caller-owned
+result storage survives eviction, but Actor handles do not keep entities alive.
+Consumers revalidate generation and freshness before subsequent use.
 
-## Ratify-or-Revise Outcomes
+### Cancellation, Capacity And Validation
 
-| Area | Current Baseline | Outcome |
-|---|---|---|
-| Query orchestration authority | Ad hoc raycasts and navigation queries scattered in gameplay code | **Revised.** `EnvironmentQueryManager` is established as the sole orchestration authority. |
-| Subsystem boundaries | Direct synchronous physics/navmesh calls | **Ratified separation.** Navigation, Physics, and Perception provide read-only data snapshots; GAI executes queries. |
-| Item types | Implicit spatial coordinates only | **Revised.** Explicit typed items (`Point`, `Actor`/`Entity`, `DirectionalRay`, `Custom`). |
-| Scoring normalization | Unbounded raw values, potential division by zero | **Revised.** Mandatory normalization to `[0.0, 1.0]`, NaN/Inf traps, and deterministic tie-breaking cascades. |
-| Execution threading | Synchronous single-tick queries risking frame drops | **Revised.** Asynchronous time-budgeted multi-frame staging with cooperative cancellation. |
-| Lifecycle safety | Unchecked raw entity handles | **Revised.** Weak entity tracking, scene generation counters, and automatic abortion on destruction. |
+Query handles include manager/scene incarnation, slot and generation. Cancellation
+requests provider interruption where supported; work already running may finish.
+Late results are discarded by query/request generation without invoking dead owners
+or mutating replacement entities. Retained leases/payloads outlive worker access;
+retired uncancellable work still consumes admission capacity until reclaimed.
+Shutdown follows ADR-010 teardown rules without ordinary tick/render/transport waits.
+
+The normative [EQS profiles](../architecture/runtime/navigation-and-ai-architecture.md#eqs-compute-profiles-and-qualification)
+set explicit LowCpu/MediumCpu/HighCpu limits for concurrent queries, candidates,
+work units, provider admissions/in-flight requests, stages, payloads and total bytes.
+Adaptive wall targets vary by profile; graphics API selection grants no EQS capacity.
+Provider quotas and GameplayAiProfile still constrain admission. Stable round-robin
+slices prevent one query consuming every tick's work; overload yields or rejects,
+never grows memory without bounds.
+
+Implementation qualification covers deterministic versus adaptive histories,
+yield/partial/deadline transitions, provider affinity/backpressure, cache dependency
+and entity invalidation, approximate input semantics, invalid math/custom schemas,
+asset versioning and cancellation of providers that cannot stop running work. These
+are downstream acceptance requirements, not tests implemented by this ADR-only PR.
 
 ## Consequences
 
-- AI tactical decision making is decoupled from low-level physics and navigation details.
-- Frame rates remain stable under heavy AI load due to strict time budgeting and asynchronous staging.
-- Tactical queries produce 100% deterministic results across replay runs.
-- Behavior trees and decision graphs interact through clean, non-blocking async task nodes.
-- Memory and entity lifetimes are protected against dangling references and orphaned background jobs.
+- Tactical orchestration is centralized without taking domain query execution away
+  from Navigation/Physics/Perception or requiring a monolithic manager class.
+- Replay guarantees match actual budgets and provider behavior rather than a seed
+  and tie-breaker alone.
+- Snapshot age, partial coverage, stale dependencies and cancellation are visible
+  typed outcomes; retained result bytes are distinct from entity lifetime.
 
 ## Rejected Alternatives
 
-- **Let Physics or Navigation subsystem own tactical queries.** Rejected: violates single responsibility and couples world geometry to gameplay decision logic.
-- **Run all queries synchronously in a single frame.** Rejected: causes catastrophic simulation frame drops when multiple agents query simultaneously.
-- **Use unbounded floating-point scores without normalization.** Rejected: leads to weighted combination imbalances, arithmetic overflow, and non-deterministic behavior.
-- **Rely on memory address or hash map iteration order for candidate ranking.** Rejected: creates non-deterministic simulation divergence across different platforms and runs.
-- **Allow queries to hold direct scene pointers.** Rejected: leads to use-after-free crashes when entities or components are removed during query execution.
+- **Passive snapshot providers with EQS-owned pathfinding**: Duplicates domain query
+  execution and breaks Navigation/Physics encapsulation.
+- **Wall-clock cutoff plus unconditional deterministic partial success**: Different
+  completion populations can change the winner across machines and runs.
+- **Terminal result at every tick-budget cutoff**: Prevents resumable staged work.
+- **Position-only keys or unconditional millimeter quantization**: Omits semantic
+  dependencies or chooses an inappropriate accuracy/cache-reuse policy.
+- **Guaranteed physical interruption of every provider job**: Not implementable for
+  all providers; cooperative cancellation and safe result suppression are required.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
+| [011](011-environment-query-ownership-item-and-scoring-model.md) | Environment Query Ownership, Item and Scoring Model | proposed | 2026-08-28 |
 | [014](014-sequencer-ownership-clock-authority-and-binding-boundary.md) | Sequencer Ownership, Clock Authority and Binding Boundary | proposed | 2026-08-28 |
 | [015](015-accessibility-ownership-typed-transport-and-non-gating-policy.md) | Accessibility Ownership, Typed Transport and Non-Gating Policy | proposed | 2026-08-28 |
 | [016](016-navigation-target-ownership-and-dependency-boundary.md) | Navigation Target Ownership and Dependency Boundary | proposed | 2026-08-28 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
-| [011](011-environment-query-ownership-item-and-scoring-model.md) | Environment Query Ownership, Item and Scoring Model | proposed | 2026-08-28 |
+| [013](013-environment-query-ownership-item-and-scoring-model.md) | Environment Query Ownership, Item and Scoring Model | proposed | 2026-08-28 |
 | [014](014-sequencer-ownership-clock-authority-and-binding-boundary.md) | Sequencer Ownership, Clock Authority and Binding Boundary | proposed | 2026-08-28 |
 | [015](015-accessibility-ownership-typed-transport-and-non-gating-policy.md) | Accessibility Ownership, Typed Transport and Non-Gating Policy | proposed | 2026-08-28 |
 | [016](016-navigation-target-ownership-and-dependency-boundary.md) | Navigation Target Ownership and Dependency Boundary | proposed | 2026-08-28 |

--- a/docs/architecture/runtime/navigation-and-ai-architecture.md
+++ b/docs/architecture/runtime/navigation-and-ai-architecture.md
@@ -634,203 +634,367 @@ struct AIPerceptionMemory {
 
 ## Environment Query System (EQS)
 
-### Purpose And Ownership Boundary
+### EQS Ownership And Provider Execution
 
-The Environment Query System (EQS) provides composable spatial and tactical
-reasoning for AI decision making (such as finding cover, establishing flanking
-angles, acquiring line of sight, or selecting ambush locations) without embedding
-ad hoc physics traces and NavMesh traversability checks inside behavior trees or
-tick callbacks.
+Gameplay AI is the sole subsystem authority for tactical orchestration and ranking.
+This is not a requirement that one manager class implement the entire subsystem:
 
-`EnvironmentQueryManager` (part of the Gameplay AI subsystem `HoroAI`) is the
-**single authority** that orchestrates query lifecycles, stage scheduling, test
-execution, score normalization, result caching, and terminal outcomes. Other
-subsystems act strictly as read-only snapshot providers:
+| Responsibility | Logical implementation owner |
+|---|---|
+| Admission, handles, cancellation, scheduling, terminal publication | EnvironmentQueryManager |
+| Bounded generator/test stage execution | QueryExecutor |
+| Normalization, aggregation and stable ranking | QueryScoring |
+| Bounded immutable result entries and eviction | QueryCache |
 
-- **Navigation System**: provides NavMesh surface projection, polygon
-  containment, traversability, and pathfinding distance/cost calculations.
-- **Physics System**: provides collision raycasts, shape sweeps, and
-  line-of-sight checks.
-- **Perception System**: provides perceived candidate entities, stimulus locations,
-  and sensory memory records.
-- **Decision Systems (Behavior Tree / State Machine / Utility AI)**: consume
-  query results asynchronously via typed task nodes; they never block fixed-tick
-  simulation loops.
+These are internal roles, not new independent services, schedulers or thread pools.
+Navigation, Physics and Perception retain authority over their data **and query
+execution**. EQS issues bounded typed read-only requests; it cannot take a NavMesh
+snapshot and implement its own pathfinder, step physics or mutate sensory memory.
 
-```text
-+-------------------------------------------------------------------------+
-|                       EnvironmentQueryManager                           |
-|  +-------------------------------------------------------------------+  |
-|  | Tick (Time-Sliced Budget: e.g. 1.5ms / max N items per frame)      |  |
-|  +-------------------------------------------------------------------+  |
-|         |                     |                      |                  |
-|  +--------------+     +----------------+     +------------------+       |
-|  | Query State: |     | Query State:   |     | Query State:     |       |
-|  | Resolving    | --> | Generating /   | --> | Scoring /        |       |
-|  | Context      |     | Nav Projection |     | Physics Traces   |       |
-|  +--------------+     +----------------+     +------------------+       |
-|                                                      |                  |
-|                                              +------------------+       |
-|                                              | Query State:     |       |
-|                                              | Completed /      |       |
-|                                              | PartialSuccess   |       |
-|                                              +------------------+       |
-+-------------------------------------------------------------------------+
-```
+| Provider | Owned operations | EQS boundary |
+|---|---|---|
+| NavigationCoordinator / NavigationApi | Projection, containment, reachability and path cost | Typed admission/result handles under ADR-016; no vendor types or independent EQS path jobs |
+| Physics owner | Raycast, sweep, overlap and geometric visibility | Owner-thread queries outside Step, or leased read-only query snapshots |
+| Perception domain | Agent-specific sensed state and memory | Immutable authorized snapshot/query; not equivalent to geometric line of sight |
+| Behavior trees / decision graphs | Tactical intent consumption | Generation-checked query handles and immutable results; never blocking waits |
 
-### Query Templates And Item Model
+### EQS Asset, Context And Extension Contracts
 
-Queries are defined by immutable compiled assets (`EnvironmentQueryPlan` /
-`EnvironmentQueryTemplate`). Each stage possesses a unique `StageId` that remains
-stable across serialization, renaming, and editor reordering.
+EnvironmentQueryTemplate is an authoring asset with stable AssetId metadata in
+AssetRegistry. Its immutable cooked EnvironmentQueryPlan contains stable StageIds,
+ordered stages, typed context/parameter schemas, provider dependencies, scoring and
+execution policy. Names and editor ordering do not determine identity. Plan identity
+includes the AssetId and exact cooked artifact digest; hot reload cannot silently
+change an in-flight plan.
+
+Cooking uses the Asset Pipeline's canonical versioned key, preserving source and
+semantic-metadata digests, effective settings, schema/cooker versions, target profile
+and artifact envelope. Plans with referenced assets or custom provider/schema
+artifacts require the dependency-aware extension (all transitive identities/digests),
+not an EQS-only replacement tuple. CookCatalog publishes the validated artifact by
+AssetId. Authoring ProjectVersion migration and cooked-format version are distinct:
+migrate authoring before cook; runtime rejects unsupported format/schema/dependencies
+before activation and retains the last valid loaded plan. Unknown newer schemas,
+cycles and over-budget plans are typed failures. These extend the ADR-017 asset
+pattern and do not claim cooker/runtime implementation is already present.
+
+The following structures are schematic typed contracts, not existing public headers:
 
 ```cpp
-enum class EnvQueryItemType : uint8_t {
-    Point,          // WorldCoordinate: spatial points (cover, vantage, patrol)
-    Actor,          // EntityId: scene entities (targets, allies, cover objects)
-    DirectionalRay, // Ray / Direction: tactical vectors (flanking, retreat angles)
-    Custom          // Extensible gameplay payload with explicit typed schema
-};
-
-enum class EnvQueryContextType : uint8_t {
-    Querier,                // Requesting agent entity
-    Target,                 // Primary adversary / focus entity
-    QuerierLocation,        // Agent world position snapshot
-    TargetLocation,         // Target world position snapshot
-    WorldOrigin,            // Scene world origin (0, 0, 0)
-    Custom                  // Pluggable registered context provider
-};
+enum class EnvQueryItemType : uint8_t { Point, Actor, DirectionalRay, Custom };
 
 struct QueryContextSnapshot {
-    EntityId           querierEntity;
-    WorldCoordinate    querierPosition;
-    Vector3            querierForward;
-    std::optional<EntityId> targetEntity;
-    std::optional<WorldCoordinate> targetPosition;
-    uint32_t           sceneGeneration;
-};
-```
-
-Context resolution snapshots values into an immutable `QueryContextSnapshot` at
-query start. Query execution never exposes raw mutable scene pointers.
-
-### Generators
-
-Generators produce bounded sets of candidate items around query contexts:
-
-- `GridGenerator`: 2D or 3D regular lattice around context with configurable
-  spacing, radius, and boundary extents.
-- `DonutRingGenerator`: Concentric radial rings around context with inner radius,
-  outer radius, and radial step counts.
-- `ConeGenerator`: Directional wedge/cone oriented along context forward vector
-  with radius, arc half-angle, and angular step count.
-- `NavMeshProjectionGenerator`: Projects spatial candidate points onto valid
-  NavMesh surfaces, discarding off-mesh or non-traversable candidates.
-- `PerceivedEntitiesGenerator`: Populates candidate items from sensory perception
-  memory matching affiliation/sense filters.
-
-All generators enforce a mandatory maximum item clamp (`maxItems`) to prevent
-unbounded allocations and CPU spikes. Every candidate item receives a stable,
-deterministic generation sequence index (`item_index`).
-
-### Tests And Filters
-
-Tests evaluate candidate items against query contexts or world providers:
-
-- `LineOfSightTest`: Raycast or shape sweep between candidate item and context
-  using Physics collision traces.
-- `DistanceTest`: Euclidean, Chebyshev, Manhattan, or NavMesh path distance
-  between candidate item and context.
-- `DotProductTest`: Directional alignment (facing angle, field of view, flanking
-  angle).
-- `PathfindingCostTest`: NavMesh path length, travel cost, or reachability.
-- `CoverExposureTest`: Obstacle height, stance clearance, and exposure angle
-  relative to threat positions.
-
-```cpp
-enum class EnvQueryTestMode : uint8_t {
-    FilterOnly,     // Discards items failing boolean condition
-    ScoreOnly,      // Assigns normalized continuous score [0.0, 1.0]
-    FilterAndScore  // Discards failing items, then scores survivors
+    EntityRef querier;                  // non-owning, scene + entity generation
+    WorldCoordinate64 querierPosition; // canonical global position (ADR-026)
+    Vec3 querierForward;
+    std::optional<EntityRef> target;
+    std::optional<WorldCoordinate64> targetPosition;
+    SimulationTick submittedTick;
+    ContextPayloadRef customContext;   // immutable bounded owned/retained bytes
 };
 
-enum class EnvQueryScoreCurve : uint8_t {
-    Linear,         // (val - min) / (max - min)
-    InverseLinear,  // 1.0 - (val - min) / (max - min)
-    Sigmoid,        // S-curve emphasizing mid-ranges
-    ThresholdStep   // Step function (0.0 or 1.0)
-};
-```
-
-### Scoring Normalization And Deterministic Tie-Breaking
-
-To prevent scoring arithmetic drift and non-deterministic behavior:
-
-1. **Normalized Range**: All scoring tests normalize raw metrics into
-   `[0.0, 1.0]` using the configured `EnvQueryScoreCurve`.
-2. **Arithmetic Safety**: Non-finite numbers (`NaN`, `+Inf`, `-Inf`) and
-   division-by-zero are trapped; offending items receive a score of `0.0` with
-   diagnostic logging and cannot be selected as winning candidates.
-3. **Total Score Weighted Sum**:
-   $$\text{TotalScore} = \frac{\sum_{i=1}^{N} w_i \cdot s_i}{\sum_{i=1}^{N} w_i}$$
-   where $w_i \ge 0$ is the stage weight and $s_i \in [0.0, 1.0]$ is the normalized test score.
-4. **Deterministic Tie-Breaking Cascade**:
-   - Primary: Highest `TotalScore`.
-   - Secondary: Configured tie-breaker test score (e.g. minimum distance to Querier).
-   - Tertiary: Stable item generation sequence index (`item_index`).
-   Candidate ranking is 100% reproducible and independent of multi-threaded job
-   scheduling or memory allocation layout.
-
-### Time-Budgeted Asynchronous Execution
-
-```cpp
-enum class QueryResultStatus : uint8_t {
-    Completed,      // All stages evaluated, candidates ranked
-    PartialSuccess, // Budget exhausted; best candidate evaluated so far returned
-    Cancelled,      // Cancelled by caller token or task abort
-    TimedOut,       // Maximum frame/tick duration exceeded
-    Aborted         // Querier, target, or scene destroyed in-flight
+struct QueryCustomPayload {
+    CustomItemTypeId type;
+    uint32_t schemaVersion;
+    uint32_t size;                      // validated <= bytes.size()
+    std::array<std::byte, 64> bytes;
 };
 
 struct ScoredItem {
     EnvQueryItemType itemType;
-    WorldCoordinate  position;        // Point / Actor location
-    EntityId         entity;          // valid when itemType == Actor
-    Vec3             direction;       // valid when itemType == DirectionalRay
-    uint32_t         customTypeId{0}; // valid when itemType == Custom
-    std::array<uint8_t, 16> customPayload{};
-    float            totalScore;      // Normalized [0.0, 1.0]
-    uint32_t         itemIndex;       // Stable generation index
-};
-
-struct QueryResult {
-    QueryResultStatus         status;
-    std::vector<ScoredItem>   items;           // Ranked by score and tie-breaker
-    std::optional<ScoredItem> winningItem;     // Highest ranked candidate
-    uint64_t                  executionTicks;  // Duration across slices
+    WorldCoordinate64 position;         // Point, or captured Actor/ray origin
+    std::optional<EntityRef> entity;     // Actor only; never an owning reference
+    Vec3 direction;                     // DirectionalRay only, finite normalized vector
+    QueryCustomPayload custom;          // Custom only
+    ScoreKey totalScore;                // canonical rank key from [0,1]
+    uint32_t itemIndex;                  // stable generator-assigned identity
 };
 ```
 
-1. **Time-Sliced Execution**: Queries execute across multiple simulation ticks
-   under a global per-tick time budget (e.g. `1.5ms` per frame) or candidate item
-   batch limits. High-cost queries yield at stage or item boundaries and resume
-   on subsequent frames.
-2. **Partial-Result Fallback**: When configured, queries encountering budget
-   exhaustion return `QueryResultStatus::PartialSuccess` containing the best
-   valid item evaluated before yielding.
-3. **Deterministic Replay**: Fixed-seed generation and index-based tie-breaking
-   guarantee deterministic tactical decisions in replay and automated tests.
-4. **Caching And Invalidation**:
-   - Query results may be cached using a composite key:
-     `CacheKey(QueryTemplateId, ContextSnapshotHash, NavMeshRevision, PhysicsRevision)` where `ContextSnapshotHash` quantizes querier/target `WorldCoordinate` to integer millimeters (raw floats would miss every moving-agent tick).
-   - Results are retained in a bounded LRU cache with time-to-live (TTL).
-   - Cache eviction never invalidates caller-owned immutable `QueryResult` copies.
-5. **Lifecycle Safety And Cancellation**:
-   - Queries track weak `EntityId` handles and scene generation counters.
-   - When a querier entity, target entity, or scene is destroyed, in-flight
-     queries transition immediately to `Aborted`; outstanding physics traces
-     and pathfinding jobs are cancelled without dangling pointer access.
+Built-in contexts are Querier, Target, their captured locations and the canonical
+WorldOrigin, never an implicit rebased float origin. Custom context/parameter bytes
+include all declared inputs such as team, faction, stance, gameplay tags, masks,
+seed and tunable query parameters. Required contexts resolve at successful
+submission on the simulation owner against the current declared snapshots. A
+provider unable to capture immediately returns AdmissionDeferred/Rejected without
+an accepted query; it never blocks or changes the meaning of submission time.
 
+An accepted query always evaluates its submission context and captured provider
+read set. A result carries submitted/completed ticks, plan digest, input digest and
+provider revisions so consumers can enforce maximum age. Consumers needing fresher
+positions cancel/reissue; in-flight context is never silently refreshed. Provider
+snapshots may have different declared source ticks, but one immutable revision set
+is fixed for the query. A provider must execute against that retained version or
+validate that its state still matches; otherwise the query ends with StaleInputs.
+Memory leases preserve bytes, not permission to treat logically invalid data as
+current. Cancellation, scene changes and provider invalidation remain observable.
+
+Custom item/context/stage providers use inert domain descriptors composed by the
+host, following ADR-018's registration discipline. They declare stable namespaced
+IDs, schema versions, bounded sizes/alignment, capabilities, owner thread/safe point,
+provider dependencies, serialization and canonical equality/hash functions. Creation
+has no registration or service-discovery side effects. Composition rejects duplicate
+IDs, incompatible versions, missing dependencies, cycles and unsupported modes.
+
+Custom bytes are canonical serialized values, not arbitrary native object memory:
+no raw pointers, borrowed views, owning C++ objects or callbacks. They remain immutable
+while retained and use bounded Foundation-owned storage. The inline item cap is 64
+bytes; larger items require a separately reviewed schema, not an unbounded allocation.
+Context payloads have a profile cap. Canonical encoding excludes padding, normalizes
+endianness and floating zero, and rejects non-finite inputs. Cacheable custom values
+must provide complete stable hash/equality; otherwise the whole query bypasses cache.
+
+### EQS Generators And Tests
+
+GridGenerator, DonutRingGenerator and ConeGenerator produce bounded candidate sets.
+NavMeshProjectionGenerator submits Navigation-owned projection requests; it does
+not execute pathfinding internally. PerceivedEntitiesGenerator reads an authorized
+perception snapshot and enumerates stable entity identities, not hash-map order.
+All generators validate dimensions, spacing and arithmetic overflow at cook/admission
+and enforce maxItems. Item indices are assigned in stable generation order **before**
+provider dispatch; async completion order cannot change candidate identity.
+
+| Test | Meaning / execution owner |
+|---|---|
+| GeometryLineOfSightTest | Physics ray/sweep obstruction for declared geometry/layer policy |
+| PerceivedVisibilityTest | Agent-specific sensed/remembered visibility from Perception |
+| DistanceTest | EQS math for Euclidean/Manhattan/Chebyshev; Navigation for path distance |
+| DotProductTest | EQS directional alignment from captured finite inputs |
+| PathfindingCostTest | Navigation-owned bounded path/cost request |
+| CoverExposureTest | Composes declared bounded Physics queries and captured stance/threat context |
+
+The old LineOfSightTest name migrates to GeometryLineOfSightTest explicitly; it
+cannot silently switch between physical obstruction and an agent's perception.
+Tests declare FilterOnly, ScoreOnly or FilterAndScore. The compiled plan records the
+union of **all** generator, context, filter, scoring and tie-breaker dependencies,
+including custom providers. Query execution cannot perform undeclared reads.
+
+### EQS Scoring And Ranking
+
+Scoring maps finite metrics to [0,1] with explicit fixed ranges and curves (linear,
+inverse linear, bounded sigmoid or threshold step). Ranges are plan/context inputs,
+not min/max estimates that change with whichever candidates happened to finish.
+Any future population-dependent normalization needs a full-stage barrier and cannot
+publish partial rankings before its domain is complete.
+
+For scored plans, TotalScore = sum(weight * normalizedScore) / sum(weight).
+Cook and admission require finite nonnegative weights, valid normalization ranges
+and a finite strictly positive total weight. They reject zero denominators and
+statically reproducible invalid math. An explicitly filter-only plan does not use
+this formula; surviving candidates use the configured stable selection ordering.
+
+Runtime non-finite intermediate values or aggregation overflow mark a candidate
+InvalidScore and exclude it from eligibility, even if every other score is zero.
+Diagnostics are typed, bounded and deduplicated; assigning a display score of zero
+never makes an invalid candidate a winner. Validation/dev tests must report the
+reproducible source stage rather than silently hide authoring errors.
+
+ScoreKey is a plan-versioned fixed-point rank value obtained with declared precision,
+rounding and overflow rules after normalization. Ranking is highest total ScoreKey,
+then configured tie-breaker key/direction, then stable itemIndex. Aggregation follows
+compiled StageId order; no pointer/hash iteration or epsilon-based non-transitive
+sort comparisons are allowed. Deterministic ranking assumes identical complete
+provider inputs and the declared platform/numeric contract; it is not a blanket
+cross-platform physics or floating-point bit-identity guarantee.
+
+### EQS Owner Thread, Safe Points And Provider Budgets
+
+EnvironmentQueryManager runs on the scene's simulation owner; it has no dedicated
+thread. It uses the existing ADR-021/022 phase order, not an extra AI phase:
+
+1. BlackboardSync drains eligible immutable completions, validates generation and
+   captured revisions, and publishes terminal records before blackboards freeze.
+   A behavior observer may copy a result through the normal blackboard write seam.
+2. At the start of AiDecisionEvaluate, QueryExecutor advances previously admitted
+   queries under the EQS budget. Decision nodes then submit new requests or consume
+   published results. A newly accepted query first executes on a later tick.
+3. Provider requests execute/publish at their declared owner seams. Navigation uses
+   NavIntentCommit per ADR-016; Physics immediate kernels run on its owner outside
+   Step, or its adapter dispatches leased-snapshot work. Results feed the next
+   eligible BlackboardSync, never a reentrant decision callback.
+
+Both cached hits and cheap/null-provider failures use scheduled publication; neither
+completes inline at Submit. Null navigation reports NoNavigationData, never a fake
+successful path. Queries do not run inside arbitrary console WorkerJob callbacks.
+ADR-018 OwnerThreadNextFrame commands enqueue bounded admission for the simulation
+owner; they do not mutate manager state from transport/render/editor threads.
+
+EQS budgets stage advancement, candidate batches and provider **admissions**.
+Providers retain their own bounded kernel/scratch/queue budgets. Accepted work is
+charged once to each relevant budget; an EQS slice cannot reset a provider's quota,
+create a nested thread pool or reserve unbounded child requests. Backpressure leaves
+the stage AwaitingAdmission until a later bounded attempt or hard deadline.
+Already accepted work is not resubmitted on every tick.
+
+All background work uses Foundation JobSystem with JobId correlation. Workers read
+retained immutable inputs and write bounded result records, never live blackboards
+or manager state. Owner callbacks never Wait/Join, and workers never block waiting
+for nested provider jobs. Only exposed diagnostic/tool operations need OperationId
+in the application-owned OperationStore under ADR-010/018; ordinary per-agent queries
+use their own generation-checked request handles, not competing operation stores.
+
+### EQS Execution Modes And Terminal Outcomes
+
+| Mode | Scheduling contract | Guarantee |
+|---|---|---|
+| DeterministicWorkUnits | Stable query/stage/item order; explicit operation quotas and tick deadlines; provider-owned bounded deterministic kernels at declared ticks | Repeatable semantic result and publication tick for identical submissions, revision histories and declared numeric/provider contract |
+| AdaptiveRealtime | Same hard memory/work caps plus an optional host wall-time stop at item/stage boundaries; async provider jobs | Bounded work and stable ordering of available data; completion timing and partial candidate population are not replay-deterministic |
+
+Deterministic mode follows ADR-016's owning-executor kernel path, not whichever
+worker finishes first. Each plan/provider declares the bounded units and publication
+latency of its operations. Host composition validates compatible phase placement and
+reserves quotas before admitting deterministic work. A provider without this mode,
+pinned inputs or a bounded kernel returns UnsupportedMode/AdmissionRejected; EQS
+never substitutes timing-dependent partial results or waits for a worker. Results
+for a deterministic batch become visible at its declared tick in stable order.
+Query result caching is disabled in deterministic mode so hit/miss/eviction cannot
+change work allocation or terminal timing; cooked-asset caching is unaffected.
+
+Adaptive mode may use a wall-time target such as the MediumCpu profile's 1500 us,
+but it is not a hard preemption guarantee. A running unit completes within its own
+validated bound before yielding. Replay of adaptive decisions requires recording
+submissions, provider outcomes and chosen publication/terminal ticks; a random seed
+and tie-breaker alone cannot reproduce the scheduling history.
+
+```text
+Accepted -> Running -> Yielded / AwaitingAdmission / AwaitingProvider -> Running
+                                  (all nonterminal)
+Running -> Completed / PartialSuccess / TimedOut / Failed / StaleInputs
+Any nonterminal -> Cancelled / Aborted
+Terminal record published once at BlackboardSync
+```
+
+- **Completed**: All planned stages finished, with ranked eligible items. An empty
+  result is Completed with no winner, not a timeout.
+- **Yielded**: Per-tick budget ended; retain work and resume. It is never a
+  QueryResultStatus and never produces PartialSuccess by itself.
+- **PartialSuccess**: Only if caller opted into partial results and a hard query
+  deadline or explicit FinishEarly request ends execution with at least one fully
+  generated, filtered and scored candidate. Unfinished-stage candidates are ineligible.
+- **TimedOut**: Hard deadline reached without an allowed partial result, including
+  when valid candidates exist but the caller requested complete results only.
+- **Failed**: InvalidScore for all otherwise eligible scoring candidates or a terminal
+  provider/schema error; preserve its typed cause, not a fabricated zero-score winner.
+- **StaleInputs**: A required captured provider version can no longer be honored.
+- **Cancelled / Aborted**: Caller cancellation / required entity or scene invalidation.
+  Neither returns a tactical winner; terminalReason distinguishes explicit early
+  finish without eligible items (NoEligiblePartial, Failed) from hard timeout.
+
+The plan declares hard deadline in simulation ticks from accepted submission.
+Pause freezes this tick-age; cancellation/shutdown remains serviced by host lifecycle
+work. During pause/teardown, that owner service may finalize cancellation records
+without invoking behavior callbacks; ordinary tactical publication still uses
+BlackboardSync. At a boundary, lifecycle invalidation and cancellation take precedence, then
+eligible completions (including on the deadline tick), then deadline resolution.
+Only fully evaluated candidates participate in partial ranking. A partial result
+includes coverage counts and all snapshot provenance; it is not a complete result
+and is never inserted into the result cache.
+
+### EQS Cache Identity, Quantization And Result Lifetime
+
+Adaptive-mode cache keys contain:
+
+- Template AssetId, exact plan artifact digest, schema/extension/numeric versions.
+- Canonical **complete** context and dynamic-input bytes (not only positions), seed,
+  filters, mode, result/early-exit policy and relevant effective configuration.
+- The sorted dependency-revision set for every read: provider instance/incarnation,
+  dependency ID, global or spatial scope, and revision token. Include Perception,
+  tags/team/faction/custom context providers whenever consumed, plus scene incarnation
+  and lifecycle revisions for entity-bearing inputs/results.
+
+Hash equality alone is insufficient: compare canonical key data to avoid collision
+aliasing. TTL is an additional eviction policy, never a substitute for revision and
+entity validation. Scoped tile/region/broadphase tokens may reduce unrelated misses;
+a provider unable to identify the complete read footprint uses a conservative global
+token or marks the query uncacheable. Unknown dependencies cannot be ignored.
+If execution discovers additional regions, validate the stored complete read footprint
+on lookup; the initial hash is only an index until full dependency equality is proven.
+
+ContextQuantizationPolicy is a versioned template policy: Exact by default, or an
+explicit positive spatial grid with declared error tolerance and rounding. Canonical
+millimeter WorldCoordinate64 storage is not a mandatory EQS quantization cell. A
+coarser cell is opt-in approximate semantics, not a free exact-result optimization:
+evaluate on that same canonicalized context, return its provenance, and require the
+caller to accept the tolerance. Keep entity identities, directions, flags and other
+inputs exact unless their schema declares an equally explicit policy. Quantizing only
+the cache hash while evaluating unquantized inputs is forbidden. Before acting, the
+consumer revalidates live geometry/target eligibility through the owning domain.
+
+Cache stores only successful complete immutable data snapshots. Lookup rechecks
+provider revisions, scene incarnation, request authority and every referenced EntityRef
+generation/identity; a dead entity or stale dependency makes it a miss, never a
+silently filtered/re-ranked hit. QueryResult uses owned/retained bounded storage, so
+eviction cannot free a caller's data. This does not keep Actor entities alive. Results
+carry as-of ticks/revisions and consumers validate entity/scene generation and their
+freshness tolerance again before later use. A retained result is a historical snapshot,
+not permission to dereference a stale handle or apply a now-invalid tactical action.
+
+### EQS Cancellation And Resource Reclamation
+
+A query handle includes scene/manager incarnation, slot and generation. EntityRef is
+a non-owning generation-validated identity, not a weak_ptr. Required querier/target
+or scene invalidation stops admission immediately and marks the query Aborted on the
+owner; every result publication also checks lifecycle validity before delivery.
+
+Cancellation is cooperative: request provider cancellation where supported; already
+running work may finish. Completion records carry query generation and provider
+request identity, so late/cancelled/aborted results are discarded without invoking a
+dead behavior owner or mutating replacement entities. Terminal publication occurs
+once; cancellation after publication does not retroactively undo an observed result.
+
+Retain provider snapshot leases, custom payloads and result slots until workers and
+provider operations release them. Retired work still counts against global in-flight
+limits; releasing a query handle cannot bypass capacity by starting more uncancellable
+jobs. Reclamation occurs on the owning service, outside worker access. Shutdown closes
+admission, cancels requests, suppresses callbacks and retires resources under ADR-010's
+allowed teardown rules, without ordinary tick/render/transport waits.
+
+### EQS Compute Profiles And Qualification
+
+EqsExecutionProfile is a host-selected CPU/memory policy independent of renderer
+backend. These baseline caps are explicit defaults, not measured platform promises:
+
+| Field | LowCpu | MediumCpu | HighCpu / DedicatedServer |
+|---|---:|---:|---:|
+| Active queries (including cancelling/retired work) | 16 | 64 | 256 |
+| Candidates per query | 128 | 512 | 2048 |
+| EQS item-stage work units per tick | 128 | 1024 | 4096 |
+| Provider admissions per tick | 16 | 64 | 256 |
+| Total in-flight provider requests | 32 | 256 | 1024 |
+| Maximum stages per plan | 16 | 32 | 64 |
+| Custom context bytes per query | 1024 | 4096 | 16384 |
+| Total query/cache/retained bytes | 4194304 | 33554432 | 134217728 |
+| Adaptive wall-time target (us; unused in deterministic mode) | 500 | 1500 | 3000 |
+
+Every work unit has a validated bound; provider node-expansion/trace quotas and
+hard query deadlines are part of the plan/provider contract, not inferred from the
+wall-time target. Host composition intersects EQS admissions with provider and
+GameplayAiProfile limits; selecting a larger EQS profile grants no extra Navigation,
+Physics or Perception capacity. Round-robin slices in stable query-ID order prevent
+one query monopolizing all work. Work-unit and byte exhaustion yields or rejects
+admission as specified above, never grows containers or blocks. Record counters for
+units, pending requests, cache hits/misses, stale results, partial coverage, invalid
+scores and budget exhaustion; wall duration is telemetry in deterministic mode.
+
+Required implementation tests (not implemented by this documentation change):
+
+- Deterministic queries reproduce results/publication ticks with identical inputs
+  under varied render rates and worker completion order; unsupported providers fail
+  mode selection. Adaptive partial outcomes explicitly carry weaker guarantees.
+- Per-tick yield resumes; complete/empty, opt-in partial, timeout with/without valid
+  candidates, early finish and same-tick cancel/deadline precedence are distinct.
+- Navigation/Physics retain query execution and owner affinity; no nested waits,
+  duplicate admissions or per-query pools; backpressure respects both budgets.
+- Invalidate cached results on Perception/team/tag/parameter/schema/region changes,
+  collision-safe canonical equality, and entity destruction after completion. Test
+  exact and approximate quantization at cell edges and after origin rebase.
+- Reject zero total weights, invalid ranges, NaN/Inf, generator overflow, duplicate
+  extension IDs, pointer-bearing payload schemas, oversized/custom invalid bytes,
+  undeclared provider reads, newer cooked versions and broken dependency digests.
+- Same-scene respawn, scene replacement, cancel-before/after-publication and providers
+  that cannot stop in-flight work never deliver to dead owners or free leased data.
+- Capacity includes retired work and retained results; stress cache eviction, owner
+  teardown and cancellation storms without orphaned requests or unbounded growth.
 
 ## AI Architecture And Runtime Ownership
 

--- a/docs/architecture/runtime/navigation-and-ai-architecture.md
+++ b/docs/architecture/runtime/navigation-and-ai-architecture.md
@@ -1398,7 +1398,7 @@ These are required downstream runtime/CI tests, not tests implemented by this AD
 
 ## Related Documents
 
-- [ADR-011: Environment Query Ownership, Item and Scoring Model](../../adr/011-environment-query-ownership-item-and-scoring-model.md)
+- [ADR-013: Environment Query Ownership, Item and Scoring Model](../../adr/013-environment-query-ownership-item-and-scoring-model.md)
 
 - [ADR-010: Job Waiting and Operation Store Ownership](../../adr/010-job-waiting-and-operation-store-ownership.md)
 - [ADR-017: Prefab Asset and Spawn Contracts](../../adr/017-prefab-role-ownership-and-capability-tiers.md)

--- a/docs/architecture/runtime/navigation-and-ai-architecture.md
+++ b/docs/architecture/runtime/navigation-and-ai-architecture.md
@@ -794,8 +794,11 @@ enum class QueryResultStatus : uint8_t {
 
 struct ScoredItem {
     EnvQueryItemType itemType;
-    WorldCoordinate  position;
-    EntityId         entity;
+    WorldCoordinate  position;        // Point / Actor location
+    EntityId         entity;          // valid when itemType == Actor
+    Vec3             direction;       // valid when itemType == DirectionalRay
+    uint32_t         customTypeId{0}; // valid when itemType == Custom
+    std::array<uint8_t, 16> customPayload{};
     float            totalScore;      // Normalized [0.0, 1.0]
     uint32_t         itemIndex;       // Stable generation index
 };
@@ -819,7 +822,7 @@ struct QueryResult {
    guarantee deterministic tactical decisions in replay and automated tests.
 4. **Caching And Invalidation**:
    - Query results may be cached using a composite key:
-     `CacheKey(QueryTemplateId, ContextSnapshotHash, NavMeshRevision, PhysicsRevision)`.
+     `CacheKey(QueryTemplateId, ContextSnapshotHash, NavMeshRevision, PhysicsRevision)` where `ContextSnapshotHash` quantizes querier/target `WorldCoordinate` to integer millimeters (raw floats would miss every moving-agent tick).
    - Results are retained in a bounded LRU cache with time-to-live (TTL).
    - Cache eviction never invalidates caller-owned immutable `QueryResult` copies.
 5. **Lifecycle Safety And Cancellation**:

--- a/docs/architecture/runtime/navigation-and-ai-architecture.md
+++ b/docs/architecture/runtime/navigation-and-ai-architecture.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document defines the navigation (NavMesh), pathfinding, and AI subsystems
+This document defines the navigation (NavMesh), pathfinding, tactical environment queries, and AI subsystems
 for Horo Engine. It covers navigation mesh generation, runtime pathfinding,
 dynamic obstacle avoidance, AI perception, behavior integration, crowd
 simulation, fixed-tick simulation phase ordering, network authority roles,
@@ -632,6 +632,203 @@ struct AIPerceptionMemory {
      stale handles and discard the record immediately, preventing use-after-free
      and stale target locking.
 
+## Environment Query System (EQS)
+
+### Purpose And Ownership Boundary
+
+The Environment Query System (EQS) provides composable spatial and tactical
+reasoning for AI decision making (such as finding cover, establishing flanking
+angles, acquiring line of sight, or selecting ambush locations) without embedding
+ad hoc physics traces and NavMesh traversability checks inside behavior trees or
+tick callbacks.
+
+`EnvironmentQueryManager` (part of the Gameplay AI subsystem `HoroAI`) is the
+**single authority** that orchestrates query lifecycles, stage scheduling, test
+execution, score normalization, result caching, and terminal outcomes. Other
+subsystems act strictly as read-only snapshot providers:
+
+- **Navigation System**: provides NavMesh surface projection, polygon
+  containment, traversability, and pathfinding distance/cost calculations.
+- **Physics System**: provides collision raycasts, shape sweeps, and
+  line-of-sight checks.
+- **Perception System**: provides perceived candidate entities, stimulus locations,
+  and sensory memory records.
+- **Decision Systems (Behavior Tree / State Machine / Utility AI)**: consume
+  query results asynchronously via typed task nodes; they never block fixed-tick
+  simulation loops.
+
+```text
++-------------------------------------------------------------------------+
+|                       EnvironmentQueryManager                           |
+|  +-------------------------------------------------------------------+  |
+|  | Tick (Time-Sliced Budget: e.g. 1.5ms / max N items per frame)      |  |
+|  +-------------------------------------------------------------------+  |
+|         |                     |                      |                  |
+|  +--------------+     +----------------+     +------------------+       |
+|  | Query State: |     | Query State:   |     | Query State:     |       |
+|  | Resolving    | --> | Generating /   | --> | Scoring /        |       |
+|  | Context      |     | Nav Projection |     | Physics Traces   |       |
+|  +--------------+     +----------------+     +------------------+       |
+|                                                      |                  |
+|                                              +------------------+       |
+|                                              | Query State:     |       |
+|                                              | Completed /      |       |
+|                                              | PartialSuccess   |       |
+|                                              +------------------+       |
++-------------------------------------------------------------------------+
+```
+
+### Query Templates And Item Model
+
+Queries are defined by immutable compiled assets (`EnvironmentQueryPlan` /
+`EnvironmentQueryTemplate`). Each stage possesses a unique `StageId` that remains
+stable across serialization, renaming, and editor reordering.
+
+```cpp
+enum class EnvQueryItemType : uint8_t {
+    Point,          // WorldCoordinate: spatial points (cover, vantage, patrol)
+    Actor,          // EntityId: scene entities (targets, allies, cover objects)
+    DirectionalRay, // Ray / Direction: tactical vectors (flanking, retreat angles)
+    Custom          // Extensible gameplay payload with explicit typed schema
+};
+
+enum class EnvQueryContextType : uint8_t {
+    Querier,                // Requesting agent entity
+    Target,                 // Primary adversary / focus entity
+    QuerierLocation,        // Agent world position snapshot
+    TargetLocation,         // Target world position snapshot
+    WorldOrigin,            // Scene world origin (0, 0, 0)
+    Custom                  // Pluggable registered context provider
+};
+
+struct QueryContextSnapshot {
+    EntityId           querierEntity;
+    WorldCoordinate    querierPosition;
+    Vector3            querierForward;
+    std::optional<EntityId> targetEntity;
+    std::optional<WorldCoordinate> targetPosition;
+    uint32_t           sceneGeneration;
+};
+```
+
+Context resolution snapshots values into an immutable `QueryContextSnapshot` at
+query start. Query execution never exposes raw mutable scene pointers.
+
+### Generators
+
+Generators produce bounded sets of candidate items around query contexts:
+
+- `GridGenerator`: 2D or 3D regular lattice around context with configurable
+  spacing, radius, and boundary extents.
+- `DonutRingGenerator`: Concentric radial rings around context with inner radius,
+  outer radius, and radial step counts.
+- `ConeGenerator`: Directional wedge/cone oriented along context forward vector
+  with radius, arc half-angle, and angular step count.
+- `NavMeshProjectionGenerator`: Projects spatial candidate points onto valid
+  NavMesh surfaces, discarding off-mesh or non-traversable candidates.
+- `PerceivedEntitiesGenerator`: Populates candidate items from sensory perception
+  memory matching affiliation/sense filters.
+
+All generators enforce a mandatory maximum item clamp (`maxItems`) to prevent
+unbounded allocations and CPU spikes. Every candidate item receives a stable,
+deterministic generation sequence index (`item_index`).
+
+### Tests And Filters
+
+Tests evaluate candidate items against query contexts or world providers:
+
+- `LineOfSightTest`: Raycast or shape sweep between candidate item and context
+  using Physics collision traces.
+- `DistanceTest`: Euclidean, Chebyshev, Manhattan, or NavMesh path distance
+  between candidate item and context.
+- `DotProductTest`: Directional alignment (facing angle, field of view, flanking
+  angle).
+- `PathfindingCostTest`: NavMesh path length, travel cost, or reachability.
+- `CoverExposureTest`: Obstacle height, stance clearance, and exposure angle
+  relative to threat positions.
+
+```cpp
+enum class EnvQueryTestMode : uint8_t {
+    FilterOnly,     // Discards items failing boolean condition
+    ScoreOnly,      // Assigns normalized continuous score [0.0, 1.0]
+    FilterAndScore  // Discards failing items, then scores survivors
+};
+
+enum class EnvQueryScoreCurve : uint8_t {
+    Linear,         // (val - min) / (max - min)
+    InverseLinear,  // 1.0 - (val - min) / (max - min)
+    Sigmoid,        // S-curve emphasizing mid-ranges
+    ThresholdStep   // Step function (0.0 or 1.0)
+};
+```
+
+### Scoring Normalization And Deterministic Tie-Breaking
+
+To prevent scoring arithmetic drift and non-deterministic behavior:
+
+1. **Normalized Range**: All scoring tests normalize raw metrics into
+   `[0.0, 1.0]` using the configured `EnvQueryScoreCurve`.
+2. **Arithmetic Safety**: Non-finite numbers (`NaN`, `+Inf`, `-Inf`) and
+   division-by-zero are trapped; offending items receive a score of `0.0` with
+   diagnostic logging and cannot be selected as winning candidates.
+3. **Total Score Weighted Sum**:
+   $$\text{TotalScore} = \frac{\sum_{i=1}^{N} w_i \cdot s_i}{\sum_{i=1}^{N} w_i}$$
+   where $w_i \ge 0$ is the stage weight and $s_i \in [0.0, 1.0]$ is the normalized test score.
+4. **Deterministic Tie-Breaking Cascade**:
+   - Primary: Highest `TotalScore`.
+   - Secondary: Configured tie-breaker test score (e.g. minimum distance to Querier).
+   - Tertiary: Stable item generation sequence index (`item_index`).
+   Candidate ranking is 100% reproducible and independent of multi-threaded job
+   scheduling or memory allocation layout.
+
+### Time-Budgeted Asynchronous Execution
+
+```cpp
+enum class QueryResultStatus : uint8_t {
+    Completed,      // All stages evaluated, candidates ranked
+    PartialSuccess, // Budget exhausted; best candidate evaluated so far returned
+    Cancelled,      // Cancelled by caller token or task abort
+    TimedOut,       // Maximum frame/tick duration exceeded
+    Aborted         // Querier, target, or scene destroyed in-flight
+};
+
+struct ScoredItem {
+    EnvQueryItemType itemType;
+    WorldCoordinate  position;
+    EntityId         entity;
+    float            totalScore;      // Normalized [0.0, 1.0]
+    uint32_t         itemIndex;       // Stable generation index
+};
+
+struct QueryResult {
+    QueryResultStatus         status;
+    std::vector<ScoredItem>   items;           // Ranked by score and tie-breaker
+    std::optional<ScoredItem> winningItem;     // Highest ranked candidate
+    uint64_t                  executionTicks;  // Duration across slices
+};
+```
+
+1. **Time-Sliced Execution**: Queries execute across multiple simulation ticks
+   under a global per-tick time budget (e.g. `1.5ms` per frame) or candidate item
+   batch limits. High-cost queries yield at stage or item boundaries and resume
+   on subsequent frames.
+2. **Partial-Result Fallback**: When configured, queries encountering budget
+   exhaustion return `QueryResultStatus::PartialSuccess` containing the best
+   valid item evaluated before yielding.
+3. **Deterministic Replay**: Fixed-seed generation and index-based tie-breaking
+   guarantee deterministic tactical decisions in replay and automated tests.
+4. **Caching And Invalidation**:
+   - Query results may be cached using a composite key:
+     `CacheKey(QueryTemplateId, ContextSnapshotHash, NavMeshRevision, PhysicsRevision)`.
+   - Results are retained in a bounded LRU cache with time-to-live (TTL).
+   - Cache eviction never invalidates caller-owned immutable `QueryResult` copies.
+5. **Lifecycle Safety And Cancellation**:
+   - Queries track weak `EntityId` handles and scene generation counters.
+   - When a querier entity, target entity, or scene is destroyed, in-flight
+     queries transition immediately to `Aborted`; outstanding physics traces
+     and pathfinding jobs are cancelled without dangling pointer access.
+
+
 ## AI Architecture And Runtime Ownership
 
 ### Subsystem Boundaries And Decoupling From Editor AI
@@ -1197,6 +1394,8 @@ changes require workload, platform, and measurement evidence, not a new ADR.
 These are required downstream runtime/CI tests, not tests implemented by this ADR-only change.
 
 ## Related Documents
+
+- [ADR-011: Environment Query Ownership, Item and Scoring Model](../../adr/011-environment-query-ownership-item-and-scoring-model.md)
 
 - [ADR-010: Job Waiting and Operation Store Ownership](../../adr/010-job-waiting-and-operation-store-ownership.md)
 - [ADR-017: Prefab Asset and Spawn Contracts](../../adr/017-prefab-role-ownership-and-capability-tiers.md)


### PR DESCRIPTION
## Summary

Propose ADR-013 and reconcile EQS orchestration, provider execution, scoring,
scheduling, caching and lifecycle contracts with both supplied reviews. Rebase onto
main preserves the previously merged Navigation/AI ownership and fixed-tick work.

## Motivation

The earlier proposal conflated read-only data access with provider-owned query
execution and promised deterministic partial results despite wall-clock cutoffs.
Its cache omitted provider/context dependencies and cancellation implied that every
running operation could be physically interrupted.

## Implementation Notes

- Keep tactical authority in Gameplay AI, while splitting internal manager, executor,
  scoring and cache roles; providers retain their domain queries and data.
- Define simulation-owner BlackboardSync/AiDecisionEvaluate seams and Navigation/
  Physics publication boundaries without nested schedulers or synchronous waits.
- Separate deterministic work-unit scheduling from adaptive wall-time targets.
  Disable result caching in deterministic mode so cache timing cannot alter work
  allocation. Provider mode/latency/quota compatibility is validated at admission.
- Make ordinary yield nonterminal; specify opt-in partial results, hard tick deadlines,
  empty completion, stale inputs, invalid scores and cancellation precedence.
- Capture immutable submission context and provider read revisions. Cache keys include
  complete inputs, Perception/custom dependencies, scoped revisions and entity lifetime.
  Explicit approximate quantization evaluates the same context that it hashes.
- Validate positive aggregate weights and normalization ranges; invalid runtime math
  excludes candidates rather than creating zero-score winners.
- Define bounded canonical custom items/contexts and inert descriptor composition.
  Tie query templates/plans to AssetRegistry, CookCatalog, versioned cook identities
  and separate ProjectVersion authoring migration/runtime format validation.
- Define cooperative provider cancellation, late-result suppression and retention
  accounting for uncancellable work and caller-held immutable results.

## Validation

- Passed `git diff --check`.
- Checked all three changed Markdown files: 57 relative links resolve and code fences
  are balanced.
- Manually reconciled both reviews with ADR-010/016/017/018/021/022/024/026 and the
  current Navigation, Physics, Asset Pipeline and AI phase contracts.
- Gitar and Codacy are checked on the final pushed commit along with PR comments
  and unresolved review threads before merge.
- Documentation-only change: runtime builds/tests were not rerun. Required
  implementation qualification is documented, not claimed as already executed.

## Risks

Provider deterministic-kernel capabilities, versioned query cooking, runtime cache
and cancellation infrastructure remain follow-up implementation work. Adaptive
completion timing and partial populations are intentionally not replay-deterministic
without recorded outcomes. Actual native/provider implementations require qualification.

## Issue Links

- Jira: HORO-1346
- GitHub: Closes #1346

## Reviewer Notes

Read ADR-013, then the EQS section of Navigation And AI Architecture. The ADR remains
Proposed, consistent with the index; this PR does not claim formal acceptance or
change existing accepted ADRs. Non-EQS Navigation/AI contracts from main are preserved.
