### PR TITLE
docs(network): target ownership and dependency boundary decision HORO-1098 #1098 [NET-001.1]

### DIFF
--- a/docs/adr/011-network-target-ownership-and-dependency-boundary.md
+++ b/docs/adr/011-network-target-ownership-and-dependency-boundary.md
@@ -54,6 +54,7 @@ The network subsystem is decomposed into four discrete CMake targets:
 ```
 
 Rules:
+
 1. `HoroEngine::NetworkApi` depends **only** on `HoroEngine::Foundation`. It contains zero runtime logic, background threads, or socket code.
 2. `HoroEngine::NetworkRuntime` depends on `NetworkApi`, `Foundation`, and `Runtime`. It never links a concrete transport backend directly.
 3. Concrete transports (`NetworkTransportNull`, `NetworkTransportENet`) depend on `NetworkApi` and `Foundation` (plus private third-party libraries). They do not depend on `NetworkRuntime` or `HoroEngine::Runtime`.
@@ -62,6 +63,7 @@ Rules:
 ### 2. Encapsulation and Native Type Shielding
 
 Public headers under `include/Horo/Network/` and `include/Horo/Runtime/` MUST NOT include or expose:
+
 - OS socket headers (`<sys/socket.h>`, `<netinet/in.h>`, `<arpa/inet.h>`, `<winsock2.h>`, `<ws2tcpip.h>`)
 - Native socket descriptors or OS handles (`SOCKET`, `int fd`, file descriptors)
 - Cryptography / TLS context types (`SSL*`, `SSL_CTX*`, OpenSSL / mbedTLS headers)
@@ -73,6 +75,7 @@ All OS and third-party types remain strictly internal to the private compilation
 ### 3. Optional Link and Host Composition
 
 Networking is an optional engine capability.
+
 - **Offline / Non-Networked Products**: Products (such as single-player offline games, command-line utilities like `horopak`, asset compilers, or headless tools) do not link `NetworkRuntime` or concrete transports. Core engine composition, ECS, asset loading, and renderer pipelines operate normally without networking libraries present in the link graph.
 - **Single-Player / Headless Simulation**: If a game project uses replication interfaces or network components locally, the host composition root injects `HoroEngine::NetworkTransportNull`. `NetworkTransportNull` simulates loopback transport in memory without opening OS sockets or creating network I/O threads.
 - **Multiplayer Desktop & Dedicated Server**: Composition roots (`HoroEditor`, `horo-engine server`, game client) explicitly instantiate the chosen transport (`NetworkTransportENet` or platform backend) during startup and register it with `NetworkRuntime`. No static discovery or global registry side effects are allowed.
@@ -112,6 +115,7 @@ Network processing is cleanly partitioned between asynchronous I/O and frame-syn
 ```
 
 Key concurrency and lifecycle rules:
+
 - **Zero I/O Mutation**: Network I/O threads MUST NEVER mutate Scene, ECS, Entity, Component, Editor, or Gameplay state directly.
 - **Dedicated Frame Phases**: Frame execution includes explicit `NetworkPoll` (pre-simulation) and `NetworkFlush` (post-simulation) stages in `FrameScheduler`.
 - **Bounded Queues & Backpressure**: Inbound and outbound message queues have strict, configurable capacity limits. Queue overflow triggers explicit message-class policies (e.g. drop oldest unreliable state snapshot, reject send, or disconnect failing peer) rather than unbounded heap growth.
@@ -120,6 +124,7 @@ Key concurrency and lifecycle rules:
 ### 5. Deterministic Cancellation and Shutdown
 
 Network shutdown is deterministic, bounded, and resource-safe:
+
 - **Connection Teardown**: Transition through `Active -> Closing -> Closed`. A graceful disconnect sends a final disconnect packet with a reason code within a bounded timeout deadline (e.g., 200 ms). If the peer does not acknowledge within the timeout, the local connection is forcefully terminated.
 - **Cancellation**: Asynchronous operations (resolving DNS, connecting, transferring large assets) accept a `CancellationToken`. Triggering cancellation immediately halts processing and reclaims temporary resources without blocking caller threads.
 - **Host Teardown Order**: During engine shutdown, the composition root shuts down `NetworkRuntime` before `Runtime` and `Foundation`:
@@ -132,12 +137,14 @@ Network shutdown is deterministic, bounded, and resource-safe:
 ## Consequences
 
 ### Positive
+
 - Strict compile-time insulation: Changing transport libraries (e.g. upgrading ENet or adding WebRTC) never requires recompilation of gameplay or editor headers.
 - Safe concurrency: Main simulation and editor threads are completely protected from data races, mutex contention, and socket blocking.
 - Clean headless and test execution: `NetworkTransportNull` enables fast, fully deterministic unit and integration testing of replication and session logic without OS socket permissions or network ports.
 - Predictable performance: Bounded queues and dedicated frame ticking prevent network traffic bursts from causing memory blowouts or frame-rate hitches.
 
 ### Negative / Trade-offs
+
 - Message data must be copied across thread boundaries from I/O queues to the simulation thread (mitigated by bounded buffer pools and move semantics).
 - Disconnecting peers requires asynchronous coordination or bounded timeouts rather than instant synchronous socket teardown.
 

--- a/docs/adr/011-network-target-ownership-and-dependency-boundary.md
+++ b/docs/adr/011-network-target-ownership-and-dependency-boundary.md
@@ -1,0 +1,149 @@
+# ADR-011: Network Target Ownership and Dependency Boundary
+
+- **Status**: Proposed
+- **Date**: 2026-08-28
+- **Supersedes**: None
+- **Scope**: Network target topology, compile-time dependency directions, public API encapsulation, optional linking and composition, threading model, and deterministic lifecycle/shutdown.
+- **Issue**: [#1098](https://github.com/abdullahbodur/horo-engine/issues/1098) ([NET-001.1])
+- **JIRA**: HORO-1088
+- **Normative documents**:
+  - [Networking Architecture](../architecture/runtime/networking-architecture.md)
+  - [System Design](../architecture/foundation/system-design.md)
+  - [Desired Project Trees](../architecture/desired-project-tree.md)
+  - [Multiplayer Replication Architecture](../architecture/runtime/multiplayer-replication-architecture.md)
+
+## Context
+
+Horo Engine is a modular C++20 game engine and editor IDE. Real-time multiplayer and networked services require low-latency, reliable and unreliable packet transmission, session negotiation, state replication, and RPC mechanisms. However, networking is not required by every game, tool, or runtime composition (e.g. offline single-player games, offline command-line tooling, asset baking, or isolated simulation testing).
+
+In addition, networking implementations typically depend on platform-specific socket APIs (e.g., Berkeley sockets, Windows Sockets 2) and third-party transport/cryptography libraries (e.g., ENet, OpenSSL, libuv, WebRTC, SteamNetworkingSockets). Exposing raw socket descriptors, native event loops, or third-party headers to gameplay or editor code causes header pollution, fragile platform coupling, undefined concurrency behavior, and ABI instability.
+
+`docs/architecture/foundation/system-design.md` and `docs/architecture/runtime/networking-architecture.md` outline a layered design. Before implementation of [NET-001] proceeds, this ADR ratifies the exact CMake target boundaries, public/private header ownership, optional composition rules, frame scheduling phases, and lifecycle invariants.
+
+## Decision
+
+**The network subsystem is structured into four distinct target tiers with strict compile-time boundaries: `HoroEngine::NetworkApi` (public backend-neutral interfaces and value types), `HoroEngine::NetworkRuntime` (session coordination, message queues, and replication runtime), and private concrete transports (`HoroEngine::NetworkTransportENet`, `HoroEngine::NetworkTransportNull`). Public headers strictly encapsulate all native socket descriptors, TLS contexts, event loops, and third-party transport types. Networking is fully optional; applications and tools may link without network targets or compose `NetworkTransportNull`. All network ticking executes in dedicated frame phases (`NetworkPoll` and `NetworkFlush`), isolating background I/O threads from gameplay and editor state via bounded, thread-safe message queues.**
+
+### 1. Target Topology and Allowed Dependencies
+
+The network subsystem is decomposed into four discrete CMake targets:
+
+| Target | Role | Allowed Direct First-Party Dependencies | Public Surface |
+|---|---|---|---|
+| `HoroEngine::NetworkApi` | Backend-neutral public types, handles, traits, interfaces | `HoroEngine::Foundation` | Value types (`NetworkId`, `NetworkAddress`, `DeliveryPolicy`), generation handles (`ConnectionHandle`, `ListenerHandle`), error codes, message views, abstract `INetworkTransport` interfaces, replication traits |
+| `HoroEngine::NetworkRuntime` | Session management, replication engine, packet queueing | `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Runtime` | `NetworkRuntimeCoordinator`, `ConnectionStateMachine`, `ReplicationManager`, `NetworkSession`, channel multiplexing, bounded buffer policies |
+| `HoroEngine::NetworkTransportNull` | Deterministic in-memory/loopback/null transport | `HoroEngine::NetworkApi`, `HoroEngine::Foundation` | `NullTransportBackend` factory / descriptor for testing, headless simulation, and network-disabled fallback |
+| `HoroEngine::NetworkTransportENet` | Concrete UDP transport implementation | `HoroEngine::NetworkApi`, `HoroEngine::Foundation` | `ENetTransportBackend` factory / descriptor. All ENet headers, sockets, and platform dependencies are `PRIVATE` |
+
+```text
+               +---------------------------+
+               |   HoroEngine::Foundation  |
+               +-------------+-------------+
+                             ^
+                             |
+               +-------------+-------------+
+               |   HoroEngine::NetworkApi  |
+               +------+--------------+-----+
+                      ^              ^
+                      |              |
++---------------------+----+   +-----+-------------------------+
+| HoroEngine::NetworkRuntime|   | Concrete Transports (Private) |
+| (depends also on Runtime) |   | - NetworkTransportNull        |
++---------------------------+   | - NetworkTransportENet        |
+                                +-------------------------------+
+```
+
+Rules:
+1. `HoroEngine::NetworkApi` depends **only** on `HoroEngine::Foundation`. It contains zero runtime logic, background threads, or socket code.
+2. `HoroEngine::NetworkRuntime` depends on `NetworkApi`, `Foundation`, and `Runtime`. It never links a concrete transport backend directly.
+3. Concrete transports (`NetworkTransportNull`, `NetworkTransportENet`) depend on `NetworkApi` and `Foundation` (plus private third-party libraries). They do not depend on `NetworkRuntime` or `HoroEngine::Runtime`.
+4. Feature modules, gameplay modules, and editor panels consume `NetworkApi` and `NetworkRuntime` interfaces; they **never** depend on concrete transport targets.
+
+### 2. Encapsulation and Native Type Shielding
+
+Public headers under `include/Horo/Network/` and `include/Horo/Runtime/` MUST NOT include or expose:
+- OS socket headers (`<sys/socket.h>`, `<netinet/in.h>`, `<arpa/inet.h>`, `<winsock2.h>`, `<ws2tcpip.h>`)
+- Native socket descriptors or OS handles (`SOCKET`, `int fd`, file descriptors)
+- Cryptography / TLS context types (`SSL*`, `SSL_CTX*`, OpenSSL / mbedTLS headers)
+- Event loop types (libuv `uv_loop_t`, epoll, kqueue, IOCP handles)
+- Third-party transport types (`ENetHost`, `ENetPeer`, `ENetPacket`, `SteamNetworkingSockets`, etc.)
+
+All OS and third-party types remain strictly internal to the private compilation units (`src/runtime/networking/backends/...`) and are encapsulated via interface implementations or Pimpl idioms. Addresses are represented by `Horo::Network::NetworkAddress` value types; connections and listeners are referenced by generation-checked `ConnectionHandle` and `ListenerHandle` identifiers.
+
+### 3. Optional Link and Host Composition
+
+Networking is an optional engine capability.
+- **Offline / Non-Networked Products**: Products (such as single-player offline games, command-line utilities like `horopak`, asset compilers, or headless tools) do not link `NetworkRuntime` or concrete transports. Core engine composition, ECS, asset loading, and renderer pipelines operate normally without networking libraries present in the link graph.
+- **Single-Player / Headless Simulation**: If a game project uses replication interfaces or network components locally, the host composition root injects `HoroEngine::NetworkTransportNull`. `NetworkTransportNull` simulates loopback transport in memory without opening OS sockets or creating network I/O threads.
+- **Multiplayer Desktop & Dedicated Server**: Composition roots (`HoroEditor`, `horo-engine server`, game client) explicitly instantiate the chosen transport (`NetworkTransportENet` or platform backend) during startup and register it with `NetworkRuntime`. No static discovery or global registry side effects are allowed.
+
+### 4. Threading Model and Frame Lifecycle
+
+Network processing is cleanly partitioned between asynchronous I/O and frame-synchronized gameplay execution:
+
+```text
+[ Background I/O Thread ]
+  Socket poll / recv / decrypt / frame
+         |
+         v (Push to bounded thread-safe queue)
+  +----------------------------------------------------+
+  | Inbound Message Queue (Bounded Ring / Mutex Queue) |
+  +----------------------------------------------------+
+         |
+         v (Drain during NetworkPoll phase)
+[ Simulation / Game Main Thread ]
+  1. FrameScheduler -> NetworkPoll phase:
+     - Drain inbound queues
+     - Update ConnectionStateMachine
+     - Dispatch received messages & snapshots to ReplicationManager / Game
+  2. FrameScheduler -> Simulation / Physics / Behaviors
+  3. FrameScheduler -> NetworkFlush phase:
+     - Collect dirty replicated properties
+     - Serialize outbound replication snapshots and RPCs
+     - Push to outbound queues
+         |
+         v
+  +-----------------------------------------------------+
+  | Outbound Message Queue (Bounded Ring / Mutex Queue) |
+  +-----------------------------------------------------+
+         |
+         v (Drain, encrypt, socket send)
+[ Background I/O Thread ]
+```
+
+Key concurrency and lifecycle rules:
+- **Zero I/O Mutation**: Network I/O threads MUST NEVER mutate Scene, ECS, Entity, Component, Editor, or Gameplay state directly.
+- **Dedicated Frame Phases**: Frame execution includes explicit `NetworkPoll` (pre-simulation) and `NetworkFlush` (post-simulation) stages in `FrameScheduler`.
+- **Bounded Queues & Backpressure**: Inbound and outbound message queues have strict, configurable capacity limits. Queue overflow triggers explicit message-class policies (e.g. drop oldest unreliable state snapshot, reject send, or disconnect failing peer) rather than unbounded heap growth.
+- **Continuations**: State transitions (e.g. peer connected, disconnected, auth failed) are marshaled to the owner thread via lightweight continuations executed during `NetworkPoll`.
+
+### 5. Deterministic Cancellation and Shutdown
+
+Network shutdown is deterministic, bounded, and resource-safe:
+- **Connection Teardown**: Transition through `Active -> Closing -> Closed`. A graceful disconnect sends a final disconnect packet with a reason code within a bounded timeout deadline (e.g., 200 ms). If the peer does not acknowledge within the timeout, the local connection is forcefully terminated.
+- **Cancellation**: Asynchronous operations (resolving DNS, connecting, transferring large assets) accept a `CancellationToken`. Triggering cancellation immediately halts processing and reclaims temporary resources without blocking caller threads.
+- **Host Teardown Order**: During engine shutdown, the composition root shuts down `NetworkRuntime` before `Runtime` and `Foundation`:
+  1. Stop accepting new connections on all listeners.
+  2. Flush critical pending reliable disconnect notices within a bounded grace period.
+  3. Signal I/O threads to stop and join all network worker threads.
+  4. Release sockets, cryptographic contexts, and transport buffers.
+  5. Destroy `NetworkRuntime` and transport instances in reverse dependency order.
+
+## Consequences
+
+### Positive
+- Strict compile-time insulation: Changing transport libraries (e.g. upgrading ENet or adding WebRTC) never requires recompilation of gameplay or editor headers.
+- Safe concurrency: Main simulation and editor threads are completely protected from data races, mutex contention, and socket blocking.
+- Clean headless and test execution: `NetworkTransportNull` enables fast, fully deterministic unit and integration testing of replication and session logic without OS socket permissions or network ports.
+- Predictable performance: Bounded queues and dedicated frame ticking prevent network traffic bursts from causing memory blowouts or frame-rate hitches.
+
+### Negative / Trade-offs
+- Message data must be copied across thread boundaries from I/O queues to the simulation thread (mitigated by bounded buffer pools and move semantics).
+- Disconnecting peers requires asynchronous coordination or bounded timeouts rather than instant synchronous socket teardown.
+
+## Rejected Alternatives
+
+- **Monolithic `HoroEngine::Networking` Target**: Combining API, runtime, and concrete socket libraries into one library was rejected because it would force all engine consumers to link socket/transport dependencies and prevent optional headless or null configurations.
+- **Direct Sockets in Public APIs**: Exposing `SOCKET` handles, `<sys/socket.h>`, or `ENetHost*` in public headers was rejected as it violates Horo Engine's backend-neutral architecture and leaks third-party dependencies.
+- **Direct Callback Invocation on I/O Threads**: Allowing network read callbacks to invoke gameplay code directly was rejected because it introduces widespread concurrency bugs, thread-safety overhead across ECS components, and non-deterministic frame execution.
+- **Global / Ambient Network Service Locator**: Using a global singleton `GetNetworkService()` was rejected; network instances must be composed explicitly by the host application.

--- a/docs/adr/020-network-target-ownership-and-dependency-boundary.md
+++ b/docs/adr/020-network-target-ownership-and-dependency-boundary.md
@@ -5,7 +5,7 @@
 - **Supersedes**: None
 - **Scope**: Network target topology, compile-time dependency directions, public API encapsulation, optional linking and composition, threading model, and deterministic lifecycle/shutdown.
 - **Issue**: [#1098](https://github.com/abdullahbodur/horo-engine/issues/1098) ([NET-001.1])
-- **JIRA**: HORO-1088
+- **JIRA**: HORO-1098
 - **Normative documents**:
   - [Networking Architecture](../architecture/runtime/networking-architecture.md)
   - [System Design](../architecture/foundation/system-design.md)

--- a/docs/adr/020-network-target-ownership-and-dependency-boundary.md
+++ b/docs/adr/020-network-target-ownership-and-dependency-boundary.md
@@ -1,4 +1,4 @@
-# ADR-011: Network Target Ownership and Dependency Boundary
+# ADR-020: Network Target Ownership and Dependency Boundary
 
 - **Status**: Proposed
 - **Date**: 2026-08-28

--- a/docs/adr/020-network-target-ownership-and-dependency-boundary.md
+++ b/docs/adr/020-network-target-ownership-and-dependency-boundary.md
@@ -32,8 +32,8 @@ The network subsystem is decomposed into four discrete CMake targets:
 |---|---|---|---|
 | `HoroEngine::NetworkApi` | Backend-neutral public types, handles, traits, interfaces | `HoroEngine::Foundation` | Value types (`NetworkId`, `NetworkAddress`, `DeliveryPolicy`), generation handles (`ConnectionHandle`, `ListenerHandle`), error codes, message views, abstract `INetworkTransport` interfaces, replication traits |
 | `HoroEngine::NetworkRuntime` | Session management, replication engine, packet queueing | `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Runtime` | `NetworkRuntimeCoordinator`, `ConnectionStateMachine`, `ReplicationManager`, `NetworkSession`, channel multiplexing, bounded buffer policies |
-| `HoroEngine::NetworkTransportNull` | Deterministic in-memory/loopback/null transport | `HoroEngine::NetworkApi`, `HoroEngine::Foundation` | `NullTransportBackend` factory / descriptor for testing, headless simulation, and network-disabled fallback |
-| `HoroEngine::NetworkTransportENet` | Concrete UDP transport implementation | `HoroEngine::NetworkApi`, `HoroEngine::Foundation` | `ENetTransportBackend` factory / descriptor. All ENet headers, sockets, and platform dependencies are `PRIVATE` |
+| `HoroEngine::NetworkTransportNull` | Deterministic in-memory/loopback/null transport | `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Platform` | `NullTransportBackend` factory / descriptor for testing, headless simulation, and network-disabled fallback |
+| `HoroEngine::NetworkTransportENet` | Concrete UDP transport implementation | `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Platform` | `ENetTransportBackend` factory / descriptor. All ENet headers, sockets, and platform dependencies are `PRIVATE` |
 
 ```text
                +---------------------------+
@@ -57,7 +57,7 @@ Rules:
 
 1. `HoroEngine::NetworkApi` depends **only** on `HoroEngine::Foundation`. It contains zero runtime logic, background threads, or socket code.
 2. `HoroEngine::NetworkRuntime` depends on `NetworkApi`, `Foundation`, and `Runtime`. It never links a concrete transport backend directly.
-3. Concrete transports (`NetworkTransportNull`, `NetworkTransportENet`) depend on `NetworkApi` and `Foundation` (plus private third-party libraries). They do not depend on `NetworkRuntime` or `HoroEngine::Runtime`.
+3. Concrete transports (`NetworkTransportNull`, `NetworkTransportENet`) depend on `NetworkApi`, `Foundation`, and `Platform` (plus private third-party libraries). They do not depend on `NetworkRuntime` or `HoroEngine::Runtime`.
 4. Feature modules, gameplay modules, and editor panels consume `NetworkApi` and `NetworkRuntime` interfaces; they **never** depend on concrete transport targets.
 
 ### 2. Encapsulation and Native Type Shielding
@@ -125,7 +125,7 @@ Key concurrency and lifecycle rules:
 
 Network shutdown is deterministic, bounded, and resource-safe:
 
-- **Connection Teardown**: Transition through `Active -> Closing -> Closed`. A graceful disconnect sends a final disconnect packet with a reason code within a bounded timeout deadline (e.g., 200 ms). If the peer does not acknowledge within the timeout, the local connection is forcefully terminated.
+- **Connection Teardown**: Transition through `Active -> Closing -> Closed`. A graceful disconnect sends a final disconnect packet with a reason code within a configurable bounded deadline derived from measured RTT and clamped by the host policy (default 2 seconds). If the peer does not acknowledge within the deadline, the local connection is forcefully terminated.
 - **Cancellation**: Asynchronous operations (resolving DNS, connecting, transferring large assets) accept a `CancellationToken`. Triggering cancellation immediately halts processing and reclaims temporary resources without blocking caller threads.
 - **Host Teardown Order**: During engine shutdown, the composition root shuts down `NetworkRuntime` before `Runtime` and `Foundation`:
   1. Stop accepting new connections on all listeners.

--- a/docs/adr/020-network-target-ownership-and-dependency-boundary.md
+++ b/docs/adr/020-network-target-ownership-and-dependency-boundary.md
@@ -22,7 +22,7 @@ In addition, networking implementations typically depend on platform-specific so
 
 ## Decision
 
-**The network subsystem is structured into four distinct target tiers with strict compile-time boundaries: `HoroEngine::NetworkApi` (public backend-neutral interfaces and value types), `HoroEngine::NetworkRuntime` (session coordination, message queues, and replication runtime), and private concrete transports (`HoroEngine::NetworkTransportENet`, `HoroEngine::NetworkTransportNull`). Public headers strictly encapsulate all native socket descriptors, TLS contexts, event loops, and third-party transport types. Networking is fully optional; applications and tools may link without network targets or compose `NetworkTransportNull`. All network ticking executes in dedicated frame phases (`NetworkPoll` and `NetworkFlush`), isolating background I/O threads from gameplay and editor state via bounded, thread-safe message queues.**
+**The network subsystem is structured into four distinct target tiers with strict compile-time boundaries: `HoroEngine::NetworkApi` (public backend-neutral interfaces and value types), `HoroEngine::NetworkRuntime` (session, authentication, and replication runtime), and private concrete transports (`HoroEngine::NetworkTransportENet`, `HoroEngine::NetworkTransportNull`). `INetworkTransport` is a handle-based packet-transport abstraction; protocol negotiation and authentication belong to `NetworkRuntime`. The host injects a unique `INetworkTransport` into the runtime. Public headers strictly encapsulate all native socket descriptors, TLS contexts, event loops, and third-party transport types. Networking is fully optional; applications and tools may link without network targets or compose `NetworkTransportNull`. Transports own cross-thread queues. Runtime observes inbound events only through `PollEvents()` during `NetworkPoll`, and submits outbound payloads during `NetworkFlush`.**
 
 ### 1. Target Topology and Allowed Dependencies
 
@@ -30,10 +30,10 @@ The network subsystem is decomposed into four discrete CMake targets:
 
 | Target | Role | Allowed Direct First-Party Dependencies | Public Surface |
 |---|---|---|---|
-| `HoroEngine::NetworkApi` | Backend-neutral public types, handles, traits, interfaces | `HoroEngine::Foundation` | Value types (`NetworkId`, `NetworkAddress`, `DeliveryPolicy`), generation handles (`ConnectionHandle`, `ListenerHandle`), error codes, message views, abstract `INetworkTransport` interfaces, replication traits |
-| `HoroEngine::NetworkRuntime` | Session management, replication engine, packet queueing | `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Runtime` | `NetworkRuntimeCoordinator`, `ConnectionStateMachine`, `ReplicationManager`, `NetworkSession`, channel multiplexing, bounded buffer policies |
-| `HoroEngine::NetworkTransportNull` | Deterministic in-memory/loopback/null transport | `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Platform` | `NullTransportBackend` factory / descriptor for testing, headless simulation, and network-disabled fallback |
-| `HoroEngine::NetworkTransportENet` | Concrete UDP transport implementation | `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Platform` | `ENetTransportBackend` factory / descriptor. All ENet headers, sockets, and platform dependencies are `PRIVATE` |
+| `HoroEngine::NetworkApi` | Backend-neutral public types, handles, traits, interfaces | `HoroEngine::Foundation` | Value types (`NetworkId`, `NetworkAddress`, `DeliveryPolicy`), generation handles (`ConnectionHandle`, `ListenerHandle`), error codes, message views, `INetworkTransport`, `TransportEvent`, replication traits |
+| `HoroEngine::NetworkRuntime` | Session management, protocol negotiation, authentication, replication | `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Runtime` | `NetworkRuntimeCoordinator`, `NetworkSession`, `SessionStateMachine`, `ReplicationManager`. Owns the injected `unique_ptr<INetworkTransport>` |
+| `HoroEngine::NetworkTransportNull` | Deterministic in-memory/loopback/null transport | `HoroEngine::NetworkApi`, `HoroEngine::Foundation` | `NullTransportBackend` factory / descriptor for testing, headless simulation, and network-disabled fallback. No Platform, sockets, or I/O thread |
+| `HoroEngine::NetworkTransportENet` | Concrete UDP transport implementation | `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Platform` | `ENetTransportBackend` factory / descriptor. Owns I/O thread and queues. All ENet headers, sockets, and platform dependencies are `PRIVATE` |
 
 ```text
                +---------------------------+
@@ -56,9 +56,10 @@ The network subsystem is decomposed into four discrete CMake targets:
 Rules:
 
 1. `HoroEngine::NetworkApi` depends **only** on `HoroEngine::Foundation`. It contains zero runtime logic, background threads, or socket code.
-2. `HoroEngine::NetworkRuntime` depends on `NetworkApi`, `Foundation`, and `Runtime`. It never links a concrete transport backend directly.
-3. Concrete transports (`NetworkTransportNull`, `NetworkTransportENet`) depend on `NetworkApi`, `Foundation`, and `Platform` (plus private third-party libraries). They do not depend on `NetworkRuntime` or `HoroEngine::Runtime`.
+2. `HoroEngine::NetworkRuntime` depends on `NetworkApi`, `Foundation`, and `Runtime`. It never links a concrete transport backend directly. The composition root instantiates the backend and transfers `std::unique_ptr<INetworkTransport>` into the runtime.
+3. `NetworkTransportNull` depends only on `NetworkApi` and `Foundation`. It does not depend on `Platform`, open OS sockets, or create I/O threads. `NetworkTransportENet` depends on `NetworkApi`, `Foundation`, and `Platform` (plus private third-party libraries). Transports do not depend on `NetworkRuntime` or `HoroEngine::Runtime`.
 4. Feature modules, gameplay modules, and editor panels consume `NetworkApi` and `NetworkRuntime` interfaces; they **never** depend on concrete transport targets.
+5. Public `NetworkApi` exposes handle-based `INetworkTransport` only. `ITransportConnection` and `ITransportListener` are not public types.
 
 ### 2. Encapsulation and Native Type Shielding
 
@@ -78,61 +79,70 @@ Networking is an optional engine capability.
 
 - **Offline / Non-Networked Products**: Products (such as single-player offline games, command-line utilities like `horopak`, asset compilers, or headless tools) do not link `NetworkRuntime` or concrete transports. Core engine composition, ECS, asset loading, and renderer pipelines operate normally without networking libraries present in the link graph.
 - **Single-Player / Headless Simulation**: If a game project uses replication interfaces or network components locally, the host composition root injects `HoroEngine::NetworkTransportNull`. `NetworkTransportNull` simulates loopback transport in memory without opening OS sockets or creating network I/O threads.
-- **Multiplayer Desktop & Dedicated Server**: Composition roots (`HoroEditor`, `horo-engine server`, game client) explicitly instantiate the chosen transport (`NetworkTransportENet` or platform backend) during startup and register it with `NetworkRuntime`. No static discovery or global registry side effects are allowed.
+- **Multiplayer Desktop & Dedicated Server**: Composition roots (`HoroEditor`, `horo-engine server`, game client) explicitly instantiate the chosen transport (`NetworkTransportENet` or platform backend) during startup and transfer unique ownership into `NetworkRuntime`. No static discovery, shared_ptr sharing, or global registry side effects are allowed.
 
 ### 4. Threading Model and Frame Lifecycle
 
 Network processing is cleanly partitioned between asynchronous I/O and frame-synchronized gameplay execution:
 
 ```text
-[ Background I/O Thread ]
-  Socket poll / recv / decrypt / frame
-         |
-         v (Push to bounded thread-safe queue)
-  +----------------------------------------------------+
-  | Inbound Message Queue (Bounded Ring / Mutex Queue) |
-  +----------------------------------------------------+
-         |
-         v (Drain during NetworkPoll phase)
-[ Simulation / Game Main Thread ]
-  1. FrameScheduler -> NetworkPoll phase:
-     - Drain inbound queues
-     - Update ConnectionStateMachine
-     - Dispatch received messages & snapshots to ReplicationManager / Game
-  2. FrameScheduler -> Simulation / Physics / Behaviors
-  3. FrameScheduler -> NetworkFlush phase:
-     - Collect dirty replicated properties
-     - Serialize outbound replication snapshots and RPCs
-     - Push to outbound queues
+[ Background I/O Thread ]                 // ENet; Null has none
+  Socket poll / recv / frame
          |
          v
-  +-----------------------------------------------------+
-  | Outbound Message Queue (Bounded Ring / Mutex Queue) |
-  +-----------------------------------------------------+
+  +--------------------------------------+
+  | Transport-owned inbound event queue  |
+  | (bounded, thread-safe)               |
+  +--------------------------------------+
          |
-         v (Drain, encrypt, socket send)
+         v transport.PollEvents() during NetworkPoll
+[ Simulation / Game Main Thread ]
+  1. FrameScheduler -> NetworkPoll:
+     - Drain transport events
+     - Advance transport connection state
+     - Create/advance NetworkSession (negotiate, authenticate)
+     - Dispatch Active-session messages
+  2. FrameScheduler -> Simulation / Physics / Behaviors
+  3. FrameScheduler -> NetworkFlush:
+     - Collect dirty replicated properties
+     - Serialize outbound snapshots and RPCs
+     - transport.Send() copies into the outbound queue
+  4. FrameScheduler -> RenderExtraction / Render
+         |
+         v
+  +--------------------------------------+
+  | Transport-owned outbound send queue  |
+  | (bounded, thread-safe)               |
+  +--------------------------------------+
+         |
+         v
 [ Background I/O Thread ]
 ```
+
+The transport owns the inbound event queue and outbound send queue. `NetworkRuntime` does not implement transport-specific synchronization. Queue implementation (mutex, ring buffer, or otherwise) is a backend detail; the contract is a bounded thread-safe queue.
 
 Key concurrency and lifecycle rules:
 
 - **Zero I/O Mutation**: Network I/O threads MUST NEVER mutate Scene, ECS, Entity, Component, Editor, or Gameplay state directly.
-- **Dedicated Frame Phases**: Frame execution includes explicit `NetworkPoll` (pre-simulation) and `NetworkFlush` (post-simulation) stages in `FrameScheduler`.
-- **Bounded Queues & Backpressure**: Inbound and outbound message queues have strict, configurable capacity limits. Queue overflow triggers explicit message-class policies (e.g. drop oldest unreliable state snapshot, reject send, or disconnect failing peer) rather than unbounded heap growth.
-- **Continuations**: State transitions (e.g. peer connected, disconnected, auth failed) are marshaled to the owner thread via lightweight continuations executed during `NetworkPoll`.
+- **Async Connect**: `INetworkTransport::Connect()` validates the request, allocates a generation-checked handle, and returns immediately. Establishment (`Resolving` / `Connecting` / `Connected`) is reported through `PollEvents()`. Callers must not treat `Connect()` as a blocking connected-session API.
+- **Copy-On-Send**: `Send()` copies payload bytes before returning and does not retain the caller span.
+- **Dedicated Frame Phases**: Frame execution includes explicit `NetworkPoll` (pre-simulation) and `NetworkFlush` (post-simulation, before render extraction) stages in `FrameScheduler`. `NetworkFlush` does not depend on render command extraction.
+- **Bounded Queues & Backpressure**: Transport queues have strict, configurable capacity limits. Queue overflow triggers explicit message-class policies (e.g. drop oldest unreliable state snapshot, reject send, or disconnect failing peer) rather than unbounded heap growth.
+- **Split Lifecycles**: Transport states are `Created -> Resolving -> Connecting -> Connected -> Closing -> Closed`. Session states are `Created -> Negotiating -> Authenticating -> Active -> Closing -> Closed`. Authentication is a runtime/session concern, not a transport backend concern.
+- **Continuations**: Transport and session state transitions are observed on the owner thread during `NetworkPoll`.
 
 ### 5. Deterministic Cancellation and Shutdown
 
 Network shutdown is deterministic, bounded, and resource-safe:
 
-- **Connection Teardown**: Transition through `Active -> Closing -> Closed`. A graceful disconnect sends a final disconnect packet with a reason code within a configurable bounded deadline derived from measured RTT and clamped by the host policy (default 2 seconds). If the peer does not acknowledge within the deadline, the local connection is forcefully terminated.
+- **Connection Teardown**: The session transitions `Active -> Closing -> Closed` and then requests transport `Close()`. A graceful disconnect sends a final disconnect packet with a reason code within a configurable bounded deadline derived from measured RTT and clamped by the host policy (default 2 seconds). If the peer does not acknowledge within the deadline, the local transport connection is forcefully terminated. Duplicate `Close()` on a generation-matching terminal handle is success; stale handles return `InvalidHandle`.
 - **Cancellation**: Asynchronous operations (resolving DNS, connecting, transferring large assets) accept a `CancellationToken`. Triggering cancellation immediately halts processing and reclaims temporary resources without blocking caller threads.
 - **Host Teardown Order**: During engine shutdown, the composition root shuts down `NetworkRuntime` before `Runtime` and `Foundation`:
   1. Stop accepting new connections on all listeners.
   2. Flush critical pending reliable disconnect notices within a bounded grace period.
   3. Signal I/O threads to stop and join all network worker threads.
   4. Release sockets, cryptographic contexts, and transport buffers.
-  5. Destroy `NetworkRuntime` and transport instances in reverse dependency order.
+  5. `NetworkRuntime` destroys the unique transport, then the host destroys `NetworkRuntime`.
 
 ## Consequences
 
@@ -154,3 +164,6 @@ Network shutdown is deterministic, bounded, and resource-safe:
 - **Direct Sockets in Public APIs**: Exposing `SOCKET` handles, `<sys/socket.h>`, or `ENetHost*` in public headers was rejected as it violates Horo Engine's backend-neutral architecture and leaks third-party dependencies.
 - **Direct Callback Invocation on I/O Threads**: Allowing network read callbacks to invoke gameplay code directly was rejected because it introduces widespread concurrency bugs, thread-safety overhead across ECS components, and non-deterministic frame execution.
 - **Global / Ambient Network Service Locator**: Using a global singleton `GetNetworkService()` was rejected; network instances must be composed explicitly by the host application.
+- **Runtime-Owned Inbound I/O Queue**: Pushing transport receive callbacks directly into a runtime-owned queue was rejected. The transport owns inbound/outbound queues; runtime drains them only through `PollEvents()`.
+- **Object-Based Public Connection API**: Public `ITransportConnection` / `ITransportListener` objects were rejected in favor of generation-checked handles on `INetworkTransport`.
+- **Transport-Level Application Authentication**: Embedding session tokens or auth state machines in ENet/Null backends was rejected so future transports (SteamNetworkingSockets, WebRTC) can replace packet transport without inheriting game authentication.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
+| [011](011-network-target-ownership-and-dependency-boundary.md) | Network Target Ownership and Dependency Boundary | proposed | 2026-08-28 |
 
 ## Conventions
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
-| [011](020-network-target-ownership-and-dependency-boundary.md) | Network Target Ownership and Dependency Boundary | proposed | 2026-08-28 |
+| [020](020-network-target-ownership-and-dependency-boundary.md) | Network Target Ownership and Dependency Boundary | proposed | 2026-08-28 |
 
 ## Conventions
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
-| [011](011-network-target-ownership-and-dependency-boundary.md) | Network Target Ownership and Dependency Boundary | proposed | 2026-08-28 |
+| [011](020-network-target-ownership-and-dependency-boundary.md) | Network Target Ownership and Dependency Boundary | proposed | 2026-08-28 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -124,8 +124,8 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Game UI And HUD](./runtime/game-ui-and-hud.md): runtime game menus, HUDs,
   canvases, UI primitives, focus/navigation, and UI rendering.
 - [Networking Architecture](./runtime/networking-architecture.md): optional
-  transports, typed protocols, bounded I/O, runtime integration, and remote
-  security.
+  handle-based transports, session/authentication runtime, bounded I/O, and
+  remote security.
 - [Asset Pipeline](./runtime/asset-pipeline.md): import, cook, package, runtime
   loading, cache, and hot reload.
 - [Prefab Architecture](./runtime/prefab-architecture.md): authored prefab

--- a/docs/architecture/delivery/build-system.md
+++ b/docs/architecture/delivery/build-system.md
@@ -177,6 +177,8 @@ audio/
 network/
     HoroEngine::NetworkApi
     HoroEngine::NetworkRuntime
+    HoroEngine::NetworkTransportNull
+    HoroEngine::NetworkTransportENet
 
 asset/
     HoroEngine::Assets

--- a/docs/architecture/desired-project-tree.md
+++ b/docs/architecture/desired-project-tree.md
@@ -233,8 +233,18 @@ horo-engine/
 │       │   │   ├── RenderBackend.h
 │       │   │   ├── RenderBackendRegistry.h
 │       │   │   ├── RenderFrontend.h
-│       │   │   └── NullBackendModule.h
-│       │   ├── Networking.h
+│       │   ├── Network/
+│       │   │   ├── NetworkApi.h
+│       │   │   ├── NetworkHandles.h
+│       │   │   ├── NetworkTypes.h
+│       │   │   ├── NetworkAddress.h
+│       │   │   ├── NetworkMessage.h
+│       │   │   ├── NetworkErrors.h
+│       │   │   ├── INetworkTransport.h
+│       │   │   ├── NetworkRuntime.h
+│       │   │   ├── NetworkSession.h
+│       │   │   ├── ReplicationManager.h
+│       │   │   └── ReplicationTraits.h
 │       │   ├── GameUI.h
 │       │   ├── DebugConsole.h
 │       │   ├── PlatformServices.h
@@ -396,6 +406,22 @@ horo-engine/
 │   │   │       ├── SdlInputBackend.h
 │   │   │       └── SdlInputBackend.cpp
 │   │   ├── networking/
+│   │   │   ├── api/
+│   │   │   │   ├── NetworkAddress.cpp
+│   │   │   │   ├── NetworkErrors.cpp
+│   │   │   │   └── NetworkMessage.cpp
+│   │   │   ├── runtime/
+│   │   │   │   ├── NetworkRuntime.cpp
+│   │   │   │   ├── NetworkSession.cpp
+│   │   │   │   ├── ConnectionStateMachine.cpp
+│   │   │   │   └── ReplicationManager.cpp
+│   │   │   └── backends/
+│   │   │       ├── null/
+│   │   │       │   ├── NullTransportBackend.h
+│   │   │       │   └── NullTransportBackend.cpp
+│   │   │       └── enet/
+│   │   │           ├── ENetTransportBackend.h
+│   │   │           └── ENetTransportBackend.cpp
 │   │   ├── debug/
 │   │   └── platform_services/
 │   │       ├── frontend/
@@ -599,6 +625,14 @@ horo-engine/
 │   │   │   │   └── middleware_bridge/
 │   │   │   ├── input/
 │   │   │   ├── networking/
+│   │   │   │   ├── NetworkAddressTests.cpp
+│   │   │   │   ├── NetworkApiTests.cpp
+│   │   │   │   ├── ConnectionStateMachineTests.cpp
+│   │   │   │   ├── BoundedMessageQueueTests.cpp
+│   │   │   │   ├── ReplicationManagerTests.cpp
+│   │   │   │   ├── NetworkTransportNullTests.cpp
+│   │   │   │   ├── NetworkTransportENetTests.cpp
+│   │   │   │   └── NetworkLifecycleAndShutdownTests.cpp
 │   │   │   ├── game_ui/
 │   │   │   ├── debug/
 │   │   │   └── platform_services/

--- a/docs/architecture/desired-project-tree.md
+++ b/docs/architecture/desired-project-tree.md
@@ -414,7 +414,7 @@ horo-engine/
 │   │   │   ├── runtime/
 │   │   │   │   ├── NetworkRuntime.cpp
 │   │   │   │   ├── NetworkSession.cpp
-│   │   │   │   ├── ConnectionStateMachine.cpp
+│   │   │   │   ├── SessionStateMachine.cpp
 │   │   │   │   └── ReplicationManager.cpp
 │   │   │   └── backends/
 │   │   │       ├── null/
@@ -628,8 +628,10 @@ horo-engine/
 │   │   │   ├── networking/
 │   │   │   │   ├── NetworkAddressTests.cpp
 │   │   │   │   ├── NetworkApiTests.cpp
-│   │   │   │   ├── ConnectionStateMachineTests.cpp
-│   │   │   │   ├── BoundedMessageQueueTests.cpp
+│   │   │   │   ├── TransportConnectionStateTests.cpp
+│   │   │   │   ├── SessionStateMachineTests.cpp
+│   │   │   │   ├── NetworkHandleTests.cpp
+│   │   │   │   ├── SendPayloadLifetimeTests.cpp
 │   │   │   │   ├── ReplicationManagerTests.cpp
 │   │   │   │   ├── NetworkTransportNullTests.cpp
 │   │   │   │   ├── NetworkTransportENetTests.cpp

--- a/docs/architecture/desired-project-tree.md
+++ b/docs/architecture/desired-project-tree.md
@@ -208,6 +208,14 @@ horo-engine/
 │       │   ├── ProjectSession.h
 │       │   ├── RecentProject.h
 │       │   └── RecentProjectInspectionService.h
+│       ├── Network/
+│       │   ├── NetworkApi.h
+│       │   ├── NetworkHandles.h
+│       │   ├── NetworkTypes.h
+│       │   ├── NetworkAddress.h
+│       │   ├── NetworkMessage.h
+│       │   ├── NetworkErrors.h
+│       │   └── INetworkTransport.h
 │       ├── Runtime/
 │       │   ├── Runtime.h
 │       │   ├── RuntimeLifecycle.h
@@ -234,13 +242,6 @@ horo-engine/
 │       │   │   ├── RenderBackendRegistry.h
 │       │   │   ├── RenderFrontend.h
 │       │   ├── Network/
-│       │   │   ├── NetworkApi.h
-│       │   │   ├── NetworkHandles.h
-│       │   │   ├── NetworkTypes.h
-│       │   │   ├── NetworkAddress.h
-│       │   │   ├── NetworkMessage.h
-│       │   │   ├── NetworkErrors.h
-│       │   │   ├── INetworkTransport.h
 │       │   │   ├── NetworkRuntime.h
 │       │   │   ├── NetworkSession.h
 │       │   │   ├── ReplicationManager.h

--- a/docs/architecture/foundation/current-target-and-dependency-inventory.md
+++ b/docs/architecture/foundation/current-target-and-dependency-inventory.md
@@ -185,7 +185,7 @@ conflicts are recorded rather than treated as additional implementations.
 | `HoroEngine::AudioNull` | Absent | No target or implementation path. |
 | `HoroEngine::NetworkApi` | Planned | Architecture exists; no production target. |
 | `HoroEngine::NetworkRuntime` | Planned | Architecture exists; no production target. |
-| `HoroEngine::NetworkTransportNull` | Planned | Null transport peer behind `NetworkApi`; no production target yet. |
+| `HoroEngine::NetworkTransportNull` | Planned | Null transport peer behind `NetworkApi`; Foundation-only, no `Platform`; no production target yet. |
 | `HoroEngine::NetworkTransportENet` | Planned | ENet transport peer behind `NetworkApi`; no production target yet. |
 | `HoroEngine::RenderApi` | Implemented | `HoroRenderApi` |
 | `HoroEngine::RenderFrontend` | Implemented | `HoroRenderFrontend` |

--- a/docs/architecture/foundation/current-target-and-dependency-inventory.md
+++ b/docs/architecture/foundation/current-target-and-dependency-inventory.md
@@ -185,7 +185,8 @@ conflicts are recorded rather than treated as additional implementations.
 | `HoroEngine::AudioNull` | Absent | No target or implementation path. |
 | `HoroEngine::NetworkApi` | Planned | Architecture exists; no production target. |
 | `HoroEngine::NetworkRuntime` | Planned | Architecture exists; no production target. |
-| `HoroEngine::NetworkSockets` | Absent | No target or implementation path. |
+| `HoroEngine::NetworkTransportNull` | Planned | Null transport peer behind `NetworkApi`; no production target yet. |
+| `HoroEngine::NetworkTransportENet` | Planned | ENet transport peer behind `NetworkApi`; no production target yet. |
 | `HoroEngine::RenderApi` | Implemented | `HoroRenderApi` |
 | `HoroEngine::RenderFrontend` | Implemented | `HoroRenderFrontend` |
 | `HoroEngine::RenderModuleAbi` | Planned | Renderer module manifest/distribution contracts exist; no target. |

--- a/docs/architecture/foundation/system-design.md
+++ b/docs/architecture/foundation/system-design.md
@@ -294,7 +294,8 @@ HoroEngine::AudioPlatform
 HoroEngine::AudioNull
 HoroEngine::NetworkApi
 HoroEngine::NetworkRuntime
-HoroEngine::NetworkSockets
+HoroEngine::NetworkTransportNull
+HoroEngine::NetworkTransportENet
 HoroEngine::RenderApi
 HoroEngine::RenderFrontend
 HoroEngine::RenderModuleAbi
@@ -338,9 +339,10 @@ horopak
 ```
 
 `AudioPlatform` selects only the native implementation for the target platform;
-native audio headers remain private to that target. `NetworkSockets` owns the
-optional native socket and TLS implementation and remains separate from typed
-session/protocol coordination in `NetworkRuntime`. `GameplayApi` owns the public
+native audio headers remain private to that target. `NetworkTransportENet` owns the
+optional native UDP socket and ENet implementation and remains separate from typed
+session/protocol coordination in `NetworkRuntime`. `NetworkTransportNull` provides
+deterministic in-memory/null transport for headless runs, mock testing, and offline modes. `GameplayApi` owns the public
 registration, descriptor, behavior, and runtime-capability contracts used by
 project gameplay modules. Generated project modules link this API rather than
 `ExtensionApi` or editor internals.
@@ -381,7 +383,8 @@ render-frontend / pipeline ------------------------------> neutral APIs and mode
 
 runtime-scene -------------------------------------------> runtime + assets + foundation
 
-audio-platform / audio-null / network-sockets /
+audio-platform / audio-null /
+network-transport-null / network-transport-enet /
 render-opengl / render-null / render-vulkan ------------> platform + owning API
 
 application / editor-model / editor-services -----------> neutral APIs,

--- a/docs/architecture/foundation/system-design.md
+++ b/docs/architecture/foundation/system-design.md
@@ -341,8 +341,8 @@ horopak
 `AudioPlatform` selects only the native implementation for the target platform;
 native audio headers remain private to that target. `NetworkTransportENet` owns the
 optional native UDP socket and ENet implementation and remains separate from typed
-session/protocol coordination in `NetworkRuntime`. `NetworkTransportNull` provides
-deterministic in-memory/null transport for headless runs, mock testing, and offline modes. `GameplayApi` owns the public
+session/protocol/authentication coordination in `NetworkRuntime`. `NetworkTransportNull` provides
+deterministic in-memory/null transport for headless runs, mock testing, and offline modes; it depends on `NetworkApi` and `Foundation` only, not `Platform`. The host composition root transfers unique `INetworkTransport` ownership into `NetworkRuntime`. `GameplayApi` owns the public
 registration, descriptor, behavior, and runtime-capability contracts used by
 project gameplay modules. Generated project modules link this API rather than
 `ExtensionApi` or editor internals.

--- a/docs/architecture/runtime/networking-architecture.md
+++ b/docs/architecture/runtime/networking-architecture.md
@@ -280,7 +280,7 @@ The networking subsystem requires targeted automated verification:
 
 ## Related Documents
 
-- [ADR-011: Network Target Ownership and Dependency Boundary](../../adr/011-network-target-ownership-and-dependency-boundary.md)
+- [ADR-020: Network Target Ownership and Dependency Boundary](../../adr/020-network-target-ownership-and-dependency-boundary.md)
 - [System Design](../foundation/system-design.md)
 - [Desired Project Trees](../desired-project-tree.md)
 - [Multiplayer Replication Architecture](./multiplayer-replication-architecture.md)

--- a/docs/architecture/runtime/networking-architecture.md
+++ b/docs/architecture/runtime/networking-architecture.md
@@ -12,10 +12,15 @@ do not construct, link, or activate concrete transport backends.
 ## Core Decisions
 
 - **Strict Layered Architecture**: Networking is separated into target-level tiers: public contracts and types (`HoroEngine::NetworkApi`), session coordination and replication runtime (`HoroEngine::NetworkRuntime`), and private concrete transport backends (`HoroEngine::NetworkTransportNull`, `HoroEngine::NetworkTransportENet`).
+- **Transport vs Session Split**: `INetworkTransport` is a packet-transport abstraction. Protocol negotiation, authentication, replication, and `NetworkSession` live in `NetworkRuntime`. Transport backends do not implement application authentication.
+- **Handle-Based Public Transport API**: Public transport operations use `INetworkTransport` plus generation-checked `ConnectionHandle` / `ListenerHandle` values. `ITransportConnection` and `ITransportListener` are not public types.
 - **Complete Native Encapsulation**: Public headers expose zero OS socket descriptors (`SOCKET`, `int fd`), OS socket headers, TLS/OpenSSL contexts (`SSL*`), event loops, or third-party transport structures (`ENetHost`, `SteamNetworkingSockets`).
 - **Optional Link and Composition**: Single-player games, asset tools, and offline CLI utilities compile and run without linking transport backends. Products can compose `NetworkTransportNull` or omit the network runtime entirely.
-- **Thread Isolation & Zero I/O State Mutation**: Network I/O executes on dedicated background worker threads. I/O threads never directly mutate Scene, ECS, Entity, Component, Editor, or Gameplay state.
-- **Dedicated Frame Schedule Phases**: Inbound messages and connection state updates are processed on the simulation/main thread during `FrameScheduler::Phase::NetworkPoll`. Outbound replication snapshots and RPCs are serialized and queued during `FrameScheduler::Phase::NetworkFlush`.
+- **Host-Owned Injection**: The composition root instantiates a concrete transport and transfers unique ownership into `NetworkRuntime`. `NetworkRuntime` never links a concrete backend directly.
+- **Thread Isolation & Zero I/O State Mutation**: Network I/O executes on dedicated background worker threads owned by the concrete transport that needs them. I/O threads never directly mutate Scene, ECS, Entity, Component, Editor, or Gameplay state.
+- **Transport-Owned Cross-Thread Queues**: The transport owns inbound event and outbound send queues. `NetworkRuntime` observes inbound traffic only by calling `PollEvents()` on the simulation thread.
+- **Dedicated Frame Schedule Phases**: Inbound transport events and session state updates are processed on the simulation/main thread during `FrameScheduler::Phase::NetworkPoll`. Outbound replication snapshots and RPCs are serialized and submitted during `FrameScheduler::Phase::NetworkFlush`. These phases do not depend on render command extraction.
+- **Copy-On-Send Payloads**: `Send()` copies caller payload bytes before returning. The transport does not retain the caller-provided span.
 - **Bounded Queues and Backpressure**: Inbound and outbound message queues enforce fixed capacity bounds and deterministic drop/rejection policies for overloaded connections.
 - **Explicit Schemas & Negotiation**: Messages use typed schemas and handshake negotiation. Raw C++ memory layout, vtables, pointers, and unstructured object graphs are never serialized.
 - **Deterministic Cancellation and Shutdown**: Every connection reaches a definitive terminal state. Disconnections, timeouts, cancellations, and engine shutdown follow bounded, leak-free teardown protocols.
@@ -52,31 +57,36 @@ The network subsystem is organized into four distinct CMake targets with strict 
   - Generation-checked opaque handles: `ConnectionHandle`, `ListenerHandle`.
   - Result and error types: `Result<T, NetworkErrorCode>`, `NetworkErrorCode`, `DisconnectReason`.
   - Message abstractions: `MessageView`, `ConstMessageSpan`, `IMessageSerializer`.
-  - Transport interfaces: `INetworkTransport`, `ITransportListener`, `ITransportConnection`, `TransportCapabilities`.
+  - Transport interface and events: `INetworkTransport`, `ITransportEventConsumer`, `TransportEvent`, `TransportConnectionState`, `TransportCapabilities`.
   - Replication traits and property condition flags: `ReplicationTraits<T>`, `ReplicationCondition`.
+- **Not Public**: `ITransportConnection`, `ITransportListener`, native peers, OS sockets, and backend queue types.
 
 ### 2. `HoroEngine::NetworkRuntime`
 
-- **Role**: State session management, replication coordination, message dispatching, and queue management.
+- **Role**: Session management, protocol negotiation, authentication, replication coordination, and simulation-thread dispatch.
 - **Direct Dependencies**: `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Runtime`.
+- **Does Not Own**: Transport I/O threads, native connection objects, or the cross-thread inbound/outbound queues. Those remain inside the injected transport.
+- **Construction**: Receives `std::unique_ptr<INetworkTransport>` from the host composition root. The runtime destroys the transport only after `Shutdown()`.
 - **Key Components**:
-  - `NetworkRuntimeCoordinator`: Owns active sessions, ties into the `FrameScheduler`, and coordinates transports.
-  - `ConnectionStateMachine`: Manages deterministic peer transitions (`Created` -> `Connecting` -> `Authenticating` -> `Active` -> `Closing` -> `Closed`).
+  - `NetworkRuntimeCoordinator`: Owns the injected transport and active sessions, and ticks during `NetworkPoll` / `NetworkFlush`.
+  - `NetworkSession`: Application-facing session that starts after the transport reports `Connected`.
+  - `SessionStateMachine`: Manages session transitions (`Created` -> `Negotiating` -> `Authenticating` -> `Active` -> `Closing` -> `Closed`).
   - `ReplicationManager`: Manages dirty property tracking, delta compression, interest management sets, and authoritative snapshot generation.
   - `MessageDispatcher`: Routes incoming RPCs and replication payloads to registered game handlers on the simulation thread.
-  - `BoundedMessageQueue`: Thread-safe FIFO ring buffers with explicit overload and snapshot-replacement policies.
 
 ### 3. `HoroEngine::NetworkTransportNull`
 
 - **Role**: Deterministic in-memory loopback and null transport backend.
 - **Direct Dependencies**: `HoroEngine::NetworkApi`, `HoroEngine::Foundation`.
-- **Purpose**: Unit testing, CI verification, single-player offline simulation, and synthetic latency/loss testing harnesses. Does not open OS sockets or spawn network I/O threads.
+- **Must Not Depend On**: `HoroEngine::Platform`, OS sockets, or a network I/O thread.
+- **Purpose**: Unit testing, CI verification, single-player offline simulation, and synthetic latency/loss testing harnesses. `PollEvents()` and `Send()` run on the caller thread against in-memory queues.
 
 ### 4. `HoroEngine::NetworkTransportENet`
 
 - **Role**: High-performance reliable and unreliable UDP transport implementation.
-- **Direct Dependencies**: `HoroEngine::NetworkApi`, `HoroEngine::Foundation` (with private ENet / socket links).
+- **Direct Dependencies**: `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Platform`.
 - **Encapsulation**: Links third-party ENet and platform socket libraries strictly as `PRIVATE`. No third-party headers or socket types leak into public includes.
+- **Owns**: I/O thread, native ENet/socket state, inbound event queue, and outbound send queue.
 
 ## Public Header Encapsulation
 
@@ -88,6 +98,24 @@ To maintain portability, compile speed, and memory safety, public headers under 
 4. **No Native Event Loops**: Event loop primitives (libuv `uv_loop_t`, epoll file descriptors, kqueue, IOCP handles) remain private to backend implementations.
 5. **No Third-Party Types**: `ENetHost`, `ENetPeer`, `ENetPacket`, or Steam networking structs are strictly confined to concrete backend sources.
 
+## Host Composition and Transport Ownership
+
+The host composition root selects and instantiates the backend. `NetworkRuntime` never links `NetworkTransportNull` or `NetworkTransportENet`.
+
+```cpp
+auto transport = CreateENetTransport(config); // or CreateNullTransport(config)
+NetworkRuntime runtime({
+    .transport = std::move(transport),
+});
+```
+
+Ownership rules:
+
+- The host transfers unique ownership of `INetworkTransport` into `NetworkRuntime`.
+- Shared ownership is forbidden. The runtime is the sole owner after injection.
+- The host must not call `PollEvents`, `Send`, `Close`, or `Shutdown` on a transport after transferring it.
+- `NetworkRuntime::Shutdown()` shuts down the transport, joins any I/O thread the backend owns, then destroys the `unique_ptr`.
+
 ## Capability Interface
 
 ```cpp
@@ -97,7 +125,7 @@ struct ConnectRequest {
     NetworkAddress endpoint;
     std::chrono::milliseconds timeout{5000};
     uint32_t channelCount{2};
-    std::span<const uint8_t> authenticationToken;
+    CancellationToken cancellation{};
 };
 
 struct ListenRequest {
@@ -126,75 +154,163 @@ public:
 
 Handles are 64-bit generation-checked identifiers preventing ABA handle reuse issues.
 
-## Connection Lifecycle
+### Connect and Listen Semantics
+
+`Connect()` is asynchronous:
+
+- After request validation, `Connect()` allocates a `ConnectionHandle` and returns it immediately.
+- The returned connection is `Created`, or `Resolving` when `endpoint` contains a hostname.
+- DNS, socket connect, and transport handshake continue in the backend. They must not block the caller.
+- State changes and inbound packets are reported later through `PollEvents()`.
+- A successful `Connect()` return is not a connected session and is not an authenticated `NetworkSession`.
+
+`Listen()` likewise returns a `ListenerHandle` immediately after bind-request validation. Accept events arrive through `PollEvents()`.
+
+### Payload Lifetime
+
+- `Send()` copies the caller-provided `ConstMessageSpan` before returning. The transport does not retain that span.
+- The caller may destroy or reuse the source buffer as soon as `Send()` returns.
+- `MessageView` values delivered to `ITransportEventConsumer` are valid only for the duration of that callback. Consumers that retain payload bytes must copy them.
+
+### Handle Lifetime
+
+| Call | Result |
+|---|---|
+| `Connect()` / `Listen()` validation failure | No handle is issued; typed `NetworkErrorCode` |
+| `Send` / `Close` with never-issued or generation-mismatched handle | `NetworkErrorCode::InvalidHandle` |
+| `Send` on a handle whose connection is `Closing`, `Closed`, or `Failed` | `NetworkErrorCode::ConnectionClosed` |
+| `Close` on an already `Closed` or `Failed` handle with matching generation | Success (idempotent) |
+| `Close` on `InvalidHandle` | `NetworkErrorCode::InvalidHandle` |
+
+A handle remains generation-valid until the transport reclaims the slot. After reclaim, the same bit pattern is `InvalidHandle`.
+
+## NetworkAddress
+
+`NetworkAddress` is a first-class endpoint value. It must represent:
+
+- IPv4 literals: `127.0.0.1:7777`
+- IPv6 literals: `[::1]:7777`
+- Hostnames: `game.example.com:7777`
+
+Literal addresses skip `Resolving`. Hostname endpoints require asynchronous DNS as part of the transport connection lifecycle. Resolution failure transitions the transport connection to `Failed` with `NetworkErrorCode::NameResolutionFailed`.
+
+Public `NetworkAddress` stores host text or numeric form plus port. It never exposes `sockaddr`, `addrinfo`, or other OS types.
+
+## Transport and Session Lifecycles
+
+Transport connection state and session state are distinct machines. Authentication is not a transport state.
 
 ```text
-Created
-  -> Resolving
-  -> Connecting
-  -> Authenticating
-  -> Active
-  -> Closing
-  -> Closed
+TransportConnection
+  Created
+    -> Resolving          // hostname only
+    -> Connecting
+    -> Connected
+    -> Closing
+    -> Closed
 
-Any non-terminal state -> Failed
+  Any non-terminal state -> Failed
 ```
 
-- **Created**: Handle allocated; request validated.
-- **Resolving**: Asynchronous DNS / endpoint resolution in progress.
-- **Connecting**: Transport-level handshake in progress.
-- **Authenticating**: Security token validation and protocol version negotiation.
-- **Active**: Fully established session exchanging application messages.
-- **Closing**: Graceful disconnect notification sent; awaiting bounded peer acknowledgement or timeout.
-- **Closed**: Connection teardown complete; socket and memory reclaimed.
-- **Failed**: Network failure, timeout, auth rejection, or protocol error.
+```text
+NetworkSession
+  Created                 // allocated when transport reaches Connected
+    -> Negotiating        // protocol version, channels, capabilities
+    -> Authenticating     // runtime/session token validation
+    -> Active
+    -> Closing
+    -> Closed
 
-Every accepted connection reaches exactly one terminal state (`Closed` or `Failed`).
+  Any non-terminal state -> Failed
+```
+
+- **Transport `Created`**: Handle allocated; request validated. `Connect()` has already returned.
+- **Transport `Resolving`**: Asynchronous DNS for a hostname endpoint.
+- **Transport `Connecting`**: Native connect and transport-level handshake (for example ENet peer connect). No application token is exchanged here.
+- **Transport `Connected`**: Packets can flow. `NetworkRuntime` now creates a `NetworkSession`.
+- **Session `Negotiating`**: Schema/protocol version, compression, and MTU agreement.
+- **Session `Authenticating`**: `NetworkRuntime` validates application credentials. Tokens are runtime/session data, not `ConnectRequest` fields on the transport.
+- **Session `Active`**: Gameplay messages, RPCs, and replication are admitted.
+- **Closing / Closed / Failed**: Each layer tears down independently. Session close requests transport `Close()`. Transport `Failed` fails the associated session.
+
+Future transports (SteamNetworkingSockets, WebRTC, and similar) replace only the transport machine. They must not absorb session authentication.
+
+## Queue Ownership
+
+Model A is normative:
+
+```text
+Transport I/O thread (ENet) or caller thread (Null)
+    -> transport-owned inbound event queue
+    -> NetworkRuntime calls transport.PollEvents(consumer)
+
+NetworkRuntime NetworkFlush
+    -> transport.Send(...)            // copies into transport-owned outbound queue
+    -> transport I/O thread sends
+```
+
+The transport owns:
+
+- I/O thread, when the backend needs one
+- raw/native connection state
+- inbound event queue
+- outbound send queue
+
+`NetworkRuntime` does not know the queue's mutex, lock-free, or ring-buffer implementation. The architecture requires a bounded thread-safe queue. Spinlock versus mutex is a backend implementation choice, not a public contract.
+
+`PollEvents()` may be called only on the simulation/main thread during `NetworkPoll`. It drains the transport-owned inbound queue into `ITransportEventConsumer` callbacks. Those callbacks must not block, allocate unboundedly, or re-enter the transport.
 
 ## Threading Model and Frame Schedule Phases
 
 To prevent race conditions and frame stalls, network operations are strictly partitioned:
 
 ```text
-[ Background I/O Worker Thread ]
-  OS Socket Poll -> Recv Packets -> Decrypt & Validate -> Framing
-         |
-         v (Enqueues framed messages)
-  +-------------------------------------------------------------+
-  | Inbound Bounded Queue (Thread-Safe Ring Buffer / Spinlock)  |
-  +-------------------------------------------------------------+
-         |
-         v (Drained during NetworkPoll phase)
-[ Simulation / Main Engine Thread ]
-  Frame Phase: NetworkPoll
-    - Drain inbound queue
-    - Update ConnectionStateMachine transitions
-    - Dispatch received RPCs and snapshots to Gameplay/Scene/ReplicationManager
-  Frame Phase: Simulation & Gameplay Update (Fixed / Variable Tick)
-  Frame Phase: NetworkFlush
-    - ReplicationManager collects dirty properties
-    - Serialize outbound state snapshots & client RPCs
-    - Push outbound messages to queue
+[ Background I/O Worker Thread ]          // ENet only; Null has none
+  OS Socket Poll -> Recv Packets -> Framing
          |
          v
-  +-------------------------------------------------------------+
-  | Outbound Bounded Queue (Thread-Safe Ring Buffer / Spinlock) |
-  +-------------------------------------------------------------+
+  +--------------------------------------+
+  | Transport-owned inbound event queue  |
+  | (bounded, thread-safe)               |
+  +--------------------------------------+
          |
-         v (Drained by I/O thread)
+         v  NetworkRuntime::PollEvents during NetworkPoll
+[ Simulation / Main Engine Thread ]
+  Frame Phase: NetworkPoll
+    - transport.PollEvents(consumer)
+    - advance TransportConnection states
+    - create/advance NetworkSession (negotiate, authenticate)
+    - dispatch Active-session messages to ReplicationManager / gameplay
+  Frame Phase: Simulation & Gameplay Update
+  Frame Phase: NetworkFlush
+    - ReplicationManager collects dirty properties
+    - serialize outbound snapshots and RPCs
+    - transport.Send(...) for Active sessions
+  Frame Phase: RenderExtraction
+  Frame Phase: Render
+         |
+         v
+  +--------------------------------------+
+  | Transport-owned outbound send queue  |
+  | (bounded, thread-safe)               |
+  +--------------------------------------+
+         |
+         v
 [ Background I/O Worker Thread ]
-  Encrypt & Packetize -> OS Socket Send
+  Packetize -> OS Socket Send
 ```
 
 ### Dedicated Frame Scheduler Phases
 
 1. `FrameScheduler::Phase::NetworkPoll`:
-   - Runs prior to scene simulation and physics update.
-   - Drains inbound transport queues into typed message dispatches.
-   - Dispatches connection state continuations onto the main thread.
+   - Runs before scene simulation and physics update.
+   - Drains transport events and advances session state on the simulation thread.
 2. `FrameScheduler::Phase::NetworkFlush`:
-   - Runs after scene simulation and render command extraction.
-   - Gathers replicated component changes, builds delta frames, and queues outbound packets to background I/O workers.
+   - Runs after scene simulation and before render command extraction.
+   - Submits outbound packets from post-simulation dirty state.
+   - Has no dependency on render extraction. Flush is ordered before extract so replication latency is not coupled to rendering work.
+
+Allowed adjacent orders are `NetworkPoll -> Simulation -> NetworkFlush -> RenderExtraction -> Render`. `NetworkFlush` after `RenderExtraction` is forbidden as the default because it adds render-extract latency to the network path without a transport requirement.
 
 ## Message Schema and Protocol Negotiation
 
@@ -205,13 +321,13 @@ Messages consist of:
 - 32-bit Sequence / Acknowledgement Numbers.
 - Bounded payload bytes with validated length headers.
 
-Peers perform handshake negotiation upon initial connection:
+`NetworkRuntime` performs handshake negotiation after the transport reports `Connected`:
 
 - Minimum and maximum supported protocol versions.
 - Supported compression algorithms and MTU payload limits.
 - Authentication credentials and capability flags.
 
-Mismatched protocol versions or invalid authentication tokens immediately reject the connection with a typed `NetworkErrorCode::IncompatibleProtocol` or `NetworkErrorCode::AuthenticationFailed`.
+Mismatched protocol versions or invalid authentication tokens fail the **session** with `NetworkErrorCode::IncompatibleProtocol` or `NetworkErrorCode::AuthenticationFailed`. The transport connection is then closed. Transport backends must not interpret authentication tokens.
 
 ## Delivery Semantics and Backpressure
 
@@ -224,7 +340,7 @@ Delivery policies:
 
 ### Backpressure and Overload Policies
 
-All internal queues have bounded capacities:
+All transport queues have bounded capacities:
 
 - **DropOldestSnapshot**: When the outbound queue for unreliable state exceeds threshold, older snapshots are discarded in favor of the latest state.
 - **RejectSend**: Reliable message requests exceeding queue limits return `NetworkErrorCode::QueueFull`.
@@ -232,14 +348,14 @@ All internal queues have bounded capacities:
 
 ## Deterministic Cancellation and Shutdown
 
-- **Cancellation**: Connect and resolve requests accept `CancellationToken`. Triggering cancellation immediately halts DNS lookups and connection attempts, returning `NetworkErrorCode::OperationCancelled`.
-- **Graceful Teardown**: When closing a connection, the runtime transmits a disconnect frame and initiates a bounded drain timer (e.g., 200 ms). Upon expiry or peer ACK, the socket closes cleanly.
+- **Cancellation**: Connect and resolve requests accept `CancellationToken`. Triggering cancellation immediately halts DNS lookups and connection attempts. The transport connection moves to `Failed` with `NetworkErrorCode::OperationCancelled`, reported through `PollEvents()`.
+- **Graceful Teardown**: Session close asks the transport to `Close()`. The transport transmits a disconnect frame and starts a bounded drain timer. Upon expiry or peer ACK, native resources are reclaimed.
 - **Process Shutdown Sequence**:
-  1. `NetworkRuntime::Shutdown()` is invoked by the host composition root.
-  2. All listener sockets are immediately closed to stop incoming connections.
-  3. Active connections are sent disconnect notices.
-  4. Background I/O threads are signaled to stop and joined with a bounded timeout.
-  5. Transport memory, socket buffers, and session pools are freed.
+  1. The host calls `NetworkRuntime::Shutdown()`.
+  2. Runtime fails/closes all sessions and stops admitting gameplay messages.
+  3. Runtime calls `INetworkTransport::Shutdown()`: listeners stop accepting, connections send disconnect notices, I/O threads stop and join with a bounded timeout.
+  4. Runtime destroys the unique transport.
+  5. Session pools and dispatcher tables are freed.
 
 ## Optional Composition and Product Configurations
 
@@ -249,7 +365,7 @@ Horo Engine products compose networking according to their needs:
 |---|---|---|
 | **Editor / IDE** (`HoroEditor`) | `NetworkApi`, `NetworkRuntime`, `NetworkTransportENet` | Full multiplayer preview, network debugger panel, local test servers. |
 | **Dedicated Server** (`horo-engine server`) | `NetworkApi`, `NetworkRuntime`, `NetworkTransportENet` | Headless execution, high-tick simulation, no rendering or audio dependencies. |
-| **Offline Game Client** | `NetworkApi`, `NetworkRuntime`, `NetworkTransportNull` | Uses replication/session API locally; zero socket operations or I/O threads. |
+| **Offline Game Client** | `NetworkApi`, `NetworkRuntime`, `NetworkTransportNull` | Uses replication/session API locally; zero socket operations, Platform sockets, or I/O threads. |
 | **Tooling / Packager** (`horopak`) | *None* | Links zero network targets; compiles cleanly with minimal footprint. |
 
 ## Observability and Diagnostics
@@ -258,24 +374,28 @@ Networking integrates with Horo's diagnostic and metric infrastructure:
 
 - **Counters**: `net.bytes_sent`, `net.bytes_received`, `net.packets_lost`, `net.packets_dropped`.
 - **Gauges**: `net.active_connections`, `net.inbound_queue_depth`, `net.outbound_queue_depth`, `net.rtt_ms`.
-- **Tracing**: Connection lifecycle events and session handshakes log to the `LogCategory::Network` category. Payloads are scrubbed of sensitive data by default.
+- **Tracing**: Transport connection events and session handshakes log to the `LogCategory::Network` category. Payloads are scrubbed of sensitive data by default.
 
 ## Testing and Verification Strategy
 
 The networking subsystem requires targeted automated verification:
 
 1. **Unit Tests (`tests/unit/runtime/networking/`)**:
-   - `NetworkAddressTests`: IPv4, IPv6, loopback, port parsing, serialization.
-   - `ConnectionStateMachineTests`: State transitions, invalid transitions, timeout handling.
-   - `BoundedQueueTests`: Capacity enforcement, FIFO ordering, snapshot replacement policy.
+   - `NetworkAddressTests`: IPv4, IPv6, hostname, loopback, port parsing, serialization.
+   - `TransportConnectionStateTests`: `Connect()` returns immediately; `Created` / `Resolving` / `Connecting` / `Connected`; invalid transitions; timeout.
+   - `SessionStateMachineTests`: `Negotiating` / `Authenticating` / `Active`; auth failure does not require transport-level auth.
+   - `NetworkHandleTests`: stale handle -> `InvalidHandle`; send-after-close -> `ConnectionClosed`; duplicate `Close` is idempotent.
+   - `SendPayloadLifetimeTests`: caller buffer may be overwritten after `Send()` returns.
    - `ReplicationManagerTests`: Dirty property extraction, delta compression, interest management queries.
 2. **Deterministic Transport Tests (`NetworkTransportNullTests`)**:
+   - No `Platform` link; no OS sockets; no I/O thread.
    - Simulated latency, jitter, packet loss, duplicate packets, and out-of-order delivery.
-   - Handshake negotiation and rejection of unsupported protocol versions.
+   - `PollEvents()` drains the transport-owned in-memory queue on the caller thread.
    - Graceful disconnect and timeout handling.
 3. **Integration & Lifecycle Tests**:
-   - Full client-server connect, transfer, and disconnect sequences.
-   - Cancellation during active connection attempts.
+   - Full client-server connect, session authenticate, transfer, and disconnect sequences.
+   - Cancellation during DNS and connect; `Connect()` already returned a handle.
+   - Unique-ptr injection: runtime shutdown destroys the transport exactly once.
    - Process shutdown with active connections and pending queued messages without hangs or memory leaks.
 
 ## Related Documents

--- a/docs/architecture/runtime/networking-architecture.md
+++ b/docs/architecture/runtime/networking-architecture.md
@@ -199,12 +199,14 @@ To prevent race conditions and frame stalls, network operations are strictly par
 ## Message Schema and Protocol Negotiation
 
 Messages consist of:
+
 - 16-bit Protocol Identifier and 16-bit Schema Version.
 - 16-bit Message Type ID.
 - 32-bit Sequence / Acknowledgement Numbers.
 - Bounded payload bytes with validated length headers.
 
 Peers perform handshake negotiation upon initial connection:
+
 - Minimum and maximum supported protocol versions.
 - Supported compression algorithms and MTU payload limits.
 - Authentication credentials and capability flags.
@@ -214,6 +216,7 @@ Mismatched protocol versions or invalid authentication tokens immediately reject
 ## Delivery Semantics and Backpressure
 
 Delivery policies:
+
 - **UnreliableUnordered**: Fast state updates (e.g. high-frequency physics/transform telemetry); latest packet overwrites previous.
 - **UnreliableSequenced**: Discards out-of-order packets; only newer packets are accepted.
 - **ReliableOrdered**: Guaranteed delivery in order (e.g., game events, inventory actions, chat).
@@ -222,6 +225,7 @@ Delivery policies:
 ### Backpressure and Overload Policies
 
 All internal queues have bounded capacities:
+
 - **DropOldestSnapshot**: When the outbound queue for unreliable state exceeds threshold, older snapshots are discarded in favor of the latest state.
 - **RejectSend**: Reliable message requests exceeding queue limits return `NetworkErrorCode::QueueFull`.
 - **DisconnectAbusivePeer**: Inbound queues experiencing sustained flood without consumption trigger connection termination.
@@ -251,6 +255,7 @@ Horo Engine products compose networking according to their needs:
 ## Observability and Diagnostics
 
 Networking integrates with Horo's diagnostic and metric infrastructure:
+
 - **Counters**: `net.bytes_sent`, `net.bytes_received`, `net.packets_lost`, `net.packets_dropped`.
 - **Gauges**: `net.active_connections`, `net.inbound_queue_depth`, `net.outbound_queue_depth`, `net.rtt_ms`.
 - **Tracing**: Connection lifecycle events and session handshakes log to the `LogCategory::Network` category. Payloads are scrubbed of sensitive data by default.

--- a/docs/architecture/runtime/networking-architecture.md
+++ b/docs/architecture/runtime/networking-architecture.md
@@ -2,58 +2,129 @@
 
 ## Purpose
 
-This document defines optional network transport, connection lifecycle,
+This document defines the optional network transport, connection lifecycle,
 message serialization, asynchronous I/O, security boundaries, runtime
-integration, and observability.
+integration, and observability for Horo Engine.
 
-Networking is an optional engine capability. Hosts and games that do not need it
-do not construct or link a concrete transport backend.
+Networking is an optional engine capability. Hosts, tools, and games that do not need it
+do not construct, link, or activate concrete transport backends.
 
 ## Core Decisions
 
-- Networking is layered into transport, protocol, and gameplay/application
-  semantics.
-- Network I/O never mutates scene, editor, or application state from an I/O
-  thread.
-- Messages use explicit schemas and version negotiation.
-- Buffers, queues, message sizes, connection counts, and rates are bounded.
-- Security policy is mandatory for remote communication.
-- General engine data-bus events are not serialized automatically.
-- Simulation inputs and state replication use dedicated protocols rather than
-  arbitrary ECS memory or C++ object serialization.
+- **Strict Layered Architecture**: Networking is separated into target-level tiers: public contracts and types (`HoroEngine::NetworkApi`), session coordination and replication runtime (`HoroEngine::NetworkRuntime`), and private concrete transport backends (`HoroEngine::NetworkTransportNull`, `HoroEngine::NetworkTransportENet`).
+- **Complete Native Encapsulation**: Public headers expose zero OS socket descriptors (`SOCKET`, `int fd`), OS socket headers, TLS/OpenSSL contexts (`SSL*`), event loops, or third-party transport structures (`ENetHost`, `SteamNetworkingSockets`).
+- **Optional Link and Composition**: Single-player games, asset tools, and offline CLI utilities compile and run without linking transport backends. Products can compose `NetworkTransportNull` or omit the network runtime entirely.
+- **Thread Isolation & Zero I/O State Mutation**: Network I/O executes on dedicated background worker threads. I/O threads never directly mutate Scene, ECS, Entity, Component, Editor, or Gameplay state.
+- **Dedicated Frame Schedule Phases**: Inbound messages and connection state updates are processed on the simulation/main thread during `FrameScheduler::Phase::NetworkPoll`. Outbound replication snapshots and RPCs are serialized and queued during `FrameScheduler::Phase::NetworkFlush`.
+- **Bounded Queues and Backpressure**: Inbound and outbound message queues enforce fixed capacity bounds and deterministic drop/rejection policies for overloaded connections.
+- **Explicit Schemas & Negotiation**: Messages use typed schemas and handshake negotiation. Raw C++ memory layout, vtables, pointers, and unstructured object graphs are never serialized.
+- **Deterministic Cancellation and Shutdown**: Every connection reaches a definitive terminal state. Disconnections, timeouts, cancellations, and engine shutdown follow bounded, leak-free teardown protocols.
 
-## Layer Model
+## Target Topology and Module Ownership
+
+The network subsystem is organized into four distinct CMake targets with strict compile-time boundaries:
 
 ```text
-Gameplay / Application Protocol
-            |
-            v
-Typed Message And Session Layer
-            |
-            v
-Reliable / Unreliable Transport Interface
-            |
-            v
-Platform Socket / TLS Backend
+               +---------------------------+
+               |   HoroEngine::Foundation  |
+               +-------------+-------------+
+                             ^
+                             |
+               +-------------+-------------+
+               |   HoroEngine::NetworkApi  |
+               +------+--------------+-----+
+                      ^              ^
+                      |              |
++---------------------+----+   +-----+-------------------------+
+| HoroEngine::NetworkRuntime|   | Concrete Transports (Private) |
+| (depends also on Runtime) |   | - NetworkTransportNull        |
++---------------------------+   | - NetworkTransportENet        |
+                                +-------------------------------+
 ```
 
-Transport implementations own sockets, encryption sessions, and native event
-loops. Protocols own message identity, schema, ordering, and compatibility.
+### 1. `HoroEngine::NetworkApi`
+
+- **Role**: Backend-neutral public interface and data type definitions.
+- **Direct Dependencies**: `HoroEngine::Foundation` only.
+- **Public Header Location**: `include/Horo/Network/`
+- **Exposed Contracts**:
+  - Stable value types: `NetworkAddress`, `NetworkId`, `DeliveryPolicy`, `ChannelId`, `NetworkRole`.
+  - Generation-checked opaque handles: `ConnectionHandle`, `ListenerHandle`.
+  - Result and error types: `Result<T, NetworkErrorCode>`, `NetworkErrorCode`, `DisconnectReason`.
+  - Message abstractions: `MessageView`, `ConstMessageSpan`, `IMessageSerializer`.
+  - Transport interfaces: `INetworkTransport`, `ITransportListener`, `ITransportConnection`, `TransportCapabilities`.
+  - Replication traits and property condition flags: `ReplicationTraits<T>`, `ReplicationCondition`.
+
+### 2. `HoroEngine::NetworkRuntime`
+
+- **Role**: State session management, replication coordination, message dispatching, and queue management.
+- **Direct Dependencies**: `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Runtime`.
+- **Key Components**:
+  - `NetworkRuntimeCoordinator`: Owns active sessions, ties into the `FrameScheduler`, and coordinates transports.
+  - `ConnectionStateMachine`: Manages deterministic peer transitions (`Created` -> `Connecting` -> `Authenticating` -> `Active` -> `Closing` -> `Closed`).
+  - `ReplicationManager`: Manages dirty property tracking, delta compression, interest management sets, and authoritative snapshot generation.
+  - `MessageDispatcher`: Routes incoming RPCs and replication payloads to registered game handlers on the simulation thread.
+  - `BoundedMessageQueue`: Thread-safe FIFO ring buffers with explicit overload and snapshot-replacement policies.
+
+### 3. `HoroEngine::NetworkTransportNull`
+
+- **Role**: Deterministic in-memory loopback and null transport backend.
+- **Direct Dependencies**: `HoroEngine::NetworkApi`, `HoroEngine::Foundation`.
+- **Purpose**: Unit testing, CI verification, single-player offline simulation, and synthetic latency/loss testing harnesses. Does not open OS sockets or spawn network I/O threads.
+
+### 4. `HoroEngine::NetworkTransportENet`
+
+- **Role**: High-performance reliable and unreliable UDP transport implementation.
+- **Direct Dependencies**: `HoroEngine::NetworkApi`, `HoroEngine::Foundation` (with private ENet / socket links).
+- **Encapsulation**: Links third-party ENet and platform socket libraries strictly as `PRIVATE`. No third-party headers or socket types leak into public includes.
+
+## Public Header Encapsulation
+
+To maintain portability, compile speed, and memory safety, public headers under `include/Horo/` enforce complete encapsulation:
+
+1. **No Socket Headers**: Headers such as `<sys/socket.h>`, `<netinet/in.h>`, `<arpa/inet.h>`, `<winsock2.h>`, and `<ws2tcpip.h>` are forbidden in public headers.
+2. **No Native Sockets / Handles**: Sockets are encapsulated as opaque integer handles or private members within backend `.cpp` files. Public APIs operate exclusively on `ConnectionHandle` and `ListenerHandle`.
+3. **No TLS / Crypto Contexts**: OpenSSL, mbedTLS, or native TLS context pointers (`SSL*`, `SSL_CTX*`) never appear in public interfaces.
+4. **No Native Event Loops**: Event loop primitives (libuv `uv_loop_t`, epoll file descriptors, kqueue, IOCP handles) remain private to backend implementations.
+5. **No Third-Party Types**: `ENetHost`, `ENetPeer`, `ENetPacket`, or Steam networking structs are strictly confined to concrete backend sources.
 
 ## Capability Interface
 
 ```cpp
-class NetworkService {
-public:
-    Result<ConnectionHandle> Connect(const ConnectRequest&);
-    Result<ListenerHandle> Listen(const ListenRequest&);
-    Result<void> Send(ConnectionHandle, MessageView, SendPolicy);
-    Result<void> Close(ConnectionHandle, CloseReason);
+namespace Horo::Network {
+
+struct ConnectRequest {
+    NetworkAddress endpoint;
+    std::chrono::milliseconds timeout{5000};
+    uint32_t channelCount{2};
+    std::span<const uint8_t> authenticationToken;
 };
+
+struct ListenRequest {
+    NetworkAddress bindAddress;
+    uint32_t maxConnections{32};
+    uint32_t channelCount{2};
+};
+
+class INetworkTransport {
+public:
+    virtual ~INetworkTransport() = default;
+
+    virtual Result<void> Initialize(const TransportConfig& config) = 0;
+    virtual Result<void> Shutdown() = 0;
+
+    virtual Result<ListenerHandle> Listen(const ListenRequest& request) = 0;
+    virtual Result<ConnectionHandle> Connect(const ConnectRequest& request) = 0;
+    virtual Result<void> Send(ConnectionHandle handle, ChannelId channel, ConstMessageSpan payload, DeliveryPolicy policy) = 0;
+    virtual Result<void> Close(ConnectionHandle handle, DisconnectReason reason) = 0;
+
+    virtual void PollEvents(ITransportEventConsumer& consumer) = 0;
+};
+
+} // namespace Horo::Network
 ```
 
-Handles are generation checked. Connection and listener identity is never a raw
-socket descriptor.
+Handles are 64-bit generation-checked identifiers preventing ABA handle reuse issues.
 
 ## Connection Lifecycle
 
@@ -69,158 +140,145 @@ Created
 Any non-terminal state -> Failed
 ```
 
-Every accepted connection reaches one terminal state. Timeouts and cancellation
-are distinct from protocol rejection and transport failure.
+- **Created**: Handle allocated; request validated.
+- **Resolving**: Asynchronous DNS / endpoint resolution in progress.
+- **Connecting**: Transport-level handshake in progress.
+- **Authenticating**: Security token validation and protocol version negotiation.
+- **Active**: Fully established session exchanging application messages.
+- **Closing**: Graceful disconnect notification sent; awaiting bounded peer acknowledgement or timeout.
+- **Closed**: Connection teardown complete; socket and memory reclaimed.
+- **Failed**: Network failure, timeout, auth rejection, or protocol error.
 
-## I/O Threading
+Every accepted connection reaches exactly one terminal state (`Closed` or `Failed`).
 
-Network I/O runs through an owned I/O service. It:
+## Threading Model and Frame Schedule Phases
 
-- reads into bounded buffers
-- performs framing and basic validation
-- enqueues typed inbound messages
-- consumes bounded outbound queues
-- publishes connection-state changes through an owner-thread continuation
+To prevent race conditions and frame stalls, network operations are strictly partitioned:
 
-Application, scene, editor, and gameplay handlers execute on their declared
-owner thread or job context.
+```text
+[ Background I/O Worker Thread ]
+  OS Socket Poll -> Recv Packets -> Decrypt & Validate -> Framing
+         |
+         v (Enqueues framed messages)
+  +-------------------------------------------------------------+
+  | Inbound Bounded Queue (Thread-Safe Ring Buffer / Spinlock)  |
+  +-------------------------------------------------------------+
+         |
+         v (Drained during NetworkPoll phase)
+[ Simulation / Main Engine Thread ]
+  Frame Phase: NetworkPoll
+    - Drain inbound queue
+    - Update ConnectionStateMachine transitions
+    - Dispatch received RPCs and snapshots to Gameplay/Scene/ReplicationManager
+  Frame Phase: Simulation & Gameplay Update (Fixed / Variable Tick)
+  Frame Phase: NetworkFlush
+    - ReplicationManager collects dirty properties
+    - Serialize outbound state snapshots & client RPCs
+    - Push outbound messages to queue
+         |
+         v
+  +-------------------------------------------------------------+
+  | Outbound Bounded Queue (Thread-Safe Ring Buffer / Spinlock) |
+  +-------------------------------------------------------------+
+         |
+         v (Drained by I/O thread)
+[ Background I/O Worker Thread ]
+  Encrypt & Packetize -> OS Socket Send
+```
 
-## Message Schema
+### Dedicated Frame Scheduler Phases
 
-Messages have:
+1. `FrameScheduler::Phase::NetworkPoll`:
+   - Runs prior to scene simulation and physics update.
+   - Drains inbound transport queues into typed message dispatches.
+   - Dispatches connection state continuations onto the main thread.
+2. `FrameScheduler::Phase::NetworkFlush`:
+   - Runs after scene simulation and render command extraction.
+   - Gathers replicated component changes, builds delta frames, and queues outbound packets to background I/O workers.
 
-- stable protocol and message IDs
-- schema version
-- bounded encoded size
-- required and optional typed fields
-- validation before allocation or dispatch
-- explicit unknown-field/version behavior
+## Message Schema and Protocol Negotiation
 
-C++ memory layout, vtables, pointers, RTTI names, and unrestricted object graphs
-are never serialized.
+Messages consist of:
+- 16-bit Protocol Identifier and 16-bit Schema Version.
+- 16-bit Message Type ID.
+- 32-bit Sequence / Acknowledgement Numbers.
+- Bounded payload bytes with validated length headers.
 
-## Protocol Negotiation
+Peers perform handshake negotiation upon initial connection:
+- Minimum and maximum supported protocol versions.
+- Supported compression algorithms and MTU payload limits.
+- Authentication credentials and capability flags.
 
-Peers negotiate:
+Mismatched protocol versions or invalid authentication tokens immediately reject the connection with a typed `NetworkErrorCode::IncompatibleProtocol` or `NetworkErrorCode::AuthenticationFailed`.
 
-- protocol version range
-- required features
-- compression
-- authentication mechanism
-- maximum frame/message sizes
-- optional unreliable channel support
+## Delivery Semantics and Backpressure
 
-Failure to agree closes the session with a safe stable reason.
+Delivery policies:
+- **UnreliableUnordered**: Fast state updates (e.g. high-frequency physics/transform telemetry); latest packet overwrites previous.
+- **UnreliableSequenced**: Discards out-of-order packets; only newer packets are accepted.
+- **ReliableOrdered**: Guaranteed delivery in order (e.g., game events, inventory actions, chat).
+- **ReliableUnordered**: Guaranteed delivery without strict ordering constraints.
 
-## Delivery Semantics
+### Backpressure and Overload Policies
 
-Each message type declares:
+All internal queues have bounded capacities:
+- **DropOldestSnapshot**: When the outbound queue for unreliable state exceeds threshold, older snapshots are discarded in favor of the latest state.
+- **RejectSend**: Reliable message requests exceeding queue limits return `NetworkErrorCode::QueueFull`.
+- **DisconnectAbusivePeer**: Inbound queues experiencing sustained flood without consumption trigger connection termination.
 
-- reliable or unreliable delivery
-- ordering scope
-- duplicate handling
-- expiration/deadline
-- backpressure policy
-- maximum rate
+## Deterministic Cancellation and Shutdown
 
-The transport does not imply that all application messages require global
-ordering.
+- **Cancellation**: Connect and resolve requests accept `CancellationToken`. Triggering cancellation immediately halts DNS lookups and connection attempts, returning `NetworkErrorCode::OperationCancelled`.
+- **Graceful Teardown**: When closing a connection, the runtime transmits a disconnect frame and initiates a bounded drain timer (e.g., 200 ms). Upon expiry or peer ACK, the socket closes cleanly.
+- **Process Shutdown Sequence**:
+  1. `NetworkRuntime::Shutdown()` is invoked by the host composition root.
+  2. All listener sockets are immediately closed to stop incoming connections.
+  3. Active connections are sent disconnect notices.
+  4. Background I/O threads are signaled to stop and joined with a bounded timeout.
+  5. Transport memory, socket buffers, and session pools are freed.
 
-## Runtime Simulation Integration
+## Optional Composition and Product Configurations
 
-Real-time gameplay networking uses typed simulation messages such as:
+Horo Engine products compose networking according to their needs:
 
-- input frames
-- snapshots
-- authoritative corrections
-- acknowledgements
-- spawn/despawn records with stable network IDs
+| Configuration | Composed Targets | Behavior |
+|---|---|---|
+| **Editor / IDE** (`HoroEditor`) | `NetworkApi`, `NetworkRuntime`, `NetworkTransportENet` | Full multiplayer preview, network debugger panel, local test servers. |
+| **Dedicated Server** (`horo-engine server`) | `NetworkApi`, `NetworkRuntime`, `NetworkTransportENet` | Headless execution, high-tick simulation, no rendering or audio dependencies. |
+| **Offline Game Client** | `NetworkApi`, `NetworkRuntime`, `NetworkTransportNull` | Uses replication/session API locally; zero socket operations or I/O threads. |
+| **Tooling / Packager** (`horopak`) | *None* | Links zero network targets; compiles cleanly with minimal footprint. |
 
-Network IDs are separate from local ECS entity handles. Resolution is owned by
-the active networked scene/session.
+## Observability and Diagnostics
 
-Fixed-tick consumption and prediction policy are game protocol decisions built
-on [Runtime Lifecycle](./runtime-lifecycle.md) and
-[Input Architecture](./input-architecture.md).
+Networking integrates with Horo's diagnostic and metric infrastructure:
+- **Counters**: `net.bytes_sent`, `net.bytes_received`, `net.packets_lost`, `net.packets_dropped`.
+- **Gauges**: `net.active_connections`, `net.inbound_queue_depth`, `net.outbound_queue_depth`, `net.rtt_ms`.
+- **Tracing**: Connection lifecycle events and session handshakes log to the `LogCategory::Network` category. Payloads are scrubbed of sensitive data by default.
 
-## Data Bus Relationship
+## Testing and Verification Strategy
 
-`EngineDataBus` events are process-local and are not automatically sent over the
-network. A protocol adapter may observe a committed authority and create an
-explicit versioned network message.
+The networking subsystem requires targeted automated verification:
 
-Inbound messages invoke validated application/gameplay operations. They do not
-publish fake local commands onto a generic bus.
-
-## Security
-
-Remote communication requires:
-
-- authenticated peers where the protocol changes state
-- encryption for credentials and sensitive data
-- certificate or key validation
-- replay and downgrade resistance where applicable
-- connection, rate, size, and resource limits
-- safe parsing before dispatch
-
-MCP remote access follows its own protocol and
-[Application Security](../security/application-security.md); it is not exposed through a
-game networking listener by default.
-
-## Backpressure
-
-Inbound and outbound queues are bounded per connection and globally. Queue-full
-policy is declared by message class:
-
-- reject new send
-- replace stale state snapshot
-- drop expired unreliable message
-- close abusive or non-reading peer
-
-The simulation and main thread never block indefinitely on network I/O.
-
-## Configuration
-
-Network configuration includes endpoints, limits, timeouts, and protocol
-features. Secrets and private keys are credential references, not ordinary
-configuration values.
-
-Binding non-loopback listeners requires explicit application/game policy.
-
-## Observability
-
-Metrics include:
-
-- connection counts and states
-- bytes and messages by bounded protocol category
-- queue depth and drops
-- round-trip time and loss where supported
-- parse, authentication, timeout, and rate-limit failures
-
-Logs avoid payload contents by default and correlate safe connection/session IDs.
-
-## Testing
-
-Required tests cover:
-
-- framing fragmentation and coalescing
-- malformed size and schema rejection
-- version negotiation
-- cancellation and timeout
-- queue saturation and snapshot replacement
-- owner-thread dispatch
-- authentication and downgrade failure
-- deterministic simulated latency, loss, duplication, and reordering
-- stale network ID rejection after scene replacement
-- clean shutdown with active connections
+1. **Unit Tests (`tests/unit/runtime/networking/`)**:
+   - `NetworkAddressTests`: IPv4, IPv6, loopback, port parsing, serialization.
+   - `ConnectionStateMachineTests`: State transitions, invalid transitions, timeout handling.
+   - `BoundedQueueTests`: Capacity enforcement, FIFO ordering, snapshot replacement policy.
+   - `ReplicationManagerTests`: Dirty property extraction, delta compression, interest management queries.
+2. **Deterministic Transport Tests (`NetworkTransportNullTests`)**:
+   - Simulated latency, jitter, packet loss, duplicate packets, and out-of-order delivery.
+   - Handshake negotiation and rejection of unsupported protocol versions.
+   - Graceful disconnect and timeout handling.
+3. **Integration & Lifecycle Tests**:
+   - Full client-server connect, transfer, and disconnect sequences.
+   - Cancellation during active connection attempts.
+   - Process shutdown with active connections and pending queued messages without hangs or memory leaks.
 
 ## Related Documents
 
-- [Network Debugger UI Reference](./network-debugger.html): replication, bandwidth, RPC log, and latency simulation panel.
-
+- [ADR-011: Network Target Ownership and Dependency Boundary](../../adr/011-network-target-ownership-and-dependency-boundary.md)
+- [System Design](../foundation/system-design.md)
+- [Desired Project Trees](../desired-project-tree.md)
+- [Multiplayer Replication Architecture](./multiplayer-replication-architecture.md)
 - [Runtime Lifecycle](./runtime-lifecycle.md)
-- [Input Architecture](./input-architecture.md)
 - [Concurrency And Job System](../foundation/concurrency-and-jobs.md)
-- [Application Security](../security/application-security.md)
-- [Error And Diagnostics](../foundation/error-and-diagnostics.md)
-
+- [Network Debugger UI Reference](./network-debugger.html)


### PR DESCRIPTION
## Summary
- Defines and ratifies the network target ownership, CMake boundaries, header encapsulation, optional link/composition rules, and threading/lifecycle invariants for Horo Engine before implementation begins.
- Introduces [ADR-020](docs/adr/011-network-target-ownership-and-dependency-boundary.md) and updates normative documents (`docs/architecture/runtime/networking-architecture.md`, `docs/architecture/desired-project-tree.md`, `docs/architecture/foundation/system-design.md`, and `docs/architecture/delivery/build-system.md`).

## Motivation
- Satisfies architecture decision ticket #1098 ([NET-001.1]) to freeze `NetworkApi`, `NetworkRuntime`, concrete transport, and host composition boundaries before implementing [NET-001].
- Prevents raw OS sockets, OpenSSL/TLS contexts, native event loops, and third-party transport types from polluting public engine headers.
- Guarantees that single-player games, offline tools (e.g., `horopak`), and headless tasks can build and run without concrete network dependencies.

## Implementation Notes
- **Target Topology**: Established 4 discrete targets: `HoroEngine::NetworkApi` (public typed contracts), `HoroEngine::NetworkRuntime` (session & replication engine), `HoroEngine::NetworkTransportNull` (deterministic loopback/testing backend), and `HoroEngine::NetworkTransportENet` (concrete UDP backend with private dependencies).
- **Public Header Encapsulation**: Strict rule that headers under `include/Horo/` contain zero OS socket, TLS, or third-party headers/types.
- **Threading & Frame Scheduling**: Thread-isolated I/O workers communicate with the simulation thread exclusively through thread-safe bounded message queues during dedicated `NetworkPoll` (pre-simulation) and `NetworkFlush` (post-simulation) frame scheduler phases. Zero direct mutation of Scene/ECS/Editor state from I/O threads.
- **Deterministic Teardown**: Bounded timeouts, cancellation token integration, and leak-free shutdown sequence.

## Validation
- [x] Build and CMake configuration passed (`horo-engine layout configure`, `cmake -S . -B build/test-config -DBUILD_TESTING=ON`)
- [x] Git pre-commit hooks passed (`horo clang-format staged`, layout verification)

Commands run:
```bash
cmake -S . -B build/test-config -DBUILD_TESTING=ON
```

## Risks
- Low risk (documentation and ADR ratification). Implementation of concrete transport backends and session runtime will follow these boundaries in subsequent tickets.

## Issue Links

- Jira: HORO-1098
- GitHub: Closes #1098

## Reviewer Notes
- Recommended review order:
  1. `docs/adr/011-network-target-ownership-and-dependency-boundary.md`
  2. `docs/architecture/runtime/networking-architecture.md`
  3. `docs/architecture/foundation/system-design.md`
  4. `docs/architecture/desired-project-tree.md`
  5. `docs/architecture/delivery/build-system.md`