### PR TITLE
docs(prefab): prefab role, ownership and capability-tier decision HORO-1008 #1008 [PFB-001.1]

### DIFF
--- a/docs/adr/011-prefab-role-ownership-and-capability-tiers.md
+++ b/docs/adr/011-prefab-role-ownership-and-capability-tiers.md
@@ -30,7 +30,7 @@ This discrepancy created an architectural contradiction:
 |---|---|---|
 | Prefab role in static scenes | Authoring template expanded into `RuntimeSceneDefinition` during scene cook/load | **Ratified.** Placed static scene instances are flattened at conversion/cook time for optimal runtime data locality and zero runtime expansion overhead. |
 | Prefab role in dynamic gameplay | Stated as unhandled / no runtime prefab assets shipped in release packages | **Revised.** Prefabs referenced for dynamic spawning are compiled by the asset cooker into immutable `CookedPrefab` binary assets shipped in release packages and spawned dynamically by `SceneRuntime` / `Gameplay`. |
-| Capability staging | Single-root initial limitation with informal future extensions list | **Revised.** Formalized into Tier 0 (Baseline / M1), Tier 1 (Production Target / M2), and Tier 2 (Deferred / M3+). |
+| Capability staging | Single-root initial limitation with informal future extensions list | **Revised.** Formalized into Tier 0 (Baseline / M1), Tier 1 (Engine Target / M2), and Tier 2 (Deferred / M3+). |
 | Identity authority | Mixed `prefabId` and `sourcePath` | **Revised.** Authoritative identity is Asset Registry `AssetId` (128-bit UUID). `sourcePath` is an authoring index hint only. |
 | Local object addressing | Ad-hoc or single-root string IDs | **Revised.** Local objects inside a prefab use deterministic zero-based `LocalObjectId` slots. Instantiated scene/runtime entity IDs are composed deterministically (`Hash(InstanceId, LocalObjectId)`) to prevent collisions. |
 | Component data preservation | Undefined for custom/unregistered project components | **Revised.** Opaque component payloads (`RawComponentPayload`) are preserved verbatim across authoring serialization and expansion. |
@@ -84,14 +84,14 @@ Capability delivery is partitioned into three discrete tiers:
 - Cooked prefabs participate in the standard `AssetRegistry` and `CookCatalog`, loaded via `IAssetProvider`.
 - `SceneRuntimeAccess` and `SceneCommandBuffer` expose typed spawn operations:
   ```cpp
-  Result<SpawnedPrefabHandle> SpawnPrefab(
+  Result<SpawnedPrefabHandle, PrefabError> SpawnPrefab(
       AssetId prefabAssetId,
       const Transform& spawnTransform,
       std::optional<EntityId> parentEntity = std::nullopt
   );
   ```
 - Spawn execution allocates fresh, non-colliding runtime `EntityId`s, instantiates component data, establishes hierarchy parenting, and dispatches behavior lifecycle events (`OnCreate`, followed by `OnStart` during scene synchronization).
-- Fail-safe lifecycle handling: if a cooked prefab is missing, unloadable, or corrupted, the spawn call returns an explicit `PrefabSpawnError` without corrupting active scene state or throwing unhandled exceptions.
+- Fail-safe lifecycle handling: if a cooked prefab is missing, unloadable, or corrupted, the spawn call returns an explicit `PrefabError` without corrupting active scene state or throwing unhandled exceptions.
 
 #### Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred / M3+)
 - Prefab Variants allow creating specialized prefabs that inherit from a base prefab asset and record delta overrides (property overrides, added/removed components, extra child entities).
@@ -115,7 +115,7 @@ Capability delivery is partitioned into three discrete tiers:
    - Authoring operations (clone, save, expand, instance placement) preserve raw payloads verbatim.
 2. **Fail-Safe Lifecycle Handling**:
    - Dynamic spawn operations never throw C++ exceptions across module boundaries.
-   - Missing assets, schema version mismatches, component allocation failures, or payload corruption return typed `Result<SpawnedPrefabHandle, PrefabSpawnError>`:
+   - Missing assets, schema version mismatches, component allocation failures, or payload corruption return typed `Result<SpawnedPrefabHandle, PrefabError>`:
      - `PrefabError::AssetNotFound`: Requested `AssetId` is not registered in `CookCatalog`.
      - `PrefabError::AssetNotLoaded`: Async dependency not yet available in `IAssetProvider`.
      - `PrefabError::CorruptedPayload`: Cryptographic digest or magic header validation failed.

--- a/docs/adr/011-prefab-role-ownership-and-capability-tiers.md
+++ b/docs/adr/011-prefab-role-ownership-and-capability-tiers.md
@@ -1,0 +1,139 @@
+# ADR-011: Prefab Role, Ownership and Capability-Tier Decision
+
+- **Status**: Proposed
+- **Date**: 2026-08-28
+- **Supersedes**: None
+- **Scope**: Prefab asset definition, authoring templates, runtime spawnable templates (`CookedPrefab`), capability tiers (Tier 0, Tier 1, Tier 2), asset identity, project versioning, unknown component preservation, and lifecycle safety
+- **Issue**: [#1008](https://github.com/abdullahbodur/horo-engine/issues/1008) ([PFB-001.1])
+- **Normative document**: [Prefab Architecture](../architecture/runtime/prefab-architecture.md)
+
+## Context
+
+`docs/architecture/runtime/prefab-architecture.md` initially defined a prefab strictly as an authoring-time template expanded into the containing scene's `RuntimeSceneDefinition` prior to runtime initialization, stating that release packages never ship `.prefab` files. However, Gameplay behavior authoring (`docs/architecture/extensions/gameplay-behavior-authoring.md`), the cinematic sequencer (`docs/architecture/runtime/cinematic-sequencer.html`), and dynamic VFX/projectile systems require dynamic runtime instantiation of entity templates during active gameplay.
+
+This discrepancy created an architectural contradiction:
+1. If prefabs are solely inlined and stripped at scene cook time, runtime gameplay and scene systems cannot dynamically spawn templated entities (such as projectiles, enemies, interactive props, or particle hierarchies) without inventing a duplicate ad-hoc runtime archetype or prototype system.
+2. Conversely, if raw authoring `.prefab` files are parsed at runtime, release builds incur source parsing overhead, schema version migration baggage, unvalidated editor metadata, and path-authority drift.
+3. Without explicit capability staging, baseline single-root authoring, multi-object authoring, runtime dynamic spawning, and live variant inheritance were conflated across disparate milestone goals.
+4. Authoring documents historically mixed `prefabId` and `sourcePath`, risking broken references during file moves or renames unless anchored to the Asset Registry `AssetId` and project versioning rules.
+5. Projects with custom gameplay components risked silent data stripping during authoring expansion and round-trip serialization.
+
+[PFB-001.1] establishes the normative decision resolving these ownership, lifecycle, identity, and capability boundaries before downstream implementation tickets ([PFB-001.2] through [PFB-001.10]) implement the subsystem.
+
+## Decision
+
+**Horo Engine adopts a dual-role prefab architecture spanning two explicit lifecycles: an Authoring-Time Nested Template (`PrefabDocument` / `.prefab` source asset) in the Editor/Asset Pipeline, and an immutable Runtime-Spawnable Cooked Template (`CookedPrefab` binary asset) in SceneRuntime and Gameplay. The engine structures prefab capabilities into three sequential tiers (Tier 0: Authoring Expansion, Tier 1: Runtime Dynamic Spawn, Tier 2: Live Variant Inheritance). Prefab identity reuses Asset Registry `AssetId` and project versioning. Unknown project-owned component data is preserved verbatim across authoring workflows, and runtime dynamic spawning enforces fail-safe error handling.**
+
+### Ratify-or-revise outcomes
+
+| Area | Current state | Outcome |
+|---|---|---|
+| Prefab role in static scenes | Authoring template expanded into `RuntimeSceneDefinition` during scene cook/load | **Ratified.** Placed static scene instances are flattened at conversion/cook time for optimal runtime data locality and zero runtime expansion overhead. |
+| Prefab role in dynamic gameplay | Stated as unhandled / no runtime prefab assets shipped in release packages | **Revised.** Prefabs referenced for dynamic spawning are compiled by the asset cooker into immutable `CookedPrefab` binary assets shipped in release packages and spawned dynamically by `SceneRuntime` / `Gameplay`. |
+| Capability staging | Single-root initial limitation with informal future extensions list | **Revised.** Formalized into Tier 0 (Baseline / M1), Tier 1 (Production Target / M2), and Tier 2 (Deferred / M3+). |
+| Identity authority | Mixed `prefabId` and `sourcePath` | **Revised.** Authoritative identity is Asset Registry `AssetId` (128-bit UUID). `sourcePath` is an authoring index hint only. |
+| Local object addressing | Ad-hoc or single-root string IDs | **Revised.** Local objects inside a prefab use deterministic zero-based `LocalObjectId` slots. Instantiated scene/runtime entity IDs are composed deterministically (`Hash(InstanceId, LocalObjectId)`) to prevent collisions. |
+| Component data preservation | Undefined for custom/unregistered project components | **Revised.** Opaque component payloads (`RawComponentPayload`) are preserved verbatim across authoring serialization and expansion. |
+| Dynamic spawn lifecycle | Mentioned conceptually in gameplay behavior hooks | **Revised.** Explicit `SceneCommandBuffer::SpawnPrefab` and `SceneRuntimeAccess::SpawnPrefab` transaction contract with `OnCreate` -> `OnStart` behavior initialization and typed fail-safe error returns. |
+
+### Capability Tiers
+
+Capability delivery is partitioned into three discrete tiers:
+
+```text
++-------------------------------------------------------------------------------+
+| Tier 0: Authoring Template Expansion & Instantiation (Baseline / M1)          |
+| - Source .prefab assets in assets/prefabs/ conforming to ProjectVersion       |
+| - Single-root and multi-object hierarchy authoring                            |
+| - Placed instances in SceneDocument (AssetId + root transform & shallow ovr)  |
+| - Deterministic offline expansion into RuntimeSceneDefinition                 |
+| - Cycle detection rejecting recursive self-references                         |
+| - Opaque preservation of unknown project-owned component payloads             |
++-------------------------------------------------------------------------------+
+                                    |
+                                    v
++-------------------------------------------------------------------------------+
+| Tier 1: Runtime Dynamic Spawn from Cooked Prefab (Engine Target / M2)         |
+| - Cooker bakes .prefab into immutable binary CookedPrefab (core.prefab)       |
+| - Registered in AssetRegistry and CookCatalog with AssetId                    |
+| - Dynamic spawn APIs in SceneRuntime and Gameplay (SceneCommandBuffer)        |
+| - Runtime EntityId allocation, hierarchy setup, component copy, lifecycle     |
+| - Fail-safe error returns (missing asset, corrupted data, invalid component)  |
++-------------------------------------------------------------------------------+
+                                    |
+                                    v
++-------------------------------------------------------------------------------+
+| Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred / M3+) |
+| - Prefab Variants inheriting from base prefab asset with delta overrides      |
+| - Multi-level variant chains with DAG cycle verification                      |
+| - Live editor propagation across open documents upon base prefab mutation     |
+| - Granular per-property override tracking (revert/apply to base prefab)       |
++-------------------------------------------------------------------------------+
+```
+
+#### Tier 0: Authoring Template Expansion & Instantiation (Baseline / M1)
+- Authored `.prefab` files stored under `assets/prefabs/` as canonical JSON/structured source documents adhering to `ProjectVersion`.
+- Supports single-root and multi-object parent-child hierarchies within explicit bounds (max hierarchy depth 16, max object count 256, max payload size 4 MiB).
+- `SceneDocument` references prefabs via `ScenePrefabInstance` containing `AssetId` and root transform overrides.
+- Conversion pipeline expands prefab instances into the scene hierarchy deterministically before runtime initialization or offline scene baking.
+- Static cycle detection traps recursive inclusion loops (`A -> B -> A`) at validation time with clear diagnostics.
+- Serializer and expansion pipeline preserve unrecognized gameplay/plugin components as opaque typed byte payloads without data stripping.
+
+#### Tier 1: Runtime Dynamic Spawn from Cooked Prefab (Engine Target / M2)
+- Asset Pipeline cooks `.prefab` source assets into platform-optimized, immutable binary `CookedPrefab` artifacts (`core.prefab` asset type).
+- Cooked prefabs participate in the standard `AssetRegistry` and `CookCatalog`, loaded via `IAssetProvider`.
+- `SceneRuntimeAccess` and `SceneCommandBuffer` expose typed spawn operations:
+  ```cpp
+  Result<SpawnedPrefabHandle> SpawnPrefab(
+      AssetId prefabAssetId,
+      const Transform& spawnTransform,
+      std::optional<EntityId> parentEntity = std::nullopt
+  );
+  ```
+- Spawn execution allocates fresh, non-colliding runtime `EntityId`s, instantiates component data, establishes hierarchy parenting, and dispatches behavior lifecycle events (`OnCreate`, followed by `OnStart` during scene synchronization).
+- Fail-safe lifecycle handling: if a cooked prefab is missing, unloadable, or corrupted, the spawn call returns an explicit `PrefabSpawnError` without corrupting active scene state or throwing unhandled exceptions.
+
+#### Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred / M3+)
+- Prefab Variants allow creating specialized prefabs that inherit from a base prefab asset and record delta overrides (property overrides, added/removed components, extra child entities).
+- Multi-tier variant inheritance chains (`Base -> VariantA -> VariantB`) evaluated as a directed acyclic graph (DAG).
+- Editor workspace listens for base prefab mutation events and propagates updates in real time to open variant documents and active viewport previews.
+- Deep per-property override inspection, reverting, and pushing back to base prefab.
+
+### Identity and Asset Model
+
+1. **Single Source of Identity**: Prefab assets are identified exclusively by their 128-bit `AssetId` assigned in their asset sidecar metadata (`.prefab.meta`). Project paths (`assets/prefabs/enemy.prefab`) are editor convenience strings; moving or renaming a file preserves references through `AssetId`.
+2. **Project Versioning**: Prefab source documents share the unified `ProjectVersion` and migration pipeline (`docs/architecture/foundation/project-versioning-and-migration.md`). Format migrations upgrade prefabs alongside scenes and project settings.
+3. **Local Object Addressing**: Entities within a prefab are addressed by a zero-based `LocalObjectId` uint32 slot index stable across serialization.
+4. **Collision-Free Identity Composition**:
+   - During Tier 0 scene expansion: `ExpandedSceneObjectId = Hash64(InstanceSceneObjectId, LocalObjectId)`.
+   - During Tier 1 runtime spawn: Root and child entities receive fresh, runtime-allocated monotonic `EntityId` values registered in the active `SceneRuntime` entity pool.
+
+### Component Data Preservation & Fail-Safe Lifecycle Handling
+
+1. **Unknown Component Preservation**:
+   - The editor document model and prefab serializer represent unmapped or plugin-defined components as `RawComponentPayload` (preserving `componentTypeId`, `schemaVersion`, and serialized payload bytes).
+   - Authoring operations (clone, save, expand, instance placement) preserve raw payloads verbatim.
+2. **Fail-Safe Lifecycle Handling**:
+   - Dynamic spawn operations never throw C++ exceptions across module boundaries.
+   - Missing assets, schema version mismatches, component allocation failures, or payload corruption return typed `Result<SpawnedPrefabHandle, PrefabSpawnError>`:
+     - `PrefabError::AssetNotFound`: Requested `AssetId` is not registered in `CookCatalog`.
+     - `PrefabError::AssetNotLoaded`: Async dependency not yet available in `IAssetProvider`.
+     - `PrefabError::CorruptedPayload`: Cryptographic digest or magic header validation failed.
+     - `PrefabError::ComponentInstantiationFailed`: Unregistered component type or resource exhaustion.
+   - If spawn fails mid-instantiation, created entity handles and allocated memory are rolled back completely before returning the error.
+
+## Consequences
+
+- Static scenes continue to benefit from zero-cost runtime inlining and optimal contiguous memory layout.
+- Dynamic gameplay systems obtain a first-class, memory-efficient runtime spawning mechanism via `CookedPrefab` without raw JSON parsing at runtime.
+- A clear capability roadmap ensures baseline authoring (Tier 0) is delivered and stabilized in M1 without being blocked by complex live variant inheritance (Tier 2).
+- Single asset identity (`AssetId`) eliminates broken references upon asset renames.
+- Plugin developers and gameplay programmers can author custom components with guaranteed serialization preservation.
+
+## Rejected Alternatives
+
+- **Pure Authoring-Time Inlining Only**: Rejected. Precluding runtime template instantiation breaks dynamic gameplay requirements (projectiles, enemy spawners, inventory drop items, VFX hierarchies).
+- **Shipping Raw `.prefab` JSON Files to Runtime**: Rejected. Parsing JSON and running authoring migrations on the client runtime incurs massive CPU/memory overhead, requires shipping full reflection metadata, and risks security vulnerabilities.
+- **Runtime Prototype/ECS Archetype Inheritance**: Rejected. Resolving component property inheritance dynamically at runtime adds pointer indirection, cache misses, and invalidation hazards in performance-critical tick loops.
+- **Path-Authoritative References**: Rejected. File paths break when assets are moved, reorganized, or localized across platforms.
+- **Silent Stripping of Unknown Components**: Rejected. Stripping unparsed components causes silent data loss when opening projects with plugins or gameplay modules.

--- a/docs/adr/011-prefab-role-ownership-and-capability-tiers.md
+++ b/docs/adr/011-prefab-role-ownership-and-capability-tiers.md
@@ -12,6 +12,7 @@
 `docs/architecture/runtime/prefab-architecture.md` initially defined a prefab strictly as an authoring-time template expanded into the containing scene's `RuntimeSceneDefinition` prior to runtime initialization, stating that release packages never ship `.prefab` files. However, Gameplay behavior authoring (`docs/architecture/extensions/gameplay-behavior-authoring.md`), the cinematic sequencer (`docs/architecture/runtime/cinematic-sequencer.html`), and dynamic VFX/projectile systems require dynamic runtime instantiation of entity templates during active gameplay.
 
 This discrepancy created an architectural contradiction:
+
 1. If prefabs are solely inlined and stripped at scene cook time, runtime gameplay and scene systems cannot dynamically spawn templated entities (such as projectiles, enemies, interactive props, or particle hierarchies) without inventing a duplicate ad-hoc runtime archetype or prototype system.
 2. Conversely, if raw authoring `.prefab` files are parsed at runtime, release builds incur source parsing overhead, schema version migration baggage, unvalidated editor metadata, and path-authority drift.
 3. Without explicit capability staging, baseline single-root authoring, multi-object authoring, runtime dynamic spawning, and live variant inheritance were conflated across disparate milestone goals.
@@ -72,6 +73,7 @@ Capability delivery is partitioned into three discrete tiers:
 ```
 
 #### Tier 0: Authoring Template Expansion & Instantiation (Baseline / M1)
+
 - Authored `.prefab` files stored under `assets/prefabs/` as canonical JSON/structured source documents adhering to `ProjectVersion`.
 - Supports single-root and multi-object parent-child hierarchies within explicit bounds (max hierarchy depth 16, max object count 256, max payload size 4 MiB).
 - `SceneDocument` references prefabs via `ScenePrefabInstance` containing `AssetId` and root transform overrides.
@@ -80,6 +82,7 @@ Capability delivery is partitioned into three discrete tiers:
 - Serializer and expansion pipeline preserve unrecognized gameplay/plugin components as opaque typed byte payloads without data stripping.
 
 #### Tier 1: Runtime Dynamic Spawn from Cooked Prefab (Engine Target / M2)
+
 - Asset Pipeline cooks `.prefab` source assets into platform-optimized, immutable binary `CookedPrefab` artifacts (`core.prefab` asset type).
 - Cooked prefabs participate in the standard `AssetRegistry` and `CookCatalog`, loaded via `IAssetProvider`.
 - `SceneRuntimeAccess` and `SceneCommandBuffer` expose typed spawn operations:
@@ -94,6 +97,7 @@ Capability delivery is partitioned into three discrete tiers:
 - Fail-safe lifecycle handling: if a cooked prefab is missing, unloadable, or corrupted, the spawn call returns an explicit `PrefabError` without corrupting active scene state or throwing unhandled exceptions.
 
 #### Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred / M3+)
+
 - Prefab Variants allow creating specialized prefabs that inherit from a base prefab asset and record delta overrides (property overrides, added/removed components, extra child entities).
 - Multi-tier variant inheritance chains (`Base -> VariantA -> VariantB`) evaluated as a directed acyclic graph (DAG).
 - Editor workspace listens for base prefab mutation events and propagates updates in real time to open variant documents and active viewport previews.

--- a/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
+++ b/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
@@ -5,6 +5,7 @@
 - **Supersedes**: None
 - **Scope**: Prefab asset definition, authoring templates, runtime spawnable templates (`CookedPrefab`), capability tiers (Tier 0, Tier 1, Tier 2), asset identity, project versioning, unknown component preservation, and lifecycle safety
 - **Issue**: [#1008](https://github.com/abdullahbodur/horo-engine/issues/1008) ([PFB-001.1])
+- **JIRA**: HORO-1008
 - **Normative document**: [Prefab Architecture](../architecture/runtime/prefab-architecture.md)
 
 ## Context

--- a/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
+++ b/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
@@ -10,7 +10,7 @@
 
 ## Context
 
-`docs/architecture/runtime/prefab-architecture.md` initially defined a prefab strictly as an authoring-time template expanded into the containing scene's `RuntimeSceneDefinition` prior to runtime initialization, stating that release packages never ship `.prefab` files. However, Gameplay behavior authoring (`docs/architecture/extensions/gameplay-behavior-authoring.md`), the cinematic sequencer (`docs/architecture/runtime/cinematic-sequencer.html`), and dynamic VFX/projectile systems require dynamic runtime instantiation of entity templates during active gameplay.
+`docs/architecture/runtime/prefab-architecture.md` initially defined a prefab strictly as an authoring-time template expanded into the containing scene's `RuntimeSceneDefinition` prior to runtime initialization, stating that release packages never ship `.prefab` files. However, Gameplay behavior authoring (`docs/architecture/extensions/gameplay-behavior-authoring.md`), the cinematic sequencer (`docs/architecture/runtime/cinematic-sequencer-architecture.md`), and dynamic VFX/projectile systems require dynamic runtime instantiation of entity templates during active gameplay.
 
 This discrepancy created an architectural contradiction:
 

--- a/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
+++ b/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
@@ -26,7 +26,7 @@ This discrepancy created an architectural contradiction:
 
 **Horo Engine adopts a dual-role prefab architecture spanning two explicit lifecycles: an Authoring-Time Nested Template (`PrefabDocument` / `.prefab` source asset) in the Editor/Asset Pipeline, and an immutable Runtime-Spawnable Cooked Template (`CookedPrefab` binary asset) in SceneRuntime and Gameplay. The engine structures prefab capabilities into three sequential tiers (Tier 0: Authoring Expansion, Tier 1: Runtime Dynamic Spawn, Tier 2: Live Variant Inheritance). Prefab identity reuses Asset Registry `AssetId` and project versioning. Unknown project-owned component data is preserved verbatim across authoring workflows, and runtime dynamic spawning enforces fail-safe error handling.**
 
-Milestone numbering in this ADR is the *product delivery* ladder for prefab capability, not a second architecture-baseline clock. [ADR-018](https://github.com/abdullahbodur/horo-engine/pull/2347) (companion PR; not in this tree until it lands) and [ADR-010](010-job-waiting-and-operation-store-ownership.md) describe the M0 architecture baseline (console, jobs, safe points). Prefab Tier 0 / 1 / 2 map to M1 / M2 / M3+ *after* that baseline. M0 does not block T0 authoring work in editor/tools; T1 runtime spawn must conform to the M0 threading and `OperationStore` contracts.
+Capability tiers describe subsystem scope, not product milestone assignments or a global execution order. The [Product Roadmap Model](../architecture/delivery/product-roadmap.md) owns whole-product checkpoints; issue milestones and native dependency links determine delivery requirements. Tier 1 runtime spawn conforms to [ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md) dispatch and [ADR-010](010-job-waiting-and-operation-store-ownership.md) operation ownership, regardless of its delivery milestone.
 
 ### Ratify-or-revise outcomes
 
@@ -34,13 +34,13 @@ Milestone numbering in this ADR is the *product delivery* ladder for prefab capa
 |---|---|---|
 | Prefab role in static scenes | Authoring template expanded into `RuntimeSceneDefinition` during scene cook/load | **Ratified.** Placed static scene instances are flattened at conversion/cook time for optimal runtime data locality and zero runtime expansion overhead. |
 | Prefab role in dynamic gameplay | Stated as unhandled / no runtime prefab assets shipped in release packages | **Revised.** Prefabs referenced for dynamic spawning are compiled by the asset cooker into immutable `CookedPrefab` binary assets shipped in release packages and spawned dynamically by `SceneRuntime` / `Gameplay`. |
-| Capability staging | Single-root initial limitation with informal future extensions list | **Revised.** Formalized into Tier 0 (Baseline / M1), Tier 1 (Engine Target / M2), and Tier 2 (Deferred / M3+). |
+| Capability staging | Single-root initial limitation with informal future extensions list | **Revised.** Formalized into Tier 0 (Baseline), Tier 1 (Runtime Spawn), and Tier 2 (Deferred). |
 | Identity authority | Mixed `prefabId` and `sourcePath` | **Revised.** Authoritative identity is Asset Registry `AssetId` (128-bit UUID). `sourcePath` is an authoring index hint only. |
-| Local object addressing | Ad-hoc or single-root string IDs | **Revised.** Local objects inside a prefab use deterministic zero-based `LocalObjectId` slots. Instantiated scene/runtime entity IDs are composed deterministically (`Hash(InstanceId, LocalObjectId)`) to prevent collisions. |
+| Local object addressing | Ad-hoc or single-root string IDs | **Revised.** Persisted `LocalObjectId` slots identify authoring objects; deterministic expansion IDs are collision-checked. Runtime spawning uses the existing generation-checked scene entity allocator, not hashed or globally monotonic IDs. |
 | Component data preservation | Undefined for custom/unregistered project components | **Revised.** Opaque component payloads (`RawComponentPayload`) are preserved verbatim across authoring serialization and expansion. |
-| Dynamic spawn lifecycle | Mentioned conceptually in gameplay behavior hooks | **Revised.** `SceneCommandBuffer::RequestSpawnPrefab` enqueues from any thread (`OperationId`, ADR-018). `SceneRuntimeAccess::SpawnPrefab` commits on `OwnerThreadNextFrame` only. `OnCreate`/`OnStart` run after commit. |
+| Dynamic spawn lifecycle | Mentioned conceptually in gameplay behavior hooks | **Revised.** `SceneCommandBuffer::RequestSpawnPrefab` admits from any thread (`Result<OperationId, PrefabError>`). Owner-thread commit uses `CommitDeferredLifecycleChanges`; gameplay lifecycle hooks follow publication and enable-state rules. |
 | Spawn threading / async | Unspecified vs ADR-018 safe points | **Revised.** Spawn commit is `CommandThreadPolicy::OwnerThreadNextFrame`. Unloaded assets become an `OperationStore` load-then-spawn job, not a poll loop on `AssetNotLoaded`. |
-| Runtime spawn recursion | Static cycle detection only (Tier 0) | **Revised.** Owner-thread spawn call stack rejects re-entrant `SpawnPrefab` of an in-flight `AssetId` (`PrefabError::SpawnRecursionDetected`). |
+| Runtime spawn recursion | Static cycle detection only (Tier 0) | **Revised.** An immutable spawn lineage follows queued requests, loads, and lifecycle continuations; repeated `AssetId`s and excessive lineage depth are rejected before staging. |
 | CookedPrefab versioning | Source `.prefab` shares `ProjectVersion` only | **Revised.** Cooked blobs carry a distinct `cookedFormatVersion`. `ProjectVersion` migration invalidates cook cache and forces recook; runtime never migrates cooked bytes. |
 
 ### Capability Tiers
@@ -48,37 +48,37 @@ Milestone numbering in this ADR is the *product delivery* ladder for prefab capa
 Capability delivery is partitioned into three discrete tiers:
 
 ```text
-+-------------------------------------------------------------------------------+
-| Tier 0: Authoring Template Expansion & Instantiation (Baseline / M1)          |
-| - Source .prefab assets in assets/prefabs/ conforming to ProjectVersion       |
-| - Single-root and multi-object hierarchy authoring                            |
-| - Placed instances in SceneDocument (AssetId + root transform & shallow ovr)  |
-| - Deterministic offline expansion into RuntimeSceneDefinition                 |
-| - Cycle detection rejecting recursive self-references                         |
-| - Opaque preservation of unknown project-owned component payloads             |
-+-------------------------------------------------------------------------------+
++------------------------------------------------------------------------------+
+| Tier 0: Authoring Template Expansion & Instantiation (Baseline)              |
+| - Source .prefab assets in assets/prefabs/ conforming to ProjectVersion      |
+| - Single-root and multi-object hierarchy authoring                           |
+| - Placed instances in SceneDocument (AssetId + root transform & shallow ovr) |
+| - Deterministic offline expansion into RuntimeSceneDefinition                |
+| - Cycle detection rejecting recursive self-references                        |
+| - Opaque preservation of unknown project-owned component payloads            |
++------------------------------------------------------------------------------+
                                     |
                                     v
-+-------------------------------------------------------------------------------+
-| Tier 1: Runtime Dynamic Spawn from Cooked Prefab (Engine Target / M2)         |
-| - Cooker bakes .prefab into immutable binary CookedPrefab (core.prefab)       |
-| - Registered in AssetRegistry and CookCatalog with AssetId                    |
-| - Dynamic spawn APIs in SceneRuntime and Gameplay (SceneCommandBuffer)        |
-| - Runtime EntityId allocation, hierarchy setup, component copy, lifecycle     |
-| - Fail-safe error returns (missing asset, corrupted data, invalid component)  |
-+-------------------------------------------------------------------------------+
++------------------------------------------------------------------------------+
+| Tier 1: Runtime Dynamic Spawn from Cooked Prefab (Runtime Spawn)             |
+| - Cooker bakes .prefab into immutable binary CookedPrefab (core.prefab)      |
+| - Registered in AssetRegistry and CookCatalog with AssetId                   |
+| - Dynamic spawn APIs in SceneRuntime and Gameplay (SceneCommandBuffer)       |
+| - Runtime EntityId allocation, hierarchy setup, component copy, lifecycle    |
+| - Fail-safe error returns (missing asset, corrupted data, invalid component) |
++------------------------------------------------------------------------------+
                                     |
                                     v
-+-------------------------------------------------------------------------------+
-| Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred / M3+) |
-| - Prefab Variants inheriting from base prefab asset with delta overrides      |
-| - Multi-level variant chains with DAG cycle verification                      |
-| - Live editor propagation across open documents upon base prefab mutation     |
-| - Granular per-property override tracking (revert/apply to base prefab)       |
-+-------------------------------------------------------------------------------+
++------------------------------------------------------------------------------+
+| Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred)      |
+| - Prefab Variants inheriting from base prefab asset with delta overrides     |
+| - Multi-level variant chains with DAG cycle verification                     |
+| - Live editor propagation across open documents upon base prefab mutation    |
+| - Granular per-property override tracking (revert/apply to base prefab)      |
++------------------------------------------------------------------------------+
 ```
 
-#### Tier 0: Authoring Template Expansion & Instantiation (Baseline / M1)
+#### Tier 0: Authoring Template Expansion & Instantiation (Baseline)
 
 - Authored `.prefab` files stored under `assets/prefabs/` as canonical JSON/structured source documents adhering to `ProjectVersion`.
 - Supports single-root and multi-object parent-child hierarchies within explicit bounds (max hierarchy depth 16, max object count 256, max payload size 4 MiB).
@@ -87,26 +87,29 @@ Capability delivery is partitioned into three discrete tiers:
 - Static cycle detection traps recursive inclusion loops (`A -> B -> A`) at validation time with clear diagnostics.
 - Serializer and expansion pipeline preserve unrecognized gameplay/plugin components as opaque typed byte payloads without data stripping.
 
-#### Tier 1: Runtime Dynamic Spawn from Cooked Prefab (Engine Target / M2)
+#### Tier 1: Runtime Dynamic Spawn from Cooked Prefab (Runtime Spawn)
 
 - Asset Pipeline cooks `.prefab` source assets into platform-optimized, immutable binary `CookedPrefab` artifacts (`core.prefab` asset type).
 - Cooked prefabs participate in the standard `AssetRegistry` and `CookCatalog`, loaded via `IAssetProvider`.
-- Two APIs, one contract, reconciled with [ADR-018](https://github.com/abdullahbodur/horo-engine/pull/2347) (threading policy) and [ADR-010](010-job-waiting-and-operation-store-ownership.md) (`OperationStore`):
+- Two APIs, one contract, reconciled with [ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md) (threading policy) and [ADR-010](010-job-waiting-and-operation-store-ownership.md) (`OperationStore`):
   ```cpp
-  // Any thread. Enqueue only. Never mutates SceneRuntime.
-  // Returns an OperationId immediately (ADR-010 OperationStore).
-  OperationId SceneCommandBuffer::RequestSpawnPrefab(const PrefabSpawnRequest& request);
+  class SceneCommandBuffer {
+  public:
+      // Any thread; typed admission error or an OperationId. Never mutates SceneRuntime.
+      Result<OperationId, PrefabError> RequestSpawnPrefab(const PrefabSpawnRequest& request);
+  };
 
-  // SceneRuntime owner thread only (CommandThreadPolicy::OwnerThreadNextFrame).
-  // Requires a resident CookedPrefab. Gameplay uses the buffer, not this entry point.
-  Result<SpawnedPrefabHandle, PrefabError> SceneRuntimeAccess::SpawnPrefab(
-      const PrefabSpawnRequest& request);
+  class SceneRuntimeAccess {
+  public:
+      // Internal owner-thread drain; resident assets and captured context required.
+      Result<SpawnedPrefabHandle, PrefabError> SpawnPrefab(const PrefabSpawnRequest& request);
+  };
   ```
-  `SceneCommandBuffer::RequestSpawnPrefab` is the public gameplay seam. It records a spawn operation and returns. `SceneRuntimeAccess::SpawnPrefab` is the owner-thread drain of that queue. The access function does not wrap the buffer; the buffer wraps the access function.
-- Spawn commit (owner thread) allocates fresh monotonic `EntityId`s from the scene pool, copies component data, establishes hierarchy, then **commits**. `OnCreate` runs only after commit; `OnStart` runs at the following scene synchronization point.
+  `SceneCommandBuffer::RequestSpawnPrefab` is the planned gameplay admission seam; successful admission returns an `OperationId`, while a full queue/store or closed scene returns a typed error without creating an operation. A host-composed spawn coordinator exclusively mutates the authoritative `OperationStore`. `SceneRuntimeAccess::SpawnPrefab` is the internal owner-thread drain, never a gameplay bypass. This Tier 1 extension adds a thread-safe admission facade without making existing SCN-001 owner-thread command-buffer methods thread-safe.
+- Spawn staging uses the existing scene allocator for fresh generation-checked `EntityId`s, copies component data, and establishes hierarchy before **commit**. `OnCreate` runs after commit, then `OnEnable` if enabled; `OnStart` runs once after first enable and before the first eligible fixed update. Created-disabled behaviors defer `OnEnable`/`OnStart` until enabled, as required by Gameplay Behavior Authoring.
 - Fail-safe: missing catalog entries, corrupted or version-mismatched cooked blobs, unregistered component types, component allocation failure, or spawn recursion return typed `PrefabError` without publishing entities or invoking behavior hooks.
 
-#### Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred / M3+)
+#### Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred)
 
 - Prefab Variants allow creating specialized prefabs that inherit from a base prefab asset and record delta overrides (property overrides, added/removed components, extra child entities).
 - Multi-tier variant inheritance chains (`Base -> VariantA -> VariantB`) evaluated as a directed acyclic graph (DAG).
@@ -117,10 +120,10 @@ Capability delivery is partitioned into three discrete tiers:
 
 1. **Single Source of Identity**: Prefab assets are identified exclusively by their 128-bit `AssetId` assigned in their asset sidecar metadata (`.prefab.meta`). Project paths (`assets/prefabs/enemy.prefab`) are editor convenience strings; moving or renaming a file preserves references through `AssetId`.
 2. **Project Versioning**: Prefab source documents share the unified `ProjectVersion` and migration pipeline (`docs/architecture/foundation/project-versioning-and-migration.md`). Format migrations upgrade prefabs alongside scenes and project settings.
-3. **Local Object Addressing**: Entities within a prefab are addressed by a zero-based `LocalObjectId` uint32 slot index stable across serialization.
-4. **Collision-Free Identity Composition**:
-   - During Tier 0 scene expansion: `ExpandedSceneObjectId = Hash64(InstanceSceneObjectId, LocalObjectId)`.
-   - During Tier 1 runtime spawn: Root and child entities receive fresh, monotonic `EntityId` values allocated from the `SceneRuntime` entity pool. Allocation runs **only** on the scene owner thread while draining spawn commands. Worker jobs and other threads never touch the counter; because the owner-thread queue serializes commit, the counter is not atomic and needs no lock-free increment.
+3. **Local Object Addressing**: Entities within a prefab have persisted `LocalObjectId` uint32 slots, with root slot zero. Reordering, insertion, and deletion must not renumber surviving slots or reuse deleted slots while references may remain; slots may be sparse and are not vector positions. Cook builds a separate dense slot remap.
+4. **Scoped Identity Composition**:
+   - During Tier 0 scene expansion, a fixed versioned hash over canonical instance-scope and local-ID bytes produces a deterministic candidate `ExpandedSceneObjectId`. Each nested instance extends the scope with its owning local slot. Validate all candidates against authored and expanded scene IDs before publication; collisions return `PrefabError::IdentityCollision` rather than overwriting an object. A 64-bit hash alone does not guarantee uniqueness.
+   - During Tier 1 runtime spawn: use the existing `EntityId { index, generation }` allocator and scene-qualified `EntityRef { SceneRuntimeId, EntityId }` from Scene Runtime. Reused slots increment generations and retire on exhaustion; no new monotonic counter is introduced. Allocation and publication remain owner-thread-only. Requests capture the target scene identity and optional parent `EntityRef`; commit rejects an unloaded/replaced scene or stale/cross-scene parent.
 
 ### Component Data Preservation & Fail-Safe Lifecycle Handling
 
@@ -136,43 +139,47 @@ Capability delivery is partitioned into three discrete tiers:
      - `PrefabError::CorruptedPayload`: Magic header or cryptographic digest failed.
      - `PrefabError::ComponentTypeUnregistered`: Cooked template references a component type not registered in this runtime. Distinct from allocation failure.
      - `PrefabError::ComponentAllocationFailed`: Component pool or heap allocation failed while staging. Distinct from `ComponentTypeUnregistered`.
-     - `PrefabError::SpawnRecursionDetected`: `SpawnPrefab` of an `AssetId` already on the owner-thread spawn call stack.
+     - `PrefabError::SpawnRecursionDetected`: requested `AssetId` already appears in the inherited spawn lineage, including delayed load and lifecycle continuations.
+     - `PrefabError::SpawnDepthExceeded`: appending the target exceeds `MaximumRuntimeSpawnDepth` (8).
+     - `PrefabError::AdmissionRejected` / `Cancelled` / `SceneUnavailable` / `InvalidParent`: bounded admission, cancellation, or captured scene/parent lifetime validation fails.
+     - `PrefabError::EntityAllocationExhausted` / `IdentityCollision` / `InvalidHierarchy` / `ComponentCountExceeded`: allocator capacity, authoring identity, graph structure, or per-object component limits fail.
      - `PrefabError::HierarchyDepthExceeded` / `ObjectCountExceeded` / `PayloadTooLarge`: Bounds failed at authoring, cook, or runtime defense-in-depth.
-   - Staging vs commit: entity handles and component bytes are staged first with **no** behavior hooks, bus events, or network emits. If staging fails, staged memory and handles are discarded. `OnCreate` has not run, so `OnDestroy` is not invoked. `OnCreate` / `OnStart` run only after commit; spawn rollback therefore never has to unwind subsystem registrations or unsend events. If `OnCreate` itself fails, the entities are already committed and later teardown uses the normal `OnDestroy` path; `OnCreate` must not be treated as part of the spawn transaction.
+   - Staging vs commit: stage entity handles, component bytes, validated behavior descriptors, and reserved behavior storage with **no constructed gameplay behavior instances**, hooks, bus events, or network emits. Staging failure discards unpublished storage and handles, so no `OnDestroy` is due. After publication, construct behaviors and run the normal gameplay lifecycle. Spawn success means structural commit; post-commit construction/hook faults are reported through gameplay fault handling and do not change a committed spawn into a rolled-back failure. Faulted behaviors do not start/update; every constructed instance receives normal `OnDestroy` exactly once at teardown.
 
 ### Reconciliation with ADR-018 (Threading, Async, Recursion)
 
 Tier 1 spawn is an ADR-018 `OwnerThreadNextFrame` mutation, not an `ImmediateConsoleThread` call and not a main-thread `Wait()` on a worker ([ADR-010](010-job-waiting-and-operation-store-ownership.md)).
 
-1. **Who may call what.** Any thread (gameplay, CLI, MCP, jobs) may call `SceneCommandBuffer::RequestSpawnPrefab`. That call only enqueues. Only the SceneRuntime owner thread calls `SceneRuntimeAccess::SpawnPrefab`, during the deterministic frame phase that drains the command buffer (`PreUpdate` / `DebugPhase`).
-2. **Unloaded assets.** If `RequestSpawnPrefab` finds the `CookedPrefab` absent from `IAssetProvider` but present in `CookCatalog`, it does **not** fail with `AssetNotLoaded` and it does **not** ask the caller to poll. It starts an ADR-018 `WorkerJob` that waits on the provider, then re-enqueues owner-thread commit. Progress is an `OperationId` in `OperationStore`. Completing the operation publishes `SpawnedPrefabHandle`. Catalog misses (`AssetNotFound`) fail the operation immediately.
-3. **Runtime recursion.** Nested prefab *references* are flattened at cook time; runtime spawn of A does not recursively `SpawnPrefab` B. The remaining hazard is a behavior `OnCreate` (or a same-drain command) requesting another spawn of an in-flight `AssetId`, directly or through a chain. SceneRuntime keeps an owner-thread spawn call stack of `AssetId`. Push before staging, pop after commit or rollback. If the id is already on the stack, return `PrefabError::SpawnRecursionDetected` and do not stage. `OnCreate` may call `RequestSpawnPrefab` for a *different* asset; that enqueue is drained after the current stack frame pops (same safe point or next frame) and is still subject to the stack if it re-enters. Behaviors must not spawn their own `AssetId` from `OnCreate`.
-4. **EntityId concurrency.** The monotonic pool counter is owner-thread-only. Worker jobs load bytes; they never allocate `EntityId`. No atomic increment, because ADR-018 already serializes scene mutations onto one drain.
+1. **Admission and owner-thread commit.** Any thread may submit an owned request through the scene-bound admission facade. The coordinator captures target `SceneRuntimeId`, optional parent `EntityRef`, cancellation, diagnostics/configuration, and explicit spawn lineage before enqueue. The owner thread validates and stages; publication occurs only at Scene Runtime's `CommitDeferredLifecycleChanges`. `OwnerThreadNextFrame` describes dispatch to that commit phase, not a second structural-mutation phase in `PreUpdate` / `DebugPhase`.
+2. **Unloaded assets and ownership.** Catalog misses fail accepted operations with `AssetNotFound`. Non-resident templates and required dependencies load through the host-composed `AssetLoadService` / `IAssetProvider` path; workers perform bounded, cancellation-aware I/O and never wait for another queued worker or owner-thread commit. Completion schedules an owner-thread continuation holding immutable asset leases. The coordinator owns one operation from admission through terminal commit/failure/cancellation; runtime code and workers do not write `OperationStore` independently.
+3. **Recursion across asynchronous boundaries.** Each accepted spawn carries immutable lineage ending in its target `AssetId`. Requests originating from its `OnCreate`, initial `OnEnable`/`OnStart`, or their asynchronous continuations inherit that lineage through an explicit bound command context. Before appending a target, reject a repeated ID with `SpawnRecursionDetected`, or depth above 8 with `SpawnDepthExceeded`. A call stack or thread-local scope alone is insufficient: lineage survives frame changes, loads, and queue deferral. Independent later gameplay requests start fresh lineages, so spawning the same prefab at different times is valid. The internal direct entry cannot bypass lineage validation. Child admission failure leaves an already-committed parent intact.
+4. **Drain and lifetime safety.** Lifecycle-created requests are eligible only in a subsequent bounded drain batch, never recursively executed in the current batch. Admission and per-drain work have host-configured count/byte budgets. Before publication, recheck cancellation, scene identity, parent generation, and pinned dependency validity. Unload/replacement closes scene admission, cancels its pending operations, and invalidates late continuations. Cancellation before commit publishes nothing; commit and cancellation are serialized so cancellation after commit never pretends the entities were rolled back.
 
 ### CookedPrefab Versioning and Cook Cache Invalidation
 
 - Source `.prefab` documents share `ProjectVersion` and its migration pipeline.
 - `CookedPrefab` carries a separate `cookedFormatVersion` in the binary header, independent of `ProjectVersion`. Runtime never runs authoring migrations on cooked bytes.
-- Cook cache key: `(AssetId, sourceDigest, ProjectVersion, cookedFormatVersion, cookerRevision)`. A `ProjectVersion` migration of the source, a cooker bump, or a format bump invalidates the catalog entry and forces recook before the blob can be loaded.
-- `UnsupportedCookedVersion` is not `CorruptedPayload`. Corruption is digest/magic failure. Version mismatch is a defined, recoverable catalog miss after recook.
+- Prefab cooking extends the Asset Pipeline's canonical versioned cache key; it does not replace it with a prefab-only tuple. Preserve asset identity/type, exact source and cooker-input metadata digests, effective settings/schema, cooker identity/version, typed target/profile, and artifact-envelope version. Add `ProjectVersion`, `cookedFormatVersion`, and canonically ordered transitive dependency identities/artifact digests through the explicit dependency-aware extension. The dependency-free AST-001C `CacheKeyV1` cannot cook nested prefabs; Tier 1 requires that extension first.
+- Source migration, dependency changes, target/settings changes, and cooker/format changes invalidate affected cooked output. Runtime rejects `UnsupportedCookedVersion` and never recooks; authoring/build tools rebuild and republish a compatible catalog/artifact before a later runtime request can succeed.
+- Source/dependency digests establish cook provenance. A separate artifact-envelope digest verifies the actual cooked payload bytes, with length/offset checks; hashing source alone does not detect corruption in shipped cooked bytes.
 
 ### Authoring Bound Enforcement
 
-`MaximumPrefabHierarchyDepth` (16), `MaximumPrefabObjectCount` (256), and `MaximumPrefabPayloadBytes` (4 MiB) are rejected at **two** gates, with runtime as defense in depth:
+`MaximumPrefabHierarchyDepth` (16), `MaximumPrefabObjectCount` (256), `MaximumPrefabPayloadBytes` (4 MiB), and `MaximumPrefabComponentsPerObject` (64) are rejected at **two** gates, with runtime as defense in depth:
 
 | Gate | When | On exceed |
 |---|---|---|
 | Authoring validation | Save, import, instance placement, editor expand | Document command fails with a typed diagnostic. The `.prefab` is not written / the instance is not placed. |
 | Cook | Prefab cook | Cook fails. No `CookedPrefab` artifact is emitted. |
-| Runtime | Header check before staging | `HierarchyDepthExceeded` / `ObjectCountExceeded` / `PayloadTooLarge`. No entities published. |
+| Runtime | Envelope and full table validation before staging | Typed bounds/structure error. No entities published. |
 
-Static inclusion cycles (`A -> B -> A`) remain a validation-time rejection (`CyclicReferenceDetected`) at the authoring and cook gates.
+Limits apply to the fully expanded hierarchy, not only each source file: count the root as depth 1, all expanded objects, all component kinds per object, and bounded source/expanded/cooked payloads. Validate incrementally before exceeding allocation limits. Reject duplicate local IDs, missing/invalid parents, multiple roots, cycles, and invalid table offsets with `InvalidHierarchy` or `CorruptedPayload` as appropriate. Static inclusion cycles (`A -> B -> A`) remain `CyclicReferenceDetected` at authoring and cook gates.
 
 ## Consequences
 
 - Static scenes continue to benefit from zero-cost runtime inlining and optimal contiguous memory layout.
 - Dynamic gameplay systems obtain a first-class, memory-efficient runtime spawning mechanism via `CookedPrefab` without raw JSON parsing at runtime.
-- A clear capability roadmap ensures baseline authoring (Tier 0) is delivered and stabilized in M1 without being blocked by complex live variant inheritance (Tier 2).
+- A clear capability roadmap ensures baseline authoring (Tier 0) can be delivered and stabilized without being blocked by complex live variant inheritance (Tier 2).
 - Single asset identity (`AssetId`) eliminates broken references upon asset renames.
 - Plugin developers and gameplay programmers can author custom components with guaranteed serialization preservation.
 

--- a/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
+++ b/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
@@ -26,6 +26,8 @@ This discrepancy created an architectural contradiction:
 
 **Horo Engine adopts a dual-role prefab architecture spanning two explicit lifecycles: an Authoring-Time Nested Template (`PrefabDocument` / `.prefab` source asset) in the Editor/Asset Pipeline, and an immutable Runtime-Spawnable Cooked Template (`CookedPrefab` binary asset) in SceneRuntime and Gameplay. The engine structures prefab capabilities into three sequential tiers (Tier 0: Authoring Expansion, Tier 1: Runtime Dynamic Spawn, Tier 2: Live Variant Inheritance). Prefab identity reuses Asset Registry `AssetId` and project versioning. Unknown project-owned component data is preserved verbatim across authoring workflows, and runtime dynamic spawning enforces fail-safe error handling.**
 
+Milestone numbering in this ADR is the *product delivery* ladder for prefab capability, not a second architecture-baseline clock. [ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md) and [ADR-010](010-job-waiting-and-operation-store-ownership.md) describe the M0 architecture baseline (console, jobs, safe points). Prefab Tier 0 / 1 / 2 map to M1 / M2 / M3+ *after* that baseline. M0 does not block T0 authoring work in editor/tools; T1 runtime spawn must conform to the M0 threading and `OperationStore` contracts.
+
 ### Ratify-or-revise outcomes
 
 | Area | Current state | Outcome |
@@ -36,7 +38,10 @@ This discrepancy created an architectural contradiction:
 | Identity authority | Mixed `prefabId` and `sourcePath` | **Revised.** Authoritative identity is Asset Registry `AssetId` (128-bit UUID). `sourcePath` is an authoring index hint only. |
 | Local object addressing | Ad-hoc or single-root string IDs | **Revised.** Local objects inside a prefab use deterministic zero-based `LocalObjectId` slots. Instantiated scene/runtime entity IDs are composed deterministically (`Hash(InstanceId, LocalObjectId)`) to prevent collisions. |
 | Component data preservation | Undefined for custom/unregistered project components | **Revised.** Opaque component payloads (`RawComponentPayload`) are preserved verbatim across authoring serialization and expansion. |
-| Dynamic spawn lifecycle | Mentioned conceptually in gameplay behavior hooks | **Revised.** Explicit `SceneCommandBuffer::SpawnPrefab` and `SceneRuntimeAccess::SpawnPrefab` transaction contract with `OnCreate` -> `OnStart` behavior initialization and typed fail-safe error returns. |
+| Dynamic spawn lifecycle | Mentioned conceptually in gameplay behavior hooks | **Revised.** `SceneCommandBuffer::RequestSpawnPrefab` enqueues from any thread (`OperationId`, ADR-018). `SceneRuntimeAccess::SpawnPrefab` commits on `OwnerThreadNextFrame` only. `OnCreate`/`OnStart` run after commit. |
+| Spawn threading / async | Unspecified vs ADR-018 safe points | **Revised.** Spawn commit is `CommandThreadPolicy::OwnerThreadNextFrame`. Unloaded assets become an `OperationStore` load-then-spawn job, not a poll loop on `AssetNotLoaded`. |
+| Runtime spawn recursion | Static cycle detection only (Tier 0) | **Revised.** Owner-thread spawn call stack rejects re-entrant `SpawnPrefab` of an in-flight `AssetId` (`PrefabError::SpawnRecursionDetected`). |
+| CookedPrefab versioning | Source `.prefab` shares `ProjectVersion` only | **Revised.** Cooked blobs carry a distinct `cookedFormatVersion`. `ProjectVersion` migration invalidates cook cache and forces recook; runtime never migrates cooked bytes. |
 
 ### Capability Tiers
 
@@ -86,16 +91,20 @@ Capability delivery is partitioned into three discrete tiers:
 
 - Asset Pipeline cooks `.prefab` source assets into platform-optimized, immutable binary `CookedPrefab` artifacts (`core.prefab` asset type).
 - Cooked prefabs participate in the standard `AssetRegistry` and `CookCatalog`, loaded via `IAssetProvider`.
-- `SceneRuntimeAccess` and `SceneCommandBuffer` expose typed spawn operations:
+- Two APIs, one contract, reconciled with [ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md):
   ```cpp
-  Result<SpawnedPrefabHandle, PrefabError> SpawnPrefab(
-      AssetId prefabAssetId,
-      const Transform& spawnTransform,
-      std::optional<EntityId> parentEntity = std::nullopt
-  );
+  // Any thread. Enqueue only. Never mutates SceneRuntime.
+  // Returns an OperationId immediately (ADR-010 OperationStore).
+  OperationId SceneCommandBuffer::RequestSpawnPrefab(const PrefabSpawnRequest& request);
+
+  // SceneRuntime owner thread only (CommandThreadPolicy::OwnerThreadNextFrame).
+  // Requires a resident CookedPrefab. Gameplay uses the buffer, not this entry point.
+  Result<SpawnedPrefabHandle, PrefabError> SceneRuntimeAccess::SpawnPrefab(
+      const PrefabSpawnRequest& request);
   ```
-- Spawn execution allocates fresh, non-colliding runtime `EntityId`s, instantiates component data, establishes hierarchy parenting, and dispatches behavior lifecycle events (`OnCreate`, followed by `OnStart` during scene synchronization).
-- Fail-safe lifecycle handling: if a cooked prefab is missing, unloadable, or corrupted, the spawn call returns an explicit `PrefabError` without corrupting active scene state or throwing unhandled exceptions.
+  `SceneCommandBuffer::RequestSpawnPrefab` is the public gameplay seam. It records a spawn operation and returns. `SceneRuntimeAccess::SpawnPrefab` is the owner-thread drain of that queue. The access function does not wrap the buffer; the buffer wraps the access function.
+- Spawn commit (owner thread) allocates fresh monotonic `EntityId`s from the scene pool, copies component data, establishes hierarchy, then **commits**. `OnCreate` runs only after commit; `OnStart` runs at the following scene synchronization point.
+- Fail-safe: missing catalog entries, corrupted or version-mismatched cooked blobs, allocation failure, or spawn recursion return typed `PrefabError` without publishing entities or invoking behavior hooks.
 
 #### Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred / M3+)
 
@@ -111,7 +120,7 @@ Capability delivery is partitioned into three discrete tiers:
 3. **Local Object Addressing**: Entities within a prefab are addressed by a zero-based `LocalObjectId` uint32 slot index stable across serialization.
 4. **Collision-Free Identity Composition**:
    - During Tier 0 scene expansion: `ExpandedSceneObjectId = Hash64(InstanceSceneObjectId, LocalObjectId)`.
-   - During Tier 1 runtime spawn: Root and child entities receive fresh, runtime-allocated monotonic `EntityId` values registered in the active `SceneRuntime` entity pool.
+   - During Tier 1 runtime spawn: Root and child entities receive fresh, monotonic `EntityId` values allocated from the `SceneRuntime` entity pool. Allocation runs **only** on the scene owner thread while draining spawn commands. Worker jobs and other threads never touch the counter; because the owner-thread queue serializes commit, the counter is not atomic and needs no lock-free increment.
 
 ### Component Data Preservation & Fail-Safe Lifecycle Handling
 
@@ -120,12 +129,43 @@ Capability delivery is partitioned into three discrete tiers:
    - Authoring operations (clone, save, expand, instance placement) preserve raw payloads verbatim.
 2. **Fail-Safe Lifecycle Handling**:
    - Dynamic spawn operations never throw C++ exceptions across module boundaries.
-   - Missing assets, schema version mismatches, component allocation failures, or payload corruption return typed `Result<SpawnedPrefabHandle, PrefabError>`:
-     - `PrefabError::AssetNotFound`: Requested `AssetId` is not registered in `CookCatalog`.
-     - `PrefabError::AssetNotLoaded`: Async dependency not yet available in `IAssetProvider`.
-     - `PrefabError::CorruptedPayload`: Cryptographic digest or magic header validation failed.
+   - Typed errors:
+     - `PrefabError::AssetNotFound`: `AssetId` is not in `CookCatalog`. The operation completes failed; callers do not poll.
+     - `PrefabError::AssetNotLoaded`: Direct `SceneRuntimeAccess::SpawnPrefab` was invoked while the blob was not resident. This is a programming error on the owner-thread path. The supported gameplay path (`RequestSpawnPrefab`) never returns this to the caller; it records an `OperationStore` load-then-spawn job instead (see below).
+     - `PrefabError::UnsupportedCookedVersion`: Header `cookedFormatVersion` is newer or older than this runtime understands. Distinct from corruption.
+     - `PrefabError::CorruptedPayload`: Magic header or cryptographic digest failed.
      - `PrefabError::ComponentInstantiationFailed`: Unregistered component type or resource exhaustion.
-   - If spawn fails mid-instantiation, created entity handles and allocated memory are rolled back completely before returning the error.
+     - `PrefabError::SpawnRecursionDetected`: `SpawnPrefab` of an `AssetId` already on the owner-thread spawn call stack.
+     - `PrefabError::HierarchyDepthExceeded` / `ObjectCountExceeded` / `PayloadTooLarge`: Bounds failed at authoring, cook, or runtime defense-in-depth.
+   - Staging vs commit: entity handles and component bytes are staged first with **no** behavior hooks, bus events, or network emits. If staging fails, staged memory and handles are discarded. `OnCreate` has not run, so `OnDestroy` is not invoked. `OnCreate` / `OnStart` run only after commit; spawn rollback therefore never has to unwind subsystem registrations or unsend events. If `OnCreate` itself fails, the entities are already committed and later teardown uses the normal `OnDestroy` path; `OnCreate` must not be treated as part of the spawn transaction.
+
+### Reconciliation with ADR-018 (Threading, Async, Recursion)
+
+Tier 1 spawn is an ADR-018 `OwnerThreadNextFrame` mutation, not an `ImmediateConsoleThread` call and not a main-thread `Wait()` on a worker ([ADR-010](010-job-waiting-and-operation-store-ownership.md)).
+
+1. **Who may call what.** Any thread (gameplay, CLI, MCP, jobs) may call `SceneCommandBuffer::RequestSpawnPrefab`. That call only enqueues. Only the SceneRuntime owner thread calls `SceneRuntimeAccess::SpawnPrefab`, during the deterministic frame phase that drains the command buffer (`PreUpdate` / `DebugPhase`).
+2. **Unloaded assets.** If `RequestSpawnPrefab` finds the `CookedPrefab` absent from `IAssetProvider` but present in `CookCatalog`, it does **not** fail with `AssetNotLoaded` and it does **not** ask the caller to poll. It starts an ADR-018 `WorkerJob` that waits on the provider, then re-enqueues owner-thread commit. Progress is an `OperationId` in `OperationStore`. Completing the operation publishes `SpawnedPrefabHandle`. Catalog misses (`AssetNotFound`) fail the operation immediately.
+3. **Runtime recursion.** Nested prefab *references* are flattened at cook time; runtime spawn of A does not recursively `SpawnPrefab` B. The remaining hazard is a behavior `OnCreate` (or a same-drain command) requesting another spawn of an in-flight `AssetId`, directly or through a chain. SceneRuntime keeps an owner-thread spawn call stack of `AssetId`. Push before staging, pop after commit or rollback. If the id is already on the stack, return `PrefabError::SpawnRecursionDetected` and do not stage. `OnCreate` may call `RequestSpawnPrefab` for a *different* asset; that enqueue is drained after the current stack frame pops (same safe point or next frame) and is still subject to the stack if it re-enters. Behaviors must not spawn their own `AssetId` from `OnCreate`.
+4. **EntityId concurrency.** The monotonic pool counter is owner-thread-only. Worker jobs load bytes; they never allocate `EntityId`. No atomic increment, because ADR-018 already serializes scene mutations onto one drain.
+
+### CookedPrefab Versioning and Cook Cache Invalidation
+
+- Source `.prefab` documents share `ProjectVersion` and its migration pipeline.
+- `CookedPrefab` carries a separate `cookedFormatVersion` in the binary header, independent of `ProjectVersion`. Runtime never runs authoring migrations on cooked bytes.
+- Cook cache key: `(AssetId, sourceDigest, ProjectVersion, cookedFormatVersion, cookerRevision)`. A `ProjectVersion` migration of the source, a cooker bump, or a format bump invalidates the catalog entry and forces recook before the blob can be loaded.
+- `UnsupportedCookedVersion` is not `CorruptedPayload`. Corruption is digest/magic failure. Version mismatch is a defined, recoverable catalog miss after recook.
+
+### Authoring Bound Enforcement
+
+`MaximumPrefabHierarchyDepth` (16), `MaximumPrefabObjectCount` (256), and `MaximumPrefabPayloadBytes` (4 MiB) are rejected at **two** gates, with runtime as defense in depth:
+
+| Gate | When | On exceed |
+|---|---|---|
+| Authoring validation | Save, import, instance placement, editor expand | Document command fails with a typed diagnostic. The `.prefab` is not written / the instance is not placed. |
+| Cook | Prefab cook | Cook fails. No `CookedPrefab` artifact is emitted. |
+| Runtime | Header check before staging | `HierarchyDepthExceeded` / `ObjectCountExceeded` / `PayloadTooLarge`. No entities published. |
+
+Static inclusion cycles (`A -> B -> A`) remain a validation-time rejection (`CyclicReferenceDetected`) at the authoring and cook gates.
 
 ## Consequences
 

--- a/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
+++ b/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
@@ -26,7 +26,7 @@ This discrepancy created an architectural contradiction:
 
 **Horo Engine adopts a dual-role prefab architecture spanning two explicit lifecycles: an Authoring-Time Nested Template (`PrefabDocument` / `.prefab` source asset) in the Editor/Asset Pipeline, and an immutable Runtime-Spawnable Cooked Template (`CookedPrefab` binary asset) in SceneRuntime and Gameplay. The engine structures prefab capabilities into three sequential tiers (Tier 0: Authoring Expansion, Tier 1: Runtime Dynamic Spawn, Tier 2: Live Variant Inheritance). Prefab identity reuses Asset Registry `AssetId` and project versioning. Unknown project-owned component data is preserved verbatim across authoring workflows, and runtime dynamic spawning enforces fail-safe error handling.**
 
-Milestone numbering in this ADR is the *product delivery* ladder for prefab capability, not a second architecture-baseline clock. [ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md) and [ADR-010](010-job-waiting-and-operation-store-ownership.md) describe the M0 architecture baseline (console, jobs, safe points). Prefab Tier 0 / 1 / 2 map to M1 / M2 / M3+ *after* that baseline. M0 does not block T0 authoring work in editor/tools; T1 runtime spawn must conform to the M0 threading and `OperationStore` contracts.
+Milestone numbering in this ADR is the *product delivery* ladder for prefab capability, not a second architecture-baseline clock. [ADR-018](https://github.com/abdullahbodur/horo-engine/pull/2347) (companion PR; not in this tree until it lands) and [ADR-010](010-job-waiting-and-operation-store-ownership.md) describe the M0 architecture baseline (console, jobs, safe points). Prefab Tier 0 / 1 / 2 map to M1 / M2 / M3+ *after* that baseline. M0 does not block T0 authoring work in editor/tools; T1 runtime spawn must conform to the M0 threading and `OperationStore` contracts.
 
 ### Ratify-or-revise outcomes
 
@@ -91,7 +91,7 @@ Capability delivery is partitioned into three discrete tiers:
 
 - Asset Pipeline cooks `.prefab` source assets into platform-optimized, immutable binary `CookedPrefab` artifacts (`core.prefab` asset type).
 - Cooked prefabs participate in the standard `AssetRegistry` and `CookCatalog`, loaded via `IAssetProvider`.
-- Two APIs, one contract, reconciled with [ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md):
+- Two APIs, one contract, reconciled with [ADR-018](https://github.com/abdullahbodur/horo-engine/pull/2347) (threading policy) and [ADR-010](010-job-waiting-and-operation-store-ownership.md) (`OperationStore`):
   ```cpp
   // Any thread. Enqueue only. Never mutates SceneRuntime.
   // Returns an OperationId immediately (ADR-010 OperationStore).
@@ -104,7 +104,7 @@ Capability delivery is partitioned into three discrete tiers:
   ```
   `SceneCommandBuffer::RequestSpawnPrefab` is the public gameplay seam. It records a spawn operation and returns. `SceneRuntimeAccess::SpawnPrefab` is the owner-thread drain of that queue. The access function does not wrap the buffer; the buffer wraps the access function.
 - Spawn commit (owner thread) allocates fresh monotonic `EntityId`s from the scene pool, copies component data, establishes hierarchy, then **commits**. `OnCreate` runs only after commit; `OnStart` runs at the following scene synchronization point.
-- Fail-safe: missing catalog entries, corrupted or version-mismatched cooked blobs, allocation failure, or spawn recursion return typed `PrefabError` without publishing entities or invoking behavior hooks.
+- Fail-safe: missing catalog entries, corrupted or version-mismatched cooked blobs, unregistered component types, component allocation failure, or spawn recursion return typed `PrefabError` without publishing entities or invoking behavior hooks.
 
 #### Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred / M3+)
 
@@ -134,7 +134,8 @@ Capability delivery is partitioned into three discrete tiers:
      - `PrefabError::AssetNotLoaded`: Direct `SceneRuntimeAccess::SpawnPrefab` was invoked while the blob was not resident. This is a programming error on the owner-thread path. The supported gameplay path (`RequestSpawnPrefab`) never returns this to the caller; it records an `OperationStore` load-then-spawn job instead (see below).
      - `PrefabError::UnsupportedCookedVersion`: Header `cookedFormatVersion` is newer or older than this runtime understands. Distinct from corruption.
      - `PrefabError::CorruptedPayload`: Magic header or cryptographic digest failed.
-     - `PrefabError::ComponentInstantiationFailed`: Unregistered component type or resource exhaustion.
+     - `PrefabError::ComponentTypeUnregistered`: Cooked template references a component type not registered in this runtime. Distinct from allocation failure.
+     - `PrefabError::ComponentAllocationFailed`: Component pool or heap allocation failed while staging. Distinct from `ComponentTypeUnregistered`.
      - `PrefabError::SpawnRecursionDetected`: `SpawnPrefab` of an `AssetId` already on the owner-thread spawn call stack.
      - `PrefabError::HierarchyDepthExceeded` / `ObjectCountExceeded` / `PayloadTooLarge`: Bounds failed at authoring, cook, or runtime defense-in-depth.
    - Staging vs commit: entity handles and component bytes are staged first with **no** behavior hooks, bus events, or network emits. If staging fails, staged memory and handles are discarded. `OnCreate` has not run, so `OnDestroy` is not invoked. `OnCreate` / `OnStart` run only after commit; spawn rollback therefore never has to unwind subsystem registrations or unsend events. If `OnCreate` itself fails, the entities are already committed and later teardown uses the normal `OnDestroy` path; `OnCreate` must not be treated as part of the spawn transaction.

--- a/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
+++ b/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
@@ -1,4 +1,4 @@
-# ADR-011: Prefab Role, Ownership and Capability-Tier Decision
+# ADR-017: Prefab Role, Ownership and Capability-Tier Decision
 
 - **Status**: Proposed
 - **Date**: 2026-08-28

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
+| [011](011-prefab-role-ownership-and-capability-tiers.md) | Prefab Role, Ownership and Capability-Tier Decision | proposed | 2026-08-28 |
 | [018](018-command-registration-permissions-threading-and-packaged-build-policy.md) | Command Registration, Permissions, Threading and Packaged-Build Policy | proposed | 2026-08-28 |
 | [020](020-network-target-ownership-and-dependency-boundary.md) | Network Target Ownership and Dependency Boundary | proposed | 2026-08-28 |
 | [021](021-gameplay-ai-ownership-scheduling-and-behavior-boundary.md) | Gameplay AI Ownership, Scheduling and Behavior Boundary | proposed | 2026-08-28 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
-| [011](017-prefab-role-ownership-and-capability-tiers.md) | Prefab Role, Ownership and Capability-Tier Decision | proposed | 2026-08-28 |
+| [017](017-prefab-role-ownership-and-capability-tiers.md) | Prefab Role, Ownership and Capability-Tier Decision | proposed | 2026-08-28 |
 | [018](018-command-registration-permissions-threading-and-packaged-build-policy.md) | Command Registration, Permissions, Threading and Packaged-Build Policy | proposed | 2026-08-28 |
 | [020](020-network-target-ownership-and-dependency-boundary.md) | Network Target Ownership and Dependency Boundary | proposed | 2026-08-28 |
 | [021](021-gameplay-ai-ownership-scheduling-and-behavior-boundary.md) | Gameplay AI Ownership, Scheduling and Behavior Boundary | proposed | 2026-08-28 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
-| [011](011-prefab-role-ownership-and-capability-tiers.md) | Prefab Role, Ownership and Capability-Tier Decision | proposed | 2026-08-28 |
+| [011](017-prefab-role-ownership-and-capability-tiers.md) | Prefab Role, Ownership and Capability-Tier Decision | proposed | 2026-08-28 |
 | [018](018-command-registration-permissions-threading-and-packaged-build-policy.md) | Command Registration, Permissions, Threading and Packaged-Build Policy | proposed | 2026-08-28 |
 | [020](020-network-target-ownership-and-dependency-boundary.md) | Network Target Ownership and Dependency Boundary | proposed | 2026-08-28 |
 | [021](021-gameplay-ai-ownership-scheduling-and-behavior-boundary.md) | Gameplay AI Ownership, Scheduling and Behavior Boundary | proposed | 2026-08-28 |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -128,8 +128,8 @@ dependency direction in [System Design](./foundation/system-design.md).
   remote security.
 - [Asset Pipeline](./runtime/asset-pipeline.md): import, cook, package, runtime
   loading, cache, and hot reload.
-- [Prefab Architecture](./runtime/prefab-architecture.md): authored prefab
-  assets, scene instance references, expansion, and cook-time inlining.
+- [Prefab Architecture](./runtime/prefab-architecture.md): dual-role authoring
+  templates, runtime dynamic spawning (`CookedPrefab`), and capability tiers.
 - [Built-In Scene Primitives](./runtime/built-in-scene-primitives.md): core
   procedural meshes, collider shapes, and scene object primitives available
   without external packages.

--- a/docs/architecture/runtime/prefab-architecture.md
+++ b/docs/architecture/runtime/prefab-architecture.md
@@ -26,11 +26,11 @@ architecture spanning two lifecycles:
    - Compiled by the Asset Pipeline from source `.prefab` files into immutable,
      platform-optimized binary artifacts (`core.prefab` asset type).
    - Registered in the `AssetRegistry` and `CookCatalog` with a stable 128-bit `AssetId`.
-   - Dynamically instantiated at runtime via `SceneCommandBuffer::SpawnPrefab` or
-     `SceneRuntimeAccess::SpawnPrefab` during active gameplay (e.g. projectiles, dynamic enemies,
-     VFX hierarchies, procedural loot drops).
-   - Instantiation allocates fresh runtime `EntityId`s, initializes components, sets up
-     hierarchy parenting, and triggers standard behavior lifecycle events (`OnCreate`, `OnStart`).
+   - Gameplay requests spawn via `SceneCommandBuffer::RequestSpawnPrefab` (any thread,
+     `OperationId`). `SceneRuntimeAccess::SpawnPrefab` commits on the scene owner thread
+     (`OwnerThreadNextFrame`, [ADR-018](../../adr/018-command-registration-permissions-threading-and-packaged-build-policy.md)).
+   - Commit allocates fresh `EntityId`s, copies components, and parents the hierarchy, then
+     publishes. `OnCreate` / `OnStart` run only after commit.
 
 ```text
 +-----------------------------------------------------------------------------------+
@@ -52,8 +52,8 @@ architecture spanning two lifecycles:
 |           |                                                     |
 |           v                                                     v
 |   [SceneRuntime Active] <====== (Dynamic Spawn at runtime) <----+
-|   - Contiguous ECS pools         - SceneCommandBuffer::SpawnPrefab
-|   - Pre-allocated entity IDs     - Allocates fresh EntityIds & runs OnCreate/OnStart
+|   - Contiguous ECS pools         - Buffer enqueue any thread; commit owner thread
+|   - Owner-thread EntityId pool   - OnCreate/OnStart only after commit
 +-----------------------------------------------------------------------------------+
 ```
 
@@ -113,12 +113,14 @@ Prefab capabilities are staged across three sequential, contract-stable tiers:
 - **Cooked Binary Artifact**: The Asset Pipeline compiles `.prefab` assets into immutable binary
   `CookedPrefab` artifacts registered under `core.prefab` in `CookCatalog`.
 - **Runtime Asset Management**: Loaded through `IAssetProvider` via stable `AssetId`.
-- **Dynamic Spawn API**: `SceneCommandBuffer` and `SceneRuntimeAccess` expose transactional spawn
-  requests returning `Result<SpawnedPrefabHandle, PrefabError>`.
-- **Lifecycle Guarantees**: Fresh runtime `EntityId` allocation, component instantiation, hierarchy
-  assembly, followed by `OnCreate` and `OnStart` behavior hooks during tick synchronization.
-- **Fail-Safe Robustness**: Missing assets, invalid formats, or allocation limits fail safely with
-  typed error diagnostics without crashing the runtime or corrupting existing entities.
+- **Dynamic Spawn API**: `SceneCommandBuffer::RequestSpawnPrefab` (any thread, returns `OperationId`)
+  wraps `SceneRuntimeAccess::SpawnPrefab` (owner thread, `OwnerThreadNextFrame`).
+- **Lifecycle Guarantees**: Owner-thread `EntityId` allocation, staged component copy, commit,
+  then `OnCreate`; `OnStart` at the next scene sync. Recursion of an in-flight `AssetId` is rejected.
+- **Fail-Safe Robustness**: Catalog misses, cooked-version mismatch, corruption, bounds, and
+  spawn recursion fail the operation without publishing entities or invoking hooks.
+- **Async load**: Unloaded-but-catalogued assets become an ADR-018 `WorkerJob` + `OperationStore`
+  load-then-spawn. Callers do not poll `AssetNotLoaded`.
 
 ### Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred / M3+)
 
@@ -175,7 +177,9 @@ namespace Horo::Prefab {
 
 - **Tier 1 Runtime Spawning**:
   When `CookedPrefab` is spawned into `SceneRuntime`, root and child entities receive fresh,
-  monotonic `EntityId` values allocated directly from the active runtime scene's entity pool.
+  monotonic `EntityId` values allocated from the scene entity pool **on the owner thread only**.
+  Worker jobs never increment the counter; the ADR-018 command drain serializes allocation, so
+  the counter is not atomic.
 
 ---
 
@@ -190,8 +194,15 @@ namespace Horo::Prefab {
     inline constexpr std::size_t MaximumPrefabObjectCount    = 256;
     inline constexpr std::size_t MaximumPrefabPayloadBytes   = 4 * 1024 * 1024; // 4 MiB
     inline constexpr std::size_t MaximumPrefabComponentsPerObject = 64;
+    inline constexpr std::size_t MaximumRuntimeSpawnDepth = 8; // owner-thread spawn call stack
 }
 ```
+
+These limits are enforced at authoring validation (save / import / instance placement; the
+document command fails and nothing is written), again at cook (no `CookedPrefab` is emitted),
+and at runtime as a header check before staging (`HierarchyDepthExceeded`,
+`ObjectCountExceeded`, `PayloadTooLarge`). Static inclusion cycles (`A -> B -> A`) are
+rejected at the authoring and cook gates with `CyclicReferenceDetected`.
 
 ### Authoring Document Structure (`PrefabDocument`)
 
@@ -227,10 +238,16 @@ struct PrefabDocument {
 
 The Asset Pipeline cooks source `.prefab` files into immutable `CookedPrefab` artifacts.
 
+Source `.prefab` files share `ProjectVersion` and its migration pipeline. Cooked blobs do **not**.
+The header carries a distinct `cookedFormatVersion`. Runtime never migrates cooked bytes.
+The cook cache key is `(AssetId, sourceDigest, ProjectVersion, cookedFormatVersion, cookerRevision)`.
+A source migration, cooker bump, or format bump invalidates the catalog entry and forces recook.
+`UnsupportedCookedVersion` is a version mismatch; `CorruptedPayload` is digest or magic failure.
+
 ### Binary Layout
 
-- **Header**: Magic bytes (`HPFB`), schema version, cryptographic digest (SHA-256 of source and dependencies),
-  and object count.
+- **Header**: Magic bytes (`HPFB`), `cookedFormatVersion`, cryptographic digest (SHA-256 of source and dependencies),
+  object count, and payload size.
 - **Hierarchy Table**: Flat array of parent-child slot indices and local transforms.
 - **Component Tables**: Contiguous, aligned arrays of primitive component data and behavioral descriptors.
 - **Asset Reference Table**: List of dependent `AssetId`s required for instantiation.
@@ -252,8 +269,10 @@ namespace Horo::Runtime {
 
 ## Dynamic Runtime Spawning Contract
 
-Gameplay behaviors and runtime systems request prefab spawning through transactional command buffers
-or direct runtime access:
+This contract conforms to [ADR-018](../../adr/018-command-registration-permissions-threading-and-packaged-build-policy.md)
+and [ADR-010](../../adr/010-job-waiting-and-operation-store-ownership.md). Spawn *commit* is
+`CommandThreadPolicy::OwnerThreadNextFrame`. The main/editor thread never `Wait()`s a worker
+for spawn completion.
 
 ```cpp
 namespace Horo::Runtime {
@@ -267,22 +286,67 @@ namespace Horo::Runtime {
         EntityId rootEntity;
         std::vector<EntityId> childEntities;
     };
+
+    // Any thread. Enqueue only. Returns OperationId immediately.
+    OperationId SceneCommandBuffer::RequestSpawnPrefab(const PrefabSpawnRequest& request);
+
+    // Owner thread only. Resident CookedPrefab required. Buffer drain calls this.
+    Result<SpawnedPrefabHandle, PrefabError>
+    SceneRuntimeAccess::SpawnPrefab(const PrefabSpawnRequest& request);
 }
 ```
 
-### Spawning Execution Sequence
+`RequestSpawnPrefab` is the gameplay seam. `SpawnPrefab` on `SceneRuntimeAccess` is the
+owner-thread implementation. The buffer wraps access; access does not wrap the buffer.
+Two functions sharing one request struct is intentional. They are not interchangeable
+call sites.
+
+### Loaded vs not-yet-loaded
+
+- Catalog miss → operation completes with `PrefabError::AssetNotFound`. No polling.
+- Catalog hit, blob not resident → `RequestSpawnPrefab` starts a `WorkerJob` that waits
+  on `IAssetProvider`, then re-enqueues owner-thread commit. `OperationStore` is the
+  progress surface. Callers subscribe to the `OperationId`; they do not poll
+  `AssetNotLoaded`.
+- Direct `SceneRuntimeAccess::SpawnPrefab` with a non-resident blob returns
+  `PrefabError::AssetNotLoaded` as a misuse diagnostic. Gameplay must not use that path.
+
+### Spawning Execution Sequence (owner-thread drain)
 
 ```text
-SceneCommandBuffer::SpawnPrefab(request)
-  -> Verify prefab asset is loaded in AssetRegistry / IAssetProvider
-  -> Check scene entity capacity (reject if capacity exceeded)
-  -> Allocate monotonic EntityId for root and each child object
-  -> Apply spawnTransform to root; set up parent-child entity relations
-  -> Copy component data into scene contiguous component pools
-  -> Attach gameplay behaviors and invoke OnCreate()
-  -> Commit transaction at SceneRuntime tick synchronization point
-  -> Invoke OnStart() for all newly spawned behaviors
+SceneCommandBuffer::RequestSpawnPrefab(request)     // any thread
+  -> if not in CookCatalog: fail operation (AssetNotFound)
+  -> if not resident: WorkerJob load -> re-enqueue; return OperationId
+  -> else enqueue OwnerThreadNextFrame drain; return OperationId
+
+SceneRuntimeAccess::SpawnPrefab(request)            // owner thread only
+  -> if AssetId is on the spawn call stack: SpawnRecursionDetected
+  -> push AssetId
+  -> check cookedFormatVersion, digest, bounds, entity capacity
+  -> STAGE: allocate EntityIds, parent links, copy components (no hooks, no bus, no net)
+  -> on staging failure: discard staged memory/handles; pop; fail operation
+  -> COMMIT: publish entities into the live world
+  -> pop AssetId
+  -> OnCreate() on committed behaviors
+  -> OnStart() at the next scene synchronization point
 ```
+
+`OnCreate` is outside the staging transaction. Spawn rollback never calls `OnDestroy` and
+never unsends events, because those side effects cannot have run. If `OnCreate` fails,
+entities are already live and later teardown uses the normal `OnDestroy` path.
+
+### Runtime spawn recursion
+
+Cook flattens nested prefab *references* into one `CookedPrefab`. Runtime spawn of A does
+not `SpawnPrefab` B. The remaining hazard is `OnCreate` (or another command in the same
+drain) requesting spawn of an `AssetId` already on the owner-thread call stack.
+
+- Push `AssetId` before staging; pop after commit or staging rollback.
+- Re-entry of that id → `PrefabError::SpawnRecursionDetected`, no staging.
+- `OnCreate` may `RequestSpawnPrefab` a *different* asset; that work runs after the
+  current frame pops and is still subject to the stack.
+- Behaviors must not spawn their own `AssetId` from `OnCreate`.
+- `MaximumRuntimeSpawnDepth` caps the stack (direct plus indirect).
 
 ---
 
@@ -303,7 +367,7 @@ To support modular gameplay packages and project-specific C++ plugins:
    or expanding the prefab preserves these components without truncation.
 3. **Runtime Spawning Safety**: If an unregistered component type is encountered during runtime
    spawn, the transaction aborts before publishing entities or invoking behavior lifecycle hooks.
-   The runtime discards all staged entities and returns `PrefabError::ComponentTypeUnregistered`.
+   Staging discards those entities (no `OnCreate` has run, so no `OnDestroy`) and returns `PrefabError::ComponentTypeUnregistered`.
 
 ---
 
@@ -315,11 +379,14 @@ Dynamic spawning and authoring expansion report structured, typed errors:
 enum class PrefabError : std::uint32_t {
     Success = 0,
     AssetNotFound,              // AssetId not registered in CookCatalog / AssetRegistry
-    AssetNotLoaded,             // Async asset load still pending
+    AssetNotLoaded,             // Direct owner-thread spawn while blob is not resident (misuse)
+    UnsupportedCookedVersion,   // cookedFormatVersion not understood by this runtime
     CorruptedPayload,           // Checksum or magic header validation failed
     HierarchyDepthExceeded,     // Template exceeds MaximumPrefabHierarchyDepth (16)
     ObjectCountExceeded,        // Template exceeds MaximumPrefabObjectCount (256)
-    CyclicReferenceDetected,    // Nested prefab inclusion contains a cycle
+    PayloadTooLarge,            // Template exceeds MaximumPrefabPayloadBytes (4 MiB)
+    CyclicReferenceDetected,    // Nested prefab inclusion contains a cycle (authoring/cook)
+    SpawnRecursionDetected,     // Runtime SpawnPrefab re-entered an in-flight AssetId
     EntityAllocationExhausted,  // Scene runtime ran out of available EntityIds
     ComponentTypeUnregistered,  // Cooked template references an unavailable component type
     ComponentAllocationFailed   // Memory allocation failed for component pool
@@ -339,15 +406,23 @@ enum class PrefabError : std::uint32_t {
 | **Malformed** | Cycle detection (`A -> B -> A`) | Rejection with `PrefabError::CyclicReferenceDetected` |
 | **Malformed** | Hierarchy depth > 16 or count > 256 | Rejection with boundary error diagnostic |
 | **Malformed** | Corrupted magic header or truncated payload | Rejection with `PrefabError::CorruptedPayload` |
-| **Lifecycle** | Spawn non-existent `AssetId` | Returns `PrefabError::AssetNotFound`; no scene leak |
-| **Lifecycle** | Unknown component in cooked template | Preserves/skips component safely without crashing |
+| **Lifecycle** | Spawn non-existent `AssetId` | Operation fails `AssetNotFound`; no scene leak; no poll |
+| **Lifecycle** | Spawn catalogued but not-yet-loaded prefab | `OperationId` load-then-spawn; not a sync `AssetNotLoaded` |
+| **Lifecycle** | `OnCreate` spawns the same `AssetId` | `SpawnRecursionDetected`; no extra entities |
+| **Lifecycle** | Staging fails after some entities allocated | Discard staged handles; no `OnCreate` / no `OnDestroy` |
+| **Lifecycle** | Cooked format newer than runtime | `UnsupportedCookedVersion`; not `CorruptedPayload` |
+| **Lifecycle** | Unknown component in cooked template | Staging abort; no hooks; `ComponentTypeUnregistered` |
 | **Lifecycle** | Scene destruction with active spawned entities | Cleanly tears down entities and behavior instances |
+| **Malformed** | Authoring depth > 16 on save | Save rejected; `.prefab` not written |
+| **Malformed** | Cook of over-limit prefab | Cook fails; no `CookedPrefab` artifact |
 
 ---
 
 ## Related Documents
 
 - [ADR-017: Prefab Role, Ownership and Capability-Tier Decision](../../adr/017-prefab-role-ownership-and-capability-tiers.md)
+- [ADR-018: Command Registration, Permissions, Threading and Packaged-Build Policy](../../adr/018-command-registration-permissions-threading-and-packaged-build-policy.md)
+- [ADR-010: Job Waiting and Operation Store Ownership](../../adr/010-job-waiting-and-operation-store-ownership.md)
 - [Scene Runtime Architecture](./scene-runtime.md)
 - [Asset Pipeline Architecture](./asset-pipeline.md)
 - [Gameplay Behavior Authoring](../extensions/gameplay-behavior-authoring.md)

--- a/docs/architecture/runtime/prefab-architecture.md
+++ b/docs/architecture/runtime/prefab-architecture.md
@@ -28,7 +28,7 @@ architecture spanning two lifecycles:
    - Registered in the `AssetRegistry` and `CookCatalog` with a stable 128-bit `AssetId`.
    - Gameplay requests spawn via `SceneCommandBuffer::RequestSpawnPrefab` (any thread,
      `OperationId`). `SceneRuntimeAccess::SpawnPrefab` commits on the scene owner thread
-     (`OwnerThreadNextFrame`, [ADR-018](../../adr/018-command-registration-permissions-threading-and-packaged-build-policy.md)).
+     (`OwnerThreadNextFrame`, [ADR-018](https://github.com/abdullahbodur/horo-engine/pull/2347); job wait in [ADR-010](../../adr/010-job-waiting-and-operation-store-ownership.md)).
    - Commit allocates fresh `EntityId`s, copies components, and parents the hierarchy, then
      publishes. `OnCreate` / `OnStart` run only after commit.
 
@@ -269,8 +269,9 @@ namespace Horo::Runtime {
 
 ## Dynamic Runtime Spawning Contract
 
-This contract conforms to [ADR-018](../../adr/018-command-registration-permissions-threading-and-packaged-build-policy.md)
-and [ADR-010](../../adr/010-job-waiting-and-operation-store-ownership.md). Spawn *commit* is
+This contract conforms to [ADR-018](https://github.com/abdullahbodur/horo-engine/pull/2347)
+(companion PR) and [ADR-010](../../adr/010-job-waiting-and-operation-store-ownership.md)
+(in this tree). Spawn *commit* is
 `CommandThreadPolicy::OwnerThreadNextFrame`. The main/editor thread never `Wait()`s a worker
 for spawn completion.
 
@@ -421,7 +422,7 @@ enum class PrefabError : std::uint32_t {
 ## Related Documents
 
 - [ADR-017: Prefab Role, Ownership and Capability-Tier Decision](../../adr/017-prefab-role-ownership-and-capability-tiers.md)
-- [ADR-018: Command Registration, Permissions, Threading and Packaged-Build Policy](../../adr/018-command-registration-permissions-threading-and-packaged-build-policy.md)
+- [ADR-018: Command Registration, Permissions, Threading and Packaged-Build Policy](https://github.com/abdullahbodur/horo-engine/pull/2347) (companion PR; file is not in this branch until #2347 lands)
 - [ADR-010: Job Waiting and Operation Store Ownership](../../adr/010-job-waiting-and-operation-store-ownership.md)
 - [Scene Runtime Architecture](./scene-runtime.md)
 - [Asset Pipeline Architecture](./asset-pipeline.md)

--- a/docs/architecture/runtime/prefab-architecture.md
+++ b/docs/architecture/runtime/prefab-architecture.md
@@ -302,8 +302,8 @@ To support modular gameplay packages and project-specific C++ plugins:
    the base editor binary, the data is preserved in `RawComponentPayload` verbatim. Saving, cloning,
    or expanding the prefab preserves these components without truncation.
 3. **Runtime Spawning Safety**: If an unregistered component type is encountered during runtime
-   spawn, the runtime skips the unrecognized component, records a structured diagnostic warning,
-   and completes valid entity and behavior instantiation without aborting.
+   spawn, the transaction aborts before publishing entities or invoking behavior lifecycle hooks.
+   The runtime discards all staged entities and returns `PrefabError::ComponentTypeUnregistered`.
 
 ---
 
@@ -321,6 +321,7 @@ enum class PrefabError : std::uint32_t {
     ObjectCountExceeded,        // Template exceeds MaximumPrefabObjectCount (256)
     CyclicReferenceDetected,    // Nested prefab inclusion contains a cycle
     EntityAllocationExhausted,  // Scene runtime ran out of available EntityIds
+    ComponentTypeUnregistered,  // Cooked template references an unavailable component type
     ComponentAllocationFailed   // Memory allocation failed for component pool
 };
 ```

--- a/docs/architecture/runtime/prefab-architecture.md
+++ b/docs/architecture/runtime/prefab-architecture.md
@@ -114,7 +114,7 @@ Prefab capabilities are staged across three sequential, contract-stable tiers:
   `CookedPrefab` artifacts registered under `core.prefab` in `CookCatalog`.
 - **Runtime Asset Management**: Loaded through `IAssetProvider` via stable `AssetId`.
 - **Dynamic Spawn API**: `SceneCommandBuffer` and `SceneRuntimeAccess` expose transactional spawn
-  requests returning `Result<SpawnedPrefabHandle, PrefabSpawnError>`.
+  requests returning `Result<SpawnedPrefabHandle, PrefabError>`.
 - **Lifecycle Guarantees**: Fresh runtime `EntityId` allocation, component instantiation, hierarchy
   assembly, followed by `OnCreate` and `OnStart` behavior hooks during tick synchronization.
 - **Fail-Safe Robustness**: Missing assets, invalid formats, or allocation limits fail safely with

--- a/docs/architecture/runtime/prefab-architecture.md
+++ b/docs/architecture/runtime/prefab-architecture.md
@@ -2,232 +2,353 @@
 
 ## Purpose
 
-This document defines Horo Engine's prefab system: how an authored object or
-object group is saved as a reusable prefab asset, how prefab instances are placed
-in scenes, how per-instance overrides are applied, and how prefabs expand into
-the runtime scene definition.
+This document defines Horo Engine's prefab system: how reusable entity hierarchies
+are authored, validated, and versioned as project assets, how prefab instances are
+placed and expanded in scenes, and how cooked prefabs are dynamically spawned at
+runtime by Gameplay and SceneRuntime systems.
 
-A prefab is an authoring-time template. It is stored on disk as a reusable asset
-and instantiated into scenes by reference, not by embedding its contents into
-every scene that uses it.
+## Core Decisions And Dual-Role Model
 
-## Core Decisions
+Horo Engine resolves the tension between authoring convenience, static scene
+optimization, and dynamic gameplay spawning through an explicit **dual-role**
+architecture spanning two lifecycles:
 
-- A prefab is a first-class authored asset, distinct from imported mesh/texture/audio assets.
-- Prefabs serialize as a subset of `SceneDocument` so the same scene serializer,
-  validation, and runtime conversion logic applies.
-- A scene object stores a stable prefab reference (`prefabId` + `sourcePath`), not the prefab's internal data.
-- Per-instance overrides are limited, explicit, and applied after expansion.
-- Runtime conversion expands prefabs into the containing scene's `RuntimeSceneDefinition`.
-- Prefab-owned assets are merged into the scene's asset registry during conversion.
-- Prefabs are not runtime ECS archetypes; they are authoring templates resolved before instantiation.
+1. **Authoring-Time Nested Template (`PrefabDocument` / `.prefab`)**:
+   - Authored in the Editor and stored under `assets/prefabs/`.
+   - Serialized as structured, project-versioned documents conforming to `ProjectVersion`.
+   - Supports multi-object hierarchies, nested prefab instances, and shallow/deep overrides.
+   - For static scene objects, authoring instances are **pre-expanded and flattened** into
+     the containing `SceneDocument` (viewport preview) and baked into `RuntimeSceneDefinition`
+     (scene cook). This delivers optimal contiguous runtime memory layout with zero runtime
+     template expansion overhead.
 
-## Prefab As Authoring Asset
-
-Prefabs live in the project under `assets/prefabs/`:
-
-```text
-assets/
-  prefabs/
-    player.prefab
-    enemy.prefab
-    weapons/
-      rifle_demo.prefab
-```
-
-A `.prefab` file is a `SceneDocument` that describes the prefab root object, its
-components, and any prefab-local asset references. The file uses the same schema
-version and serialization rules as `.horo` scene files.
-
-```cpp
-struct ScenePrefabReference {
-    std::string prefabId;    // stable logical prefab identity
-    std::string sourcePath;  // project-relative path to the .prefab file
-};
-
-struct ScenePrefabInstance {
-    ScenePrefabReference reference;
-    std::optional<std::string> overrideId;
-    std::optional<Vec3> overridePosition;
-    std::optional<Vec3> overrideScale;
-    std::optional<float> overrideYaw;
-    std::optional<float> overridePitch;
-    std::optional<float> overrideRoll;
-    std::optional<std::string> overrideParentId;
-};
-```
-
-The `prefabId` is the stable identity. The `sourcePath` resolves the file on
-editor/conversion load. Both are persisted so the reference survives renames when
-the path index or sidecar metadata is updated.
-
-## Instance Placement
-
-When a prefab is placed into a scene, the scene object stores the reference and
-any allowed overrides:
-
-```cpp
-struct SceneObject {
-    std::string id;
-    std::string parentId;     // empty for root-level objects
-    Vec3 position;
-    Vec3 scale;
-    float yaw = 0.0f;
-    float pitch = 0.0f;
-    float roll = 0.0f;
-    std::optional<ScenePrefabInstance> prefabInstance;
-    // ... other fields
-};
-```
-
-Allowed overrides on the instance are applied during expansion:
-
-- `id` — the instance's scene object ID (root identity in the containing scene).
-- `position`, `scale`, `yaw`, `pitch`, `roll` — instance transform.
-- `parentId` — optional reparenting inside the scene hierarchy.
-
-All other properties come from the prefab file. Deep per-component overrides are
-not supported in the initial system.
-
-## Editor Workflow
+2. **Runtime-Spawnable Cooked Template (`CookedPrefab`)**:
+   - Compiled by the Asset Pipeline from source `.prefab` files into immutable,
+     platform-optimized binary artifacts (`core.prefab` asset type).
+   - Registered in the `AssetRegistry` and `CookCatalog` with a stable 128-bit `AssetId`.
+   - Dynamically instantiated at runtime via `SceneCommandBuffer::SpawnPrefab` or
+     `SceneRuntimeAccess::SpawnPrefab` during active gameplay (e.g. projectiles, dynamic enemies,
+     VFX hierarchies, procedural loot drops).
+   - Instantiation allocates fresh runtime `EntityId`s, initializes components, sets up
+     hierarchy parenting, and triggers standard behavior lifecycle events (`OnCreate`, `OnStart`).
 
 ```text
-select object in editor
-  -> Create Prefab command
-    -> write .prefab file under assets/prefabs/
-    -> replace selected object with prefab instance reference
-    -> scene now references the prefab by path
++-----------------------------------------------------------------------------------+
+| AUTHORING LIFECYCLE (Editor / Tools)                                              |
+|                                                                                   |
+|  [Authored Object(s)] ---> (Create Prefab) ---> [assets/prefabs/enemy.prefab]     |
+|                                                      |          ^                 |
+|                                    Placed in Scene   |          | Nested ref      |
+|                                          v           |          |                 |
+|    [SceneDocument] <--- (Instance Ref + Overrides) --+          +-- [nested.prefab]
+|           |                                                     |
+|           v (Scene Cook / Flattening)                           v (Prefab Cook)
++-----------+-----------------------------------------------------+-----------------+
+| RUNTIME LIFECYCLE (SceneRuntime / Gameplay)                     |
+|           |                                                     |
+|           v                                                     v
+|   [RuntimeSceneDefinition]                             [CookedPrefab Asset]
+|   (Static pre-expanded entities)                       (Immutable binary template)
+|           |                                                     |
+|           v                                                     v
+|   [SceneRuntime Active] <====== (Dynamic Spawn at runtime) <----+
+|   - Contiguous ECS pools         - SceneCommandBuffer::SpawnPrefab
+|   - Pre-allocated entity IDs     - Allocates fresh EntityIds & runs OnCreate/OnStart
++-----------------------------------------------------------------------------------+
 ```
 
-The create-prefab command is an undoable document transaction. It:
+---
 
-1. captures the selected object's state,
-2. writes the prefab asset to a unique project-relative path,
-3. replaces the source object's contents with a `prefabInstance` reference,
-4. preserves the original transform as the first instance override.
+## Capability Tiers
 
-Placing an existing prefab into a scene creates a new scene object whose
-`prefabInstance` points at the prefab file. The editor resolves and expands the
-prefab for viewport preview and runtime conversion.
-
-## Runtime Expansion
-
-During `SceneDocument -> RuntimeSceneDefinition` conversion, prefab references
-are resolved before the runtime scene is built.
+Prefab capabilities are staged across three sequential, contract-stable tiers:
 
 ```text
-SceneDocument
-  -> for each object with prefabInstance
-       load prefab file
-       merge prefab assets into scene asset registry
-       copy prefab root object
-       apply instance overrides
-  -> continue normal conversion
++-------------------------------------------------------------------------------+
+| Tier 0: Authoring Template Expansion & Instantiation (Baseline / M1)          |
+| - Canonical source .prefab format governed by ProjectVersion                  |
+| - Single-root and multi-object parent-child hierarchies                       |
+| - Placed instances in SceneDocument (AssetId + root transform & overrides)    |
+| - Deterministic offline expansion into RuntimeSceneDefinition                 |
+| - Static cycle detection rejecting recursive inclusion loops                  |
+| - Opaque roundtrip preservation of unknown project-owned component data      |
++-------------------------------------------------------------------------------+
+                                    |
+                                    v
++-------------------------------------------------------------------------------+
+| Tier 1: Runtime Dynamic Spawn from Cooked Prefab (Engine Target / M2)         |
+| - Asset Pipeline compiles .prefab into binary CookedPrefab (core.prefab)      |
+| - Registered in AssetRegistry and CookCatalog with AssetId                    |
+| - Dynamic spawn APIs in SceneRuntime and Gameplay (SceneCommandBuffer)        |
+| - Runtime EntityId allocation, hierarchy setup, component copy, lifecycle     |
+| - Fail-safe error returns (missing asset, corrupted data, invalid component)  |
++-------------------------------------------------------------------------------+
+                                    |
+                                    v
++-------------------------------------------------------------------------------+
+| Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred / M3+) |
+| - Prefab Variants inheriting from base prefab asset with delta overrides      |
+| - Multi-level variant chains with DAG cycle verification                      |
+| - Live editor propagation across open documents upon base prefab mutation     |
+| - Granular per-property override tracking (revert/apply to base prefab)       |
++-------------------------------------------------------------------------------+
 ```
 
-Rules:
+### Tier 0: Authoring Template Expansion & Instantiation (Baseline / M1)
 
-- A missing or unloadable prefab emits a conversion diagnostic; the instance is skipped.
-- Prefab asset IDs that collide with scene asset IDs are resolved by the scene's
-  asset merge policy. The scene's explicit asset definition wins.
-- The expanded object retains its original scene object ID so behaviors, scripts,
-  and references resolve correctly.
-- Prefab expansion produces a flat `RuntimeSceneDefinition`. The expansion path
-  is recursive, but because the initial prefab system is single-root and does not
-  allow a prefab to contain another prefab reference, nested expansion does not
-  occur in practice today.
+- **Source Asset Format**: `.prefab` files stored in `assets/prefabs/` as canonical JSON/structured
+  documents governed by `ProjectVersion` (`docs/architecture/foundation/project-versioning-and-migration.md`).
+- **Hierarchy Support**: Single-root and multi-object parent-child hierarchies within explicit bounds.
+- **Scene Placement**: `SceneDocument` stores lightweight instance references (`ScenePrefabInstance`)
+  comprising an `AssetId` and explicit root transform/property overrides.
+- **Authoring Expansion**: The editor expands prefab instances during scene loading and viewport
+  rendering. Scene cook flattens all static prefab instances into `RuntimeSceneDefinition`.
+- **Cycle Detection**: Static validation traps recursive inclusion chains (`A -> B -> A`) before
+  expansion or serialization.
+- **Component Preservation**: Unknown/plugin-owned component payloads are retained opaquely
+  (`RawComponentPayload`) without data loss.
 
-## Prefab Root And Object Count
+### Tier 1: Runtime Dynamic Spawn from Cooked Prefab (Engine Target / M2)
 
-The initial implementation supports a **single root object** per prefab:
+- **Cooked Binary Artifact**: The Asset Pipeline compiles `.prefab` assets into immutable binary
+  `CookedPrefab` artifacts registered under `core.prefab` in `CookCatalog`.
+- **Runtime Asset Management**: Loaded through `IAssetProvider` via stable `AssetId`.
+- **Dynamic Spawn API**: `SceneCommandBuffer` and `SceneRuntimeAccess` expose transactional spawn
+  requests returning `Result<SpawnedPrefabHandle, PrefabSpawnError>`.
+- **Lifecycle Guarantees**: Fresh runtime `EntityId` allocation, component instantiation, hierarchy
+  assembly, followed by `OnCreate` and `OnStart` behavior hooks during tick synchronization.
+- **Fail-Safe Robustness**: Missing assets, invalid formats, or allocation limits fail safely with
+  typed error diagnostics without crashing the runtime or corrupting existing entities.
 
-- The prefab file may contain exactly one authored object that defines the prefab.
-- Multi-object prefabs (a root with children, or a group of sibling objects) are a
-  recognized future extension.
-- Scene hierarchy (`parentId`) may be used for simple parenting, but the prefab
-  itself does not yet store a subtree.
+### Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred / M3+)
 
-This limitation means an object composed of multiple independent primitives — for
-example, a castle built from many separate cubes — cannot currently be saved as
-one prefab. Such a composition should either be merged into a single mesh asset
-through an external DCC tool and imported, or split into one prefab per logical
-part.
+- **Prefab Variants**: A variant `.prefab` references a parent base prefab `AssetId` and stores
+  only delta overrides (modified property fields, added/removed components, extra child objects).
+- **Variant Inheritance DAG**: Multi-level variant chains (`Base -> VariantA -> VariantB`) validated
+  for acyclicity.
+- **Live Editor Propagation**: When a base prefab is modified and saved, open variant documents,
+  scenes referencing the prefab, and active viewport sessions update in real time.
+- **Granular Override Management**: Deep per-property diffing, revert-to-prefab, and apply-to-prefab
+  workflows in the Inspector panel.
 
-## Asset Ownership
+---
 
-A prefab may reference its own assets:
+## Identity, Hierarchy, And Asset Model
+
+### Single Source of Identity
+
+1. **Asset Registry Integration**: Prefabs are first-class assets. Every prefab is identified
+   authoritatively by its 128-bit `AssetId` declared in its companion sidecar (`.prefab.meta`).
+2. **Path Decoupling**: Project paths (`assets/prefabs/weapons/rifle.prefab`) are editor convenience
+   hints. If a prefab is moved or renamed, references remain valid through `AssetId`.
+3. **Project Versioning**: Prefab documents share the unified project schema versioning and
+   automated migration framework (`docs/architecture/foundation/project-versioning-and-migration.md`).
+
+### Hierarchy Addressing And Scoped Identity Composition
+
+A prefab defines a self-contained hierarchy of authored objects. To guarantee collision-free
+identities across multiple instances and nested scopes:
 
 ```cpp
-struct SceneAssetDefinition {
-    std::string id;
-    std::string mesh;
-    // maps, scale, guid, displayName, ...
+namespace Horo::Prefab {
+    /** @brief Zero-based slot index identifying an object inside a prefab template. */
+    struct LocalObjectId {
+        std::uint32_t value{0};
+        [[nodiscard]] constexpr bool IsRoot() const noexcept { return value == 0; }
+        [[nodiscard]] constexpr auto operator<=>(const LocalObjectId&) const noexcept = default;
+    };
+
+    /** @brief Reference to a prefab asset in authoring documents. */
+    struct PrefabAssetReference {
+        Assets::AssetId assetId;
+        std::string pathHint; // Advisory authoring path
+    };
+}
+```
+
+- **Tier 0 Authoring Expansion**:
+  When a prefab instance with `SceneObjectId instanceId` expands into a `SceneDocument`, each
+  expanded object receives a deterministic ID:
+  $$\text{ExpandedObjectId} = \text{Hash64}(\text{instanceId.value}, \text{localId.value})$$
+  This guarantees deterministic identity generation across editor reloads and prevents ID collisions
+  between repeated instances of the same prefab.
+
+- **Tier 1 Runtime Spawning**:
+  When `CookedPrefab` is spawned into `SceneRuntime`, root and child entities receive fresh,
+  monotonic `EntityId` values allocated directly from the active runtime scene's entity pool.
+
+---
+
+## Prefab Document Schema And Explicit Bounds
+
+Prefab documents enforce strict structural bounds to prevent unbounded memory growth, stack
+overflows during recursive expansion, and allocation spikes:
+
+```cpp
+namespace Horo::Prefab {
+    inline constexpr std::size_t MaximumPrefabHierarchyDepth = 16;
+    inline constexpr std::size_t MaximumPrefabObjectCount    = 256;
+    inline constexpr std::size_t MaximumPrefabPayloadBytes   = 4 * 1024 * 1024; // 4 MiB
+    inline constexpr std::size_t MaximumPrefabComponentsPerObject = 64;
+}
+```
+
+### Authoring Document Structure (`PrefabDocument`)
+
+```cpp
+struct PrefabObjectNode {
+    LocalObjectId localId;
+    std::optional<LocalObjectId> parentLocalId;
+    std::string name;
+    Vec3 localPosition{0.0f, 0.0f, 0.0f};
+    Vec3 localScale{1.0f, 1.0f, 1.0f};
+    Quat localRotation{Quat::Identity()};
+
+    // Component payloads (typed built-in components + opaque custom payloads)
+    std::optional<Runtime::MeshComponent> mesh;
+    std::optional<Runtime::CameraComponent> camera;
+    std::optional<Runtime::LightComponent> light;
+    std::optional<Runtime::AudioSourceComponent> audioSource;
+    std::vector<RawComponentPayload> customComponents;
+    std::vector<Gameplay::BehaviorAttachmentDefinition> behaviors;
+};
+
+struct PrefabDocument {
+    std::uint32_t schemaVersion{1};
+    Assets::AssetId assetId;
+    std::vector<PrefabObjectNode> objects; // objects[0] is root (LocalObjectId{0})
+    std::vector<Assets::AssetId> referencedAssets;
 };
 ```
 
-When the prefab expands, its assets are merged into the scene model. The merge
-policy is:
+---
 
-- Same `id` and compatible definition: keep the scene's existing entry.
-- Same `id` with conflicting definition: emit a conversion diagnostic and keep
-  the scene's entry.
-- New `id`: add to the scene asset list.
+## Runtime Cooked Prefab (`CookedPrefab`)
 
-## Identity, Renames, And References
+The Asset Pipeline cooks source `.prefab` files into immutable `CookedPrefab` artifacts.
 
-Prefabs use the same stable GUID rules as other assets. The `prefabId` is the
-primary identity; `sourcePath` is the resolution hint. If a prefab file is moved
-or renamed, the path index must be updated. References that cannot be resolved
-by path may be recovered through the `prefabId` if the project asset index maps
-it to a new location.
+### Binary Layout
 
-## Cooking And Packaging
+- **Header**: Magic bytes (`HPFB`), schema version, cryptographic digest (SHA-256 of source and dependencies),
+  and object count.
+- **Hierarchy Table**: Flat array of parent-child slot indices and local transforms.
+- **Component Tables**: Contiguous, aligned arrays of primitive component data and behavioral descriptors.
+- **Asset Reference Table**: List of dependent `AssetId`s required for instantiation.
 
-Prefabs participate in the asset pipeline as authored assets:
+```cpp
+namespace Horo::Runtime {
+    class CookedPrefab final {
+    public:
+        [[nodiscard]] Assets::AssetId GetAssetId() const noexcept;
+        [[nodiscard]] std::uint32_t GetObjectCount() const noexcept;
+        [[nodiscard]] std::span<const PrefabSlotDescriptor> GetHierarchy() const noexcept;
+        [[nodiscard]] std::span<const Assets::AssetId> GetDependencies() const noexcept;
+        // ... internal typed component table accessors
+    };
+}
+```
 
-- The editor saves prefabs as source `.prefab` files.
-- The cook step resolves prefab references inside scenes and inlines the expanded
-  objects into the cooked scene artifact.
-- Release packages do not ship raw `.prefab` files as runtime data; they ship
-  cooked scenes where prefabs have already been expanded and validated.
-- Prefab source files may be included in developer-facing source or editor package
-  profiles, but not in release player builds.
+---
 
-## Relationship To Other Systems
+## Dynamic Runtime Spawning Contract
 
-- **Editor Document Model**: prefab creation is a document command; prefab
-  placement creates a scene object with a `prefabInstance` reference.
-- **Asset Pipeline**: prefabs are authored assets with sidecar metadata and
-  stable identity. They are resolved and inlined during cook.
-- **Scene Runtime**: runtime scenes never see prefab references directly; they
-  receive an already-expanded `RuntimeSceneDefinition`.
-- **Gameplay Behaviors**: a behavior attached to a prefab root is instantiated
-  for each expanded instance using the same lifecycle as any scene object.
+Gameplay behaviors and runtime systems request prefab spawning through transactional command buffers
+or direct runtime access:
 
-## Diagnostics
+```cpp
+namespace Horo::Runtime {
+    struct PrefabSpawnRequest {
+        Assets::AssetId prefabAssetId;
+        Transform spawnTransform;
+        std::optional<EntityId> parentEntity{std::nullopt};
+    };
 
-Conversion must report clear diagnostics for:
+    struct SpawnedPrefabHandle {
+        EntityId rootEntity;
+        std::vector<EntityId> childEntities;
+    };
+}
+```
 
-- missing prefab file
-- prefab file with unsupported schema version
-- prefab root object missing
-- asset ID conflict between prefab and scene
-- invalid instance override (unknown field, malformed transform)
+### Spawning Execution Sequence
 
-## Future Extensions
+```text
+SceneCommandBuffer::SpawnPrefab(request)
+  -> Verify prefab asset is loaded in AssetRegistry / IAssetProvider
+  -> Check scene entity capacity (reject if capacity exceeded)
+  -> Allocate monotonic EntityId for root and each child object
+  -> Apply spawnTransform to root; set up parent-child entity relations
+  -> Copy component data into scene contiguous component pools
+  -> Attach gameplay behaviors and invoke OnCreate()
+  -> Commit transaction at SceneRuntime tick synchronization point
+  -> Invoke OnStart() for all newly spawned behaviors
+```
 
-- Multi-object prefabs with an explicit root/children subtree.
-- Prefab variants that inherit from a base prefab and apply delta overrides.
-- Nested prefab references where one prefab can place another prefab as a child.
-- Component-level overrides on instances.
-- Prefab thumbnails and viewport drag-and-drop placement.
+---
+
+## Preservation Of Unknown Project Components
+
+To support modular gameplay packages and project-specific C++ plugins:
+
+1. **Opaque Preservation Contract**:
+   ```cpp
+   struct RawComponentPayload {
+       std::string componentTypeId;
+       std::uint32_t schemaVersion{1};
+       std::vector<std::uint8_t> serializedBytes;
+   };
+   ```
+2. **Editor Roundtrip**: If an authored prefab or scene contains custom component types unknown to
+   the base editor binary, the data is preserved in `RawComponentPayload` verbatim. Saving, cloning,
+   or expanding the prefab preserves these components without truncation.
+3. **Runtime Spawning Safety**: If an unregistered component type is encountered during runtime
+   spawn, the runtime skips the unrecognized component, records a structured diagnostic warning,
+   and completes valid entity and behavior instantiation without aborting.
+
+---
+
+## Diagnostics And Error Model
+
+Dynamic spawning and authoring expansion report structured, typed errors:
+
+```cpp
+enum class PrefabError : std::uint32_t {
+    Success = 0,
+    AssetNotFound,              // AssetId not registered in CookCatalog / AssetRegistry
+    AssetNotLoaded,             // Async asset load still pending
+    CorruptedPayload,           // Checksum or magic header validation failed
+    HierarchyDepthExceeded,     // Template exceeds MaximumPrefabHierarchyDepth (16)
+    ObjectCountExceeded,        // Template exceeds MaximumPrefabObjectCount (256)
+    CyclicReferenceDetected,    // Nested prefab inclusion contains a cycle
+    EntityAllocationExhausted,  // Scene runtime ran out of available EntityIds
+    ComponentAllocationFailed   // Memory allocation failed for component pool
+};
+```
+
+### Validation Matrix
+
+| Case Category | Test Scenario | Expected Outcome |
+|---|---|---|
+| **Valid** | Single-root prefab with mesh & transform | Expands/spawns correctly; root entity created |
+| **Valid** | Multi-object hierarchy (depth 3, 5 objects) | Preserves relative transforms and child parenting |
+| **Valid** | Dynamic spawn with attached gameplay behavior | Calls `OnCreate` followed by `OnStart` |
+| **Boundary** | Maximum hierarchy depth (exactly 16) | Expansion and spawn succeed |
+| **Boundary** | Maximum object count (exactly 256) | Allocation and instantiation succeed |
+| **Boundary** | Empty overrides on placed instance | Inherits base template values completely |
+| **Malformed** | Cycle detection (`A -> B -> A`) | Rejection with `PrefabError::CyclicReferenceDetected` |
+| **Malformed** | Hierarchy depth > 16 or count > 256 | Rejection with boundary error diagnostic |
+| **Malformed** | Corrupted magic header or truncated payload | Rejection with `PrefabError::CorruptedPayload` |
+| **Lifecycle** | Spawn non-existent `AssetId` | Returns `PrefabError::AssetNotFound`; no scene leak |
+| **Lifecycle** | Unknown component in cooked template | Preserves/skips component safely without crashing |
+| **Lifecycle** | Scene destruction with active spawned entities | Cleanly tears down entities and behavior instances |
+
+---
 
 ## Related Documents
 
-- [Prefab Editor UI Reference](./prefab-editor.html): hierarchy, instance overrides, variant chain, and apply/revert panel.
-
-- [Asset Pipeline](./asset-pipeline.md)
-- [Scene Runtime](./scene-runtime.md)
+- [ADR-011: Prefab Role, Ownership and Capability-Tier Decision](../../adr/011-prefab-role-ownership-and-capability-tiers.md)
+- [Scene Runtime Architecture](./scene-runtime.md)
+- [Asset Pipeline Architecture](./asset-pipeline.md)
+- [Gameplay Behavior Authoring](../extensions/gameplay-behavior-authoring.md)
+- [Project Versioning and Migration](../foundation/project-versioning-and-migration.md)
 - [Editor Document Model](../editor/editor-document-model.md)
-- [Built-In Scene Primitives](./built-in-scene-primitives.md)
-- [Desired Project Trees](../desired-project-tree.md)

--- a/docs/architecture/runtime/prefab-architecture.md
+++ b/docs/architecture/runtime/prefab-architecture.md
@@ -346,7 +346,7 @@ enum class PrefabError : std::uint32_t {
 
 ## Related Documents
 
-- [ADR-011: Prefab Role, Ownership and Capability-Tier Decision](../../adr/011-prefab-role-ownership-and-capability-tiers.md)
+- [ADR-017: Prefab Role, Ownership and Capability-Tier Decision](../../adr/017-prefab-role-ownership-and-capability-tiers.md)
 - [Scene Runtime Architecture](./scene-runtime.md)
 - [Asset Pipeline Architecture](./asset-pipeline.md)
 - [Gameplay Behavior Authoring](../extensions/gameplay-behavior-authoring.md)

--- a/docs/architecture/runtime/prefab-architecture.md
+++ b/docs/architecture/runtime/prefab-architecture.md
@@ -16,9 +16,9 @@ architecture spanning two lifecycles:
 1. **Authoring-Time Nested Template (`PrefabDocument` / `.prefab`)**:
    - Authored in the Editor and stored under `assets/prefabs/`.
    - Serialized as structured, project-versioned documents conforming to `ProjectVersion`.
-   - Supports multi-object hierarchies, nested prefab instances, and shallow/deep overrides.
+   - Supports multi-object hierarchies, nested prefab instances, and shallow overrides in Tier 0; deep overrides and live variants belong to Tier 2.
    - For static scene objects, authoring instances are **pre-expanded and flattened** into
-     the containing `SceneDocument` (viewport preview) and baked into `RuntimeSceneDefinition`
+     a derived viewport projection of `SceneDocument` (without replacing authored instance references) and baked into `RuntimeSceneDefinition`
      (scene cook). This delivers optimal contiguous runtime memory layout with zero runtime
      template expansion overhead.
 
@@ -27,74 +27,71 @@ architecture spanning two lifecycles:
      platform-optimized binary artifacts (`core.prefab` asset type).
    - Registered in the `AssetRegistry` and `CookCatalog` with a stable 128-bit `AssetId`.
    - Gameplay requests spawn via `SceneCommandBuffer::RequestSpawnPrefab` (any thread,
-     `OperationId`). `SceneRuntimeAccess::SpawnPrefab` commits on the scene owner thread
-     (`OwnerThreadNextFrame`, [ADR-018](https://github.com/abdullahbodur/horo-engine/pull/2347); job wait in [ADR-010](../../adr/010-job-waiting-and-operation-store-ownership.md)).
+     `Result<OperationId, PrefabError>`). `SceneRuntimeAccess::SpawnPrefab` commits on the scene owner thread
+     (`OwnerThreadNextFrame`, [ADR-018](../../adr/018-command-registration-permissions-threading-and-packaged-build-policy.md); job wait in [ADR-010](../../adr/010-job-waiting-and-operation-store-ownership.md)).
    - Commit allocates fresh `EntityId`s, copies components, and parents the hierarchy, then
      publishes. `OnCreate` / `OnStart` run only after commit.
 
 ```text
-+-----------------------------------------------------------------------------------+
-| AUTHORING LIFECYCLE (Editor / Tools)                                              |
-|                                                                                   |
-|  [Authored Object(s)] ---> (Create Prefab) ---> [assets/prefabs/enemy.prefab]     |
-|                                                      |          ^                 |
-|                                    Placed in Scene   |          | Nested ref      |
-|                                          v           |          |                 |
-|    [SceneDocument] <--- (Instance Ref + Overrides) --+          +-- [nested.prefab]
-|           |                                                     |
-|           v (Scene Cook / Flattening)                           v (Prefab Cook)
-+-----------+-----------------------------------------------------+-----------------+
-| RUNTIME LIFECYCLE (SceneRuntime / Gameplay)                     |
-|           |                                                     |
-|           v                                                     v
-|   [RuntimeSceneDefinition]                             [CookedPrefab Asset]
-|   (Static pre-expanded entities)                       (Immutable binary template)
-|           |                                                     |
-|           v                                                     v
-|   [SceneRuntime Active] <====== (Dynamic Spawn at runtime) <----+
-|   - Contiguous ECS pools         - Buffer enqueue any thread; commit owner thread
-|   - Owner-thread EntityId pool   - OnCreate/OnStart only after commit
-+-----------------------------------------------------------------------------------+
+Authoring: Editor / Tools
+  [assets/prefabs/*.prefab] + [SceneDocument instance references / overrides]
+          |                                   |
+          |                                   +--> [Derived viewport projection]
+          |                                   |
+          |                                   +--> Scene cook / flatten
+          |                                             |
+          +--> Prefab cook / flatten                    v
+                    |                         [RuntimeSceneDefinition]
+                    v                                   |
+              [CookedPrefab]                            v
+                    |                          [SceneRuntime active]
+                    +--> RequestSpawnPrefab             ^
+                         -> bounded admission / load    |
+                         -> owner-thread stage / commit-+
+                         -> gameplay lifecycle after publication
 ```
 
 ---
 
 ## Capability Tiers
 
-Prefab capabilities are staged across three sequential, contract-stable tiers:
+Prefab capabilities are staged across three contract-stable tiers. They describe subsystem
+scope, not product milestone assignments or a global execution order; the
+[Product Roadmap Model](../delivery/product-roadmap.md) and native issue dependencies
+own those delivery decisions:
 
 ```text
-+-------------------------------------------------------------------------------+
-| Tier 0: Authoring Template Expansion & Instantiation (Baseline / M1)          |
-| - Canonical source .prefab format governed by ProjectVersion                  |
-| - Single-root and multi-object parent-child hierarchies                       |
-| - Placed instances in SceneDocument (AssetId + root transform & overrides)    |
-| - Deterministic offline expansion into RuntimeSceneDefinition                 |
-| - Static cycle detection rejecting recursive inclusion loops                  |
++------------------------------------------------------------------------------+
+| Tier 0: Authoring Template Expansion & Instantiation (Baseline)              |
+| - Canonical source .prefab format governed by ProjectVersion                 |
+| - Single-root and multi-object parent-child hierarchies                      |
+| - Placed instances in SceneDocument (AssetId + root transform & overrides)   |
+| - Deterministic offline expansion into RuntimeSceneDefinition                |
+| - Static cycle detection rejecting recursive inclusion loops                 |
 | - Opaque roundtrip preservation of unknown project-owned component data      |
-+-------------------------------------------------------------------------------+
++------------------------------------------------------------------------------+
                                     |
                                     v
-+-------------------------------------------------------------------------------+
-| Tier 1: Runtime Dynamic Spawn from Cooked Prefab (Engine Target / M2)         |
-| - Asset Pipeline compiles .prefab into binary CookedPrefab (core.prefab)      |
-| - Registered in AssetRegistry and CookCatalog with AssetId                    |
-| - Dynamic spawn APIs in SceneRuntime and Gameplay (SceneCommandBuffer)        |
-| - Runtime EntityId allocation, hierarchy setup, component copy, lifecycle     |
-| - Fail-safe error returns (missing asset, corrupted data, invalid component)  |
-+-------------------------------------------------------------------------------+
++------------------------------------------------------------------------------+
+| Tier 1: Runtime Dynamic Spawn from Cooked Prefab (Runtime Spawn)             |
+| - Asset Pipeline compiles .prefab into binary CookedPrefab (core.prefab)     |
+| - Registered in AssetRegistry and CookCatalog with AssetId                   |
+| - Dynamic spawn APIs in SceneRuntime and Gameplay (SceneCommandBuffer)       |
+| - Runtime EntityId allocation, hierarchy setup, component copy, lifecycle    |
+| - Fail-safe error returns (missing asset, corrupted data, invalid component) |
++------------------------------------------------------------------------------+
                                     |
                                     v
-+-------------------------------------------------------------------------------+
-| Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred / M3+) |
-| - Prefab Variants inheriting from base prefab asset with delta overrides      |
-| - Multi-level variant chains with DAG cycle verification                      |
-| - Live editor propagation across open documents upon base prefab mutation     |
-| - Granular per-property override tracking (revert/apply to base prefab)       |
-+-------------------------------------------------------------------------------+
++------------------------------------------------------------------------------+
+| Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred)      |
+| - Prefab Variants inheriting from base prefab asset with delta overrides     |
+| - Multi-level variant chains with DAG cycle verification                     |
+| - Live editor propagation across open documents upon base prefab mutation    |
+| - Granular per-property override tracking (revert/apply to base prefab)      |
++------------------------------------------------------------------------------+
 ```
 
-### Tier 0: Authoring Template Expansion & Instantiation (Baseline / M1)
+### Tier 0: Authoring Template Expansion & Instantiation (Baseline)
 
 - **Source Asset Format**: `.prefab` files stored in `assets/prefabs/` as canonical JSON/structured
   documents governed by `ProjectVersion` (`docs/architecture/foundation/project-versioning-and-migration.md`).
@@ -108,21 +105,23 @@ Prefab capabilities are staged across three sequential, contract-stable tiers:
 - **Component Preservation**: Unknown/plugin-owned component payloads are retained opaquely
   (`RawComponentPayload`) without data loss.
 
-### Tier 1: Runtime Dynamic Spawn from Cooked Prefab (Engine Target / M2)
+### Tier 1: Runtime Dynamic Spawn from Cooked Prefab (Runtime Spawn)
 
 - **Cooked Binary Artifact**: The Asset Pipeline compiles `.prefab` assets into immutable binary
   `CookedPrefab` artifacts registered under `core.prefab` in `CookCatalog`.
 - **Runtime Asset Management**: Loaded through `IAssetProvider` via stable `AssetId`.
-- **Dynamic Spawn API**: `SceneCommandBuffer::RequestSpawnPrefab` (any thread, returns `OperationId`)
+- **Dynamic Spawn API**: `SceneCommandBuffer::RequestSpawnPrefab` (any thread, returns `Result<OperationId, PrefabError>`)
   wraps `SceneRuntimeAccess::SpawnPrefab` (owner thread, `OwnerThreadNextFrame`).
 - **Lifecycle Guarantees**: Owner-thread `EntityId` allocation, staged component copy, commit,
-  then `OnCreate`; `OnStart` at the next scene sync. Recursion of an in-flight `AssetId` is rejected.
+  then `OnCreate`, `OnEnable` when enabled, and `OnStart` once before the first eligible fixed
+  update after first enable. Created-disabled behaviors defer enable/start. Repeated IDs in
+  inherited spawn lineage are rejected even across frames and asynchronous loads.
 - **Fail-Safe Robustness**: Catalog misses, cooked-version mismatch, corruption, bounds, and
   spawn recursion fail the operation without publishing entities or invoking hooks.
 - **Async load**: Unloaded-but-catalogued assets become an ADR-018 `WorkerJob` + `OperationStore`
   load-then-spawn. Callers do not poll `AssetNotLoaded`.
 
-### Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred / M3+)
+### Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred)
 
 - **Prefab Variants**: A variant `.prefab` references a parent base prefab `AssetId` and stores
   only delta overrides (modified property fields, added/removed components, extra child objects).
@@ -148,12 +147,11 @@ Prefab capabilities are staged across three sequential, contract-stable tiers:
 
 ### Hierarchy Addressing And Scoped Identity Composition
 
-A prefab defines a self-contained hierarchy of authored objects. To guarantee collision-free
-identities across multiple instances and nested scopes:
+A prefab defines a self-contained hierarchy of authored objects. Identity rules across multiple instances and nested scopes are:
 
 ```cpp
 namespace Horo::Prefab {
-    /** @brief Zero-based slot index identifying an object inside a prefab template. */
+    /** @brief Persisted local slot identifying an authored object; not a vector index. */
     struct LocalObjectId {
         std::uint32_t value{0};
         [[nodiscard]] constexpr bool IsRoot() const noexcept { return value == 0; }
@@ -168,18 +166,19 @@ namespace Horo::Prefab {
 }
 ```
 
-- **Tier 0 Authoring Expansion**:
-  When a prefab instance with `SceneObjectId instanceId` expands into a `SceneDocument`, each
-  expanded object receives a deterministic ID:
-  $$\text{ExpandedObjectId} = \text{Hash64}(\text{instanceId.value}, \text{localId.value})$$
-  This guarantees deterministic identity generation across editor reloads and prevents ID collisions
-  between repeated instances of the same prefab.
-
-- **Tier 1 Runtime Spawning**:
-  When `CookedPrefab` is spawned into `SceneRuntime`, root and child entities receive fresh,
-  monotonic `EntityId` values allocated from the scene entity pool **on the owner thread only**.
-  Worker jobs never increment the counter; the ADR-018 command drain serializes allocation, so
-  the counter is not atomic.
+- **Stable local slots**: Root slot zero is reserved. Surviving `LocalObjectId` values do not
+  change when objects are reordered, inserted, or deleted; deleted slots are not reused while
+  references may remain. Sparse authored slots are mapped to dense cooked table indices.
+- **Tier 0 Authoring Expansion**: Generate deterministic candidate scene IDs with a fixed,
+  versioned hash over canonical instance-scope/local-ID bytes. Each nested instance extends
+  the scope with its owning local slot, distinguishing repeated nested references. Check all
+  candidates against authored and expanded IDs before publication. A collision fails with
+  `PrefabError::IdentityCollision`; a 64-bit hash does not guarantee uniqueness and never
+  authorizes overwriting another object. Repeated expansion of unchanged input is stable.
+- **Tier 1 Runtime Spawning**: Use the existing Scene Runtime `EntityId { index, generation }`
+  allocator. Reused slots increment generation and retire rather than wrap. Public results
+  carry scene-qualified `EntityRef { SceneRuntimeId, EntityId }`; no prefab-specific monotonic
+  counter or hash replaces that identity model. Allocation remains owner-thread-only.
 
 ---
 
@@ -194,15 +193,22 @@ namespace Horo::Prefab {
     inline constexpr std::size_t MaximumPrefabObjectCount    = 256;
     inline constexpr std::size_t MaximumPrefabPayloadBytes   = 4 * 1024 * 1024; // 4 MiB
     inline constexpr std::size_t MaximumPrefabComponentsPerObject = 64;
-    inline constexpr std::size_t MaximumRuntimeSpawnDepth = 8; // owner-thread spawn call stack
+    inline constexpr std::size_t MaximumRuntimeSpawnDepth = 8; // inherited lineage, including target
 }
 ```
 
-These limits are enforced at authoring validation (save / import / instance placement; the
-document command fails and nothing is written), again at cook (no `CookedPrefab` is emitted),
-and at runtime as a header check before staging (`HierarchyDepthExceeded`,
-`ObjectCountExceeded`, `PayloadTooLarge`). Static inclusion cycles (`A -> B -> A`) are
-rejected at the authoring and cook gates with `CyclicReferenceDetected`.
+Limits apply to the fully expanded hierarchy as well as individual inputs: root depth is 1,
+object count includes all nested expansions, and component count includes built-in, opaque,
+and behavior components. Bound source, expanded, and cooked payload sizes independently;
+validate incrementally before expansion exceeds allocation limits. Limits are enforced at
+save/import/placement, at cook (no artifact on failure), and before runtime staging.
+
+Runtime validates the artifact envelope and actual table offsets, lengths, alignment, parent
+indices, component counts, and hierarchy; header counts alone are not trusted. Require exactly
+one root, unique local IDs, valid parents, and an acyclic connected hierarchy. Invalid authored
+graphs return `InvalidHierarchy`; malformed cooked encoding returns `CorruptedPayload`;
+well-formed over-limit input returns the relevant bounds error. Static nested-inclusion cycles
+return `CyclicReferenceDetected` at authoring/cook time.
 
 ### Authoring Document Structure (`PrefabDocument`)
 
@@ -225,9 +231,9 @@ struct PrefabObjectNode {
 };
 
 struct PrefabDocument {
-    std::uint32_t schemaVersion{1};
+    HoroProjectVersion projectVersion; // Unified authoring version, not a prefab schema counter
     Assets::AssetId assetId;
-    std::vector<PrefabObjectNode> objects; // objects[0] is root (LocalObjectId{0})
+    std::vector<PrefabObjectNode> objects; // first node is root; local IDs are persisted, possibly sparse
     std::vector<Assets::AssetId> referencedAssets;
 };
 ```
@@ -240,14 +246,26 @@ The Asset Pipeline cooks source `.prefab` files into immutable `CookedPrefab` ar
 
 Source `.prefab` files share `ProjectVersion` and its migration pipeline. Cooked blobs do **not**.
 The header carries a distinct `cookedFormatVersion`. Runtime never migrates cooked bytes.
-The cook cache key is `(AssetId, sourceDigest, ProjectVersion, cookedFormatVersion, cookerRevision)`.
-A source migration, cooker bump, or format bump invalidates the catalog entry and forces recook.
-`UnsupportedCookedVersion` is a version mismatch; `CorruptedPayload` is digest or magic failure.
+Prefab cooking preserves the Asset Pipeline's complete canonical versioned cache-key inputs:
+asset identity/type, source and cooker-input metadata digests, effective settings/schema,
+cooker contribution identity/version, typed target/profile, and artifact-envelope version.
+Its dependency-aware extension also covers `ProjectVersion`, `cookedFormatVersion`, and
+canonically ordered transitive dependency identities/artifact digests. Dependency-free
+AST-001C `CacheKeyV1` rejects nested-prefab dependencies; Tier 1 requires the explicit
+[dependency-aware cache extension](./asset-pipeline.md#incremental-cook-and-cache-reuse),
+not an incompatible change to V1 or a parallel prefab-only cache.
+
+Source migrations, dependency/target/settings changes, and cooker/format changes invalidate
+output. `UnsupportedCookedVersion` fails the runtime operation; only authoring/build tools
+recook and republish a compatible catalog/artifact. Runtime neither migrates nor recooks.
+`CorruptedPayload` is a separate envelope, magic, digest, or structural validation failure.
 
 ### Binary Layout
 
-- **Header**: Magic bytes (`HPFB`), `cookedFormatVersion`, cryptographic digest (SHA-256 of source and dependencies),
-  object count, and payload size.
+- **Header / envelope**: Magic bytes (`HPFB`), `cookedFormatVersion`, object count, and payload
+  size. The standard artifact envelope validates a cryptographic digest of the actual cooked
+  payload bytes. Source/dependency digests are provenance/cache inputs, not substitutes for
+  cooked-byte integrity verification.
 - **Hierarchy Table**: Flat array of parent-child slot indices and local transforms.
 - **Component Tables**: Contiguous, aligned arrays of primitive component data and behavioral descriptors.
 - **Asset Reference Table**: List of dependent `AssetId`s required for instantiation.
@@ -269,85 +287,122 @@ namespace Horo::Runtime {
 
 ## Dynamic Runtime Spawning Contract
 
-This contract conforms to [ADR-018](https://github.com/abdullahbodur/horo-engine/pull/2347)
-(companion PR) and [ADR-010](../../adr/010-job-waiting-and-operation-store-ownership.md)
-(in this tree). Spawn *commit* is
+This contract conforms to [ADR-018](../../adr/018-command-registration-permissions-threading-and-packaged-build-policy.md)
+and [ADR-010](../../adr/010-job-waiting-and-operation-store-ownership.md).
+Spawn *commit* is
 `CommandThreadPolicy::OwnerThreadNextFrame`. The main/editor thread never `Wait()`s a worker
 for spawn completion.
 
 ```cpp
 namespace Horo::Runtime {
     struct PrefabSpawnRequest {
+        SceneRuntimeId targetScene;
         Assets::AssetId prefabAssetId;
         Transform spawnTransform;
-        std::optional<EntityId> parentEntity{std::nullopt};
+        std::optional<EntityRef> parentEntity{std::nullopt};
     };
 
     struct SpawnedPrefabHandle {
-        EntityId rootEntity;
-        std::vector<EntityId> childEntities;
+        EntityRef rootEntity;
+        std::vector<EntityRef> childEntities;
     };
 
-    // Any thread. Enqueue only. Returns OperationId immediately.
-    OperationId SceneCommandBuffer::RequestSpawnPrefab(const PrefabSpawnRequest& request);
+    class SceneCommandBuffer {
+    public:
+        // Any thread. Enqueue only. Typed admission error or an OperationId.
+        Result<OperationId, PrefabError> RequestSpawnPrefab(const PrefabSpawnRequest& request);
+    };
 
-    // Owner thread only. Resident CookedPrefab required. Buffer drain calls this.
-    Result<SpawnedPrefabHandle, PrefabError>
-    SceneRuntimeAccess::SpawnPrefab(const PrefabSpawnRequest& request);
+    class SceneRuntimeAccess {
+    public:
+        // Internal owner-thread drain; resident assets and captured context required.
+        Result<SpawnedPrefabHandle, PrefabError> SpawnPrefab(const PrefabSpawnRequest& request);
+    };
 }
 ```
 
-`RequestSpawnPrefab` is the gameplay seam. `SpawnPrefab` on `SceneRuntimeAccess` is the
-owner-thread implementation. The buffer wraps access; access does not wrap the buffer.
-Two functions sharing one request struct is intentional. They are not interchangeable
-call sites.
+`RequestSpawnPrefab` is the planned scene-bound gameplay admission seam; `SpawnPrefab` is
+its internal owner-thread implementation. These are Tier 1 target contracts, not existing
+SCN-001 APIs. The extension adds thread-safe admission without changing the thread affinity
+of existing `SceneCommandBuffer::Create` / `Destroy`. Hierarchy staging uses the later ECS
+contract; it must not bypass Scene Runtime's transactional structural publication.
+
+Successful admission returns an `OperationId`; a closed/full queue or full operation store
+returns `AdmissionRejected` without accepting work. The host-composed spawn coordinator
+exclusively mutates the authoritative `OperationStore`. It captures owned request values,
+target scene identity, cancellation, diagnostic/configuration context, and explicit lineage
+before enqueue; workers do not retain borrowed scene/parent pointers. The internal access
+facade is bound to this captured context for the drain; the public request struct does not
+let callers manufacture or erase ancestry.
 
 ### Loaded vs not-yet-loaded
 
-- Catalog miss → operation completes with `PrefabError::AssetNotFound`. No polling.
-- Catalog hit, blob not resident → `RequestSpawnPrefab` starts a `WorkerJob` that waits
-  on `IAssetProvider`, then re-enqueues owner-thread commit. `OperationStore` is the
-  progress surface. Callers subscribe to the `OperationId`; they do not poll
-  `AssetNotLoaded`.
-- Direct `SceneRuntimeAccess::SpawnPrefab` with a non-resident blob returns
-  `PrefabError::AssetNotLoaded` as a misuse diagnostic. Gameplay must not use that path.
+- Catalog miss completes the accepted operation with `AssetNotFound`.
+- A catalogued non-resident template and its required dependencies load through the composed
+  `AssetLoadService` / `IAssetProvider` path. Workers perform bounded, cancellation-aware I/O;
+  they do not synchronously wait for another queued worker or owner-thread commit. Completion
+  schedules an owner-thread continuation holding immutable asset leases. The coordinator
+  projects progress and terminal results through the original `OperationId`.
+- Direct internal `SpawnPrefab` without resident required assets returns `AssetNotLoaded` as
+  a misuse diagnostic. Gameplay uses admission; it never polls that error.
+- Owner-thread publication revalidates cancellation, target `SceneRuntimeId`, parent generation
+  and scene membership, and pinned dependencies. Scene unload/replacement closes admission,
+  cancels pending operations, and rejects late continuations with `Cancelled` or
+  `SceneUnavailable`; stale/cross-scene parents return `InvalidParent`.
 
-### Spawning Execution Sequence (owner-thread drain)
+### Spawning Execution Sequence
 
 ```text
-SceneCommandBuffer::RequestSpawnPrefab(request)     // any thread
-  -> if not in CookCatalog: fail operation (AssetNotFound)
-  -> if not resident: WorkerJob load -> re-enqueue; return OperationId
-  -> else enqueue OwnerThreadNextFrame drain; return OperationId
+SceneCommandBuffer::RequestSpawnPrefab(request)     // any thread; bound context
+  -> validate/copy context and lineage; reserve bounded operation/queue capacity
+  -> reject admission or return OperationId; never mutate SceneRuntime
+  -> coordinator resolves catalog and schedules required asset loads
+  -> asset completion enqueues owner-thread continuation with immutable leases
 
-SceneRuntimeAccess::SpawnPrefab(request)            // owner thread only
-  -> if AssetId is on the spawn call stack: SpawnRecursionDetected
-  -> push AssetId
-  -> check cookedFormatVersion, digest, bounds, entity capacity
-  -> STAGE: allocate EntityIds, parent links, copy components (no hooks, no bus, no net)
-  -> on staging failure: discard staged memory/handles; pop; fail operation
-  -> COMMIT: publish entities into the live world
-  -> pop AssetId
-  -> OnCreate() on committed behaviors
-  -> OnStart() at the next scene synchronization point
+SceneRuntimeAccess::SpawnPrefab(request)            // internal owner-thread drain
+  -> validate inherited lineage, cancellation, scene and parent identity
+  -> validate cooked version, actual payload digest, hierarchy, bounds, capacity
+  -> STAGE: IDs, component data, behavior descriptors/storage (no behavior instances)
+  -> staging failure: discard unpublished storage and handles; fail operation
+  -> recheck cancellation and lifetime at CommitDeferredLifecycleChanges
+  -> COMMIT: atomically publish the complete hierarchy and successful handle
+  -> construct behaviors; OnCreate; OnEnable if enabled
+  -> OnStart once after first enable, before the first eligible fixed update
 ```
 
-`OnCreate` is outside the staging transaction. Spawn rollback never calls `OnDestroy` and
-never unsends events, because those side effects cannot have run. If `OnCreate` fails,
-entities are already live and later teardown uses the normal `OnDestroy` path.
+`OwnerThreadNextFrame` is the dispatch classification. Structural publication uses Scene
+Runtime's `CommitDeferredLifecycleChanges`; it is not an extra mutation phase in
+`PreUpdate` / `DebugPhase`. Preparation may precede publication but never leaks candidate
+handles or partial entities. Work submitted by lifecycle callbacks is eligible only in a
+subsequent bounded drain batch. Host-configured queue count/byte and per-drain work budgets
+prevent unbounded fan-out in a single frame.
+
+Staging does not construct gameplay behavior instances, invoke hooks, or emit bus/network
+side effects. Therefore rollback has no `OnDestroy` obligation. After structural commit,
+construction/hook faults follow normal gameplay fault handling and do not retroactively
+fail or roll back the successful structural spawn. Faulted behaviors do not start/update;
+every constructed behavior receives `OnDestroy` exactly once during normal teardown.
+Created-disabled behaviors still run `OnCreate` but defer `OnEnable` / `OnStart` until enabled.
+
+Commit and cancellation are serialized by the coordinator/owner-thread protocol: cancellation
+accepted before publication leaves no entities; cancellation after publication does not undo
+commit or change the successful spawn into a cancelled operation.
 
 ### Runtime spawn recursion
 
-Cook flattens nested prefab *references* into one `CookedPrefab`. Runtime spawn of A does
-not `SpawnPrefab` B. The remaining hazard is `OnCreate` (or another command in the same
-drain) requesting spawn of an `AssetId` already on the owner-thread call stack.
+Cook flattens nested references; runtime does not recursively expand raw prefabs. Lifecycle
+spawn chains still need protection across queues, frame boundaries, and asynchronous loads:
 
-- Push `AssetId` before staging; pop after commit or staging rollback.
-- Re-entry of that id → `PrefabError::SpawnRecursionDetected`, no staging.
-- `OnCreate` may `RequestSpawnPrefab` a *different* asset; that work runs after the
-  current frame pops and is still subject to the stack.
-- Behaviors must not spawn their own `AssetId` from `OnCreate`.
-- `MaximumRuntimeSpawnDepth` caps the stack (direct plus indirect).
+- Each accepted spawn carries immutable lineage ending in its target `AssetId`.
+- Requests originating in `OnCreate`, initial `OnEnable` / `OnStart`, or their asynchronous
+  continuations inherit that lineage through an explicitly bound command context. A caller
+  cannot drop ancestry when submitting through that context. No global or thread-local stack
+  is the authority, and the internal direct path must perform the same validation.
+- Before appending the requested ID, a repeated ID fails with `SpawnRecursionDetected`;
+  exceeding `MaximumRuntimeSpawnDepth` (8, including the new target) fails with
+  `SpawnDepthExceeded`. This rejects both `A -> A` and delayed `A -> B -> A`.
+- Independent later gameplay requests start new lineages, so repeated legitimate spawning
+  remains supported. Child rejection does not roll back an already-committed parent.
 
 ---
 
@@ -368,7 +423,7 @@ To support modular gameplay packages and project-specific C++ plugins:
    or expanding the prefab preserves these components without truncation.
 3. **Runtime Spawning Safety**: If an unregistered component type is encountered during runtime
    spawn, the transaction aborts before publishing entities or invoking behavior lifecycle hooks.
-   Staging discards those entities (no `OnCreate` has run, so no `OnDestroy`) and returns `PrefabError::ComponentTypeUnregistered`.
+   Staging discards unpublished storage (no gameplay behavior instance was constructed) and returns `PrefabError::ComponentTypeUnregistered`.
 
 ---
 
@@ -387,7 +442,15 @@ enum class PrefabError : std::uint32_t {
     ObjectCountExceeded,        // Template exceeds MaximumPrefabObjectCount (256)
     PayloadTooLarge,            // Template exceeds MaximumPrefabPayloadBytes (4 MiB)
     CyclicReferenceDetected,    // Nested prefab inclusion contains a cycle (authoring/cook)
-    SpawnRecursionDetected,     // Runtime SpawnPrefab re-entered an in-flight AssetId
+    SpawnRecursionDetected,     // Requested AssetId repeats in inherited spawn lineage
+    SpawnDepthExceeded,         // Lineage exceeds MaximumRuntimeSpawnDepth
+    AdmissionRejected,         // Queue/store capacity exhausted or admission closed
+    Cancelled,                 // Cancellation accepted before structural commit
+    SceneUnavailable,          // Captured target scene unloaded or replaced
+    InvalidParent,             // Stale generation or parent outside target scene
+    IdentityCollision,         // Deterministic authoring ID collides with another object
+    InvalidHierarchy,          // Duplicate local IDs, invalid parents, roots, or graph
+    ComponentCountExceeded,    // More than MaximumPrefabComponentsPerObject (64)
     EntityAllocationExhausted,  // Scene runtime ran out of available EntityIds
     ComponentTypeUnregistered,  // Cooked template references an unavailable component type
     ComponentAllocationFailed   // Memory allocation failed for component pool
@@ -400,7 +463,7 @@ enum class PrefabError : std::uint32_t {
 |---|---|---|
 | **Valid** | Single-root prefab with mesh & transform | Expands/spawns correctly; root entity created |
 | **Valid** | Multi-object hierarchy (depth 3, 5 objects) | Preserves relative transforms and child parenting |
-| **Valid** | Dynamic spawn with attached gameplay behavior | Calls `OnCreate` followed by `OnStart` |
+| **Valid** | Dynamic spawn with enabled gameplay behavior | `OnCreate`, `OnEnable`, then `OnStart` before first eligible fixed update |
 | **Boundary** | Maximum hierarchy depth (exactly 16) | Expansion and spawn succeed |
 | **Boundary** | Maximum object count (exactly 256) | Allocation and instantiation succeed |
 | **Boundary** | Empty overrides on placed instance | Inherits base template values completely |
@@ -416,13 +479,28 @@ enum class PrefabError : std::uint32_t {
 | **Lifecycle** | Scene destruction with active spawned entities | Cleanly tears down entities and behavior instances |
 | **Malformed** | Authoring depth > 16 on save | Save rejected; `.prefab` not written |
 | **Malformed** | Cook of over-limit prefab | Cook fails; no `CookedPrefab` artifact |
+| **Identity** | Reorder/insert/delete authored objects | Surviving local IDs and overrides remain stable |
+| **Identity** | Repeated nested instances or injected hash collision | Distinct scoped IDs; collision fails atomically with `IdentityCollision` |
+| **Identity** | Reuse a destroyed runtime entity slot | Old generation and old scene references remain invalid |
+| **Boundary** | Lineage depth 8 then 9 across queued frames | Depth 8 accepted; depth 9 returns `SpawnDepthExceeded` |
+| **Boundary** | Expanded nested count/payload or component count exceeds limit | Reject incrementally before oversized allocation or publication |
+| **Malformed** | Duplicate local IDs, missing parent, multiple roots | `InvalidHierarchy`; no authoring expansion published |
+| **Malformed** | Tampered cooked bytes with unchanged source digest | Actual artifact payload digest fails; `CorruptedPayload` |
+| **Lifecycle** | Delayed `A -> B -> A`, including asset-load continuation | `SpawnRecursionDetected`; rejected child publishes nothing |
+| **Lifecycle** | Independent later spawn of A | Fresh lineage; legitimate repeat succeeds |
+| **Lifecycle** | Spawn queue or operation store full | `AdmissionRejected`; no orphan operation or accepted work |
+| **Lifecycle** | Cancel/unload/replace scene while asset loads | No late publication into destroyed or replacement scene |
+| **Lifecycle** | Parent destroyed/reused while asset loads | `InvalidParent`; no attachment to replacement entity |
+| **Lifecycle** | Created-disabled behavior | `OnCreate` runs; `OnEnable`/`OnStart` wait for first enable |
+| **Lifecycle** | Post-commit behavior construction or hook fault | Structural spawn remains committed; fault reported; normal teardown |
+| **Cook** | Nested dependency, target, settings, or version changes | Full canonical cache key changes; no stale artifact reuse |
 
 ---
 
 ## Related Documents
 
 - [ADR-017: Prefab Role, Ownership and Capability-Tier Decision](../../adr/017-prefab-role-ownership-and-capability-tiers.md)
-- [ADR-018: Command Registration, Permissions, Threading and Packaged-Build Policy](https://github.com/abdullahbodur/horo-engine/pull/2347) (companion PR; file is not in this branch until #2347 lands)
+- [ADR-018: Command Registration, Permissions, Threading and Packaged-Build Policy](../../adr/018-command-registration-permissions-threading-and-packaged-build-policy.md)
 - [ADR-010: Job Waiting and Operation Store Ownership](../../adr/010-job-waiting-and-operation-store-ownership.md)
 - [Scene Runtime Architecture](./scene-runtime.md)
 - [Asset Pipeline Architecture](./asset-pipeline.md)


### PR DESCRIPTION
## Summary
- Resolves the contradiction between authoring-time pre-expansion/inlining of static scenes and dynamic runtime entity instantiation.
- Ratifies the dual-role prefab architecture (`PrefabDocument` authoring template vs `CookedPrefab` runtime binary template) and capability tiers (Tier 0 baseline, Tier 1 runtime spawn, Tier 2 live variants).
- Anchors prefab identity and versioning to the Asset Registry (`AssetId`) and project versioning rules.
- Establishes unknown component preservation contracts and fail-safe dynamic lifecycle handling.

## Motivation
- Static scenes benefit from zero-cost pre-expansion and contiguous ECS layout, whereas gameplay and sequencer systems require dynamic spawning of entity templates during active runtime simulation.
- Resolves [PFB-001.1] (#1008) to establish the architectural foundation for subsequent prefab tickets ([PFB-001.2] through [PFB-001.10]).

## Implementation Notes
- Authored **ADR-017: Prefab Role, Ownership and Capability-Tier Decision** (`docs/adr/017-prefab-role-ownership-and-capability-tiers.md`).
- Updated index in `docs/adr/README.md`.
- Thoroughly revised and expanded the normative specification in `docs/architecture/runtime/prefab-architecture.md` including structural bounds (max depth 16, max object count 256, max payload 4 MiB), dynamic spawn lifecycle sequences, opaque component preservation (`RawComponentPayload`), and validation test matrix.
- Updated `docs/architecture/README.md` entry.

## Review fixes
- Rebased on main after #2347 merged; ADR-018 links now point to the local document.
- Replace call-stack recursion checks with inherited spawn lineage across queues, loads, and lifecycle continuations; bound admission and drain work.
- Follow existing scene-qualified, generation-checked entity identity and the structural commit phase; revalidate cancellation, scene lifetime, and parent references before publication.
- Align post-commit lifecycle ordering with enable-state rules and distinguish structural spawn success from later gameplay faults.
- Preserve canonical asset cache inputs and dependency-aware invalidation; validate actual cooked bytes and expanded hierarchy bounds.
- Keep capability tiers separate from product milestone assignments and clarify stable local IDs and collision rejection.

## Validation
- C++20 syntax checks passed for both spawn API excerpts using dependency stubs; checked admission return type and scene-qualified parent/result types.
- All 41 local Markdown links in the ADR, prefab specification, and ADR index resolve.
- Referenced PrefabError enumerators, Markdown fences, conflict markers, blank lines, and git diff whitespace checks passed.
- Expanded the normative validation matrix for async recursion, stale parents/scenes, cancellation, admission capacity, lifecycle enable/fault behavior, bounds, and cache invalidation.
- Documentation-only change; no runtime implementation added and the full engine suite was not rerun for this revision. The previously reported 510/510 result belongs to an earlier revision.

## Risks
- These are Tier 1 target contracts, not claims that runtime spawning is implemented. Implementation depends on thread-safe admission, the later ECS hierarchy contract, and dependency-aware cooking; existing SCN-001 and CacheKeyV1 contracts remain unchanged.

## Issue Links
- GitHub: Closes #1008

## Reviewer Notes
1. Start with `docs/adr/017-prefab-role-ownership-and-capability-tiers.md` for the high-level decision, ratify/revise outcomes, and capability tier staging.
2. Review `docs/architecture/runtime/prefab-architecture.md` for the normative technical specification.