### PR TITLE
docs(world-streaming): large-world precision strategy decision HORO-1604 #1604 [WST-007.1]

### DIFF
--- a/docs/adr/014-large-world-precision-and-floating-origin-strategy.md
+++ b/docs/adr/014-large-world-precision-and-floating-origin-strategy.md
@@ -1,0 +1,173 @@
+# ADR-014: Large-World Precision and Floating Origin Strategy
+
+- **Status**: Proposed
+- **Date**: 2026-08-28
+- **Supersedes**: None
+- **Scope**: Coordinate systems, precision representations (64-bit integer, double-precision floats, camera-relative floats), floating origin rebasing transactions, platform/GPU shader performance boundaries, physics/subsystem authority, and error domains.
+- **Issue**: [#1604](https://github.com/abdullahbodur/horo-engine/issues/1604) ([WST-007.1])
+- **Parent**: [#1524](https://github.com/abdullahbodur/horo-engine/issues/1524) ([WST-007])
+- **Normative documents**:
+  - [Coordinate Precision And Origin Rebasing](../architecture/runtime/coordinate-precision-and-origin-rebasing.md)
+  - [World Streaming Architecture](../architecture/runtime/world-streaming-architecture.md)
+  - [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
+  - [Physics Architecture](../architecture/runtime/physics-architecture.md)
+  - [Scene Math](../architecture/foundation/scene-math.md)
+
+---
+
+## Context
+
+Standard 32-bit single-precision IEEE 754 floating-point coordinates (`fp32`) provide 24 bits of significand (approximately 7.2 decimal digits of precision). In large virtual worlds, this introduces severe numerical degradation as distance from the world origin $(0, 0, 0)$ increases:
+
+| Distance from Origin | Spatial Resolution ($\text{ulp}$) | Visual & Physical Artifacts |
+|---|---|---|
+| $1\,\text{km}$ ($10^3\,\text{m}$) | $\approx 0.00012\,\text{m}$ ($0.12\,\text{mm}$) | Imperceptible |
+| $10\,\text{km}$ ($10^4\,\text{m}$) | $\approx 0.00098\,\text{m}$ ($0.98\,\text{mm}$) | Sub-millimeter jitter in close-up geometry |
+| $100\,\text{km}$ ($10^5\,\text{m}$) | $\approx 0.0078\,\text{m}$ ($7.8\,\text{mm}$) | Noticeable vertex shaking, Z-fighting, physics contact instability |
+| $1,000\,\text{km}$ ($10^6\,\text{m}$) | $\approx 0.0625\,\text{m}$ ($6.25\,\text{cm}$) | Unusable physics simulation, massive mesh jitter, broken camera controls |
+| $10,000\,\text{km}$ ($10^7\,\text{m}$) | $\approx 0.5\,\text{m}$ ($50\,\text{cm}$) | Total collapse of spatial coherence |
+
+To support large-scale open worlds, flight/space simulations, and seamless multi-region environments without compromising cross-platform compatibility (e.g., Mobile OpenGL ES / Metal / Vulkan and WebGL), Horo Engine requires an explicit, normative coordinate precision and origin rebasing strategy.
+
+Key design constraints:
+1. **Universal GPU Compatibility**: Mobile GPUs (Apple Silicon mobile tiers, ARM Mali, Qualcomm Adreno) and entry-level graphics hardware lack hardware FP64 arithmetic or incur severe ALU throughput penalties (16x–32x slowdown). GPU shaders must remain 32-bit single precision (`fp32`) / half precision (`fp16`).
+2. **Physics Engine Stability**: Commercial and open-source physics engines (e.g., Jolt, PhysX, Box2D) rely on 32-bit floating point calculations for collision detection, EPA/GJK, island solving, and sleeping. Physics clusters must remain localized within low-magnitude coordinate frames.
+3. **Deterministic Persistence & Replication**: Authoring tools, spatial partitioning grids, save games, and multiplayer state replication require a stable, absolute global frame of reference that never drifts when the local rendering origin shifts.
+4. **Zero Velocity Discontinuities**: Origin rebasing is a coordinate frame re-indexing, not a physical displacement over time; it must not induce artificial velocity spikes, Doppler glitches, or particle recreation.
+
+---
+
+## Decision
+
+**Horo Engine adopts a Hybrid Hierarchical Global Coordinate representation (`WorldCoordinate64`) paired with Floating Origin Rebasing (`CameraRelativeFloat3`) for runtime rendering and local simulation clusters:**
+
+1. **Global World Coordinates (`WorldCoordinate64`)**:
+   - The authoritative representation for global world space, spatial partitioning, persistent save state, and multiplayer network replication is a 64-bit composite coordinate: an `IntVector3` grid cell coordinate (`int32_t[3]` or `int64_t[3]`) defining discrete spatial grid blocks (e.g., $1024\,\text{m}$ cell size) combined with a 32-bit `Vec3` local offset within the cell $[0, \text{CellSize})$.
+   - Alternatively convertible losslessly to/from fixed-point 64-bit integer millimeters (`int64_t[3]`, providing $\pm 9.22 \times 10^{12}\,\text{m}$ range with $1\,\text{mm}$ resolution) and double-precision floating point (`dvec3` / `DVec3`, providing 53 bits of significand for world tooling).
+2. **Floating Origin Rebasing (`CameraRelativeFloat3`)**:
+   - The active runtime view and local simulation operate in a localized single-precision floating-point frame relative to a dynamic floating origin $C_{\text{origin}}$.
+   - When the active camera or focal entity traverses beyond a configured rebasing threshold distance ($R_{\text{threshold}}$, default $1000\,\text{m}$) from $C_{\text{origin}}$, the engine executes a coordinated, atomic Origin Rebase Transaction.
+   - The origin shift offset $\Delta_{\text{origin}} = C_{\text{new}} - C_{\text{old}}$ is calculated in 64-bit precision and broadcast as a typed `OriginRebaseEvent` at a declared frame synchronization safe point.
+3. **Camera-Relative GPU Rendering**:
+   - GPU shaders remain strictly 32-bit single precision (`fp32`).
+   - High-precision world-to-view subtractions $(P_{\text{world}} - C_{\text{camera}})$ are evaluated on the CPU or during constant-buffer generation.
+   - Vertex transformations in vertex shaders consume pre-translated camera-relative model matrices $M_{\text{view\_rel}} = V_{\text{rel}} \cdot M_{\text{rel}}$, eliminating vertex jitter and z-fighting without requiring 64-bit GPU vertex attributes or shader emulation.
+4. **Local Physics and Subsystem Clusters**:
+   - The active `PhysicsWorld` resides entirely in local rebased cluster coordinates.
+   - On `OriginRebaseEvent`, the physics adapter shifts body spatial structures by $-\Delta_{\text{origin}}$ without modifying linear or angular velocities, contact manifold caches, or sleeping states.
+   - Audio listeners/emitters, VFX particle buffers, navigation agent waypoints, and camera rigs apply $-\Delta_{\text{origin}}$ cleanly without timing or derivative artifacts.
+5. **Fallible Boundaries and Typed Errors**:
+   - All spatial transformations, conversions, and rebase transactions return `Horo::Result<T, Error>` under the `horo.runtime.precision` and `horo.runtime.world_streaming` error domains per [ADR-008](008-error-model-exception-boundary-and-registry.md).
+
+---
+
+## Ratify-or-Revise Outcomes
+
+| Area | Prior Architecture State | Ratified / Revised Decision |
+|---|---|---|
+| Global World Coordinates | Implicit 32-bit `WorldCoordinate` (`Vec3`) in early sketches | **Revised.** Replaced with `WorldCoordinate64` (`IntVector3 cellIndex` + `Vec3 cellOffset`) and fixed-point `int64_t` millimeter representation. |
+| GPU Shader Precision | Undefined; potential risk of requiring `double` vertex attributes | **Ratified.** GPU shaders remain strictly `fp32`/`fp16`. Camera-relative transformation $(P_{\text{world}} - C_{\text{camera}})$ is computed on CPU during render extraction. |
+| Physics Coordinate Frame | Single global scene coordinate system | **Revised.** Physics runs in a local rebased coordinate frame. Position translation during rebasing preserves velocities and sleeping states. |
+| Origin Shift Notification | Informal event on generic bus | **Revised.** Formalized as a transactional two-phase protocol (`PrepareRebase` -> `CommitRebase`) with monotonic generation fencing via `OriginRebaseCoordinator`. |
+| Subsystem Synchronization | Subsystems handle origin drift independently | **Revised.** Synchronized broadcast at pre-physics frame safe point; unsupported or failing adapters abort the transaction with typed `Horo::Error`. |
+| Networking & Saves | Transmit local floats | **Ratified.** Saves and network authority serialize canonical `WorldCoordinate64`, decoupled from client-local floating origin states. |
+
+---
+
+## Authoritative Ownership
+
+| Subsystem / Type | Ownership Responsibility | Permitted Operations | Forbidden Operations |
+|---|---|---|---|
+| `OriginRebaseCoordinator` | Manages active floating origin $C_{\text{origin}}$, rebasing threshold checks, two-phase rebase transactions, and monotonic `OriginGeneration` | Evaluates camera position, computes $\Delta_{\text{origin}}$, dispatches `OriginRebaseEvent` at safe points | Direct mutation of private subsystem internal caches |
+| `WorldStreamingManager` | Spatial partition authority, streaming cell grid indexing, cell residency lifecycle | Converts `WorldCoordinate64` to `StreamingCellId`, queries streaming volumes | Rebasing scene geometry without coordinating with `OriginRebaseCoordinator` |
+| `RenderExtraction` / `RenderFrontend` | Computes camera-relative model-view matrices $M_{\text{view\_rel}}$, populates per-view uniform buffers | Subtracts camera origin on CPU, passes 32-bit float transforms to backend | Uploading 64-bit coordinate attributes to GPU shaders |
+| `PhysicsWorldAdapter` | Translates physics rigid bodies, colliders, character controllers, and query bounds by $-\Delta_{\text{origin}}$ | Spatial proxy shift, broadphase updates | Modifying velocities, waking sleeping bodies, applying forces during shift |
+| `AudioSubsystemAdapter` | Translates active listener and 3D spatial emitter positions | Updates emitter coordinates | Re-triggering voices, applying Doppler shifts during origin rebase |
+| `VfxSubsystemAdapter` | Translates live particle position buffers in world-space emitters | Uniform vector offset subtraction | Re-seeding emitters or resetting particle lifetimes |
+| `NavigationSubsystemAdapter` | Translates dynamic obstacle overlays and active agent paths | Translates corridor waypoints | Invalidating static NavMesh tile topology |
+| `SceneRuntime` (ECS) | Owns entity hierarchy, local transforms, and scene-level spatial components | Translates root entity rebased transforms | Desynchronizing entity global positions from cell partitions |
+
+---
+
+## Platform Cost & GPU Compatibility Analysis
+
+### 1. GPU Shader Evaluation: `fp32` vs `fp64` vs Emulated `Double-Single`
+
+| Strategy | Performance on Mobile (iOS/Android) | Performance on Desktop (Metal/Vulkan/D3D12) | Implementation Complexity | Architectural Fit |
+|---|---|---|---|---|
+| **GPU Native `fp64`** | **Unsupported / Broken** (Metal iOS & GLES lack `double` support; severe ALU penalty on desktop) | 1/4 to 1/32 FP32 ALU throughput | Low (if hardware supported) | **Rejected**: Violates mobile and console parity goals. |
+| **GPU Emulated DS (`fp32` pairs)** | 4x–8x shader ALU instruction bloat; high register pressure | 3x–4x shader ALU instruction bloat | High | **Rejected**: Excessive energy and bandwidth cost across all platforms. |
+| **Camera-Relative `fp32` (Selected)** | **Zero overhead**; native full-rate `fp32` ALUs | **Zero overhead**; native full-rate `fp32` ALUs | Low (CPU-side matrix subtraction) | **Selected**: Optimal performance, universal hardware compatibility. |
+
+### 2. CPU Precision Arithmetic Costs
+
+- Subtraction of 64-bit integer / double-precision vector coordinates on CPU occurs during **Render Extraction** (once per render instance per frame) and **Origin Rebasing** (infrequently, e.g., once every several minutes of travel).
+- SIMD-accelerated 64-bit arithmetic (`_mm256_sub_pd`, ARM Neon `vsubq_f64` / `vsubq_s64`) executes in $< 1\,\text{ns}$ per instance, resulting in negligible frame-time impact ($< 0.02\,\text{ms}$ for $10,000$ draw calls).
+
+---
+
+## Physics & Scene Authority
+
+1. **Velocity and Momentum Invariants**:
+   Under Galilean relativity, linear velocity $\vec{v} = \frac{d\vec{x}}{dt}$, angular velocity $\vec{\omega}$, acceleration $\vec{a}$, and forces $\vec{F}$ are invariant under spatial translation $\vec{x}' = \vec{x} - \Delta\vec{x}_0$.
+   Therefore, when `OriginRebaseEvent` is dispatched:
+   $$\vec{x}_{\text{body\_new}} = \vec{x}_{\text{body\_old}} - \Delta_{\text{origin}}$$
+   $$\vec{v}_{\text{body\_new}} = \vec{v}_{\text{body\_old}}, \quad \vec{\omega}_{\text{body\_new}} = \vec{\omega}_{\text{body\_old}}$$
+   The physics adapter modifies only internal broadphase bounding boxes and position state. No impulse is applied, contact manifolds preserve their local penetration normals, and sleeping islands remain asleep.
+
+2. **Rebasing Safe Points**:
+   Origin rebasing is strictly prohibited during:
+   - Fixed-step physics integration ticks (`PhysicsWorld::Step`).
+   - Active GPU command buffer recording / render pass execution.
+   - Asynchronous job execution mutating spatial components.
+   Rebasing occurs exclusively at the **Post-Simulation / Pre-Render Synchronization Point** on the main thread (`MainEditor` role).
+
+---
+
+## Fallible Results and Error Domains
+
+All precision and origin rebasing operations conform to [ADR-008](008-error-model-exception-boundary-and-registry.md):
+
+```cpp
+namespace Horo::Runtime::Precision {
+
+enum class PrecisionErrorCode {
+    CoordinateOverflow,          // Coordinate exceeds representable 64-bit world bounds
+    NonFiniteCoordinate,         // Input contains NaN or infinite floating-point values
+    InvalidRebaseDelta,          // Rebase offset vector is non-finite or exceeds maximum single shift step
+    ParticipantRebaseFailed,     // A registered subsystem adapter failed during Prepare or Commit
+    UnregisteredParticipant,     // Attempted to interact with an invalid or dead adapter handle
+    StaleOriginGeneration,       // Origin generation mismatch during transactional commit
+    RebaseDuringSimulationStep,  // Attempted to trigger rebase while physics or render graph was active
+    TransactionAborted           // Rebase aborted during preparation phase
+};
+
+} // namespace Horo::Runtime::Precision
+```
+
+---
+
+## Consequences
+
+### Positive
+- **Limitless World Scale**: Allows worlds spanning millions of kilometers (solar systems, flight sims, continuous landscapes) with sub-millimeter precision near the viewer.
+- **Universal Hardware Parity**: Shaders execute standard 32-bit single precision on iOS, Android, macOS (Metal), Linux/Windows (Vulkan/OpenGL/D3D12), and consoles.
+- **Stable Multi-User Sync & Saves**: Canonical `WorldCoordinate64` ensures world persistence and network packets never suffer from floating-origin drift or precision loss.
+- **Zero Simulation Artifacts**: Physics, audio, VFX, and AI navigate origin shifts seamlessly without momentum glitches, audio pops, or visual hitching.
+
+### Negative / Trade-offs
+- **Extraction Discipline**: Render extraction code must always calculate camera-relative matrices rather than concatenating raw absolute coordinates.
+- **Subsystem Registration**: Every spatial subsystem must implement an `IOriginRebaseParticipant` adapter and register with `OriginRebaseCoordinator`.
+
+---
+
+## Rejected Alternatives
+
+1. **Uniform 64-bit Floating-Point Everything (`dvec3` on CPU and GPU)**:
+   - *Reason for Rejection*: Mobile GPUs (Mali, Adreno, Apple Mobile) do not support native FP64 arithmetic. Emulating FP64 in GLSL/MSL shaders causes catastrophic performance loss (4x–16x frame time increase).
+2. **Periodic Scene Reload / Level Chunk Teleportation**:
+   - *Reason for Rejection*: Destroys continuity, causes massive frame hitching, breaks live physics simulations, and interrupts audio playback.
+3. **Double-Single (DS) High-Low Emulation in Shaders**:
+   - *Reason for Rejection*: Doubles memory bandwidth for vertex attributes and consumes excessive shader ALU registers, causing occupancy drops on low-end GPUs.
+4. **Local Physics Clusters with Independent Unsynchronized Origins**:
+   - *Reason for Rejection*: Creates complex boundary discontinuities when rigid bodies cross cluster boundaries; synchronizing a single global floating origin across active local clusters is vastly simpler and robust.

--- a/docs/adr/014-large-world-precision-and-floating-origin-strategy.md
+++ b/docs/adr/014-large-world-precision-and-floating-origin-strategy.md
@@ -30,6 +30,7 @@ Standard 32-bit single-precision IEEE 754 floating-point coordinates (`fp32`) pr
 To support large-scale open worlds, flight/space simulations, and seamless multi-region environments without compromising cross-platform compatibility (e.g., Mobile OpenGL ES / Metal / Vulkan and WebGL), Horo Engine requires an explicit, normative coordinate precision and origin rebasing strategy.
 
 Key design constraints:
+
 1. **Universal GPU Compatibility**: Mobile GPUs (Apple Silicon mobile tiers, ARM Mali, Qualcomm Adreno) and entry-level graphics hardware lack hardware FP64 arithmetic or incur severe ALU throughput penalties (16x–32x slowdown). GPU shaders must remain 32-bit single precision (`fp32`) / half precision (`fp16`).
 2. **Physics Engine Stability**: Commercial and open-source physics engines (e.g., Jolt, PhysX, Box2D) rely on 32-bit floating point calculations for collision detection, EPA/GJK, island solving, and sleeping. Physics clusters must remain localized within low-magnitude coordinate frames.
 3. **Deterministic Persistence & Replication**: Authoring tools, spatial partitioning grids, save games, and multiplayer state replication require a stable, absolute global frame of reference that never drifts when the local rendering origin shifts.
@@ -150,12 +151,14 @@ enum class PrecisionErrorCode {
 ## Consequences
 
 ### Positive
+
 - **Limitless World Scale**: Allows worlds spanning millions of kilometers (solar systems, flight sims, continuous landscapes) with sub-millimeter precision near the viewer.
 - **Universal Hardware Parity**: Shaders execute standard 32-bit single precision on iOS, Android, macOS (Metal), Linux/Windows (Vulkan/OpenGL/D3D12), and consoles.
 - **Stable Multi-User Sync & Saves**: Canonical `WorldCoordinate64` ensures world persistence and network packets never suffer from floating-origin drift or precision loss.
 - **Zero Simulation Artifacts**: Physics, audio, VFX, and AI navigate origin shifts seamlessly without momentum glitches, audio pops, or visual hitching.
 
 ### Negative / Trade-offs
+
 - **Extraction Discipline**: Render extraction code must always calculate camera-relative matrices rather than concatenating raw absolute coordinates.
 - **Subsystem Registration**: Every spatial subsystem must implement an `IOriginRebaseParticipant` adapter and register with `OriginRebaseCoordinator`.
 

--- a/docs/adr/014-large-world-precision-and-floating-origin-strategy.md
+++ b/docs/adr/014-large-world-precision-and-floating-origin-strategy.md
@@ -42,8 +42,8 @@ Key design constraints:
 **Horo Engine adopts a Hybrid Hierarchical Global Coordinate representation (`WorldCoordinate64`) paired with Floating Origin Rebasing (`CameraRelativeFloat3`) for runtime rendering and local simulation clusters:**
 
 1. **Global World Coordinates (`WorldCoordinate64`)**:
-   - The authoritative representation for global world space, spatial partitioning, persistent save state, and multiplayer network replication is a 64-bit composite coordinate: an `IntVector3` grid cell coordinate (`int32_t[3]` or `int64_t[3]`) defining discrete spatial grid blocks (e.g., $1024\,\text{m}$ cell size) combined with a 32-bit `Vec3` local offset within the cell $[0, \text{CellSize})$.
-   - Alternatively convertible losslessly to/from fixed-point 64-bit integer millimeters (`int64_t[3]`, providing $\pm 9.22 \times 10^{12}\,\text{m}$ range with $1\,\text{mm}$ resolution) and double-precision floating point (`dvec3` / `DVec3`, providing 53 bits of significand for world tooling).
+   - The authoritative representation for global world space, spatial partitioning, persistent save state, and multiplayer network replication is a 64-bit composite coordinate: an `IntVector3` grid cell index plus an `IntVector3 cellOffsetMm` stored in integer millimeters in the half-open range `[0, cellSizeMm)` (default cell $1024\,\text{m} = 1\,024\,000\,\text{mm}$).
+   - Round-trip conversion to/from world-space fixed-point 64-bit integer millimeters (`int64_t[3]`, $\pm 9.22 \times 10^{12}\,\text{m}$ range with $1\,\text{mm}$ resolution) is exact. `dvec3` / `DVec3` is a derived tooling view (53-bit significand), not canonical storage. A 32-bit `Vec3` cell offset is rejected: near a 1024 m cell edge fp32 ULP is ≈ 0.12 mm, so it cannot satisfy an exact millimeter round-trip.
 2. **Floating Origin Rebasing (`CameraRelativeFloat3`)**:
    - The active runtime view and local simulation operate in a localized single-precision floating-point frame relative to a dynamic floating origin $C_{\text{origin}}$.
    - When the active camera or focal entity traverses beyond a configured rebasing threshold distance ($R_{\text{threshold}}$, default $1000\,\text{m}$) from $C_{\text{origin}}$, the engine executes a coordinated, atomic Origin Rebase Transaction.
@@ -65,7 +65,7 @@ Key design constraints:
 
 | Area | Prior Architecture State | Ratified / Revised Decision |
 |---|---|---|
-| Global World Coordinates | Implicit 32-bit `WorldCoordinate` (`Vec3`) in early sketches | **Revised.** Replaced with `WorldCoordinate64` (`IntVector3 cellIndex` + `Vec3 cellOffset`) and fixed-point `int64_t` millimeter representation. |
+| Global World Coordinates | Implicit 32-bit `WorldCoordinate` (`Vec3`) in early sketches | **Revised.** Replaced with `WorldCoordinate64` (`IntVector3 cellIndex` + `IntVector3 cellOffsetMm`) and exact `int64_t` millimeter round-trip. fp32 offsets are local-frame only. |
 | GPU Shader Precision | Undefined; potential risk of requiring `double` vertex attributes | **Ratified.** GPU shaders remain strictly `fp32`/`fp16`. Camera-relative transformation $(P_{\text{world}} - C_{\text{camera}})$ is computed on CPU during render extraction. |
 | Physics Coordinate Frame | Single global scene coordinate system | **Revised.** Physics runs in a local rebased coordinate frame. Position translation during rebasing preserves velocities and sleeping states. |
 | Origin Shift Notification | Informal event on generic bus | **Revised.** Formalized as a transactional two-phase protocol (`PrepareRebase` -> `CommitRebase`) with monotonic generation fencing via `OriginRebaseCoordinator`. |

--- a/docs/adr/026-large-world-precision-and-floating-origin-strategy.md
+++ b/docs/adr/026-large-world-precision-and-floating-origin-strategy.md
@@ -5,6 +5,7 @@
 - **Supersedes**: None
 - **Scope**: Coordinate systems, precision representations (64-bit integer, double-precision floats, camera-relative floats), floating origin rebasing transactions, platform/GPU shader performance boundaries, physics/subsystem authority, and error domains.
 - **Issue**: [#1604](https://github.com/abdullahbodur/horo-engine/issues/1604) ([WST-007.1])
+- **JIRA**: HORO-1604
 - **Parent**: [#1524](https://github.com/abdullahbodur/horo-engine/issues/1524) ([WST-007])
 - **Normative documents**:
   - [Coordinate Precision And Origin Rebasing](../architecture/runtime/coordinate-precision-and-origin-rebasing.md)

--- a/docs/adr/026-large-world-precision-and-floating-origin-strategy.md
+++ b/docs/adr/026-large-world-precision-and-floating-origin-strategy.md
@@ -1,4 +1,4 @@
-# ADR-014: Large-World Precision and Floating Origin Strategy
+# ADR-026: Large-World Precision and Floating Origin Strategy
 
 - **Status**: Proposed
 - **Date**: 2026-08-28

--- a/docs/adr/026-large-world-precision-and-floating-origin-strategy.md
+++ b/docs/adr/026-large-world-precision-and-floating-origin-strategy.md
@@ -32,7 +32,7 @@ To support large-scale open worlds, flight/space simulations, and seamless multi
 
 Key design constraints:
 
-1. **Universal GPU Compatibility**: Mobile GPUs (Apple Silicon mobile tiers, ARM Mali, Qualcomm Adreno) and entry-level graphics hardware lack hardware FP64 arithmetic or incur severe ALU throughput penalties (16x–32x slowdown). GPU shaders must remain 32-bit single precision (`fp32`) / half precision (`fp16`).
+1. **Universal GPU Compatibility**: Mobile and entry-level GPUs may lack shader FP64 support or provide materially lower FP64 throughput. GPU shaders therefore remain on the supported `fp32` / `fp16` path.
 2. **Physics Engine Stability**: Commercial and open-source physics engines (e.g., Jolt, PhysX, Box2D) rely on 32-bit floating point calculations for collision detection, EPA/GJK, island solving, and sleeping. Physics clusters must remain localized within low-magnitude coordinate frames.
 3. **Deterministic Persistence & Replication**: Authoring tools, spatial partitioning grids, save games, and multiplayer state replication require a stable, absolute global frame of reference that never drifts when the local rendering origin shifts.
 4. **Zero Velocity Discontinuities**: Origin rebasing is a coordinate frame re-indexing, not a physical displacement over time; it must not induce artificial velocity spikes, Doppler glitches, or particle recreation.
@@ -98,13 +98,13 @@ Key design constraints:
 | Strategy | Performance on Mobile (iOS/Android) | Performance on Desktop (Metal/Vulkan/D3D12) | Implementation Complexity | Architectural Fit |
 |---|---|---|---|---|
 | **GPU Native `fp64`** | **Unsupported / Broken** (Metal iOS & GLES lack `double` support; severe ALU penalty on desktop) | 1/4 to 1/32 FP32 ALU throughput | Low (if hardware supported) | **Rejected**: Violates mobile and console parity goals. |
-| **GPU Emulated DS (`fp32` pairs)** | 4x–8x shader ALU instruction bloat; high register pressure | 3x–4x shader ALU instruction bloat | High | **Rejected**: Excessive energy and bandwidth cost across all platforms. |
-| **Camera-Relative `fp32` (Selected)** | **Zero overhead**; native full-rate `fp32` ALUs | **Zero overhead**; native full-rate `fp32` ALUs | Low (CPU-side matrix subtraction) | **Selected**: Optimal performance, universal hardware compatibility. |
+| **GPU Emulated DS (`fp32` pairs)** | Multiple FP32 operations per emulated scalar and increased register pressure | Multiple FP32 operations per emulated scalar and increased register pressure | High | **Rejected**: Adds shader cost and complexity to every supported platform. |
+| **Camera-Relative `fp32` (Selected)** | Uses the platform's native FP32 shader path; shifts subtraction work to extraction | Uses the platform's native FP32 shader path; shifts subtraction work to extraction | Low (CPU-side matrix subtraction) | **Selected**: Preserves broad hardware compatibility and keeps the cost measurable at one boundary. |
 
 ### 2. CPU Precision Arithmetic Costs
 
 - Subtraction of 64-bit integer / double-precision vector coordinates on CPU occurs during **Render Extraction** (once per render instance per frame) and **Origin Rebasing** (infrequently, e.g., once every several minutes of travel).
-- SIMD-accelerated 64-bit arithmetic (`_mm256_sub_pd`, ARM Neon `vsubq_f64` / `vsubq_s64`) executes in $< 1\,\text{ns}$ per instance, resulting in negligible frame-time impact ($< 0.02\,\text{ms}$ for $10,000$ draw calls).
+- Implementations must benchmark coordinate conversion and camera-relative extraction with representative instance counts, release builds, and each supported CPU architecture. This decision does not prescribe an unmeasured latency target.
 
 ---
 
@@ -153,7 +153,7 @@ enum class PrecisionErrorCode {
 
 ### Positive
 
-- **Limitless World Scale**: Allows worlds spanning millions of kilometers (solar systems, flight sims, continuous landscapes) with sub-millimeter precision near the viewer.
+- **Large Supported Range**: Allows worlds spanning the documented `WorldCoordinate64` range while preserving millimeter-scale canonical storage and high local precision near the viewer.
 - **Universal Hardware Parity**: Shaders execute standard 32-bit single precision on iOS, Android, macOS (Metal), Linux/Windows (Vulkan/OpenGL/D3D12), and consoles.
 - **Stable Multi-User Sync & Saves**: Canonical `WorldCoordinate64` ensures world persistence and network packets never suffer from floating-origin drift or precision loss.
 - **Zero Simulation Artifacts**: Physics, audio, VFX, and AI navigate origin shifts seamlessly without momentum glitches, audio pops, or visual hitching.
@@ -168,7 +168,7 @@ enum class PrecisionErrorCode {
 ## Rejected Alternatives
 
 1. **Uniform 64-bit Floating-Point Everything (`dvec3` on CPU and GPU)**:
-   - *Reason for Rejection*: Mobile GPUs (Mali, Adreno, Apple Mobile) do not support native FP64 arithmetic. Emulating FP64 in GLSL/MSL shaders causes catastrophic performance loss (4x–16x frame time increase).
+   - *Reason for Rejection*: Supported mobile APIs and GPUs do not provide a uniform native FP64 shader contract. Emulation adds substantial ALU and register pressure that must not be imposed on every draw.
 2. **Periodic Scene Reload / Level Chunk Teleportation**:
    - *Reason for Rejection*: Destroys continuity, causes massive frame hitching, breaks live physics simulations, and interrupts audio playback.
 3. **Double-Single (DS) High-Low Emulation in Shaders**:

--- a/docs/adr/026-large-world-precision-and-floating-origin-strategy.md
+++ b/docs/adr/026-large-world-precision-and-floating-origin-strategy.md
@@ -22,11 +22,13 @@ Standard 32-bit single-precision IEEE 754 floating-point coordinates (`fp32`) pr
 
 | Distance from Origin | Spatial Resolution ($\text{ulp}$) | Visual & Physical Artifacts |
 |---|---|---|
-| $1\,\text{km}$ ($10^3\,\text{m}$) | $\approx 0.00012\,\text{m}$ ($0.12\,\text{mm}$) | Imperceptible |
+| $1\,\text{km}$ ($10^3\,\text{m}$) | $\approx 0.000061\,\text{m}$ ($0.061\,\text{mm}$) | Imperceptible |
 | $10\,\text{km}$ ($10^4\,\text{m}$) | $\approx 0.00098\,\text{m}$ ($0.98\,\text{mm}$) | Sub-millimeter jitter in close-up geometry |
 | $100\,\text{km}$ ($10^5\,\text{m}$) | $\approx 0.0078\,\text{m}$ ($7.8\,\text{mm}$) | Noticeable vertex shaking, Z-fighting, physics contact instability |
 | $1,000\,\text{km}$ ($10^6\,\text{m}$) | $\approx 0.0625\,\text{m}$ ($6.25\,\text{cm}$) | Unusable physics simulation, massive mesh jitter, broken camera controls |
-| $10,000\,\text{km}$ ($10^7\,\text{m}$) | $\approx 0.5\,\text{m}$ ($50\,\text{cm}$) | Total collapse of spatial coherence |
+| $10,000\,\text{km}$ ($10^7\,\text{m}$) | $\approx 1.0\,\text{m}$ | Total collapse of spatial coherence |
+
+ULP values are IEEE-754 binary32 unit-in-the-last-place at the exact listed distance: $\mathrm{ULP}(x) = 2^{\lfloor \log_2 |x| \rfloor - 23}$ for normal numbers.
 
 To support large-scale open worlds, flight/space simulations, and seamless multi-region environments without compromising cross-platform compatibility (e.g., Mobile OpenGL ES / Metal / Vulkan and WebGL), Horo Engine requires an explicit, normative coordinate precision and origin rebasing strategy.
 
@@ -45,7 +47,7 @@ Key design constraints:
 
 1. **Global World Coordinates (`WorldCoordinate64`)**:
    - The authoritative representation for global world space, spatial partitioning, persistent save state, and multiplayer network replication is a 64-bit composite coordinate: an `IntVector3` grid cell index plus an `IntVector3 cellOffsetMm` stored in integer millimeters in the half-open range `[0, cellSizeMm)` (default cell $1024\,\text{m} = 1\,024\,000\,\text{mm}$).
-   - Round-trip conversion to/from world-space fixed-point 64-bit integer millimeters (`int64_t[3]`, $\pm 9.22 \times 10^{12}\,\text{m}$ range with $1\,\text{mm}$ resolution) is exact. `dvec3` / `DVec3` is a derived tooling view (53-bit significand), not canonical storage. A 32-bit `Vec3` cell offset is rejected: near a 1024 m cell edge fp32 ULP is ≈ 0.12 mm, so it cannot satisfy an exact millimeter round-trip.
+   - Round-trip conversion to/from world-space fixed-point 64-bit integer millimeters (`int64_t[3]`, $\pm 9.22 \times 10^{15}\,\text{m}$ range with $1\,\text{mm}$ resolution) is exact. `dvec3` / `DVec3` is a derived tooling view (53-bit significand), not canonical storage. A 32-bit `Vec3` cell offset is rejected: near a 1024 m cell edge fp32 ULP is ≈ 0.12 mm, so it cannot satisfy an exact millimeter round-trip.
 2. **Floating Origin Rebasing (`CameraRelativeFloat3`)**:
    - The active runtime view and local simulation operate in a localized single-precision floating-point frame relative to a dynamic floating origin $C_{\text{origin}}$.
    - When the active camera or focal entity traverses beyond a configured rebasing threshold distance ($R_{\text{threshold}}$, default $1000\,\text{m}$) from $C_{\text{origin}}$, the engine executes a coordinated, atomic Origin Rebase Transaction.
@@ -55,7 +57,7 @@ Key design constraints:
    - High-precision world-to-view subtractions $(P_{\text{world}} - C_{\text{camera}})$ are evaluated on the CPU or during constant-buffer generation.
    - Vertex transformations in vertex shaders consume pre-translated camera-relative model matrices $M_{\text{view\_rel}} = V_{\text{rel}} \cdot M_{\text{rel}}$, eliminating vertex jitter and z-fighting without requiring 64-bit GPU vertex attributes or shader emulation.
 4. **Local Physics and Subsystem Clusters**:
-   - The active `PhysicsWorld` resides entirely in local rebased cluster coordinates.
+   - The active `PhysicsWorld` resides entirely in local rebased cluster coordinates within $[-R_{\text{physics}}, +R_{\text{physics}}]$ (default $8192\,\text{m}$). $R_{\text{physics}}$ is independent of $R_{\text{threshold}}$ (default $1000\,\text{m}$); see the normative document.
    - On `OriginRebaseEvent`, the physics adapter shifts body spatial structures by $-\Delta_{\text{origin}}$ without modifying linear or angular velocities, contact manifold caches, or sleeping states.
    - Audio listeners/emitters, VFX particle buffers, navigation agent waypoints, and camera rigs apply $-\Delta_{\text{origin}}$ cleanly without timing or derivative artifacts.
 5. **Fallible Boundaries and Typed Errors**:
@@ -71,7 +73,7 @@ Key design constraints:
 | GPU Shader Precision | Undefined; potential risk of requiring `double` vertex attributes | **Ratified.** GPU shaders remain strictly `fp32`/`fp16`. Camera-relative transformation $(P_{\text{world}} - C_{\text{camera}})$ is computed on CPU during render extraction. |
 | Physics Coordinate Frame | Single global scene coordinate system | **Revised.** Physics runs in a local rebased coordinate frame. Position translation during rebasing preserves velocities and sleeping states. |
 | Origin Shift Notification | Informal event on generic bus | **Revised.** Formalized as a transactional two-phase protocol (`PrepareRebase` -> `CommitRebase`) with monotonic generation fencing via `OriginRebaseCoordinator`. |
-| Subsystem Synchronization | Subsystems handle origin drift independently | **Revised.** Synchronized broadcast at pre-physics frame safe point; unsupported or failing adapters abort the transaction with typed `Horo::Error`. |
+| Subsystem Synchronization | Subsystems handle origin drift independently | **Revised.** Synchronized broadcast at the post-simulation / pre-render safe point; unsupported or failing adapters abort the transaction with typed `Horo::Error`. |
 | Networking & Saves | Transmit local floats | **Ratified.** Saves and network authority serialize canonical `WorldCoordinate64`, decoupled from client-local floating origin states. |
 
 ---
@@ -122,7 +124,7 @@ Key design constraints:
    - Fixed-step physics integration ticks (`PhysicsWorld::Step`).
    - Active GPU command buffer recording / render pass execution.
    - Asynchronous job execution mutating spatial components.
-   Rebasing occurs exclusively at the **Post-Simulation / Pre-Render Synchronization Point** on the main thread (`MainEditor` role).
+   Rebasing occurs exclusively at the **Post-Simulation / Pre-Render Synchronization Point** on the host thread that ticks `SceneRuntime` (editor, game, and dedicated-server hosts). This is not an editor-type dependency.
 
 ---
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
+| [014](014-large-world-precision-and-floating-origin-strategy.md) | Large-World Precision and Floating Origin Strategy | proposed | 2026-08-28 |
 
 ## Conventions
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
-| [014](014-large-world-precision-and-floating-origin-strategy.md) | Large-World Precision and Floating Origin Strategy | proposed | 2026-08-28 |
+| [014](026-large-world-precision-and-floating-origin-strategy.md) | Large-World Precision and Floating Origin Strategy | proposed | 2026-08-28 |
 
 ## Conventions
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@ to the replacement.
 | [008](008-error-model-exception-boundary-and-registry.md) | Error Model, Exception Boundary and Registry Ownership | proposed | 2026-08-27 |
 | [009](009-configuration-schema-precedence-and-secret-boundary.md) | Configuration Schema, Precedence and Secret Boundary | proposed | 2026-08-28 |
 | [010](010-job-waiting-and-operation-store-ownership.md) | Job Waiting and Operation Store Ownership | proposed | 2026-08-28 |
-| [014](026-large-world-precision-and-floating-origin-strategy.md) | Large-World Precision and Floating Origin Strategy | proposed | 2026-08-28 |
+| [026](026-large-world-precision-and-floating-origin-strategy.md) | Large-World Precision and Floating Origin Strategy | proposed | 2026-08-28 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -144,6 +144,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [World Streaming Architecture](./runtime/world-streaming-architecture.md):
   streaming cells, volumes, priority, budgets, server authority, and editor
   world-composition tools.
+- [Coordinate Precision And Origin Rebasing](./runtime/coordinate-precision-and-origin-rebasing.md):
+  canonical 64-bit world coordinates, floating origin rebasing, camera-relative
+  rendering, and subsystem synchronizations.
 - [Save Game And Persistence](./runtime/save-game-and-persistence.md): runtime
   save state, slot format, migration, cloud save, integrity, and secure archive
   loading.

--- a/docs/architecture/foundation/scene-math.md
+++ b/docs/architecture/foundation/scene-math.md
@@ -23,10 +23,11 @@ rotation, and scale. Quaternion Euler conversion preserves the engine's existing
 X/Y/Z authored rotation order.
 
 `IntVector3` stores discrete integer 3D spatial cell coordinates. `WorldCoordinate64`
-is the composite 64-bit global world coordinate (`IntVector3 cellIndex` + `Vec3 cellOffset`),
-which converts losslessly to/from fixed-point millimeter `int64_t[3]` and double-precision
-`dvec3`. `CameraRelativeFloat3` (`Vec3`) represents high-precision localized coordinates
-relative to the active camera or floating origin.
+is the composite 64-bit global world coordinate (`IntVector3 cellIndex` +
+`IntVector3 cellOffsetMm` in integer millimeters). Round-trip to world-space
+fixed-point millimeter `int64_t[3]` is exact; `dvec3` is a derived view after
+1 mm quantization. `CameraRelativeFloat3` (`Vec3`) represents high-precision
+localized coordinates relative to the active camera or floating origin.
 
 The default comparison epsilon is `1e-6`. Callers may select a larger epsilon for
 accumulated or presentation-space computations. Inputs crossing an authoring,

--- a/docs/architecture/foundation/scene-math.md
+++ b/docs/architecture/foundation/scene-math.md
@@ -17,9 +17,16 @@ inverse, ray, or intersection implementations.
 ## Public Values
 
 The common value vocabulary is `Vec2`, `Vec3`, `Vec4`, `Quaternion`, `Mat4`,
-`Transform`, `Ray`, `Plane`, `Aabb`, `BoundingSphere`, and `RayHit`. `Transform`
-stores local translation, quaternion rotation, and scale. Quaternion Euler
-conversion preserves the engine's existing X/Y/Z authored rotation order.
+`Transform`, `Ray`, `Plane`, `Aabb`, `BoundingSphere`, `RayHit`, `IntVector3`,
+and `WorldCoordinate64`. `Transform` stores local translation, quaternion
+rotation, and scale. Quaternion Euler conversion preserves the engine's existing
+X/Y/Z authored rotation order.
+
+`IntVector3` stores discrete integer 3D spatial cell coordinates. `WorldCoordinate64`
+is the composite 64-bit global world coordinate (`IntVector3 cellIndex` + `Vec3 cellOffset`),
+which converts losslessly to/from fixed-point millimeter `int64_t[3]` and double-precision
+`dvec3`. `CameraRelativeFloat3` (`Vec3`) represents high-precision localized coordinates
+relative to the active camera or floating origin.
 
 The default comparison epsilon is `1e-6`. Callers may select a larger epsilon for
 accumulated or presentation-space computations. Inputs crossing an authoring,

--- a/docs/architecture/runtime/coordinate-precision-and-origin-rebasing.md
+++ b/docs/architecture/runtime/coordinate-precision-and-origin-rebasing.md
@@ -381,7 +381,7 @@ Automated and integration test suites must cover:
 
 ## Related Documents and ADRs
 
-- [ADR-014: Large-World Precision and Floating Origin Strategy](../../adr/014-large-world-precision-and-floating-origin-strategy.md): Ratified architecture decision and context.
+- [ADR-026: Large-World Precision and Floating Origin Strategy](../../adr/026-large-world-precision-and-floating-origin-strategy.md): Ratified architecture decision and context.
 - [World Streaming Architecture](./world-streaming-architecture.md): Spatial partitioning, streaming cells, volumes, and lifecycle.
 - [Rendering Architecture](./rendering-architecture.md): Render extraction, camera-relative matrices, and GPU resource ownership.
 - [Physics Architecture](./physics-architecture.md): Fixed-step physics, transform authority, and local world simulation.

--- a/docs/architecture/runtime/coordinate-precision-and-origin-rebasing.md
+++ b/docs/architecture/runtime/coordinate-precision-and-origin-rebasing.md
@@ -1,0 +1,375 @@
+# Coordinate Precision and Origin Rebasing
+
+## Purpose
+
+This document defines the normative coordinate precision strategy, floating origin rebasing model, GPU shader precision boundaries, physics and subsystem coordinate authority, and lifecycle contracts for large-scale world simulation in Horo Engine.
+
+---
+
+## Core Decisions
+
+- **Hybrid Global Coordinates (`WorldCoordinate64`)**: The authoritative coordinate system for global world space, spatial partitioning, save serialization, and multiplayer replication is a 64-bit composite coordinate (`IntVector3 cellIndex` + `Vec3 cellOffset`), lossless convertible to/from fixed-point integer millimeters (`int64_t[3]`) and double-precision meters (`dvec3`).
+- **Floating Origin Rebasing (`CameraRelativeFloat3`)**: Active runtime rendering, physics simulation, audio spatialization, and VFX run in localized 32-bit single-precision floating-point coordinates relative to a dynamic floating origin $C_{\text{origin}}$.
+- **Universal GPU 32-bit Shading**: GPU shaders execute exclusively in 32-bit single precision (`fp32`) / half precision (`fp16`). Camera-relative subtraction $(P_{\text{world}} - C_{\text{camera}})$ is evaluated on the CPU or constant-buffer generation during render extraction; shaders receive pre-translated model-view matrices $M_{\text{view\_rel}}$.
+- **Zero Velocity Discontinuity**: Origin shifts are discrete coordinate frame translations ($\vec{x}' = \vec{x} - \Delta_{\text{origin}}$), not physical movements over time $\Delta t$. Spatial proxies and transforms are updated without modifying linear/angular velocities, forces, audio pitches (Doppler), or particle lifetimes.
+- **Atomic Two-Phase Origin Shift Protocol**: Origin rebasing is coordinated by `OriginRebaseCoordinator` at a declared frame synchronization safe point via an atomic two-phase protocol (`PrepareRebase` -> `CommitRebase`) protected by monotonic `OriginGeneration` fencing.
+- **Fallible Typed Error Model**: All coordinate conversions, bounding queries, and rebasing operations conform to [ADR-008](../../adr/008-error-model-exception-boundary-and-registry.md) using `Horo::Result<T, Error>` under the `horo.runtime.precision` error domain.
+
+---
+
+## Mathematical and Coordinate Model
+
+```text
++-------------------------------------------------------------------------+
+|                  Global World Space (Canonical Authority)               |
+|   WorldCoordinate64 = { IntVector3 cellIndex, Vec3 cellOffset }         |
+|   - Spatial partitioning grids & world composition                      |
+|   - Save-game serialization & level persistence                         |
+|   - Multiplayer network position authority                              |
++-------------------------------------------------------------------------+
+                                    |
+                    Rebasing Transform (CPU SIMD)
+                 P_local = P_world - C_floating_origin
+                                    v
++-------------------------------------------------------------------------+
+|                 Local Simulation Frame (Rebased Cluster)                |
+|   CameraRelativeFloat3 = Vec3 (fp32) relative to C_floating_origin      |
+|   - Physics rigid bodies, shapes, constraints, broadphase               |
+|   - Audio listener & 3D sound emitters                                  |
+|   - VFX particle buffers & simulation graphs                            |
+|   - Navigation agent paths & local obstacle avoidance                   |
+|   - Camera rigs, orbit controllers, & view matrices                     |
++-------------------------------------------------------------------------+
+                                    |
+                  Render Extraction (View Matrix Setup)
+                     P_cam_rel = P_local - (C_camera - C_floating_origin)
+                                    v
++-------------------------------------------------------------------------+
+|                     GPU Vertex Pipeline (32-bit FP)                     |
+|   v_clip = ProjectionMatrix * ModelView_CameraRelative * v_mesh_local   |
+|   - Zero vertex jitter at 10,000 km distances                           |
+|   - Zero FP64 ALU penalty on Mobile / WebGL / Console                   |
+|   - Maximum FP32 mantissa precision at the camera near plane            |
++-------------------------------------------------------------------------+
+```
+
+### 1. Global World Coordinate Types
+
+```cpp
+namespace Horo::Math {
+
+/**
+ * @brief Discrete 3D integer vector for spatial grid cell indices.
+ */
+struct IntVector3 {
+    int32_t x{0};
+    int32_t y{0};
+    int32_t z{0};
+
+    [[nodiscard]] constexpr auto operator<=>(const IntVector3 &) const noexcept = default;
+
+    [[nodiscard]] friend constexpr IntVector3 operator+(IntVector3 lhs, IntVector3 rhs) noexcept {
+        return {lhs.x + rhs.x, lhs.y + rhs.y, lhs.z + rhs.z};
+    }
+
+    [[nodiscard]] friend constexpr IntVector3 operator-(IntVector3 lhs, IntVector3 rhs) noexcept {
+        return {lhs.x - rhs.x, lhs.y - rhs.y, lhs.z - rhs.z};
+    }
+};
+
+/**
+ * @brief Authoritative 64-bit composite global world coordinate.
+ * 
+ * Combines an integer cell index with a localized single-precision float offset.
+ * Default standard grid cell size is 1024.0 meters per side.
+ */
+struct WorldCoordinate64 {
+    static constexpr float DefaultCellSize = 1024.0F; // Meters per cell edge
+
+    IntVector3 cellIndex{0, 0, 0};
+    Vec3       cellOffset{0.0F, 0.0F, 0.0F}; // [0.0, CellSize) relative to cell minimum corner
+
+    [[nodiscard]] bool IsFinite() const noexcept;
+    
+    /**
+     * @brief Normalizes cellOffset into [0, cellSize) and updates cellIndex.
+     */
+    [[nodiscard]] Result<WorldCoordinate64> Normalize(float cellSize = DefaultCellSize) const noexcept;
+
+    /**
+     * @brief Lossless conversion to fixed-point integer millimeters (1 unit = 1 mm).
+     */
+    [[nodiscard]] Result<std::array<int64_t, 3>> ToMillimeters(float cellSize = DefaultCellSize) const noexcept;
+
+    /**
+     * @brief Constructs WorldCoordinate64 from fixed-point integer millimeters.
+     */
+    [[nodiscard]] static Result<WorldCoordinate64> FromMillimeters(
+        const std::array<int64_t, 3> &mm,
+        float cellSize = DefaultCellSize) noexcept;
+
+    /**
+     * @brief Converts to double-precision metric vector (meters from origin).
+     */
+    [[nodiscard]] Result<std::array<double, 3>> ToDoubleMeters(float cellSize = DefaultCellSize) const noexcept;
+
+    /**
+     * @brief Constructs WorldCoordinate64 from double-precision metric vector.
+     */
+    [[nodiscard]] static Result<WorldCoordinate64> FromDoubleMeters(
+        const std::array<double, 3> &meters,
+        float cellSize = DefaultCellSize) noexcept;
+
+    /**
+     * @brief Computes high-precision vector delta (lhs - rhs) in meters.
+     */
+    [[nodiscard]] friend Result<Vec3> SubtractToLocal(
+        const WorldCoordinate64 &lhs,
+        const WorldCoordinate64 &rhs,
+        float cellSize = DefaultCellSize) noexcept;
+};
+
+/**
+ * @brief Camera-relative or floating-origin relative 32-bit single-precision float coordinate.
+ */
+using CameraRelativeFloat3 = Vec3;
+
+} // namespace Horo::Math
+```
+
+### 2. Numerical Range and Precision Guarantees
+
+| Coordinate Format | Storage Size | Effective Range | Precision at Origin | Precision at $1000\,\text{km}$ |
+|---|---|---|---|---|
+| `WorldCoordinate64` (Standard Grid) | $12\,\text{bytes} + 12\,\text{bytes} = 24\,\text{bytes}$ | $\pm 2 \times 10^9\,\text{cells} \approx \pm 2 \times 10^{12}\,\text{m}$ | $< 0.0001\,\text{mm}$ | $< 0.0001\,\text{mm}$ |
+| Fixed-point Millimeter (`int64_t[3]`) | $24\,\text{bytes}$ | $\pm 9.22 \times 10^{12}\,\text{m}$ | $1.0\,\text{mm}$ constant | $1.0\,\text{mm}$ constant |
+| Double Precision (`dvec3` / `double[3]`) | $24\,\text{bytes}$ | $\pm 1.79 \times 10^{308}\,\text{m}$ | $10^{-16}\,\text{m}$ | $\approx 0.0001\,\text{mm}$ |
+| Camera-Relative `Vec3` (`fp32`) | $12\,\text{bytes}$ | Local cluster ($\pm 10\,\text{km}$ around camera) | $0.0001\,\text{mm}$ (at $1\,\text{m}$) | $\approx 0.1\,\text{mm}$ (within $1\,\text{km}$ of viewer) |
+
+---
+
+## Floating Origin Rebasing Architecture
+
+### 1. Origin Rebase Coordinator
+
+The `OriginRebaseCoordinator` is owned by `SceneRuntime` and updated during the pre-render frame phase on the main thread (`MainEditor` role).
+
+```cpp
+namespace Horo::Runtime::Precision {
+
+struct OriginRebaseConfig {
+    float rebasingThresholdMeters{1000.0F}; // Distance from origin before triggering shift
+    float gridCellSizeMeters{1024.0F};      // Spatial partition grid cell size
+    bool  snapToGridCells{true};            // If true, origin shifts by discrete cell increments
+};
+
+struct OriginRebaseEvent {
+    Math::WorldCoordinate64 oldOrigin;
+    Math::WorldCoordinate64 newOrigin;
+    Math::Vec3              shiftDelta;      // (newOrigin - oldOrigin) expressed in local meters
+    uint64_t                originGeneration; // Monotonically increasing origin revision
+};
+
+enum class RebasePhase : uint8_t {
+    Idle,
+    Preparing,
+    Committing,
+    RollingBack
+};
+
+class IOriginRebaseParticipant {
+public:
+    virtual ~IOriginRebaseParticipant() = default;
+    
+    [[nodiscard]] virtual std::string_view GetParticipantName() const noexcept = 0;
+    
+    /**
+     * @brief Phase 1: Validate readiness and pre-allocate migration memory.
+     * Must return Error if the subsystem cannot safely shift at this time.
+     */
+    [[nodiscard]] virtual Result<void> PrepareRebase(const OriginRebaseEvent &event) noexcept = 0;
+    
+    /**
+     * @brief Phase 2: Apply position translation atomically without velocity alteration.
+     */
+    virtual void CommitRebase(const OriginRebaseEvent &event) noexcept = 0;
+    
+    /**
+     * @brief Rollback: Executed if any participant failed during PrepareRebase.
+     */
+    virtual void RollbackRebase(const OriginRebaseEvent &event) noexcept = 0;
+};
+
+class OriginRebaseCoordinator {
+public:
+    explicit OriginRebaseCoordinator(OriginRebaseConfig config = {}) noexcept;
+    ~OriginRebaseCoordinator() noexcept;
+
+    [[nodiscard]] const Math::WorldCoordinate64 &GetActiveOrigin() const noexcept;
+    [[nodiscard]] uint64_t GetOriginGeneration() const noexcept;
+    [[nodiscard]] bool IsRebasing() const noexcept;
+
+    Result<void> RegisterParticipant(IOriginRebaseParticipant *participant) noexcept;
+    Result<void> UnregisterParticipant(IOriginRebaseParticipant *participant) noexcept;
+
+    /**
+     * @brief Evaluates camera position and executes atomic two-phase rebase if threshold is breached.
+     * Must be called at the declared post-simulation / pre-render synchronization point.
+     */
+    Result<bool> EvaluateAndRebase(const Math::WorldCoordinate64 &focalWorldPos) noexcept;
+
+    /**
+     * @brief Forces an explicit origin shift to a target world coordinate.
+     */
+    Result<void> ForceRebase(const Math::WorldCoordinate64 &targetOrigin) noexcept;
+};
+
+} // namespace Horo::Runtime::Precision
+```
+
+### 2. Two-Phase Rebasing Execution Flow
+
+```text
+       Main Simulation Frame Safe Point (Pre-Render)
+                          │
+         Check |P_camera - C_origin| > R_threshold
+                          │
+                 ┌────────┴────────┐
+                 ▼ (Threshold Met) ▼ (Inside Threshold)
+          [Begin Rebase]       [Continue Normal Frame]
+                 │
+  Phase 1: PrepareRebase (All Participants)
+    - PhysicsAdapter: Validate broadphase lock state & pre-allocate proxy buffers
+    - AudioAdapter: Validate voice locks
+    - VfxAdapter: Allocate particle shift buffers
+    - SceneRuntime: Validate entity lock state
+                 │
+       ┌─────────┴─────────┐
+       ▼ (All Success)     ▼ (Any Failure)
+  Phase 2: CommitRebase    RollbackRebase (Prepared Participants)
+    - Apply -Delta_origin  - Restore cached origins
+    - Inc OriginGeneration - Emit Diagnostic Error
+    - Broadcast Event      - Cancel shift transaction
+                 │
+       [Resume Frame Pipeline]
+```
+
+---
+
+## Subsystem Rebasing Contracts
+
+### 1. Rendering Subsystem
+
+- **GPU Shader Parity**: All vertex and fragment shaders consume standard `float` (`fp32`) and `half` (`fp16`) inputs. No backend requires 64-bit float vertex attributes or double-single software emulation.
+- **CPU Camera-Relative Matrices**:
+  During Render Extraction, for each render instance:
+  $$P_{\text{inst\_cam\_rel}} = P_{\text{inst\_local}} - (C_{\text{camera}} - C_{\text{floating\_origin}})$$
+  $$M_{\text{view\_rel}} = V_{\text{rel}} \cdot M_{\text{inst\_rel}}$$
+  The constant buffer stores $M_{\text{view\_rel}}$ and $P_{\text{projection}}$.
+- **Shadow Map Cascades & Frustum Culling**:
+  Shadow cascade splits and frustum culling calculations operate in camera-relative coordinates $P_{\text{cam\_rel}}$, ensuring sub-millimeter shadow map depth precision near the near clipping plane regardless of global distance.
+
+### 2. Physics Subsystem
+
+- **Local Physics World**: The `PhysicsWorld` simulation operates within $[-R_{\text{physics}}, +R_{\text{physics}}]$ centered around the floating origin.
+- **Coordinate Translation**:
+  When `OriginRebaseEvent` commits:
+  $$\vec{x}_{\text{body}} \leftarrow \vec{x}_{\text{body}} - \Delta_{\text{origin}}$$
+  $$\vec{x}_{\text{collider}} \leftarrow \vec{x}_{\text{collider}} - \Delta_{\text{origin}}$$
+  $$\vec{x}_{\text{broadphase\_aabb}} \leftarrow \vec{x}_{\text{broadphase\_aabb}} - \Delta_{\text{origin}}$$
+- **Preserved Physical Invariants**:
+  - Linear velocity $\vec{v}$ remains unchanged ($\Delta \vec{v} = 0$).
+  - Angular velocity $\vec{\omega}$ remains unchanged ($\Delta \vec{\omega} = 0$).
+  - Mass, moment of inertia tensor, and center-of-mass offsets remain unchanged.
+  - Contact manifolds preserve local contact normals and penetration depths.
+  - Sleeping islands remain asleep; no waking impulse is triggered.
+
+### 3. Audio Subsystem
+
+- **Listener & Emitter Positioning**: Listener world positions and 3D spatial emitter coordinates are translated by $-\Delta_{\text{origin}}$.
+- **Pitch and Doppler Protection**: The audio spatializer updates positions directly without calculating an artificial position differential $\frac{d\vec{x}}{dt}$ across the rebasing frame, preventing Doppler frequency chirps and volume clicks.
+
+### 4. VFX and Particle Subsystem
+
+- **World-Space Particles**: Live particle position buffers simulated in world space have $-\Delta_{\text{origin}}$ subtracted via SIMD or compute shader dispatch.
+- **Local-Space Emitters**: Particles simulated in emitter-local space require zero modification, as their parent entity transform is translated by the Scene Runtime.
+- **No Particle Loss**: Origin shifts do not kill, re-seed, or reset particle emitter lifecycles.
+
+### 5. Navigation and AI Subsystem
+
+- **NavMesh Tiles**: Static NavMesh geometry is partitioned per streaming cell. Tile vertices are stored in cell-local coordinates.
+- **Dynamic Obstacles & Agents**: Dynamic obstacle cylindrical bounds and agent target corridor waypoints are translated by $-\Delta_{\text{origin}}$.
+- **Path Corridors**: Path topological polygon sequence remains intact; agent steering targets are translated without triggering path recalculations.
+
+### 6. Scene Runtime (ECS)
+
+- **Root Transforms**: Root entity transforms store local positions relative to the active floating origin.
+- **Global Entity Positioning**: Components requiring absolute world queries resolve `WorldCoordinate64` on demand:
+  $$P_{\text{world}} = C_{\text{origin}} + P_{\text{local}}$$
+
+---
+
+## Error Handling and Diagnostics
+
+All fallible precision and rebasing functions return `Horo::Result<T, Error>` under the `horo.runtime.precision` error domain:
+
+```cpp
+namespace Horo::Runtime::Precision {
+
+enum class PrecisionErrorCode {
+    CoordinateOverflow,          // Coordinate exceeds representable 64-bit world bounds
+    NonFiniteCoordinate,         // Input contains NaN or infinite floating-point values
+    InvalidRebaseDelta,          // Rebase offset vector is non-finite or exceeds maximum single shift step
+    ParticipantRebaseFailed,     // A registered subsystem adapter failed during Prepare or Commit
+    UnregisteredParticipant,     // Attempted to interact with an invalid or dead adapter handle
+    StaleOriginGeneration,       // Origin generation mismatch during transactional commit
+    RebaseDuringSimulationStep,  // Attempted to trigger rebase while physics or render graph was active
+    TransactionAborted           // Rebase aborted during preparation phase
+};
+
+} // namespace Horo::Runtime::Precision
+```
+
+### Invariant Checks and Assertions
+
+1. **Finite Inputs**: Any coordinate entering a math function is validated via `Math::WorldCoordinate64::IsFinite()`. Non-finite coordinates return `PrecisionErrorCode::NonFiniteCoordinate` and emit structured diagnostics.
+2. **Bounds Checking**: Cell indices outside $[\text{INT32\_MIN} + 1, \text{INT32\_MAX} - 1]$ return `PrecisionErrorCode::CoordinateOverflow`.
+3. **Rebase Safe Point Verification**: `OriginRebaseCoordinator::EvaluateAndRebase` verifies that neither `PhysicsWorld::IsStepping()` nor `RenderFrontend::IsRecording()` is true. Calling rebasing during a step immediately returns `PrecisionErrorCode::RebaseDuringSimulationStep`.
+
+---
+
+## Concurrency, Lifecycle, and Replacement
+
+1. **Thread Role Affinity**:
+   - `EvaluateAndRebase` runs strictly on the main thread (`MainEditor` role).
+   - Subsystem adapters may dispatch parallel workers to update large particle buffers or broadphase structures using `TaskGroup` during `CommitRebase`, joining before `CommitRebase` returns.
+2. **Scene Replacement & Reload**:
+   - When loading a new scene or unloading the world, `OriginRebaseCoordinator` resets `activeOrigin` to $(0, 0, 0)$ with cell index $(0, 0, 0)$.
+   - `originGeneration` increments to invalidate any dangling asynchronous worker references.
+3. **Graceful Teardown**:
+   - During engine shutdown, all registered participants are unregistered in reverse dependency order.
+   - Pending transactions are flushed or cancelled without deadlock.
+
+---
+
+## Verification and Testing Contracts
+
+Automated and integration test suites must cover:
+
+- **Mathematical Conversion Precision**: Lossless round-trip conversions between `WorldCoordinate64`, `int64_t[3]` millimeters, and `dvec3` double meters across extreme ranges ($\pm 10^7\,\text{km}$).
+- **Non-Finite and Boundary Rejection**: Proper error return when passing NaN, $\pm\infty$, or out-of-range integer coordinates.
+- **Two-Phase Transaction Robustness**: Simulating participant failure during `PrepareRebase` and validating clean rollback with zero partial state drift.
+- **Velocity and Momentum Preservation in Physics**: Spawning rigid bodies with linear/angular velocity, triggering repeated origin shifts, and verifying that velocities, trajectory curvatures, and sleep states match unshifted baselines within floating-point tolerance ($< 10^{-5}$).
+- **Camera-Relative Rendering Accuracy**: Rendering distant meshes ($1000\,\text{km}$ from world origin) using camera-relative vertex shaders and verifying zero vertex jitter or visual artifacting compared to origin-centered renders.
+- **Audio Doppler Immunity**: Verifying that listener and emitter rebasing generates zero audio discontinuities or pitch modulations.
+
+---
+
+## Related Documents and ADRs
+
+- [ADR-014: Large-World Precision and Floating Origin Strategy](../../adr/014-large-world-precision-and-floating-origin-strategy.md): Ratified architecture decision and context.
+- [World Streaming Architecture](./world-streaming-architecture.md): Spatial partitioning, streaming cells, volumes, and lifecycle.
+- [Rendering Architecture](./rendering-architecture.md): Render extraction, camera-relative matrices, and GPU resource ownership.
+- [Physics Architecture](./physics-architecture.md): Fixed-step physics, transform authority, and local world simulation.
+- [Scene Math](../foundation/scene-math.md): Coordinate conventions, matrices, vectors, and camera projections.
+- [Error And Diagnostics](../foundation/error-and-diagnostics.md): Fallible `Result<T, Error>` error domain contracts.

--- a/docs/architecture/runtime/coordinate-precision-and-origin-rebasing.md
+++ b/docs/architecture/runtime/coordinate-precision-and-origin-rebasing.md
@@ -8,7 +8,7 @@ This document defines the normative coordinate precision strategy, floating orig
 
 ## Core Decisions
 
-- **Hybrid Global Coordinates (`WorldCoordinate64`)**: The authoritative coordinate system for global world space, spatial partitioning, save serialization, and multiplayer replication is a 64-bit composite coordinate (`IntVector3 cellIndex` + `Vec3 cellOffset`), lossless convertible to/from fixed-point integer millimeters (`int64_t[3]`) and double-precision meters (`dvec3`).
+- **Hybrid Global Coordinates (`WorldCoordinate64`)**: The authoritative coordinate system for global world space, spatial partitioning, save serialization, and multiplayer replication is a 64-bit composite coordinate (`IntVector3 cellIndex` + `IntVector3 cellOffsetMm`). The stored offset is integer millimeters in the half-open range `[0, cellSizeMm)`, so round-trip conversion to/from world-space `int64_t[3]` millimeters is exact. Conversion to `dvec3` meters is a derived view (exact after 1 mm quantization wherever double ULP is finer than 0.5 mm). fp32 `Vec3` is not a storage field of `WorldCoordinate64`; it is reserved for camera-relative / floating-origin local frames.
 - **Floating Origin Rebasing (`CameraRelativeFloat3`)**: Active runtime rendering, physics simulation, audio spatialization, and VFX run in localized 32-bit single-precision floating-point coordinates relative to a dynamic floating origin $C_{\text{origin}}$.
 - **Universal GPU 32-bit Shading**: GPU shaders execute exclusively in 32-bit single precision (`fp32`) / half precision (`fp16`). Camera-relative subtraction $(P_{\text{world}} - C_{\text{camera}})$ is evaluated on the CPU or constant-buffer generation during render extraction; shaders receive pre-translated model-view matrices $M_{\text{view\_rel}}$.
 - **Zero Velocity Discontinuity**: Origin shifts are discrete coordinate frame translations ($\vec{x}' = \vec{x} - \Delta_{\text{origin}}$), not physical movements over time $\Delta t$. Spatial proxies and transforms are updated without modifying linear/angular velocities, forces, audio pitches (Doppler), or particle lifetimes.
@@ -22,7 +22,7 @@ This document defines the normative coordinate precision strategy, floating orig
 ```text
 +-------------------------------------------------------------------------+
 |                  Global World Space (Canonical Authority)               |
-|   WorldCoordinate64 = { IntVector3 cellIndex, Vec3 cellOffset }         |
+|   WorldCoordinate64 = { IntVector3 cellIndex, IntVector3 cellOffsetMm } |
 |   - Spatial partitioning grids & world composition                      |
 |   - Save-game serialization & level persistence                         |
 |   - Multiplayer network position authority                              |
@@ -79,46 +79,60 @@ struct IntVector3 {
 
 /**
  * @brief Authoritative 64-bit composite global world coordinate.
- * 
- * Combines an integer cell index with a localized single-precision float offset.
- * Default standard grid cell size is 1024.0 meters per side.
+ *
+ * Combines an integer cell index with an integer-millimeter offset from the
+ * cell minimum corner. Default standard grid cell size is 1024 m = 1,024,000 mm
+ * per side. fp32 is not used for stored world authority: at a 1024 m cell edge
+ * a 32-bit `Vec3` offset has ULP ≈ 2^-13 m ≈ 0.12 mm, which cannot satisfy a
+ * 1 mm exact millimeter round-trip.
  */
 struct WorldCoordinate64 {
-    static constexpr float DefaultCellSize = 1024.0F; // Meters per cell edge
+    static constexpr float   DefaultCellSizeMeters      = 1024.0F;
+    static constexpr int32_t DefaultCellSizeMillimeters = 1'024'000;
+    static constexpr float   DefaultCellSize            = DefaultCellSizeMeters; // meters; alias for call sites
 
     IntVector3 cellIndex{0, 0, 0};
-    Vec3       cellOffset{0.0F, 0.0F, 0.0F}; // [0.0, CellSize) relative to cell minimum corner
+    IntVector3 cellOffsetMm{0, 0, 0}; // [0, cellSizeMm) relative to cell minimum corner
 
     [[nodiscard]] bool IsFinite() const noexcept;
-    
-    /**
-     * @brief Normalizes cellOffset into [0, cellSize) and updates cellIndex.
-     */
-    [[nodiscard]] Result<WorldCoordinate64> Normalize(float cellSize = DefaultCellSize) const noexcept;
 
     /**
-     * @brief Lossless conversion to fixed-point integer millimeters (1 unit = 1 mm).
+     * @brief Normalizes cellOffsetMm into [0, cellSizeMm) and updates cellIndex.
      */
-    [[nodiscard]] Result<std::array<int64_t, 3>> ToMillimeters(float cellSize = DefaultCellSize) const noexcept;
+    [[nodiscard]] Result<WorldCoordinate64> Normalize(int32_t cellSizeMm = DefaultCellSizeMillimeters) const noexcept;
+
+    /**
+     * @brief Exact conversion to world-space fixed-point millimeters (1 unit = 1 mm).
+     */
+    [[nodiscard]] Result<std::array<int64_t, 3>> ToMillimeters(int32_t cellSizeMm = DefaultCellSizeMillimeters) const noexcept;
 
     /**
      * @brief Constructs WorldCoordinate64 from fixed-point integer millimeters.
      */
     [[nodiscard]] static Result<WorldCoordinate64> FromMillimeters(
         const std::array<int64_t, 3> &mm,
-        float cellSize = DefaultCellSize) noexcept;
+        int32_t cellSizeMm = DefaultCellSizeMillimeters) noexcept;
 
     /**
-     * @brief Converts to double-precision metric vector (meters from origin).
+     * @brief Derived conversion to double-precision meters. Quantizes to 1 mm.
+     * Not a bit-exact inverse of FromDoubleMeters for sub-millimeter inputs.
      */
-    [[nodiscard]] Result<std::array<double, 3>> ToDoubleMeters(float cellSize = DefaultCellSize) const noexcept;
+    [[nodiscard]] Result<std::array<double, 3>> ToDoubleMeters(int32_t cellSizeMm = DefaultCellSizeMillimeters) const noexcept;
 
     /**
-     * @brief Constructs WorldCoordinate64 from double-precision metric vector.
+     * @brief Constructs WorldCoordinate64 from double-precision meters.
+     * Sub-millimeter fractions round to nearest millimeter (half away from zero
+     * is implementation-defined at the 0.5 mm boundary and must be tested).
      */
     [[nodiscard]] static Result<WorldCoordinate64> FromDoubleMeters(
         const std::array<double, 3> &meters,
-        float cellSize = DefaultCellSize) noexcept;
+        int32_t cellSizeMm = DefaultCellSizeMillimeters) noexcept;
+
+    /**
+     * @brief Derived fp32 offset in meters for local cluster math. Lossy:
+     * worst-case ULP near a 1024 m cell edge is ≈ 0.12 mm.
+     */
+    [[nodiscard]] Result<Vec3> ToCellOffsetMeters() const noexcept;
 
     /**
      * @brief Computes high-precision vector delta (lhs - rhs) in meters.
@@ -126,7 +140,7 @@ struct WorldCoordinate64 {
     [[nodiscard]] friend Result<Vec3> SubtractToLocal(
         const WorldCoordinate64 &lhs,
         const WorldCoordinate64 &rhs,
-        float cellSize = DefaultCellSize) noexcept;
+        int32_t cellSizeMm = DefaultCellSizeMillimeters) noexcept;
 };
 
 /**
@@ -141,7 +155,7 @@ using CameraRelativeFloat3 = Vec3;
 
 | Coordinate Format | Storage Size | Effective Range | Precision at Origin | Precision at $1000\,\text{km}$ |
 |---|---|---|---|---|
-| `WorldCoordinate64` (Standard Grid) | $12\,\text{bytes} + 12\,\text{bytes} = 24\,\text{bytes}$ | $\pm 2 \times 10^9\,\text{cells} \approx \pm 2 \times 10^{12}\,\text{m}$ | $< 0.0001\,\text{mm}$ | $< 0.0001\,\text{mm}$ |
+| `WorldCoordinate64` (Standard Grid) | $12\,\text{bytes} + 12\,\text{bytes} = 24\,\text{bytes}$ | $\pm 2 \times 10^9\,\text{cells} \approx \pm 2 \times 10^{12}\,\text{m}$ | $1.0\,\text{mm}$ constant | $1.0\,\text{mm}$ constant |
 | Fixed-point Millimeter (`int64_t[3]`) | $24\,\text{bytes}$ | $\pm 9.22 \times 10^{12}\,\text{m}$ | $1.0\,\text{mm}$ constant | $1.0\,\text{mm}$ constant |
 | Double Precision (`dvec3` / `double[3]`) | $24\,\text{bytes}$ | $\pm 1.79 \times 10^{308}\,\text{m}$ | $10^{-16}\,\text{m}$ | $\approx 0.0001\,\text{mm}$ |
 | Camera-Relative `Vec3` (`fp32`) | $12\,\text{bytes}$ | Local cluster ($\pm 10\,\text{km}$ around camera) | $0.0001\,\text{mm}$ (at $1\,\text{m}$) | $\approx 0.1\,\text{mm}$ (within $1\,\text{km}$ of viewer) |
@@ -356,7 +370,7 @@ enum class PrecisionErrorCode {
 
 Automated and integration test suites must cover:
 
-- **Mathematical Conversion Precision**: Lossless round-trip conversions between `WorldCoordinate64`, `int64_t[3]` millimeters, and `dvec3` double meters across extreme ranges ($\pm 10^7\,\text{km}$).
+- **Mathematical Conversion Precision**: Exact round-trip conversions between `WorldCoordinate64` and `int64_t[3]` millimeters across extreme ranges ($\pm 10^7\,\text{km}$), including cell-edge values (`cellOffsetMm = cellSizeMm - 1`). `dvec3` round-trip is required only after 1 mm quantization, and only in ranges where double ULP is finer than 0.5 mm. Derived `ToCellOffsetMeters()` must document fp32 ULP growth toward the cell edge (≈ 0.12 mm at 1024 m) and must not be treated as canonical storage.
 - **Non-Finite and Boundary Rejection**: Proper error return when passing NaN, $\pm\infty$, or out-of-range integer coordinates.
 - **Two-Phase Transaction Robustness**: Simulating participant failure during `PrepareRebase` and validating clean rollback with zero partial state drift.
 - **Velocity and Momentum Preservation in Physics**: Spawning rigid bodies with linear/angular velocity, triggering repeated origin shifts, and verifying that velocities, trajectory curvatures, and sleep states match unshifted baselines within floating-point tolerance ($< 10^{-5}$).

--- a/docs/architecture/runtime/coordinate-precision-and-origin-rebasing.md
+++ b/docs/architecture/runtime/coordinate-precision-and-origin-rebasing.md
@@ -194,20 +194,20 @@ enum class RebasePhase : uint8_t {
 class IOriginRebaseParticipant {
 public:
     virtual ~IOriginRebaseParticipant() = default;
-    
+
     [[nodiscard]] virtual std::string_view GetParticipantName() const noexcept = 0;
-    
+
     /**
      * @brief Phase 1: Validate readiness and pre-allocate migration memory.
      * Must return Error if the subsystem cannot safely shift at this time.
      */
     [[nodiscard]] virtual Result<void> PrepareRebase(const OriginRebaseEvent &event) noexcept = 0;
-    
+
     /**
      * @brief Phase 2: Apply position translation atomically without velocity alteration.
      */
     virtual void CommitRebase(const OriginRebaseEvent &event) noexcept = 0;
-    
+
     /**
      * @brief Rollback: Executed if any participant failed during PrepareRebase.
      */

--- a/docs/architecture/runtime/coordinate-precision-and-origin-rebasing.md
+++ b/docs/architecture/runtime/coordinate-precision-and-origin-rebasing.md
@@ -94,7 +94,13 @@ struct WorldCoordinate64 {
     IntVector3 cellIndex{0, 0, 0};
     IntVector3 cellOffsetMm{0, 0, 0}; // [0, cellSizeMm) relative to cell minimum corner
 
-    [[nodiscard]] bool IsFinite() const noexcept;
+    /**
+     * @brief True iff cellOffsetMm is in [0, cellSizeMm) on every axis.
+     *
+     * Integer fields cannot be NaN or Inf. IEEE-754 finiteness is checked only
+     * at floating-point conversion boundaries (`FromDoubleMeters`, `Vec3` deltas).
+     */
+    [[nodiscard]] bool IsNormalized(int32_t cellSizeMm = DefaultCellSizeMillimeters) const noexcept;
 
     /**
      * @brief Normalizes cellOffsetMm into [0, cellSizeMm) and updates cellIndex.
@@ -135,7 +141,12 @@ struct WorldCoordinate64 {
     [[nodiscard]] Result<Vec3> ToCellOffsetMeters() const noexcept;
 
     /**
-     * @brief Computes high-precision vector delta (lhs - rhs) in meters.
+     * @brief Local-cluster delta (lhs - rhs) in meters as fp32 `Vec3`.
+     *
+     * Not a globally precise subtraction. Rejects non-finite results and deltas
+     * whose magnitude exceeds the local physics half-extent R_physics
+     * (`PrecisionErrorCode::InvalidRebaseDelta`). Callers that need an exact
+     * global delta must use `ToMillimeters()`.
      */
     [[nodiscard]] friend Result<Vec3> SubtractToLocal(
         const WorldCoordinate64 &lhs,
@@ -156,9 +167,11 @@ using CameraRelativeFloat3 = Vec3;
 | Coordinate Format | Storage Size | Effective Range | Precision at Origin | Precision at $1000\,\text{km}$ |
 |---|---|---|---|---|
 | `WorldCoordinate64` (Standard Grid) | $12\,\text{bytes} + 12\,\text{bytes} = 24\,\text{bytes}$ | $\pm 2 \times 10^9\,\text{cells} \approx \pm 2 \times 10^{12}\,\text{m}$ | $1.0\,\text{mm}$ constant | $1.0\,\text{mm}$ constant |
-| Fixed-point Millimeter (`int64_t[3]`) | $24\,\text{bytes}$ | $\pm 9.22 \times 10^{12}\,\text{m}$ | $1.0\,\text{mm}$ constant | $1.0\,\text{mm}$ constant |
-| Double Precision (`dvec3` / `double[3]`) | $24\,\text{bytes}$ | $\pm 1.79 \times 10^{308}\,\text{m}$ | $10^{-16}\,\text{m}$ | $\approx 0.0001\,\text{mm}$ |
-| Camera-Relative `Vec3` (`fp32`) | $12\,\text{bytes}$ | Local cluster ($\pm 10\,\text{km}$ around camera) | $0.0001\,\text{mm}$ (at $1\,\text{m}$) | $\approx 0.1\,\text{mm}$ (within $1\,\text{km}$ of viewer) |
+| Fixed-point Millimeter (`int64_t[3]`) | $24\,\text{bytes}$ | $\pm 9.22 \times 10^{15}\,\text{m}$ | $1.0\,\text{mm}$ constant | $1.0\,\text{mm}$ constant |
+| Double Precision (`dvec3` / `double[3]`) | $24\,\text{bytes}$ | $\pm 1.79 \times 10^{308}\,\text{m}$ | $\approx 2.2 \times 10^{-16}\,\text{m}$ | $\approx 1.2 \times 10^{-7}\,\text{mm}$ |
+| Camera-Relative `Vec3` (`fp32`) | $12\,\text{bytes}$ | Local cluster (typically $\le R_{\text{threshold}}$ after rebase; fp32 ULP $\le 1\,\text{mm}$ out to $8192\,\text{m}$) | $\approx 0.00012\,\text{mm}$ (at $1\,\text{m}$) | $\approx 0.061\,\text{mm}$ (within $1\,\text{km}$ of viewer) |
+
+`int64_t` millimeters span $\lfloor \texttt{INT64\_MAX} / 1000 \rfloor \approx \pm 9.22 \times 10^{15}\,\text{m}$. `WorldCoordinate64` is narrower (`cellIndex` is `int32_t`): $2^{31} \times 1024\,\text{m} \approx \pm 2.2 \times 10^{12}\,\text{m}$. Double ULP at $10^{6}\,\text{m}$ is $2^{19-52} = 2^{-33} \approx 1.16 \times 10^{-10}\,\text{m}$ ($\approx 1.2 \times 10^{-7}\,\text{mm}$). Camera-relative fp32 ULP at $1\,\text{m}$ is $2^{-23} \approx 1.19 \times 10^{-7}\,\text{m}$; at $10^{3}\,\text{m}$ it is $2^{-14} \approx 6.1 \times 10^{-5}\,\text{m}$.
 
 ---
 
@@ -166,7 +179,7 @@ using CameraRelativeFloat3 = Vec3;
 
 ### 1. Origin Rebase Coordinator
 
-The `OriginRebaseCoordinator` is owned by `SceneRuntime` and updated during the pre-render frame phase on the main thread (`MainEditor` role).
+The `OriginRebaseCoordinator` is owned by `SceneRuntime` and updated during the pre-render frame phase on the host thread that ticks `SceneRuntime` (editor, game, and dedicated-server hosts). It is a runtime type and must not depend on editor types.
 
 ```cpp
 namespace Horo::Runtime::Precision {
@@ -180,7 +193,7 @@ struct OriginRebaseConfig {
 struct OriginRebaseEvent {
     Math::WorldCoordinate64 oldOrigin;
     Math::WorldCoordinate64 newOrigin;
-    Math::Vec3              shiftDelta;      // (newOrigin - oldOrigin) expressed in local meters
+    Math::Vec3              shiftDelta;      // fp32 local-frame view of (newOrigin - oldOrigin); exact mm via old/new Origin
     uint64_t                originGeneration; // Monotonically increasing origin revision
 };
 
@@ -286,6 +299,10 @@ public:
 ### 2. Physics Subsystem
 
 - **Local Physics World**: The `PhysicsWorld` simulation operates within $[-R_{\text{physics}}, +R_{\text{physics}}]$ centered around the floating origin.
+  - $R_{\text{physics}}$ is a `PhysicsWorld` configuration (`localHalfExtentMeters`). It is **not** an alias of $R_{\text{threshold}}$ (`OriginRebaseConfig::rebasingThresholdMeters`, default $1000\,\text{m}$).
+  - $R_{\text{threshold}}$ triggers a rebase of the floating origin. $R_{\text{physics}}$ is the half-extent of the local physics AABB after that rebase.
+  - Invariant: $\mathrm{ULP}_{\text{fp32}}(R_{\text{physics}}) \le 1\,\text{mm}$, which requires $R_{\text{physics}} < 2^{14}\,\text{m} = 16384\,\text{m}$. Default $R_{\text{physics}} = 8192\,\text{m}$ (eight default $1024\,\text{m}$ cells; ULP $= 2^{13-23} = 2^{-10}\,\text{m} \approx 0.98\,\text{mm}$).
+  - Constraint: $R_{\text{physics}} \ge R_{\text{threshold}}$. After a successful rebase every simulated body must satisfy $|\vec{x}_{\text{local}}| \le R_{\text{physics}}$; a body outside this bound is not in the local physics cluster.
 - **Coordinate Translation**:
   When `OriginRebaseEvent` commits:
   $$\vec{x}_{\text{body}} \leftarrow \vec{x}_{\text{body}} - \Delta_{\text{origin}}$$
@@ -346,8 +363,8 @@ enum class PrecisionErrorCode {
 
 ### Invariant Checks and Assertions
 
-1. **Finite Inputs**: Any coordinate entering a math function is validated via `Math::WorldCoordinate64::IsFinite()`. Non-finite coordinates return `PrecisionErrorCode::NonFiniteCoordinate` and emit structured diagnostics.
-2. **Bounds Checking**: Cell indices outside $[\text{INT32\_MIN} + 1, \text{INT32\_MAX} - 1]$ return `PrecisionErrorCode::CoordinateOverflow`.
+1. **Finite floating-point inputs**: IEEE-754 NaN/$\pm\infty$ is checked at conversion boundaries that accept floats (`FromDoubleMeters`, camera-relative `Vec3`, `shiftDelta`) via `Vec3::IsFinite` / `Math::IsFinite`. Failures return `PrecisionErrorCode::NonFiniteCoordinate`. `WorldCoordinate64` stores only integers; it has no `IsFinite()` predicate.
+2. **Normalized integer coordinates**: Authority values must satisfy `IsNormalized()` (`cellOffsetMm` in `[0, cellSizeMm)`). Unnormalized offsets are repaired by `Normalize()` or rejected. Cell indices outside $[\text{INT32\_MIN} + 1, \text{INT32\_MAX} - 1]$ return `PrecisionErrorCode::CoordinateOverflow`.
 3. **Rebase Safe Point Verification**: `OriginRebaseCoordinator::EvaluateAndRebase` verifies that neither `PhysicsWorld::IsStepping()` nor `RenderFrontend::IsRecording()` is true. Calling rebasing during a step immediately returns `PrecisionErrorCode::RebaseDuringSimulationStep`.
 
 ---
@@ -355,7 +372,7 @@ enum class PrecisionErrorCode {
 ## Concurrency, Lifecycle, and Replacement
 
 1. **Thread Role Affinity**:
-   - `EvaluateAndRebase` runs strictly on the main thread (`MainEditor` role).
+   - `EvaluateAndRebase` runs strictly on the host thread that ticks `SceneRuntime`. That affinity applies to editor, game, and dedicated-server hosts. It is forbidden on worker, render-owner, transport, and I/O threads. Do not name this an editor `MainEditor` dependency: ADR-010's `MainEditor` wait-policy role is the editor host's main thread only.
    - Subsystem adapters may dispatch parallel workers to update large particle buffers or broadphase structures using `TaskGroup` during `CommitRebase`, joining before `CommitRebase` returns.
 2. **Scene Replacement & Reload**:
    - When loading a new scene or unloading the world, `OriginRebaseCoordinator` resets `activeOrigin` to $(0, 0, 0)$ with cell index $(0, 0, 0)$.
@@ -371,7 +388,7 @@ enum class PrecisionErrorCode {
 Automated and integration test suites must cover:
 
 - **Mathematical Conversion Precision**: Exact round-trip conversions between `WorldCoordinate64` and `int64_t[3]` millimeters across extreme ranges ($\pm 10^7\,\text{km}$), including cell-edge values (`cellOffsetMm = cellSizeMm - 1`). `dvec3` round-trip is required only after 1 mm quantization, and only in ranges where double ULP is finer than 0.5 mm. Derived `ToCellOffsetMeters()` must document fp32 ULP growth toward the cell edge (≈ 0.12 mm at 1024 m) and must not be treated as canonical storage.
-- **Non-Finite and Boundary Rejection**: Proper error return when passing NaN, $\pm\infty$, or out-of-range integer coordinates.
+- **Non-Finite and Boundary Rejection**: `FromDoubleMeters` and other float ingress paths return `NonFiniteCoordinate` for NaN/$\pm\infty$. Integer overflow and unnormalized `cellOffsetMm` return `CoordinateOverflow` or are normalized via `Normalize()` as specified.
 - **Two-Phase Transaction Robustness**: Simulating participant failure during `PrepareRebase` and validating clean rollback with zero partial state drift.
 - **Velocity and Momentum Preservation in Physics**: Spawning rigid bodies with linear/angular velocity, triggering repeated origin shifts, and verifying that velocities, trajectory curvatures, and sleep states match unshifted baselines within floating-point tolerance ($< 10^{-5}$).
 - **Camera-Relative Rendering Accuracy**: Rendering distant meshes ($1000\,\text{km}$ from world origin) using camera-relative vertex shaders and verifying zero vertex jitter or visual artifacting compared to origin-centered renders.

--- a/docs/architecture/runtime/physics-architecture.md
+++ b/docs/architecture/runtime/physics-architecture.md
@@ -10,6 +10,8 @@ debugging for Horo Engine.
 
 - Each active runtime scene owns or explicitly references one physics world.
 - Physics advances only during fixed simulation ticks.
+- Physics simulation operates in local cluster coordinates relative to the active floating origin.
+- Origin shifts translate spatial proxies without altering velocities, momentum, contact caches, or waking sleeping bodies.
 - Runtime components store typed body or shape handles, not owning pointers.
 - Transform synchronization has one declared authority per body mode.
 - Structural physics changes are deferred to safe points.
@@ -173,6 +175,19 @@ definition. Stopping play destroys it without modifying authoring transforms.
 Reload rebuilds physics state by default. Preservation of velocity or sleep
 state requires a typed policy keyed by stable object ID.
 
+## Floating Origin Rebasing
+
+The active `PhysicsWorld` executes in local rebased cluster coordinates relative to the dynamic floating origin:
+
+- **Two-Phase Protocol**: As a registered `IOriginRebaseParticipant`, the physics adapter validates solver lock state during `PrepareRebase` and shifts spatial data during `CommitRebase`.
+- **Position Updates**: Bodies, colliders, broadphase bounding volumes, and raycast caches have $\Delta_{\text{origin}}$ subtracted:
+  $$\vec{x}_{\text{new}} = \vec{x}_{\text{old}} - \Delta_{\text{origin}}$$
+- **Velocity Invariance**: Because origin shifting is an instantaneous coordinate re-indexing, linear velocity $\vec{v}$, angular velocity $\vec{\omega}$, and applied forces $\vec{F}$ remain strictly unchanged ($\Delta \vec{v} = 0, \Delta \vec{\omega} = 0$).
+- **Solver State Continuity**: Contact manifolds retain relative contact points and penetration normals. Sleeping rigid bodies and deactivated islands remain asleep without triggering wake-up spikes or momentum shocks.
+- **Timing Safe Point**: Origin shifts are forbidden while `PhysicsWorld::Step` is executing. Shifts execute only at the declared pre-render frame synchronization safe point.
+
+See [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md) and [ADR-014](../../adr/014-large-world-precision-and-floating-origin-strategy.md).
+
 ## Debugging And Metrics
 
 Physics exposes:
@@ -212,13 +227,18 @@ Required tests cover:
 - reload preservation policy
 - non-finite state detection
 - core collider shape primitives resolve correctly from the primitive catalog
+- origin shift position translation without velocity or momentum alterations
+- sleeping island preservation across origin rebasing transactions
 
 ## Related Documents
 
 - [Physics Debugger UI Reference](./physics-debugger.html): collision layers, contact pairs, rigidbody inspection, and solver diagnostics panel.
 
+- [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md)
+- [ADR-014: Large-World Precision and Floating Origin Strategy](../../adr/014-large-world-precision-and-floating-origin-strategy.md)
 - [Runtime Lifecycle](./runtime-lifecycle.md)
 - [Scene Runtime](./scene-runtime.md)
+- [World Streaming Architecture](./world-streaming-architecture.md)
 - [Input Architecture](./input-architecture.md)
 - [Built-In Scene Primitives](./built-in-scene-primitives.md)
 - [Ownership And Resource Lifetime](../foundation/ownership-and-resource-lifetime.md)

--- a/docs/architecture/runtime/physics-architecture.md
+++ b/docs/architecture/runtime/physics-architecture.md
@@ -179,6 +179,7 @@ state requires a typed policy keyed by stable object ID.
 
 The active `PhysicsWorld` executes in local rebased cluster coordinates relative to the dynamic floating origin:
 
+- **Local Half-Extent**: Simulation is bounded by $[-R_{\text{physics}}, +R_{\text{physics}}]$ (default $8192\,\text{m}$). This is independent of the rebase trigger $R_{\text{threshold}}$ (default $1000\,\text{m}$). See [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md).
 - **Two-Phase Protocol**: As a registered `IOriginRebaseParticipant`, the physics adapter validates solver lock state during `PrepareRebase` and shifts spatial data during `CommitRebase`.
 - **Position Updates**: Bodies, colliders, broadphase bounding volumes, and raycast caches have $\Delta_{\text{origin}}$ subtracted:
   $$\vec{x}_{\text{new}} = \vec{x}_{\text{old}} - \Delta_{\text{origin}}$$

--- a/docs/architecture/runtime/physics-architecture.md
+++ b/docs/architecture/runtime/physics-architecture.md
@@ -186,7 +186,7 @@ The active `PhysicsWorld` executes in local rebased cluster coordinates relative
 - **Solver State Continuity**: Contact manifolds retain relative contact points and penetration normals. Sleeping rigid bodies and deactivated islands remain asleep without triggering wake-up spikes or momentum shocks.
 - **Timing Safe Point**: Origin shifts are forbidden while `PhysicsWorld::Step` is executing. Shifts execute only at the declared pre-render frame synchronization safe point.
 
-See [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md) and [ADR-014](../../adr/014-large-world-precision-and-floating-origin-strategy.md).
+See [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md) and [ADR-026](../../adr/026-large-world-precision-and-floating-origin-strategy.md).
 
 ## Debugging And Metrics
 
@@ -235,7 +235,7 @@ Required tests cover:
 - [Physics Debugger UI Reference](./physics-debugger.html): collision layers, contact pairs, rigidbody inspection, and solver diagnostics panel.
 
 - [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md)
-- [ADR-014: Large-World Precision and Floating Origin Strategy](../../adr/014-large-world-precision-and-floating-origin-strategy.md)
+- [ADR-026: Large-World Precision and Floating Origin Strategy](../../adr/026-large-world-precision-and-floating-origin-strategy.md)
 - [Runtime Lifecycle](./runtime-lifecycle.md)
 - [Scene Runtime](./scene-runtime.md)
 - [World Streaming Architecture](./world-streaming-architecture.md)

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -68,6 +68,30 @@ use `[0, 1]`. Concrete backends may apply this projection adaptation, but must
 not independently redefine scene handedness, camera policy, transform order, or
 authoring units.
 
+### Camera-Relative Rendering And Universal Shader Precision
+
+To maintain sub-millimeter visual precision across worlds spanning thousands of
+kilometers while preserving universal GPU performance across Mobile (OpenGL ES /
+Metal iOS), WebGL, Desktop, and Consoles:
+
+- **Universal 32-bit GPU Shaders**: All vertex, geometry, and fragment shaders
+  execute standard 32-bit single-precision (`fp32`) / half-precision (`fp16`)
+  floating-point arithmetic. No GPU backend requires or relies on hardware `fp64`
+  vertex attributes or double-single emulation.
+- **CPU Camera-Relative Matrices**: The high-precision subtraction
+  $P_{\text{inst\_cam\_rel}} = P_{\text{inst\_world}} - C_{\text{camera}}$ is
+  evaluated on the CPU during Render Extraction. The Model-View matrix
+  $M_{\text{view\_rel}} = V_{\text{rel}} \cdot M_{\text{inst\_rel}}$ is passed
+  in 32-bit float uniform/constant buffers.
+- **Vertex Transformation**: Vertex shaders compute
+  $v_{\text{clip}} = P_{\text{projection}} \cdot M_{\text{view\_rel}} \cdot v_{\text{mesh\_local}}$,
+  eliminating floating-point vertex jitter and Z-fighting at extreme world distances.
+- **Shadow and Culling Precision**: Frustum culling and shadow cascade splits
+  operate in camera-relative space, maximizing depth precision near the camera.
+
+See [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md)
+and [ADR-014](../../adr/014-large-world-precision-and-floating-origin-strategy.md).
+
 ## Backend Selection
 
 Renderer backend selection is host-owned startup policy. The application
@@ -676,6 +700,8 @@ Required tests cover:
 
 ## Related Documents
 
+- [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md)
+- [ADR-014: Large-World Precision and Floating Origin Strategy](../../adr/014-large-world-precision-and-floating-origin-strategy.md)
 - [Render Settings UI Reference](./render-settings.html): quality presets, render feature toggles, resolution, and GPU profiler panel.
 - [Render Backend Parity Contract](./render-backend-parity-contract.md)
 - [Renderer Distribution And Availability](./renderer-distribution-and-availability.md)

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -90,7 +90,7 @@ Metal iOS), WebGL, Desktop, and Consoles:
   operate in camera-relative space, maximizing depth precision near the camera.
 
 See [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md)
-and [ADR-014](../../adr/014-large-world-precision-and-floating-origin-strategy.md).
+and [ADR-026](../../adr/026-large-world-precision-and-floating-origin-strategy.md).
 
 ## Backend Selection
 
@@ -701,7 +701,7 @@ Required tests cover:
 ## Related Documents
 
 - [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md)
-- [ADR-014: Large-World Precision and Floating Origin Strategy](../../adr/014-large-world-precision-and-floating-origin-strategy.md)
+- [ADR-026: Large-World Precision and Floating Origin Strategy](../../adr/026-large-world-precision-and-floating-origin-strategy.md)
 - [Render Settings UI Reference](./render-settings.html): quality presets, render feature toggles, resolution, and GPU profiler panel.
 - [Render Backend Parity Contract](./render-backend-parity-contract.md)
 - [Renderer Distribution And Availability](./renderer-distribution-and-availability.md)

--- a/docs/architecture/runtime/world-streaming-architecture.md
+++ b/docs/architecture/runtime/world-streaming-architecture.md
@@ -24,12 +24,12 @@ Horo Engine uses a cell-based world-streaming model:
 
 ```cpp
 struct StreamingCell {
-    StreamingCellId   id;
-    WorldCoordinate   origin;          // world-space cell origin
-    float             cellSize;        // meters per side
-    StreamingCellState state;          // Unloaded, Loading, Loaded, Unloading, Failed
-    AssetId           cellAsset;       // baked scene asset for this cell
-    StreamingPriority priority;        // cached computed priority, updated each frame
+    StreamingCellId         id;
+    Math::WorldCoordinate64 origin;          // canonical 64-bit world-space cell origin
+    float                   cellSize;        // meters per side (default 1024m)
+    StreamingCellState      state;          // Unloaded, Loading, Loaded, Unloading, Failed
+    AssetId                 cellAsset;       // baked scene asset for this cell
+    StreamingPriority       priority;        // cached computed priority, updated each frame
 };
 ```
 
@@ -50,11 +50,11 @@ Streaming volumes define which cells should be loaded:
 
 ```cpp
 struct StreamingVolume {
-    StreamingVolumeType type;
-    WorldCoordinate     origin;
-    float               radius;
-    StreamingPriority   priority;
-    bool                unloadOutside;
+    StreamingVolumeType     type;
+    Math::WorldCoordinate64 origin;
+    float                   radius;
+    StreamingPriority       priority;
+    bool                    unloadOutside;
 };
 ```
 
@@ -259,10 +259,29 @@ Editor streaming tools register through the `EditorPanelHost` system:
 - **Streaming Budget HUD**: A bottom-dock panel showing real-time budget
   usage, load queue depth, and frame-time impact.
 
+## Large-World Coordinate Precision and Floating Origin Rebasing
+
+World streaming in Horo Engine operates on a global coordinate grid backed by 64-bit precision, avoiding single-precision float truncation over vast distances:
+
+- **Canonical Global Coordinates**: `Math::WorldCoordinate64` (`IntVector3 cellIndex` + `Vec3 cellOffset`) serves as the immutable coordinate authority for spatial cell boundaries, streaming volume queries, persistent level saves, and server multiplayer replication.
+- **Floating Origin Rebasing**: When the active player/camera exceeds a configured threshold from the active floating origin ($R_{\text{threshold}} = 1000\,\text{m}$), `OriginRebaseCoordinator` executes an atomic two-phase rebase (`PrepareRebase` -> `CommitRebase`).
+- **Subsystem Synchronization**: The resulting `OriginRebaseEvent` translates local simulation frames across Physics, Audio, VFX, Camera, and Navigation without velocity spikes, particle destruction, or Doppler glitching.
+- **GPU Compatibility**: GPU shaders remain 32-bit `fp32` across all backends. Camera-relative transformations $(P_{\text{world}} - C_{\text{camera}})$ are computed on the CPU during render extraction.
+
+See [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md) and [ADR-014](../../adr/014-large-world-precision-and-floating-origin-strategy.md) for the complete normative specification.
+
 ## Related Documents
 
+- [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md):
+  canonical 64-bit world coordinates, floating origin rebasing, and subsystem adapters
+- [ADR-014: Large-World Precision and Floating Origin Strategy](../../adr/014-large-world-precision-and-floating-origin-strategy.md):
+  ratified architectural decision and platform cost analysis
 - [Scene Runtime](./scene-runtime.md): cell loading integrates with the scene
   model
+- [Rendering Architecture](./rendering-architecture.md): camera-relative rendering
+  matrices and universal 32-bit shader pipeline
+- [Physics Architecture](./physics-architecture.md): local rebased physics clusters
+  and velocity-invariant origin shift handling
 - [Asset Pipeline](./asset-pipeline.md): streaming cell assets, `CancellationToken`,
   and async I/O contract
 - [Terrain And Foliage Architecture](./terrain-and-foliage-architecture.md):
@@ -275,3 +294,4 @@ Editor streaming tools register through the `EditorPanelHost` system:
   registration, `StreamingCellStateChangedEvent` on `EditorDataBus`
 - [Editor Document Model](../editor/editor-document-model.md): cell baking as
   editor commands
+

--- a/docs/architecture/runtime/world-streaming-architecture.md
+++ b/docs/architecture/runtime/world-streaming-architecture.md
@@ -263,7 +263,7 @@ Editor streaming tools register through the `EditorPanelHost` system:
 
 World streaming in Horo Engine operates on a global coordinate grid backed by 64-bit precision, avoiding single-precision float truncation over vast distances:
 
-- **Canonical Global Coordinates**: `Math::WorldCoordinate64` (`IntVector3 cellIndex` + `Vec3 cellOffset`) serves as the immutable coordinate authority for spatial cell boundaries, streaming volume queries, persistent level saves, and server multiplayer replication.
+- **Canonical Global Coordinates**: `Math::WorldCoordinate64` (`IntVector3 cellIndex` + `IntVector3 cellOffsetMm`) serves as the immutable coordinate authority for spatial cell boundaries, streaming volume queries, persistent level saves, and server multiplayer replication. The stored offset is integer millimeters, not fp32.
 - **Floating Origin Rebasing**: When the active player/camera exceeds a configured threshold from the active floating origin ($R_{\text{threshold}} = 1000\,\text{m}$), `OriginRebaseCoordinator` executes an atomic two-phase rebase (`PrepareRebase` -> `CommitRebase`).
 - **Subsystem Synchronization**: The resulting `OriginRebaseEvent` translates local simulation frames across Physics, Audio, VFX, Camera, and Navigation without velocity spikes, particle destruction, or Doppler glitching.
 - **GPU Compatibility**: GPU shaders remain 32-bit `fp32` across all backends. Camera-relative transformations $(P_{\text{world}} - C_{\text{camera}})$ are computed on the CPU during render extraction.

--- a/docs/architecture/runtime/world-streaming-architecture.md
+++ b/docs/architecture/runtime/world-streaming-architecture.md
@@ -268,13 +268,13 @@ World streaming in Horo Engine operates on a global coordinate grid backed by 64
 - **Subsystem Synchronization**: The resulting `OriginRebaseEvent` translates local simulation frames across Physics, Audio, VFX, Camera, and Navigation without velocity spikes, particle destruction, or Doppler glitching.
 - **GPU Compatibility**: GPU shaders remain 32-bit `fp32` across all backends. Camera-relative transformations $(P_{\text{world}} - C_{\text{camera}})$ are computed on the CPU during render extraction.
 
-See [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md) and [ADR-014](../../adr/014-large-world-precision-and-floating-origin-strategy.md) for the complete normative specification.
+See [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md) and [ADR-026](../../adr/026-large-world-precision-and-floating-origin-strategy.md) for the complete normative specification.
 
 ## Related Documents
 
 - [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin-rebasing.md):
   canonical 64-bit world coordinates, floating origin rebasing, and subsystem adapters
-- [ADR-014: Large-World Precision and Floating Origin Strategy](../../adr/014-large-world-precision-and-floating-origin-strategy.md):
+- [ADR-026: Large-World Precision and Floating Origin Strategy](../../adr/026-large-world-precision-and-floating-origin-strategy.md):
   ratified architectural decision and platform cost analysis
 - [Scene Runtime](./scene-runtime.md): cell loading integrates with the scene
   model

--- a/docs/architecture/runtime/world-streaming-architecture.md
+++ b/docs/architecture/runtime/world-streaming-architecture.md
@@ -294,4 +294,3 @@ See [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin
   registration, `StreamingCellStateChangedEvent` on `EditorDataBus`
 - [Editor Document Model](../editor/editor-document-model.md): cell baking as
   editor commands
-


### PR DESCRIPTION
## Summary
- Ratifies the large-world coordinate precision and floating origin rebasing strategy for Horo Engine ([WST-007.1] #1604).
- Introduces [ADR-026](docs/adr/014-large-world-precision-and-floating-origin-strategy.md) and the dedicated normative specification [Coordinate Precision And Origin Rebasing](docs/architecture/runtime/coordinate-precision-and-origin-rebasing.md).
- Updates world streaming, rendering, physics, and scene math architecture documents to establish unambiguous coordinate representations, camera-relative GPU transformation pipelines, local physics clusters, and two-phase origin shift contracts.

## Motivation
- Eliminates numerical truncation artifacts (vertex jitter, Z-fighting, physics solver breakdown) across open-world simulations spanning thousands of kilometers.
- Preserves universal GPU shader parity across Mobile (OpenGL ES / Metal iOS), WebGL, Desktop, and Consoles without requiring hardware `fp64` vertex attributes or costly shader software emulation.
- Guarantees zero velocity/momentum discontinuities, Doppler glitches, or sleeping island wake-ups during runtime origin shifts.

## Implementation Notes
- **Coordinate Precision Strategy**: Canonical 64-bit composite coordinate (`WorldCoordinate64` = `IntVector3 cellIndex` + `Vec3 cellOffset`), losslessly convertible to/from fixed-point millimeter integer vectors (`int64_t[3]`) and double-precision meters (`dvec3`) for persistent saves, spatial partition indexing, and multiplayer network replication.
- **Floating Origin Rebasing**: Active simulation clusters operate in localized 32-bit float frames (`CameraRelativeFloat3`) relative to a dynamic floating origin $C_{\text{origin}}$. An atomic two-phase rebase protocol (`PrepareRebase` -> `CommitRebase`) synchronizes all registered subsystem adapters at a pre-render frame safe point.
- **GPU Compatibility**: GPU shaders remain 32-bit single precision (`fp32`). Camera-relative subtraction $(P_{\text{world}} - C_{\text{camera}})$ is evaluated on CPU during Render Extraction, providing pre-translated model-view matrices $M_{\text{view\_rel}}$ in constant buffers.
- **Physics Invariants**: Physics bodies, colliders, and broadphase structures have $\Delta_{\text{origin}}$ subtracted without altering linear/angular velocities, contact caches, or sleeping states.
- **Fallible Error Boundaries**: Operations return `Horo::Result<T, Error>` with typed codes under the `horo.runtime.precision` error domain per ADR-008.

## Validation
- [x] Build passed (`cmake --build build/test-config --parallel`)
- [x] Relevant tests passed (`ctest --test-dir build/test-config -R "HoroSceneMath|HoroTransformGizmoMath"`)
- [x] Pre-commit hooks passed (`horo clang-format staged`, `horo-engine layout configure`)

Commands run:
```bash
cmake -S . -B build/test-config -DBUILD_TESTING=ON
cmake --build build/test-config --parallel
ctest --test-dir build/test-config --output-on-failure -R "HoroSceneMath|HoroTransformGizmoMath"
git commit -m "docs(world-streaming): large-world precision strategy decision #1604 [WST-007.1]"
git push -u origin docs/wst_large_world_precision_strategy
```

## Risks
- Low risk; architecture documentation and ADR ratification only.

## Issue Links

- GitHub: Closes #1604

## Reviewer Notes
- Recommended review order:
  1. `docs/adr/014-large-world-precision-and-floating-origin-strategy.md`
  2. `docs/architecture/runtime/coordinate-precision-and-origin-rebasing.md`
  3. `docs/architecture/runtime/world-streaming-architecture.md`
  4. `docs/architecture/runtime/rendering-architecture.md`
  5. `docs/architecture/runtime/physics-architecture.md`
  6. `docs/architecture/foundation/scene-math.md`