### PR TITLE
docs(cli): cli host, command ownership, adapter equivalence and horopak boundary decision HORO-1814 #1858 [CLI-001.1]

### DIFF
--- a/docs/adr/013-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
+++ b/docs/adr/013-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
@@ -83,6 +83,7 @@ Horo Engine defines three distinct executable composition roots:
 ```
 
 #### A. `horo-engine` (Primary Host & Terminal CLI)
+
 - **Role**: Headless engine host, terminal automation CLI, batch processor, and headless MCP server.
 - **Composition**: Links `HoroEngine::Application`, `HoroEngine::CliHost`, `HoroEngine::Platform`, `HoroEngine::Foundation`, `HostObservability`, and domain service libraries (`HoroEngine::Assets`, `HoroEngine::Testing`, `HoroEngine::ProjectMigrations`).
 - **Invariants**:
@@ -91,6 +92,7 @@ Horo Engine defines three distinct executable composition roots:
   - Commands requiring GPU acceleration (e.g., GPU asset baking) declare explicit capability requirements and select null/headless backends when run without display hardware.
 
 #### B. `HoroEditor` (Graphical IDE & Embedded MCP Host)
+
 - **Role**: Visual authoring environment, document workspace, docked panel host, and interactive debug session.
 - **Composition**: Links `HoroEngine::Gui`, `HoroEngine::EditorServices`, `HoroEngine::EditorRenderExtraction`, `HoroEngine::RenderFrontend`, `HoroEngine::Runtime`, concrete render viewports (`OpenGL` / `Metal`), and `HoroEngine::Mcp`.
 - **Invariants**:
@@ -98,6 +100,7 @@ Horo Engine defines three distinct executable composition roots:
   - Can host `McpServer` over stdio or local HTTP/SSE while the editor runs, dispatching agent tool calls directly to the main editor thread.
 
 #### C. `horopak` (Specialized Asset Packaging & Cook Utility)
+
 - **Role**: Standalone, lightweight CLI utility for `.horo` asset pak creation, table of contents (TOC) inspection, integrity verification, compression, encryption, and extraction.
 - **Composition**: Links ONLY `HoroEngine::Archive` (pak format, SHA-256/CRC32 verification, AES-128-CTR crypto), `HoroEngine::Foundation`, `HoroEngine::Platform`, and minimal asset compilation adapters.
 - **Invariants**:
@@ -188,6 +191,7 @@ namespace Horo::Cli {
 
 **Adapter Equivalence Rule**:
 For any shared operation (e.g., `project.create`, `project.validate`, `asset.cook`, `build.release`, `package.restore`):
+
 - GUI (Editor modal/wizard)
 - CLI (`horo-engine <command>`)
 - MCP (`tools/call`)
@@ -199,6 +203,7 @@ must invoke the exact same underlying domain use-case service (`IProjectService`
 ### 5. Output Purity & Exit Code Contract
 
 #### A. Strict Channel Separation
+
 - **`stdout`**: Reserved exclusively for command payload.
   - In `human` mode: clean, human-readable prose and interactive tables.
   - In `json` / `jsonl` mode: strictly schema-valid JSON envelopes. Zero logs, warnings, progress bars, or ANSI escape codes.
@@ -248,6 +253,7 @@ The migration path removes legacy ad-hoc parsing in `apps/horo-engine/main.cpp` 
 ## Consequences
 
 ### Positive
+
 - **Architectural Clarity**: Clear separation of responsibilities between CLI, GUI, Debug Console, and MCP interfaces.
 - **Headless & CI Readiness**: `horo-engine` and `horopak` can be built and run in lightweight headless environments without graphics drivers or display servers.
 - **Maintainability & Robustness**: Standardized descriptor validation prevents flag collisions, invalid option values, and command drift.
@@ -255,6 +261,7 @@ The migration path removes legacy ad-hoc parsing in `apps/horo-engine/main.cpp` 
 - **Single Source of Domain Truth**: Shared application use cases guarantee that builds, cooks, package restores, and project validations behave identically across GUI, CLI, and MCP.
 
 ### Negative / Trade-offs
+
 - **Descriptor Boilerplate**: Each new CLI command requires authoring a typed `CliCommandDescriptor` and implementing `ICliCommandAdapter` rather than writing a quick handler function.
 - **Multiple Executable Targets**: Requires maintaining distinct CMake compositions for `horo-engine`, `HoroEditor`, and `horopak`.
 

--- a/docs/adr/013-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
+++ b/docs/adr/013-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
@@ -1,0 +1,270 @@
+# ADR-013: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision
+
+- **Status**: Proposed
+- **Date**: 2026-08-28
+- **Supersedes**: None (Amends and extends [ADR-004](004-cli-core-gui-boundary.md))
+- **Scope**: CLI host ownership (`HoroEngine::CliHost`), command descriptor registry, option parsing, execution dispatch, structured presentation, executable responsibilities (`horo-engine`, `HoroEditor`, `horopak`), separation of concerns between CLI, runtime debug console (DBG-001), and MCP (MCP-001), console delegation seam, domain command adapter equivalence (`ICliCommandAdapter`), and `horopak` isolation boundary
+- **Issue**: [#1858](https://github.com/abdullahbodur/horo-engine/issues/1858) ([CLI-001.1])
+- **JIRA**: HORO-1858
+- **Normative document**: [CLI Architecture](../architecture/interfaces/cli-architecture.md)
+
+## Context
+
+The terminal host in `apps/horo-engine/main.cpp` currently relies on an ad hoc, handwritten option parsing loop (`ParseOptions`) that handles only a handful of hardcoded flags (`--emit-observability-smoke`, `--diagnostic-bundle`). It lacks a reusable command descriptor model, unified option validation, structured machine output schemas, cooperative cancellation propagation, signal lifecycle, standard exit-code mappings, and capability-scoped execution dispatch.
+
+Furthermore, previous architectural documentation left ambiguities across several critical boundaries:
+
+1. **Host Executable Roles**: Unclear boundaries between `horo-engine` (headless engine host, CLI, automation), `HoroEditor` (graphical IDE, embedded MCP server), and `horopak` (specialized archive and cooking utility).
+2. **Separation of Presentation Interfaces (CLI vs Debug Console vs MCP)**: Risk of creating a monolithic, string-based command registry shared between terminal CLI, runtime in-game debug console (`DBG-001`), and AI agent Model Context Protocol (`MCP-001`), or conflating terminal arguments with in-game cvars and console commands.
+3. **Domain Logic Inversion**: Risk of command-line handlers absorbing business logic (e.g., project serialization, asset dependency graph traversals, build step recipes, pak file binary packing) instead of delegating to domain use cases via typed adapters.
+4. **`horopak` Scope Creep**: Risk of `horopak` linking the entire engine runtime, scene graph, or rendering frontend rather than remaining a minimal, fast, zero-GPU standalone utility for CI/CD and containerized asset pipelines.
+
+[CLI-001.1] ratifies the ownership model, target breakdown, executable responsibilities, interface boundaries, and adapter-equivalence contracts to establish a sound foundation before implementing the CLI subsystem across M2–M4.
+
+## Decision
+
+**`HoroEngine::CliHost` is the sole owner of command-line parsing, descriptor registration, help formatting, execution dispatch, structured output presentation, and exit-code mapping. CLI commands are thin adapters (`ICliCommandAdapter`) over domain use cases. CLI, Runtime Debug Console (`DBG-001`), and MCP (`MCP-001`) maintain distinct registries and protocols while sharing domain use cases and providing explicit delegation seams. `horopak` is strictly isolated to asset cooking and `.horo` pak archive manipulation with zero GUI or rendering dependencies.**
+
+---
+
+### 1. Authoritative Ownership & Target Topology
+
+CLI responsibilities are partitioned into dedicated, single-purpose components under `HoroEngine::CliHost` (CMake target `HoroCliHost`, namespace `Horo::Cli`):
+
+| Component / Contract | Target | Ownership & Responsibility |
+|---|---|---|
+| `CliCommandDescriptor` | `HoroEngine::CliHost` | Inert metadata declaring command path, option schema, output schema, required capabilities, supported hosts, interactivity, side effects, stdin policy, cancellation, timeout, and contract version. |
+| `CliCommandRegistry` | `HoroEngine::CliHost` | Validates, deduplicates, and indexes built-in and contributed command descriptors. Rejects conflicts, duplicate options, or unauthorized capability requirements during initialization. |
+| `CliOptionParser` | `HoroEngine::CliHost` | Pure parser from `argv`, configuration snapshots, and environment into typed `CliCommandRequest` or structured diagnostics. Does NOT initiate application work or side effects. |
+| `CliDispatcher` | `HoroEngine::CliHost` | Validates permissions and required capabilities, binds `CliExecutionContext`, and invokes the registered `ICliCommandAdapter`. |
+| `CliOutputPresenter` | `HoroEngine::CliHost` | Formats typed execution results into `human` (TTY-aware styling / progress), `json` (single envelope), or `jsonl` (streaming records) while enforcing stdout purity. |
+| `ICliCommandAdapter` | `HoroEngine::CliHost` | Typed adapter interface implemented by domain modules to translate a validated `CliCommandRequest` into a domain use-case invocation and return a typed `Result<CliCommandResult>`. |
+| `CliExitCode` | `HoroEngine::CliHost` | Maps typed Horo error domains and cancellation states to stable numeric exit categories. |
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                            HoroEngine::CliHost                              │
+│                                                                             │
+│   argv ──> [ CliOptionParser ] ──> CliCommandRequest                       │
+│                    │                                                        │
+│                    v                                                        │
+│          [ CliCommandRegistry ] <── Validated Descriptors                   │
+│                    │                                                        │
+│                    v                                                        │
+│             [ CliDispatcher ] ──> Binds CliExecutionContext                │
+│                    │                                                        │
+│                    v                                                        │
+│          [ ICliCommandAdapter ] ──> Calls Application / Domain Use Case     │
+│                    │                                                        │
+│                    v                                                        │
+│            CliCommandResult                                                 │
+│                    │                                                        │
+│                    v                                                        │
+│         [ CliOutputPresenter ] ──> stdout (Pure) / stderr (Logs/Diag)       │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### 2. Executable Responsibilities and Boundaries
+
+Horo Engine defines three distinct executable composition roots:
+
+```
+┌───────────────────────────────────┐  ┌───────────────────────────────────┐  ┌───────────────────────────────────┐
+│            horo-engine            │  │            HoroEditor             │  │              horopak              │
+│                                   │  │                                   │  │                                   │
+│  - Headless host & CLI entrypoint │  │  - Graphical Editor IDE           │  │  - Standalone packaging utility   │
+│  - Application & Project services │  │  - ImGui / GUI Screen Host        │  │  - Pak archive create/inspect/read│
+│  - Asset cooker & Test runners    │  │  - Viewport Render Extraction     │  │  - Zero GUI, zero RenderApi       │
+│  - Headless MCP (`mcp serve`)     │  │  - Embedded MCP Server            │  │  - Minimal cooking toolchain      │
+│  - Zero GUI / RenderApi by default│  │  - Concrete RHI (OpenGL / Metal)  │  │  - CI / Container optimized       │
+└───────────────────────────────────┘  └───────────────────────────────────┘  └───────────────────────────────────┘
+```
+
+#### A. `horo-engine` (Primary Host & Terminal CLI)
+- **Role**: Headless engine host, terminal automation CLI, batch processor, and headless MCP server.
+- **Composition**: Links `HoroEngine::Application`, `HoroEngine::CliHost`, `HoroEngine::Platform`, `HoroEngine::Foundation`, `HostObservability`, and domain service libraries (`HoroEngine::Assets`, `HoroEngine::Testing`, `HoroEngine::ProjectMigrations`).
+- **Invariants**:
+  - Compiles and runs in purely headless environments (CI runners, Docker containers, remote servers) without requiring X11, Wayland, Cocoa, or GPU hardware contexts.
+  - Does NOT link `HoroEngine::Gui`, ImGui, or concrete viewport renderers (`HoroEngine::EditorViewportOpenGL`, `HoroEngine::EditorViewportMetal`).
+  - Commands requiring GPU acceleration (e.g., GPU asset baking) declare explicit capability requirements and select null/headless backends when run without display hardware.
+
+#### B. `HoroEditor` (Graphical IDE & Embedded MCP Host)
+- **Role**: Visual authoring environment, document workspace, docked panel host, and interactive debug session.
+- **Composition**: Links `HoroEngine::Gui`, `HoroEngine::EditorServices`, `HoroEngine::EditorRenderExtraction`, `HoroEngine::RenderFrontend`, `HoroEngine::Runtime`, concrete render viewports (`OpenGL` / `Metal`), and `HoroEngine::Mcp`.
+- **Invariants**:
+  - Owns window creation, OS presentation loops, ImGui frame rendering, and viewport picking.
+  - Can host `McpServer` over stdio or local HTTP/SSE while the editor runs, dispatching agent tool calls directly to the main editor thread.
+
+#### C. `horopak` (Specialized Asset Packaging & Cook Utility)
+- **Role**: Standalone, lightweight CLI utility for `.horo` asset pak creation, table of contents (TOC) inspection, integrity verification, compression, encryption, and extraction.
+- **Composition**: Links ONLY `HoroEngine::Archive` (pak format, SHA-256/CRC32 verification, AES-128-CTR crypto), `HoroEngine::Foundation`, `HoroEngine::Platform`, and minimal asset compilation adapters.
+- **Invariants**:
+  - Strictly forbidden from linking `HoroEngine::Gui`, `HoroEngine::RenderFrontend`, `HoroEngine::RenderApi`, `HoroEngine::RuntimeScene`, `HoroEngine::GameplayRuntime`, `HoroEngine::Physics`, `HoroEngine::Audio`, or `HoroEngine::Networking`.
+  - Cannot instantiate full scene pipelines or launch game runtime loops.
+  - Fast cold-start time (<10ms) and minimal memory footprint suitable for high-throughput containerized asset packaging.
+
+---
+
+### 3. Separation of Concerns: CLI vs Debug Console vs MCP
+
+CLI commands, Runtime Debug Console commands (`DBG-001`), and MCP tools (`MCP-001`) address different interaction paradigms and must not be collapsed into a single stringly-typed command table:
+
+```
+                  ┌──────────────────────────────────────────────┐
+                  │            Shared Domain Services            │
+                  │  (AssetCooker, ProjectService, TestRunner,   │
+                  │   ReleasePipeline, DebugConsoleService)      │
+                  └──────▲────────────────▲──────────────▲───────┘
+                         │                │              │
+                         │                │              │
+          ┌──────────────┴──────┐  ┌──────┴──────┐  ┌────┴─────────────┐
+          │ ICliCommandAdapter  │  │ IDebugCmd   │  │ McpToolAdapter   │
+          └──────────────▲──────┘  └──────▲──────┘  └────▲─────────────┘
+                         │                │              │
+     ┌───────────────────┴──────┐  ┌──────┴──────┐  ┌────┴─────────────┐
+     │   CliCommandRegistry     │  │ DebugConsole│  │ McpController    │
+     │   (HoroEngine::CliHost)  │  │ (Runtime)   │  │ (HoroEngine::Mcp)│
+     └───────────────────▲──────┘  └──────▲──────┘  └────▲─────────────┘
+                         │                │              │
+                    Terminal argv    In-Game Console   AI JSON-RPC
+```
+
+1. **Protocol & Context Differences**:
+   - **CLI (`CliCommandRegistry`)**: Shell-native argument parsing (`--flag`, positional arguments, environment, `--` termination), stdin streaming policies, ANSI/TTY-aware progress, human vs JSON/JSONL output formatting, and OS exit codes.
+   - **Debug Console (`DebugConsole`)**: In-game runtime console language (`cmd arg1 arg2`, cvar read/write, autocomplete, in-game terminal view, game pause/time step integration, product-profile gating for shipping vs dev).
+   - **MCP (`McpController`)**: JSON-RPC 2.0 protocol over stdio/SSE with JSON Schema parameter definitions, structured tool responses, and LLM-oriented context payloads.
+
+2. **Explicit Delegation Seam (`console exec`)**:
+   - The CLI does not duplicate runtime console command handlers. Instead, the CLI provides a dedicated delegation command:
+     ```bash
+     horo-engine console exec "<cmd> [args]"
+     ```
+     (or `--exec-console="<cmd>"` during startup).
+   - This command delegates execution to the authoritative `DebugConsoleService` / `IDebugConsoleHost`, validating product profiles and permissions without creating an entangled shared registry.
+
+3. **Headless MCP Serve Seam (`mcp serve`)**:
+   - `horo-engine mcp serve` initializes the headless `McpServer` over stdio or SSE.
+   - CLI ensures strict stream isolation: JSON-RPC communication on `stdout` is completely isolated from engine diagnostic logging (which is routed exclusively to `stderr`).
+
+---
+
+### 4. Adapter Equivalence & Domain Independence
+
+CLI handlers must not contain domain business logic. Domain modules own use-case logic, transactions, and state invariants, while exposing typed interfaces:
+
+```cpp
+namespace Horo::Cli {
+
+    /**
+     * @brief Context provided to a CLI command adapter during execution.
+     */
+    struct CliExecutionContext {
+        ApplicationServices& application;
+        JobSystem& jobs;
+        const ConfigurationSnapshot& configuration;
+        const CancellationToken& cancellation;
+        ICliOutputWriter& output;
+        InvocationId invocationId;
+    };
+
+    /**
+     * @brief Interface implemented by domain modules to contribute CLI behavior.
+     */
+    class ICliCommandAdapter {
+    public:
+        virtual ~ICliCommandAdapter() = default;
+
+        [[nodiscard]] virtual const CliCommandDescriptor& GetDescriptor() const noexcept = 0;
+
+        [[nodiscard]] virtual Result<CliCommandResult> Execute(
+            const CliCommandRequest& request,
+            CliExecutionContext& context) = 0;
+    };
+
+}  // namespace Horo::Cli
+```
+
+**Adapter Equivalence Rule**:
+For any shared operation (e.g., `project.create`, `project.validate`, `asset.cook`, `build.release`, `package.restore`):
+- GUI (Editor modal/wizard)
+- CLI (`horo-engine <command>`)
+- MCP (`tools/call`)
+
+must invoke the exact same underlying domain use-case service (`IProjectService`, `IAssetCooker`, `IReleasePipeline`). Differences are strictly limited to presentation formatting, progress reporting mechanisms, and transport envelopes.
+
+---
+
+### 5. Output Purity & Exit Code Contract
+
+#### A. Strict Channel Separation
+- **`stdout`**: Reserved exclusively for command payload.
+  - In `human` mode: clean, human-readable prose and interactive tables.
+  - In `json` / `jsonl` mode: strictly schema-valid JSON envelopes. Zero logs, warnings, progress bars, or ANSI escape codes.
+- **`stderr`**: Reserved for logging, diagnostic messages, interactive progress bars, prompts, and failure backtraces.
+
+#### B. Stable Exit Codes
+
+| Code | Category | Description |
+|:---:|:---|:---|
+| `0` | **Success** | Command completed successfully. |
+| `1` | **Host Failure** | Uncaught host-level exception or pre-initialization runtime failure. |
+| `2` | **Usage Error** | CLI syntax error, unknown flag, missing required argument, or invalid option value. |
+| `3` | **Input Validation Failure** | Target project, file path, scene, or input payload failed domain validation. |
+| `4` | **Capability Unavailable** | Required engine capability, host environment, or dependency is missing. |
+| `5` | **Operation Failed** | The requested domain operation encountered a functional error (e.g., compilation error, build failure). |
+| `6` | **Security / Permission Error** | Access denied, untrusted script execution, or unauthorized cvar/command execution. |
+| `7` | **Cancelled / Interrupted** | Operation was cancelled cooperatively via `SIGINT`/`SIGTERM` or cancellation token. |
+| `8` | **Timeout** | Operation exceeded its declared execution timeout. |
+| `10` | **Internal Invariant Failure** | Engine bug, unhandled internal invariant violation, or memory corruption. |
+
+---
+
+### 6. Migration Plan from Legacy Ad-Hoc Parsing
+
+The migration path removes legacy ad-hoc parsing in `apps/horo-engine/main.cpp` without maintaining competing sources of truth:
+
+1. **Step 1 ([CLI-001.2] & [CLI-001.3])**: Implement `HoroEngine::CliHost` library with `CliCommandDescriptor`, `CliCommandRegistry`, `CliOptionParser`, and unit test suite.
+2. **Step 2 ([CLI-001.5])**: Introduce `CliDispatcher`, `CliExecutionContext`, and migrate smoke tests (`--emit-observability-smoke`, `--diagnostic-bundle`) into first-class `ICliCommandAdapter` registrations (`observability.smoke`, `diagnostics.bundle`).
+3. **Step 3 ([CLI-001.6] & [CLI-001.7])**: Implement structured JSON/JSONL output presenters, cooperative cancellation handlers, and headless MCP serve composition (`horo-engine mcp serve`).
+4. **Step 4 (Phase-out)**: Replace `apps/horo-engine/main.cpp` entry point with `Horo::Cli::CliHost::Run(argc, argv)`. Remove all legacy `ParseOptions` code.
+
+---
+
+### 7. Ratify-or-Revise Outcomes
+
+| Area | Prior / Ambiguous State | Ratified Decision |
+|---|---|---|
+| CLI Parsing & Host Ownership | Ad hoc parsing loops in `apps/horo-engine/main.cpp` | **Revised.** `HoroEngine::CliHost` owns parsing, registry, validation, dispatch, and presentation. |
+| Registry Separation | Risk of sharing single command table between CLI, Debug Console, and MCP | **Ratified.** Three distinct registries with typed domain use cases and explicit delegation seams (`console exec`, `mcp serve`). |
+| Executable Boundaries | Undocumented overlap between `horo-engine`, `HoroEditor`, and `horopak` | **Ratified.** `horo-engine` (headless host), `HoroEditor` (graphical IDE/MCP), `horopak` (isolated archive/cook utility). |
+| `horopak` Linkage | Undefined dependencies on engine graphics/runtime | **Ratified.** `horopak` links ONLY `HoroEngine::Archive` and minimal cooking helpers; zero GUI/Render dependencies. |
+| Domain Business Logic | Risk of leaking file formatting and business rules into CLI handlers | **Ratified.** Domain modules expose `ICliCommandAdapter`; CLI handlers only transform inputs/outputs. |
+| Exit Codes & Output | Inconsistent exit codes (0 vs 2 vs 3) and unseparated stdout logs | **Ratified.** 10 stable exit categories and strict stdout purity in structured modes. |
+
+---
+
+## Consequences
+
+### Positive
+- **Architectural Clarity**: Clear separation of responsibilities between CLI, GUI, Debug Console, and MCP interfaces.
+- **Headless & CI Readiness**: `horo-engine` and `horopak` can be built and run in lightweight headless environments without graphics drivers or display servers.
+- **Maintainability & Robustness**: Standardized descriptor validation prevents flag collisions, invalid option values, and command drift.
+- **Scriptability & Tooling Purity**: Machine-readable JSON/JSONL output streams are guaranteed pure for downstream CI/CD pipelines and scripting tools.
+- **Single Source of Domain Truth**: Shared application use cases guarantee that builds, cooks, package restores, and project validations behave identically across GUI, CLI, and MCP.
+
+### Negative / Trade-offs
+- **Descriptor Boilerplate**: Each new CLI command requires authoring a typed `CliCommandDescriptor` and implementing `ICliCommandAdapter` rather than writing a quick handler function.
+- **Multiple Executable Targets**: Requires maintaining distinct CMake compositions for `horo-engine`, `HoroEditor`, and `horopak`.
+
+---
+
+## Rejected Alternatives
+
+1. **Monolithic Unified Command Registry**: Merging CLI commands, in-game console commands (`DBG-001`), and MCP tools (`MCP-001`) into a single global string registry.
+   - *Rejected because*: The three surfaces have fundamentally different argument lifecycles, execution contexts, security models, and presentation requirements.
+2. **`horopak` as an Alias or Headless Mode of `horo-engine`**: Implementing `horopak` as a symlink or sub-command (`horo-engine pack`) without a dedicated binary.
+   - *Rejected because*: Standalone asset packaging must have instantaneous startup, minimal memory footprint, and zero link-time dependencies on the broader engine codebase for deployment in restricted CI worker environments.
+3. **Placing Command Business Logic inside CLI Handlers**: Implementing project creation, asset cooking, or pak packing directly inside CLI command source files.
+   - *Rejected because*: Violates adapter equivalence and forces duplicate logic between CLI, GUI editor actions, and MCP agent tools.

--- a/docs/adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
+++ b/docs/adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
@@ -5,7 +5,7 @@
 - **Supersedes**: None (Amends and extends [ADR-004](004-cli-core-gui-boundary.md))
 - **Scope**: CLI host ownership (`HoroEngine::CliHost`), command descriptor registry, option parsing, execution dispatch, structured presentation, executable responsibilities (`horo-engine`, `HoroEditor`, `horopak`), separation of concerns between CLI, runtime debug console (DBG-001), and MCP (MCP-001), console delegation seam, domain command adapter equivalence (`ICliCommandAdapter`), and `horopak` isolation boundary
 - **Issue**: [#1858](https://github.com/abdullahbodur/horo-engine/issues/1858) ([CLI-001.1])
-- **JIRA**: HORO-1858
+- **JIRA**: HORO-1814
 - **Normative document**: [CLI Architecture](../architecture/interfaces/cli-architecture.md)
 
 ## Context

--- a/docs/adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
+++ b/docs/adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
@@ -161,15 +161,30 @@ CLI handlers must not contain domain business logic. Domain modules own use-case
 namespace Horo::Cli {
 
     /**
-     * @brief Context provided to a CLI command adapter during execution.
+     * @brief Presentation-independent progress/event sink exposed to adapters.
+     *
+     * `CliOutputPresenter` implements this interface. Adapters must not write
+     * stdout or stderr directly.
+     */
+    class ICliProgressSink {
+    public:
+        virtual ~ICliProgressSink() = default;
+        virtual void Report(const CliProgressEvent& event) = 0;
+    };
+
+    /**
+     * @brief Invocation-scoped context provided to a CLI command adapter during execution.
+     *
+     * Domain-service dependencies are provided to adapters by constructor injection
+     * at registration time. This context carries only values scoped to a single
+     * command invocation.
      */
     struct CliExecutionContext {
-        ApplicationServices& application;
-        JobSystem& jobs;
-        const ConfigurationSnapshot& configuration;
         const CancellationToken& cancellation;
-        ICliOutputWriter& output;
-        InvocationId invocationId;
+        InvocationId             invocationId;
+        ICliProgressSink&        progress;
+        // ApplicationServices, JobSystem, ConfigurationSnapshot, and output writers
+        // are NOT exposed here. Inject domain services via the adapter constructor.
     };
 
     /**
@@ -183,11 +198,30 @@ namespace Horo::Cli {
 
         [[nodiscard]] virtual Result<CliCommandResult> Execute(
             const CliCommandRequest& request,
-            CliExecutionContext& context) = 0;
+            CliExecutionContext&     context) = 0;
     };
 
 }  // namespace Horo::Cli
 ```
+
+**Constructor injection** is the only approved mechanism for adapters to access domain
+services:
+
+```cpp
+// Correct: domain services injected at construction, not discovered at invoke time.
+class AssetCookCliAdapter final : public ICliCommandAdapter {
+public:
+    explicit AssetCookCliAdapter(IAssetCooker& cooker);
+
+    Result<CliCommandResult> Execute(
+        const CliCommandRequest& request,
+        CliExecutionContext&     context) override;
+
+private:
+    IAssetCooker& m_cooker; // injected, never fetched from ApplicationServices
+};
+```
+
 
 **Adapter Equivalence Rule**:
 For any shared operation (e.g., `project.create`, `project.validate`, `asset.cook`, `build.release`, `package.restore`):
@@ -231,7 +265,7 @@ must invoke the exact same underlying domain use-case service (`IProjectService`
 The migration path removes legacy ad-hoc parsing in `apps/horo-engine/main.cpp` without maintaining competing sources of truth:
 
 1. **Step 1 ([CLI-001.2] & [CLI-001.3])**: Implement `HoroEngine::CliHost` library with `CliCommandDescriptor`, `CliCommandRegistry`, `CliOptionParser`, and unit test suite.
-2. **Step 2 ([CLI-001.5])**: Introduce `CliDispatcher`, `CliExecutionContext`, and migrate smoke tests (`--emit-observability-smoke`, `--diagnostic-bundle`) into first-class `ICliCommandAdapter` registrations (`observability.smoke`, `diagnostics.bundle`).
+2. **Step 2 ([CLI-001.5])**: Introduce `CliDispatcher`, `CliExecutionContext`, and migrate smoke tests (`--emit-observability-smoke`, `--diagnostic-bundle`) into first-class `ICliCommandAdapter` registrations: `CommandPath{{"observability","smoke"}}`, `CommandPath{{"diagnostics","bundle"}}`. User-facing syntax: `horo-engine observability smoke`, `horo-engine diagnostics bundle`.
 3. **Step 3 ([CLI-001.6] & [CLI-001.7])**: Implement structured JSON/JSONL output presenters, cooperative cancellation handlers, and headless MCP serve composition (`horo-engine mcp serve`).
 4. **Step 4 (Phase-out)**: Replace `apps/horo-engine/main.cpp` entry point with `Horo::Cli::CliHost::Run(argc, argv)`. Remove all legacy `ParseOptions` code.
 

--- a/docs/adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
+++ b/docs/adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
@@ -1,4 +1,4 @@
-# ADR-013: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision
+# ADR-019: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision
 
 - **Status**: Proposed
 - **Date**: 2026-08-28

--- a/docs/adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
+++ b/docs/adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
@@ -106,7 +106,7 @@ Horo Engine defines three distinct executable composition roots:
 - **Invariants**:
   - Strictly forbidden from linking `HoroEngine::Gui`, `HoroEngine::RenderFrontend`, `HoroEngine::RenderApi`, `HoroEngine::RuntimeScene`, `HoroEngine::GameplayRuntime`, `HoroEngine::Physics`, `HoroEngine::Audio`, or `HoroEngine::Networking`.
   - Cannot instantiate full scene pipelines or launch game runtime loops.
-  - Fast cold-start time (<10ms) and minimal memory footprint suitable for high-throughput containerized asset packaging.
+  - A bounded cold-start and memory budget suitable for high-throughput containerized asset packaging. Concrete thresholds require a release-build benchmark on each supported host profile.
 
 ---
 

--- a/docs/adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
+++ b/docs/adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
@@ -1,4 +1,4 @@
-# ADR-027: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision
+# ADR-019: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision
 
 - **Status**: Proposed
 - **Date**: 2026-08-28

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
-| [013](013-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md) | CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision | proposed | 2026-08-28 |
+| [013](019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md) | CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision | proposed | 2026-08-28 |
 
 ## Conventions
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,7 +29,7 @@ to the replacement.
 | [024](024-perception-ownership-sense-policy-and-budget.md) | Perception Ownership, Sense Policy and Budget Decision | proposed | 2026-08-28 |
 | [025](025-ai-decision-assets-and-gameplay-behavior-boundary.md) | AI Decision Assets and Shared Gameplay Behavior Boundary | proposed | 2026-08-28 |
 | [026](026-large-world-precision-and-floating-origin-strategy.md) | Large-World Precision and Floating Origin Strategy | proposed | 2026-08-28 |
-| [027](027-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md) | CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision | proposed | 2026-08-28 |
+| [019](019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md) | CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision | proposed | 2026-08-28 |
 
 ## Conventions
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,6 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
-| [011](011-command-registration-permissions-threading-and-packaged-build-policy.md) | Command Registration, Permissions, Threading and Packaged-Build Policy | proposed | 2026-08-28 |
 | [013](013-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md) | CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision | proposed | 2026-08-28 |
 
 ## Conventions

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,8 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
+| [011](011-command-registration-permissions-threading-and-packaged-build-policy.md) | Command Registration, Permissions, Threading and Packaged-Build Policy | proposed | 2026-08-28 |
+| [013](013-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md) | CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision | proposed | 2026-08-28 |
 
 ## Conventions
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
-| [013](019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md) | CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision | proposed | 2026-08-28 |
+| [019](019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md) | CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision | proposed | 2026-08-28 |
 
 ## Conventions
 

--- a/docs/architecture/interfaces/cli-architecture.md
+++ b/docs/architecture/interfaces/cli-architecture.md
@@ -84,9 +84,11 @@ composition roots:
 - **Ownership**: Standalone, lightweight CLI utility for `.horo` asset pak creation,
   table of contents (TOC) inspection, integrity verification, compression, encryption,
   and extraction.
-- **Dependencies**: Links ONLY `HoroEngine::Archive` (pak format, SHA-256/CRC32
-  verification, AES-128-CTR crypto), `HoroEngine::Foundation`, `HoroEngine::Platform`,
-  and minimal asset compilation adapters.
+- **Dependencies**: Links `HoroEngine::CliHost`, `HoroEngine::CliApi`,
+  `HoroEngine::Archive` (pak format, SHA-256/CRC32 verification, AES-128-CTR crypto),
+  `HoroEngine::Foundation`, `HoroEngine::Platform`, and minimal asset compilation
+  adapters. **`CliHost` is the sole argv parser for `horopak`; no second CLI
+  implementation exists.**
 - **Invariants**:
   - Strictly forbidden from linking `HoroEngine::Gui`, `HoroEngine::RenderFrontend`,
     `HoroEngine::RenderApi`, `HoroEngine::RuntimeScene`, `HoroEngine::GameplayRuntime`,
@@ -189,15 +191,31 @@ host-owned command registry.
 namespace Horo::Cli {
 
     /**
-     * @brief Context provided to a CLI command adapter during execution.
+     * @brief Presentation-independent progress/event sink exposed to adapters.
+     *
+     * `CliOutputPresenter` implements this interface and converts events to the
+     * active output mode (progress bar for human, JSONL record for jsonl).
+     * Adapters must not write stdout or stderr directly.
+     */
+    class ICliProgressSink {
+    public:
+        virtual ~ICliProgressSink() = default;
+        virtual void Report(const CliProgressEvent& event) = 0;
+    };
+
+    /**
+     * @brief Invocation-scoped context provided to a CLI command adapter during execution.
+     *
+     * Adapters receive their domain-service dependencies by constructor injection at
+     * registration time. This context carries only the values scoped to a single
+     * command invocation: cancellation, identity, and progress reporting.
      */
     struct CliExecutionContext {
-        ApplicationServices& application;
-        JobSystem& jobs;
-        const ConfigurationSnapshot& configuration;
         const CancellationToken& cancellation;
-        ICliOutputWriter& output;
-        InvocationId invocationId;
+        InvocationId             invocationId;
+        ICliProgressSink&        progress;
+        // ApplicationServices, JobSystem, ConfigurationSnapshot, and output writers
+        // are not exposed here. Domain services are injected via the adapter constructor.
     };
 
     /**
@@ -211,10 +229,28 @@ namespace Horo::Cli {
 
         [[nodiscard]] virtual Result<CliCommandResult> Execute(
             const CliCommandRequest& request,
-            CliExecutionContext& context) = 0;
+            CliExecutionContext&     context) = 0;
     };
 
 }  // namespace Horo::Cli
+```
+
+**Constructor injection** is the only approved mechanism for adapters to access domain
+services:
+
+```cpp
+// Correct: domain services injected at construction, not discovered at invoke time.
+class AssetCookCliAdapter final : public ICliCommandAdapter {
+public:
+    explicit AssetCookCliAdapter(IAssetCooker& cooker);
+
+    Result<CliCommandResult> Execute(
+        const CliCommandRequest& request,
+        CliExecutionContext&     context) override;
+
+private:
+    IAssetCooker& m_cooker; // injected, not fetched from ApplicationServices
+};
 ```
 
 ### Adapter Equivalence Contract
@@ -327,6 +363,34 @@ In structured modes:
 Commands do not silently change schema based on TTY presence. TTY detection may
 change presentation only in human mode.
 
+### Output Mode Contract
+
+| Mode | `stdout` | Progress / events |
+|:---|:---|:---|
+| `human` | Final human-readable payload | TTY: live progress bar on `stderr`. Non-TTY: rate-limited phase updates on `stderr`. |
+| `json` | **Single** final JSON envelope only. Never emits partial or streaming records. | Not emitted on `stdout`. Optional human-readable progress on `stderr`; machine consumers must ignore `stderr`. |
+| `jsonl` | One JSON object per line: zero or more progress/event records, then one terminal result record. | Events appear on `stdout` as JSONL; no ANSI sequences. |
+
+`--output=json` on a long-running operation (e.g. `horo-engine asset cook --output=json`)
+yields **one** envelope at completion. Machine consumers that need incremental progress must
+use `--output=jsonl`.
+
+### Output Ownership
+
+Final result and streaming progress have distinct owners. `CliOutputPresenter` is
+the only component that writes to `stdout` or `stderr`:
+
+```text
+Final payload:
+  adapter -> CliCommandResult -> CliOutputPresenter -> stdout
+
+Streaming progress/events:
+  adapter -> ICliProgressSink -> CliOutputPresenter -> stdout (jsonl) or stderr (human)
+```
+
+Adapters never write `stdout` or `stderr` directly. `ICliOutputWriter` is not
+part of the adapter contract.
+
 ## Structured Output Envelope
 
 Structured output modes use a stable top-level envelope unless a command
@@ -371,7 +435,26 @@ records only when requested.
 
 Progress is bounded and never delays the operation because a consumer is slow.
 
+
 ## Cancellation And Signals
+
+### Signal Ownership Chain
+
+```text
+OS SIGINT / SIGTERM
+   -> Platform signal bridge (HoroEngine::Platform)
+   -> CancellationSource.cancel()
+   -> CancellationToken
+   -> adapter / domain use case
+```
+
+- **`HoroEngine::Platform`** owns signal registration and the typed bridge. Domain
+  operations and adapters never install OS signal handlers.
+- **`CliHost`** owns orchestration: it subscribes to the process `CancellationSource`,
+  aborts in-flight dispatch, and maps cooperative cancellation to exit code `7`.
+- Domain operations observe `CancellationToken` and stop at safe checkpoints.
+
+### Cancellation Semantics
 
 The first interrupt requests cooperative cancellation. A second interrupt within
 a configured period may request forced host termination after emergency
@@ -385,6 +468,7 @@ Cancellation:
 - returns the cancellation exit category
 
 The CLI does not leave background jobs running after process exit.
+
 
 ## Input Sources
 
@@ -435,7 +519,7 @@ Stable categories:
 | `6` | **Security / Permission Error** | Access denied, untrusted script execution, or unauthorized cvar/command execution. |
 | `7` | **Cancelled / Interrupted** | Operation was cancelled cooperatively via `SIGINT`/`SIGTERM` or cancellation token. |
 | `8` | **Timeout** | Operation exceeded its declared execution timeout. |
-| `10` | **Internal Invariant Failure** | Engine bug, unhandled internal invariant violation, or memory corruption. |
+| `10` | **Internal Invariant Failure** | Engine bug or unexpected internal invariant violation detected in-process. Not a crash mapping — `SIGSEGV`, `SIGABRT`, and other fatal signals keep OS-native termination semantics and are not rewritten into `10`. |
 
 Code `1` is reserved for legacy or host-adapter failures that occur before the
 Horo error mapping layer is available, such as an uncaught host exception or a
@@ -473,7 +557,9 @@ without maintaining competing sources of truth:
    `CliCommandRegistry`, and `CliOptionParser`.
 2. **Dispatch & Adapters**: Introduce `CliDispatcher`, `CliExecutionContext`, and
    migrate built-in commands (`--emit-observability-smoke`, `--diagnostic-bundle`)
-   into typed `ICliCommandAdapter` registrations (`observability.smoke`, `diagnostics.bundle`).
+   into typed `ICliCommandAdapter` registrations:
+   `CommandPath{{"observability","smoke"}}`, `CommandPath{{"diagnostics","bundle"}}`.
+   User-facing syntax: `horo-engine observability smoke`, `horo-engine diagnostics bundle`.
 3. **Structured Streams & MCP Serve**: Implement JSON/JSONL output presenters,
    cancellation hooks, and headless `horo-engine mcp serve` composition.
 4. **Host Switchover**: Replace `apps/horo-engine/main.cpp` entry point with

--- a/docs/architecture/interfaces/cli-architecture.md
+++ b/docs/architecture/interfaces/cli-architecture.md
@@ -7,7 +7,7 @@ integration, output, exit codes, progress, cancellation, configuration,
 executable composition, adapter equivalence, and testing for the `horo-engine`
 and `horopak` command-line hosts.
 
-Normative decision: [ADR-013: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision](../../adr/013-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md).
+Normative decision: [ADR-019: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision](../../adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md).
 
 ## Core Decisions
 
@@ -497,7 +497,7 @@ Required tests cover:
 
 ## Related Documents
 
-- [ADR-013: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision](../../adr/013-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md)
+- [ADR-019: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision](../../adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md)
 - [ADR-004: CLI / Core / GUI Boundary](../../adr/004-cli-core-gui-boundary.md)
 - [System Design](../foundation/system-design.md)
 - [Error And Diagnostics](../foundation/error-and-diagnostics.md)

--- a/docs/architecture/interfaces/cli-architecture.md
+++ b/docs/architecture/interfaces/cli-architecture.md
@@ -7,7 +7,7 @@ integration, output, exit codes, progress, cancellation, configuration,
 executable composition, adapter equivalence, and testing for the `horo-engine`
 and `horopak` command-line hosts.
 
-Normative decision: [ADR-027: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision](../../adr/027-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md).
+Normative decision: [ADR-019: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision](../../adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md).
 
 ## Core Decisions
 
@@ -584,7 +584,7 @@ Required tests cover:
 
 ## Related Documents
 
-- [ADR-027: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision](../../adr/027-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md)
+- [ADR-019: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision](../../adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md)
 - [ADR-004: CLI / Core / GUI Boundary](../../adr/004-cli-core-gui-boundary.md)
 - [System Design](../foundation/system-design.md)
 - [Error And Diagnostics](../foundation/error-and-diagnostics.md)

--- a/docs/architecture/interfaces/cli-architecture.md
+++ b/docs/architecture/interfaces/cli-architecture.md
@@ -92,8 +92,9 @@ composition roots:
     `HoroEngine::RenderApi`, `HoroEngine::RuntimeScene`, `HoroEngine::GameplayRuntime`,
     `HoroEngine::Physics`, `HoroEngine::Audio`, or `HoroEngine::Networking`.
   - Cannot instantiate full scene pipelines or launch game runtime loops.
-  - Fast cold-start time (<10ms) and minimal memory footprint suitable for
-    high-throughput containerized asset packaging.
+  - A bounded cold-start and memory budget suitable for high-throughput
+    containerized asset packaging. Concrete thresholds require a release-build
+    benchmark on each supported host profile.
 
 ## Host Model and Execution Pipeline
 

--- a/docs/architecture/interfaces/cli-architecture.md
+++ b/docs/architecture/interfaces/cli-architecture.md
@@ -3,45 +3,137 @@
 ## Purpose
 
 This document defines command discovery, parsing, application use-case
-integration, output, exit codes, progress, cancellation, configuration, and
-testing for the `horo-engine` and `horopak` command-line hosts.
+integration, output, exit codes, progress, cancellation, configuration,
+executable composition, adapter equivalence, and testing for the `horo-engine`
+and `horopak` command-line hosts.
+
+Normative decision: [ADR-013: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision](../../adr/013-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md).
 
 ## Core Decisions
 
-- CLI commands are host adapters over shared application use cases.
+- `HoroEngine::CliHost` owns option parsing, command registry, help formatting,
+  execution dispatch, structured presentation, and exit-code mapping.
+- CLI commands are host presentation adapters over shared application use cases
+  via `ICliCommandAdapter`.
 - Parsing, execution, and presentation are separate stages.
 - Every command declares human and machine-readable output contracts.
 - Machine-readable stdout never contains logs, progress decoration, or prompts.
 - Exit codes represent stable categories.
 - Long-running commands expose cancellation and progress without requiring GUI.
 - Interactive prompting is explicit and disabled in non-interactive mode.
-- CLI execution can run headless without window, ImGui, or GPU dependencies
-  unless the command declares them.
+- Headless execution runs without window, ImGui, or GPU dependencies unless the
+  command explicitly declares them.
+- CLI registry, in-game Debug Console (`DBG-001`), and AI agent MCP tools (`MCP-001`)
+  maintain distinct registries with explicit delegation seams (`console exec`, `mcp serve`).
+- `horopak` is strictly limited to asset cooking, archive packing, verification, and
+  extraction, and cannot instantiate the engine GUI or rendering pipeline.
 
-## Host Model
+## Executable Composition and Responsibilities
+
+Horo Engine partitions command-line and automation tasks across three dedicated
+composition roots:
 
 ```text
-argv / environment
-        |
-        v
-CLI Parser
-        |
-        v
-Typed Command Request
-        |
-        v
-Application Use Case / Job Service
-        |
-        v
-Typed Result
-        |
-        v
-Human or Structured Presenter
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                                 Horo Engine                                 │
+├───────────────────────────┬───────────────────────────┬─────────────────────┤
+│        horo-engine        │        HoroEditor         │       horopak       │
+│                           │                           │                     │
+│ - Headless host & CLI     │ - Graphical Editor IDE    │ - Standalone pack   │
+│ - Project / Asset / Test  │ - ImGui screen host       │   and cook utility  │
+│ - Headless MCP server     │ - Viewport rendering      │ - Archive format    │
+│ - Zero GUI / GPU default  │ - Embedded MCP server     │ - Zero GUI/Renderer │
+└───────────────────────────┴───────────────────────────┴─────────────────────┘
+```
+
+### 1. `horo-engine` (Primary Host & Terminal CLI)
+
+- **Binary**: `apps/horo-engine`
+- **Ownership**: The primary terminal executable, batch automation host, test runner,
+  and headless MCP server.
+- **Dependencies**: Links `HoroEngine::Application`, `HoroEngine::CliHost`,
+  `HoroEngine::Platform`, `HoroEngine::Foundation`, `HostObservability`, and domain
+  service libraries (`HoroEngine::Assets`, `HoroEngine::Testing`,
+  `HoroEngine::ProjectMigrations`).
+- **Invariants**:
+  - Compiles and runs in headless environments (CI runners, containers, servers)
+    without display servers (X11, Wayland, Cocoa) or GPU hardware contexts.
+  - Does NOT link `HoroEngine::Gui`, ImGui, or concrete viewport renderers
+    (`HoroEngine::EditorViewportOpenGL`, `HoroEngine::EditorViewportMetal`).
+  - Commands requiring GPU acceleration (e.g. GPU baking) declare explicit
+    capabilities and select null/headless backends when run without display hardware.
+
+### 2. `HoroEditor` (Graphical IDE & Embedded MCP Host)
+
+- **Binary**: `apps/HoroEditor`
+- **Ownership**: The graphical authoring environment, document workspace, docked
+  panel host, and live viewport render extractor.
+- **Dependencies**: Links `HoroEngine::Gui`, `HoroEngine::EditorServices`,
+  `HoroEngine::EditorRenderExtraction`, `HoroEngine::RenderFrontend`,
+  `HoroEngine::Runtime`, concrete render viewports (`OpenGL` / `Metal`), and
+  `HoroEngine::Mcp`.
+- **Invariants**:
+  - Owns window creation, OS presentation loops, ImGui frame rendering, and
+    viewport picking.
+  - Can host `McpServer` over stdio or local HTTP/SSE while the editor runs,
+    dispatching agent tool calls directly to the main editor thread.
+
+### 3. `horopak` (Specialized Asset Packaging & Cook Utility)
+
+- **Binary**: `apps/horopak`
+- **Ownership**: Standalone, lightweight CLI utility for `.horo` asset pak creation,
+  table of contents (TOC) inspection, integrity verification, compression, encryption,
+  and extraction.
+- **Dependencies**: Links ONLY `HoroEngine::Archive` (pak format, SHA-256/CRC32
+  verification, AES-128-CTR crypto), `HoroEngine::Foundation`, `HoroEngine::Platform`,
+  and minimal asset compilation adapters.
+- **Invariants**:
+  - Strictly forbidden from linking `HoroEngine::Gui`, `HoroEngine::RenderFrontend`,
+    `HoroEngine::RenderApi`, `HoroEngine::RuntimeScene`, `HoroEngine::GameplayRuntime`,
+    `HoroEngine::Physics`, `HoroEngine::Audio`, or `HoroEngine::Networking`.
+  - Cannot instantiate full scene pipelines or launch game runtime loops.
+  - Fast cold-start time (<10ms) and minimal memory footprint suitable for
+    high-throughput containerized asset packaging.
+
+## Host Model and Execution Pipeline
+
+```text
+argv / environment / stdin
+          │
+          ▼
+┌──────────────────┐
+│  CliOptionParser │ ──> Syntax diagnostics (Exit Code 2)
+└─────────┬────────┘
+          │ Typed Request
+          ▼
+┌──────────────────┐
+│ CliCommandRegistry│ <── Validated Descriptors from built-in & domain modules
+└─────────┬────────┘
+          │ Resolved Descriptor & Adapter
+          ▼
+┌──────────────────┐
+│  CliDispatcher   │ ──> Binds CliExecutionContext (Jobs, Config, Token, Redaction)
+└─────────┬────────┘
+          │ Dispatches request
+          ▼
+┌──────────────────┐
+│ICliCommandAdapter│ ──> Calls Application Services / Domain Use Cases
+└─────────┬────────┘
+          │ Typed Result
+          ▼
+┌──────────────────┐
+│CliOutputPresenter│ ──> Formats stdout (Pure Human/JSON/JSONL) & stderr (Logs/Progress)
+└─────────┬────────┘
+          │
+          ▼
+     OS Exit Code (0, 2..8, 10)
 ```
 
 The CLI does not invoke GUI code or synthesize editor widget actions.
 
 ## Command Registry
+
+Every CLI command is declared through a validated `CliCommandDescriptor`:
 
 ```cpp
 struct CliCommandDescriptor {
@@ -85,32 +177,107 @@ horopak verify
 Duplicate command paths and option names are startup errors. Help is generated
 from the typed registry.
 
-## Command Contributions
+## Command Contributions & Adapter Equivalence
 
-CLI commands are contributed through validated command descriptors. Built-in
-modules, first-party tools, and approved extension packages may contribute
-commands only through the host-owned command registry.
+CLI commands are contributed through validated command descriptors and typed
+command adapters (`ICliCommandAdapter`). Built-in modules, first-party tools,
+and approved extension packages may contribute commands only through the
+host-owned command registry.
 
-A command contribution declares:
+```cpp
+namespace Horo::Cli {
 
-- command path
-- option schema
-- output schema
-- required capabilities
-- supported hosts
-- side-effect policy
-- interactive policy
-- cancellation and timeout policy
-- stdin policy
-- contract version
+    /**
+     * @brief Context provided to a CLI command adapter during execution.
+     */
+    struct CliExecutionContext {
+        ApplicationServices& application;
+        JobSystem& jobs;
+        const ConfigurationSnapshot& configuration;
+        const CancellationToken& cancellation;
+        ICliOutputWriter& output;
+        InvocationId invocationId;
+    };
 
-The host validates all command descriptors before exposing them in help,
-completion, or execution. Duplicate command paths, incompatible option schemas,
-unauthorized capability requirements, or unsupported hosts fail activation.
+    /**
+     * @brief Interface implemented by domain modules to contribute CLI behavior.
+     */
+    class ICliCommandAdapter {
+    public:
+        virtual ~ICliCommandAdapter() = default;
 
-Built-in commands and contributed commands use the same descriptor shape. The
-host rejects contributions that conflict with existing commands or that attempt
-to introduce commands without declaring their hosts and side effects.
+        [[nodiscard]] virtual const CliCommandDescriptor& GetDescriptor() const noexcept = 0;
+
+        [[nodiscard]] virtual Result<CliCommandResult> Execute(
+            const CliCommandRequest& request,
+            CliExecutionContext& context) = 0;
+    };
+
+}  // namespace Horo::Cli
+```
+
+### Adapter Equivalence Contract
+
+GUI, CLI, and MCP adapters must call the same application use cases for the same
+business operation. Differences are limited to:
+
+- input parsing and validation envelope
+- presentation format
+- transport/protocol error envelope
+- interactive prompting policy
+- progress delivery mechanism
+
+Domain modules (`AssetCooker`, `ProjectService`, `TestRunner`, `ReleasePipeline`)
+own use-case logic, transactions, and state invariants. They must never place
+business logic, scene mutation paths, asset import logic, or build algorithms
+inside CLI handlers.
+
+## Separation of Concerns: CLI, Debug Console, and MCP
+
+CLI commands, Runtime Debug Console commands (`DBG-001`), and MCP tools (`MCP-001`)
+address different interaction paradigms and maintain distinct registries:
+
+```text
+                  ┌──────────────────────────────────────────────┐
+                  │            Shared Domain Services            │
+                  │  (AssetCooker, ProjectService, TestRunner,   │
+                  │   ReleasePipeline, DebugConsoleService)      │
+                  └──────▲────────────────▲──────────────▲───────┘
+                         │                │              │
+                         │                │              │
+          ┌──────────────┴──────┐  ┌──────┴──────┐  ┌────┴─────────────┐
+          │ ICliCommandAdapter  │  │ IDebugCmd   │  │ McpToolAdapter   │
+          └──────────────▲──────┘  └──────▲──────┘  └────▲─────────────┘
+                         │                │              │
+     ┌───────────────────┴──────┐  ┌──────┴──────┐  ┌────┴─────────────┐
+     │   CliCommandRegistry     │  │ DebugConsole│  │ McpController    │
+     │   (HoroEngine::CliHost)  │  │ (Runtime)   │  │ (HoroEngine::Mcp)│
+     └───────────────────▲──────┘  └──────▲──────┘  └────▲─────────────┘
+                         │                │              │
+                    Terminal argv    In-Game Console   AI JSON-RPC
+```
+
+1. **CLI Registry (`CliCommandRegistry`)**:
+   - Shell argument syntax (`--flag`, positional arguments, `--` termination).
+   - Stdin streaming policies, human vs JSON/JSONL output formatting, and OS exit codes.
+2. **Debug Console (`DebugConsole`)**:
+   - In-game console syntax, cvar read/write, autocomplete, in-game terminal overlay,
+     game pause/step integration, product-profile gating (shipping vs dev).
+3. **MCP (`McpController`)**:
+   - JSON-RPC 2.0 protocol over stdio/SSE with JSON Schema parameter definitions,
+     structured tool responses, and LLM context payloads.
+
+### Delegation Seams
+
+- **Debug Console Delegation**:
+  The CLI does not duplicate runtime console commands. `horo-engine console exec "<cmd>"`
+  (or `--exec-console="<cmd>"`) delegates execution to `DebugConsoleService` /
+  `IDebugConsoleHost` on an initialized headless or connected instance, respecting
+  console permissions and product profiles.
+- **Headless MCP Serve**:
+  `horo-engine mcp serve` initializes the headless `McpServer` over stdio or SSE.
+  The CLI ensures strict stream isolation: JSON-RPC communication on `stdout` is
+  isolated from engine diagnostic logging (routed to `stderr`).
 
 ## Parsing
 
@@ -139,26 +306,6 @@ allowed to control.
 
 The effective safe configuration and its provenance may be shown with a
 diagnostic command. Secret values are never printed.
-
-## Execution Context
-
-```cpp
-struct CliExecutionContext {
-    ApplicationServices& application;
-    JobSystem& jobs;
-    ConfigurationSnapshot configuration;
-    CancellationToken cancellation;
-    CliOutput& output;
-};
-```
-
-Concrete commands receive the narrow application capabilities they require
-rather than an omnibus mutable engine object.
-
-Runtime console commands exposed through CLI, such as `horo-engine console exec`,
-use the same descriptor registry, product-profile policy, and permission checks
-as the in-game console. The CLI adapter may submit commands to a running process
-only through an explicitly enabled local or remote console endpoint.
 
 ## Output Modes
 
@@ -276,17 +423,18 @@ ordinary command arguments.
 
 Stable categories:
 
-| Code | Category                                      |
-| ---: | --------------------------------------------- |
-|  `0` | Success                                       |
-|  `2` | Usage or command-line validation error        |
-|  `3` | Project or input validation failure           |
-|  `4` | Required capability or dependency unavailable |
-|  `5` | Operation failed                              |
-|  `6` | Security or permission failure                |
-|  `7` | Cancelled or interrupted                      |
-|  `8` | Timeout                                       |
-| `10` | Internal invariant or unexpected host failure |
+| Code | Category | Description |
+|:---:|:---|:---|
+| `0` | **Success** | Command completed successfully. |
+| `1` | **Host Failure** | Uncaught host-level exception or pre-initialization runtime failure. |
+| `2` | **Usage Error** | CLI syntax error, unknown flag, missing required argument, or invalid option value. |
+| `3` | **Input Validation Failure** | Target project, file path, scene, or input payload failed domain validation. |
+| `4` | **Capability Unavailable** | Required engine capability, host environment, or dependency is missing. |
+| `5` | **Operation Failed** | The requested domain operation encountered a functional error (e.g. compilation error, build failure). |
+| `6` | **Security / Permission Error** | Access denied, untrusted script execution, or unauthorized cvar/command execution. |
+| `7` | **Cancelled / Interrupted** | Operation was cancelled cooperatively via `SIGINT`/`SIGTERM` or cancellation token. |
+| `8` | **Timeout** | Operation exceeded its declared execution timeout. |
+| `10` | **Internal Invariant Failure** | Engine bug, unhandled internal invariant violation, or memory corruption. |
 
 Code `1` is reserved for legacy or host-adapter failures that occur before the
 Horo error mapping layer is available, such as an uncaught host exception or a
@@ -305,15 +453,6 @@ publish command requests through `EngineDataBus`.
 
 One-shot commands stop subscriptions before application services shut down.
 
-## MCP Serve Mode
-
-`horo-engine mcp serve` composes the documented headless MCP host. CLI parsing
-configures the service; MCP requests still execute through shared application
-operations and follow [MCP Architecture](./mcp-architecture.md).
-
-Protocol output and ordinary CLI presentation use separate channels so logs
-cannot corrupt framing.
-
 ## Observability
 
 CLI logs use stderr and the common structured schema. Each command establishes
@@ -324,38 +463,42 @@ Arguments are redacted before logging. Diagnostic bundles may include the safe
 effective command configuration but not credentials or arbitrary environment
 variables.
 
+## Migration from Legacy Ad-Hoc Parsing
+
+The migration path removes legacy ad-hoc parsing in `apps/horo-engine/main.cpp`
+without maintaining competing sources of truth:
+
+1. **Foundation**: Implement `HoroEngine::CliHost` with `CliCommandDescriptor`,
+   `CliCommandRegistry`, and `CliOptionParser`.
+2. **Dispatch & Adapters**: Introduce `CliDispatcher`, `CliExecutionContext`, and
+   migrate built-in commands (`--emit-observability-smoke`, `--diagnostic-bundle`)
+   into typed `ICliCommandAdapter` registrations (`observability.smoke`, `diagnostics.bundle`).
+3. **Structured Streams & MCP Serve**: Implement JSON/JSONL output presenters,
+   cancellation hooks, and headless `horo-engine mcp serve` composition.
+4. **Host Switchover**: Replace `apps/horo-engine/main.cpp` entry point with
+   `Horo::Cli::CliHost::Run(argc, argv)` and delete legacy `ParseOptions`.
+
 ## Testing
 
 Required tests cover:
 
-- registry uniqueness and generated help
-- parser success and diagnostic failures
-- option/configuration precedence
-- stdout purity in JSON and JSONL modes
-- stable exit-code mapping
+- registry uniqueness, conflict rejection, and generated help
+- parser success, enum/range validation, and diagnostic failures
+- option/configuration precedence and provenance
+- stdout purity in JSON and JSONL modes (zero logs or control sequences)
+- stable exit-code mapping across all 10 categories
 - TTY and non-TTY progress behavior
-- cancellation and subprocess termination
-- non-interactive prompt failure
-- redaction of arguments and credentials
-- headless commands without GUI or renderer
+- cancellation, signals, and subprocess termination
+- non-interactive prompt failure and fallback
+- redaction of arguments and credentials in logs and diagnostics
+- headless commands executing without GUI or renderer targets
 - equivalence of GUI, CLI, and MCP use-case results
-
-## Adapter Equivalence
-
-GUI, CLI, and MCP adapters must call the same application use cases for the same
-business operation. Differences are limited to:
-
-- input parsing and validation envelope
-- presentation format
-- transport/protocol error envelope
-- interactive prompting policy
-- progress delivery mechanism
-
-They must not implement separate business rules, scene mutation paths, asset
-import logic, build behavior, or release policy.
+- `horopak` isolation (absence of GUI/RenderApi linkage)
 
 ## Related Documents
 
+- [ADR-013: CLI Host, Command Ownership, Adapter Equivalence and horopak Boundary Decision](../../adr/013-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md)
+- [ADR-004: CLI / Core / GUI Boundary](../../adr/004-cli-core-gui-boundary.md)
 - [System Design](../foundation/system-design.md)
 - [Error And Diagnostics](../foundation/error-and-diagnostics.md)
 - [Configuration System](../foundation/configuration-system.md)


### PR DESCRIPTION
## Summary

Completes M0 Architecture Decision ticket #1858 ([CLI-001.1]) by ratifying the ownership model, executable composition boundaries, separation of presentation interfaces (CLI vs Debug Console vs MCP), domain adapter equivalence, and `horopak` isolation.

Closes #1858

## Key Ratified Decisions

1. **CLI Host Ownership (`HoroEngine::CliHost`)**:
   - `HoroEngine::CliHost` (target `HoroCliHost`, namespace `Horo::Cli`) is the single authoritative owner of command descriptor registry (`CliCommandRegistry`), option parsing (`CliOptionParser`), execution dispatch (`CliDispatcher`), structured presentation (`CliOutputPresenter`), and exit-code mapping (`CliExitCode`).
2. **Executable Composition & Responsibilities**:
   - `horo-engine`: Primary headless engine host, automation CLI, test runner, and headless MCP server. Has zero GUI or concrete viewport renderers by default.
   - `HoroEditor`: Graphical editor IDE, viewport rendering, and embedded MCP server in GUI mode.
   - `horopak`: Specialized standalone asset packaging, cooking, and pak archive utility linking ONLY `HoroEngine::Archive`, `HoroEngine::Foundation`, and `HoroEngine::Platform`. Strictly forbidden from linking GUI, scene, or rendering pipelines.
3. **Separation of Presentation Interfaces (CLI vs Debug Console vs MCP)**:
   - CLI command registry (`CliCommandRegistry`), runtime debug console (`DebugConsole` / `DBG-001`), and MCP tools (`McpController` / `MCP-001`) maintain distinct registries tailored to their respective protocols and lifecycles.
   - **Delegation Seam**: CLI exposes `horo-engine console exec "<cmd>"` (and `--exec-console="<cmd>"`) delegating to `DebugConsoleService` / `IDebugConsoleHost`.
   - **Headless MCP Serve**: `horo-engine mcp serve` delegates JSON-RPC transport to `McpServer` with strict stdout/stderr stream isolation.
4. **Adapter Equivalence (`ICliCommandAdapter`)**:
   - Domain modules (`AssetCooker`, `ProjectService`, `TestRunner`, `ReleasePipeline`) provide typed command adapters conforming to `ICliCommandAdapter`.
   - Business rules, state mutation, and asset/build logic remain strictly within domain services. CLI handlers only transform inputs and format outputs.
5. **Output Purity & Exit Codes**:
   - Strict stdout purity in structured modes (`json`, `jsonl`) with zero logs, ANSI sequences, or prompts.
   - 10 stable numeric exit categories (`0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `10`).

## Acceptance Criteria Verification

- [x] Every CLI contract type and runtime service has one documented owner and dependency direction.
- [x] The migration path removes ad hoc parsing without preserving two competing command sources of truth.
- [x] `horopak` is limited to approved packaging capabilities and cannot expose the complete engine host.
- [x] Domain modules contribute adapters but cannot place business rules in CLI handlers.
- [x] CLI, MCP, and debug-console boundaries are explicit and protected by dependency tests.