### PR TITLE
docs(render): define capability and product profile policy HORO-296 #296 [RND-003.1]

### DIFF
--- a/docs/adr/028-renderer-capability-limits-and-product-profiles.md
+++ b/docs/adr/028-renderer-capability-limits-and-product-profiles.md
@@ -1,0 +1,321 @@
+# ADR-028: Renderer Capability, Limits and Product Profiles
+
+- **Status**: Proposed
+- **Date**: 2026-08-31
+- **Supersedes**: None
+- **Scope**: M0 renderer capability and product-policy contract; no backend implementation
+- **Jira**: [HORO-296](https://horo-engine.atlassian.net/browse/HORO-296)
+- **Issue**: [#296](https://github.com/abdullahbodur/horo-engine/issues/296) ([RND-003.1])
+- **Normative document**: [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
+
+## Context
+
+The current `RenderBackendCapabilities` exposes a small immutable set of booleans
+from an initialized backend. It does not distinguish native device support from
+implemented backend support, driver restrictions, resource limits, or product
+preferences. Material and advanced-rendering documents also use API-named tiers
+(`es3`, `dx11`, `dx12_vulkan`, `high_end`) as if a single rank could prove all
+feature and format support. This lets an API name or a quality setting appear to
+authorize resource creation that a particular device or Horo backend cannot do.
+
+RND-001.1 already defines typed resource descriptors and generation-safe handles.
+Their validation needs one capability authority that survives device loss,
+offline cooking, user settings, and explicit backend selection without inventing
+policy in each feature subsystem.
+
+## Decision
+
+### 1. Separate facts, usable support, and requested quality
+
+Use four distinct Horo-owned value contracts. The names below specify the target
+contract, not APIs claimed to exist in this M0 change.
+
+| Contract | Contents and authority |
+|---|---|
+| `ReportedDeviceCapabilities` | Selected backend translates queried adapter/device facts into Horo features, typed limits and format support. Unqueried support is unavailable, never inferred from a vendor or API name. |
+| `BackendImplementationSupport` | Selected module declares the operations and combinations it actually implements, including linked optional providers. A native feature that Horo cannot execute remains unusable. |
+| `EffectiveRenderCapabilities` | Renderer frontend owns the immutable intersection of reported and implemented support, reduced by the selected driver-workaround policy. Includes restrictions and their provenance. This is the resource/plan admission authority. |
+| `RenderProfilePolicy` / `ResolvedRenderProfile` | Application supplies validated product/cook/user preferences and required features. Frontend resolves them against effective support and available cooked variants into an immutable rendering plan selection with recorded fallback reasons. Profiles never grant capabilities. |
+
+`RenderApi` owns the public value contracts and pure support predicates;
+`RenderFrontend` owns resolution and admission. Concrete backends own native
+queries and translation. Application composition selects backend, adapter and
+policy inputs; it does not inspect native graphics types. Feature systems declare
+requirements and consume the resolved result. GUI, CLI and MCP are adapters over
+the same application queries, not independent capability resolvers.
+
+Reported and effective snapshots are distinct types. Resource creation,
+execution-plan admission, material variant selection and feature activation use
+only the effective snapshot. Reported facts remain available for diagnostics.
+No process-global capability singleton or mutable per-feature copy is allowed.
+
+### 2. Typed features, limits and format predicates
+
+- Features use a Horo-owned `RenderFeature` identity, not extension-name strings.
+  Compute, indirect draw, descriptor indexing/bindless, mesh shaders, ray queries,
+  ray pipelines and timestamp queries are independently represented. Compute
+  does not imply a separate asynchronous compute queue. Ray queries do not imply
+  ray pipelines. A provider is usable only when its own requirements also pass.
+- Limits have named fields and units: bytes for buffer/range sizes and shared
+  memory; texels for extents; counts for attachments, descriptors, array layers,
+  workgroup axes/invocations and frames in flight; bytes for offset alignment.
+  Queue operations and shader stages are typed sets, not an assumed queue count.
+- Numeric zero is not an unknown/unlimited sentinel. Optional limits are absent
+  when the corresponding operation is unavailable. Unknown enum values, malformed
+  records, overflow and contradictory advertised feature/limit combinations
+  produce a typed capability-data failure before snapshot publication.
+- Bounds are checked together: each workgroup axis and the checked product must
+  fit; ranges must fit their resource; offsets must satisfy every applicable
+  alignment. A maximum capacity is reduced by taking the tighter upper bound;
+  alignment is a conjunction of divisibility constraints, not a minimum or a
+  casual maximum. Combining alignments uses checked arithmetic and rejects an
+  unrepresentable constraint. This rule applies to backend and driver limits.
+- `FormatSupportRequest` describes a `TextureFormat`, texture dimension, complete
+  usage combination, sample count, and relevant view-format compatibility.
+  `SupportsFormat(request)` evaluates the combination, not independent flags.
+  Sampled support does not imply filtering, color attachment, blending, storage,
+  depth/stencil attachment, copy or resolve support. Sample counts are a typed
+  supported set, not a maximum assumed to include all smaller integers.
+- The format table is bounded by the versioned Horo format/usage domain and is
+  queried without driver calls or allocation on the frame path. Missing entries
+  return unsupported. Descriptor validation still checks usage, extent, mip,
+  layer, view and cross-attachment compatibility before the backend validates
+  native feasibility. Effective support is not a promise that allocation cannot
+  fail due to memory pressure or device loss.
+
+Dynamic available-memory estimates are telemetry, not immutable capability limits
+or guaranteed reservations. Residency/upload budgets belong to their owners and
+are validated separately; a valid capability predicate cannot bypass budget admission.
+
+These predicates extend the validation boundary in
+[ADR-027](027-renderer-resource-identity-and-descriptors.md); they do not replace
+its identity, pending/ready state, error or deferred-retirement rules. Unsupported
+resources fail before registry reservation/native allocation. Resource APIs do
+not silently change format, sample count, usage, backend, or profile.
+
+### 3. Driver adjustments only restrict support
+
+The compatibility registry in RND-017.6 supplies a versioned, validated policy
+snapshot at composition time. Rules match typed backend/adapter identity,
+driver-version ranges, OS/runtime version and module version as applicable.
+Unknown driver identity cannot satisfy a version-specific match; general rules
+still apply and diagnostics retain the unknown identity.
+
+Each matching rule has a stable ID and reason. It may deny a feature/format/usage,
+reduce a capacity, strengthen an alignment requirement, or select a tested private
+backend workaround that preserves the public operation's semantics. It cannot
+enable an unreported or unimplemented operation. Conflicting restrictions compose
+conservatively; rule ordering cannot restore denied support. Duplicate IDs or
+invalid ranges reject the policy snapshot rather than silently disabling safety
+rules. Diagnostics enumerate matching rule IDs in stable order.
+
+The renderer computes feature dependency closure after restrictions. For example,
+disabling compute makes a compute-dependent culling recipe unavailable, even when
+indirect draw remains supported. It does not invent a hardware dependency between
+otherwise independent feature bits. No project/user setting may bypass a driver
+restriction. Missing required support is reported to the host, which may try only
+an explicitly permitted backend fallback.
+
+### 4. Product profiles select recipes, not hardware classes
+
+`RenderProductProfile` has four ordered preference levels: `Baseline`, `Standard`,
+`High`, `Ultra` (serialized as `baseline`, `standard`, `high`, `ultra`). Ordering
+permits policy ceilings; it is not a feature-subset test or a performance promise.
+It is separate from Editor/Development/Profile/Shipping/Server build profiles,
+roadmap milestones, navigation/AI budgets, and gameplay authority.
+
+| Profile | Preferred rendering recipe | Explicit fallback policy |
+|---|---|---|
+| Baseline | Forward raster, bounded CPU light/culling preparation, bound resources, baked/ambient lighting and probes. No compute, bindless, ray tracing or mesh-shader requirement. | Required raster/material/host operations must pass; unsupported required operations fail admission. |
+| Standard | Forward+ with compute light preparation when supported; shadow atlas, SSR and temporal effects may be enabled by product settings. | CPU light preparation and forward raster; probes for optional SSR; native resolution for optional temporal upscaling. |
+| High | Deferred lighting when the full attachment/format/limit contract passes; GPU culling and optional screen-space GI. | Standard recipe; CPU culling and baked GI/probes when those optional paths fail their predicates. |
+| Ultra | High recipe plus explicitly enabled ray effects, meshlet/mesh-shader submission, bindless resources and advanced shadow/upscale providers. | High recipe; raster effects, indexed geometry, bound resources and native resolution as declared by each enabled feature. |
+
+These are recipe preferences, not new feature implementations or fixed universal
+budgets. Each selected recipe declares exact required feature/format/limit
+predicates and finite product budgets before it can be admitted. The
+[interactive parity contract](../architecture/runtime/render-backend-parity-contract.md#required-baseline-capability)
+remains mandatory for every interactive backend at every profile. Meeting that
+lifecycle contract alone does not prove a material/scene recipe is supported.
+
+There is no `if (profile >= High)` hardware admission. Numeric budgets come from
+the typed product/cook settings and must be within effective limits; the profile
+name never chooses an undocumented light count, texture size or memory budget.
+An optional feature without an implemented and cooked fallback is unavailable;
+it cannot become a promised degradation path merely by appearing in this table.
+If content explicitly requires it, absence fails admission instead of disabling it.
+
+Resolution is deterministic for the same inputs:
+
+1. Resolve backend selection through existing host precedence and explicit
+   backend fallback rules; never select a different API from a profile name.
+2. Validate the product's allowed profile set, maximum profile, required features,
+   finite budgets and ordered allowed fallback profiles. Reject an empty set,
+   unknown values, duplicate fallback entries or contradictory policy.
+3. Select the requested profile from explicit host override, user/project
+   preference, then the product default (Baseline when omitted). Overrides cannot
+   widen product/cook policy. A request outside the allowed set/ceiling returns a
+   typed policy error; the UI may offer supported choices but cannot silently clamp.
+4. Intersect product, cook and user feature permissions. Validate material minimum
+   profiles, required feature predicates and budgets against the effective snapshot
+   and cooked variants.
+   Required content never becomes optional because a lower profile was requested.
+5. Resolve optional features using their declared ordered fallbacks. If the
+   requested profile cannot satisfy required content, evaluate only the declared
+   fallback profile list in order, applying the same requirements to each. No
+   viable result returns `ProfileUnsupported`; no partial plan becomes active.
+6. Publish requested and selected profile, selected feature/variant recipes,
+   effective-snapshot revision, budget/settings revision and bounded diagnostics.
+   Successful degradation is observable even when the selected profile name is
+   unchanged. A lower profile cannot fix a globally required missing feature.
+
+Fallback profiles may change rendering recipes, not gameplay requirements. For
+example, compute disabled by a driver rule selects CPU light preparation only
+when its required material variant exists and the product budget permits it. A
+required compute-only content path fails; it is not disguised as Baseline success.
+
+### 5. Snapshot lifetime, startup and reconfiguration
+
+Pre-window module metadata and helper-process probes remain advisory for project
+capability fit. Probe success establishes component availability, not the final
+effective support of the device and surface later created by the host. Final
+admission occurs after initialization on the host-declared render-capable thread
+and before scene/GUI resource work is accepted. Failure rolls back initialization
+and returns an actionable startup result; no half-initialized renderer is exposed.
+
+The frontend publishes a snapshot scoped to its owner ID, device incarnation and
+capability revision. Consumers receive immutable owned snapshots or lifetime-bound
+read leases, never a reference surviving frontend teardown. CPU queries perform
+no native calls or blocking synchronization. Worker plan preparation captures the
+snapshot identity; admission revalidates it on the render-capable thread and
+rejects stale work with `StaleCapabilities` before reserving resources.
+Prepared work also captures the resolved-policy revision. A changed policy requires
+revalidation/repreparation before admission, so work prepared under an older user
+budget or disabled feature cannot bypass the new policy.
+
+Dynamic user quality/budget changes publish a new resolved-policy revision at a
+frame boundary after complete validation; the effective device snapshot stays
+unchanged. Failure retains the previous valid policy. Frames already admitted
+retain their old policy and resource leases until retirement. Enabling a native
+device feature not enabled at creation requires host-owned recreation, not an
+in-place boolean change. Surface format/extent/presentation support has its own
+generation and is rechecked on resize without mutating device facts.
+
+Device/context loss or adapter/backend replacement invalidates admission for the
+old incarnation. Re-query, reapply driver policy and re-resolve the product profile
+before reconstruction under ADR-027. Unsupported recovery returns a typed result
+to the host; it neither retains old handles nor silently changes API. Driver-policy
+updates affecting support take effect through the same quiesce/recreate path;
+they cannot revoke live resources halfway through a frame. Host workflows use
+ADR-010 job/operation ownership and ADR-018 render safe points when asynchronous
+preparation is needed; no frame-thread wait for worker or GPU completion is added.
+
+### 6. Cooking, Null and diagnostics
+
+Offline cooking uses explicit versioned target requirement manifests, never the
+cook machine's GPU snapshot. Each profile/feature recipe declares required
+features, limits, formats and shader/provider variants. Cook rejects missing
+required variants and includes every allowed runtime fallback variant. Cache keys
+include target platform/backend shader format, profile-policy version, feature
+recipe and shader layout; runtime plan caches also include device/capability and
+settings revisions. Runtime admission verifies the actual effective snapshot;
+successful cook does not prove arbitrary hardware support.
+
+Null is an explicitly selected headless/test backend, not a product profile or a
+surrogate GPU. Production Null reports only its implemented validation operations
+and no presentation. Tests may inject a bounded synthetic capability fixture for
+the same resolver/validator, marked synthetic in diagnostics. It cannot establish
+hardware parity or GPU execution support. Unsupported plans fail identically;
+timing/lifetime follow the owning frame/resource contract rather than completing
+pending operations early for tests.
+
+Every result identifies requested/selected backend and profile, adapter/device
+incarnation, effective revision, policy version, relevant feature/format/limit and
+driver restriction IDs. Diagnostics distinguish `InvalidCapabilityData`,
+`InvalidProfilePolicy`, `FeatureUnsupported`, `FormatUnsupported`, `LimitExceeded`,
+`MissingVariant`, `ProfileUnsupported` and `StaleCapabilities`. These are typed
+categories for implementation in the existing error registry, not new string-based
+control flow. Messages are bounded and produced at resolution/admission, not by
+polling the driver each frame. No report treats an unknown value as supported.
+
+### 7. Migration and downstream ownership
+
+1. RND-003.2 and RND-017.6 implement reported facts, backend implementation support,
+   driver rules and the effective snapshot. Existing `RenderBackendCapabilities`
+   booleans remain transitional; do not reinterpret hardware support as implemented
+   support or add a competing global tier authority.
+2. RND-003.3/.4 consume effective queue/feature/format/limit predicates at admission;
+   RND-003.7 rebuilds snapshots and invalidates old plans during recovery.
+3. Material/shader cooking and frontend selection replace API-named tiers with
+   profile policy plus explicit feature requirements. The mechanical preference
+   mapping is `es3` -> `baseline`, `dx11` -> `standard`, `dx12_vulkan` -> `high`,
+   `high_end` -> `ultra`; it never selects an API or grants feature support.
+   `minTier`, `preferredTier`, `tierOverrides` migrate to `minProfile`,
+   `preferredProfile`, `profileOverrides`. Material minimums restrict profile
+   eligibility only; variant predicates still decide actual support.
+4. Existing authored requirements stay required. Migration translates the old
+   feature expectations into explicit recipe requirements/fallbacks and reports
+   incompatible content. Merely renaming `high_end` to `ultra` cannot silently
+   drop formerly required ray/mesh/bindless paths. Unknown or conflicting old/new
+   fields fail staged validation. Persist changes through the existing ProjectVersion
+   migration transaction and recook affected variants; do not maintain two writable
+   settings formats. `EditorRenderingTier` and persisted editor preferences migrate
+   in the settings owner, not in a backend.
+5. Legacy tier tables remaining in feature documents describe visual intent under
+   this mapping only. They cannot authorize resources or derive AI/navigation/
+   streaming budgets. Accessibility remains available at every supported profile.
+   This ADR owns profile meaning; feature documents own concrete recipe predicates,
+   budgets and fallbacks. Their implementations must replace legacy tier branches.
+
+No public header or persisted asset schema is changed by this documentation PR.
+The new material examples describe the target schema and require the above
+migration before implementation. M0 closes the decision; implementation and
+hardware qualification remain in their owning downstream tickets.
+
+## Validation obligations
+
+RND-003.9 and the owning subsystem tests must cover:
+
+- identical reported facts with different backend implementation masks or driver
+  rules producing different effective support, with stable restriction provenance;
+- denied features never restored by profiles, overrides, emulation claims or rule
+  ordering; malformed records, duplicate rules and unknown values rejected;
+- exact/over-limit extents and workgroups, multiplication overflow, combined
+  alignment constraints, and usage/sample/view-format combinations where each
+  individual capability exists but the requested combination is unsupported;
+- every profile on a baseline-only fixture; optional fallback versus required
+  feature failure; invalid ceilings, missing cooked fallback, and empty allowed set;
+- identical profile names on different devices selecting different valid recipes;
+- probe/device mismatch, stale worker plans, failed transactional quality updates,
+  settings changes with frames in flight, and device recovery with reduced support;
+- offline cooks independent of the build GPU, legacy profile migration preserving
+  requirements, and synthetic Null results never qualifying an interactive backend.
+
+These are downstream executable requirements. This M0 PR validates documentation
+links, policy consistency and example syntax; it does not claim GPU test coverage.
+
+## Consequences
+
+Features can ask precise support questions without branching on API identity.
+Driver restrictions, absent backend implementations and optional-quality fallback
+become explainable. Cooking and runtime admission share requirement semantics while
+using different evidence sources. The cost is a richer typed capability schema,
+versioned recipe/policy data, explicit fallback variants and migration of legacy
+settings. That cost avoids late native failures and silent content degradation.
+
+## Rejected alternatives
+
+- **One capability boolean set for everything**: loses whether a feature is
+  physically present, implemented, disabled by a workaround or unwanted by policy.
+- **API/vendor tier implies support**: ignores per-device formats, limits, driver
+  problems and incomplete Horo backend implementations; violates backend parity.
+- **Profiles are mandatory cumulative hardware feature sets**: makes Ultra imply
+  every optional technology and cannot represent devices with incomparable features.
+- **Always clamp to the highest supported tier**: hides user/product errors and
+  missing cooked content; explicit recipe and profile fallbacks are reviewable.
+- **Let each feature query the native API**: duplicates policy, leaks native types,
+  adds frame-path work and creates inconsistent decisions after device recreation.
+- **Live mutation of capability booleans**: invalidates admitted plans and resource
+  assumptions without an owner/generation boundary.
+- **Cook against the developer GPU or treat Null as fully capable**: confuses
+  reproducible target validation with hardware availability and qualification.

--- a/docs/adr/028-renderer-capability-limits-and-product-profiles.md
+++ b/docs/adr/028-renderer-capability-limits-and-product-profiles.md
@@ -150,8 +150,10 @@ Resolution is deterministic for the same inputs:
 1. Resolve backend selection through existing host precedence and explicit
    backend fallback rules; never select a different API from a profile name.
 2. Validate the product's allowed profile set, maximum profile, required features,
-   finite budgets and ordered allowed fallback profiles. Reject an empty set,
-   unknown values, duplicate fallback entries or contradictory policy.
+   finite budgets and ordered allowed fallback profiles. Reject an empty allowed
+   set, unknown values, duplicate fallback entries or contradictory policy. An
+   omitted fallback list is not empty: it selects the default descending chain
+   below. An explicitly declared empty fallback list is invalid.
 3. Select the requested profile from explicit host override, user/project
    preference, then the product default (Baseline when omitted). Overrides cannot
    widen product/cook policy. A request outside the allowed set/ceiling returns a
@@ -161,9 +163,16 @@ Resolution is deterministic for the same inputs:
    and cooked variants.
    Required content never becomes optional because a lower profile was requested.
 5. Resolve optional features using their declared ordered fallbacks. If the
-   requested profile cannot satisfy required content, evaluate only the declared
-   fallback profile list in order, applying the same requirements to each. No
-   viable result returns `ProfileUnsupported`; no partial plan becomes active.
+   requested profile cannot satisfy required content, evaluate the profile fallback
+   list in order, applying the same requirements to each. When the product omits
+   `fallbackProfiles`, use the canonical descending chain `Ultra` → `High` →
+   `Standard` → `Baseline`, keeping only profiles that are strictly below the
+   requested profile, inside the allowed set, at or below the ceiling, and at or
+   above every material `minProfile`. When the product declares the list, use that
+   order as written and do not inject omitted lower profiles. No viable result
+   returns `ProfileUnsupported`; no partial plan becomes active. Defaulting the
+   omitted chain never strips a required feature or admits a recipe that failed
+   its predicates.
 6. Publish requested and selected profile, selected feature/variant recipes,
    effective-snapshot revision, budget/settings revision and bounded diagnostics.
    Successful degradation is observable even when the selected profile name is

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,6 +39,7 @@ to the replacement.
 | [025](025-ai-decision-assets-and-gameplay-behavior-boundary.md) | AI Decision Assets and Shared Gameplay Behavior Boundary | proposed | 2026-08-28 |
 | [026](026-large-world-precision-and-floating-origin-strategy.md) | Large-World Precision and Floating Origin Strategy | proposed | 2026-08-28 |
 | [027](027-renderer-resource-identity-and-descriptors.md) | Renderer Resource Identity and Descriptors | proposed | 2026-08-31 |
+| [028](028-renderer-capability-limits-and-product-profiles.md) | Renderer Capability, Limits and Product Profiles | proposed | 2026-08-31 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -95,6 +95,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Render Backend Parity Contract](./runtime/render-backend-parity-contract.md):
   equal lifecycle, presentation, editor integration, and verification obligations
   for interactive renderer backends.
+- [Renderer Capability, Limits and Product Profiles](../adr/028-renderer-capability-limits-and-product-profiles.md):
+  reported versus effective support, driver restrictions, typed format/limit
+  admission, and Baseline through Ultra quality policy.
 - [Renderer Distribution And Availability](./runtime/renderer-distribution-and-availability.md):
   optional renderer components, install/repair/probe states, launcher recovery,
   and selection policy.

--- a/docs/architecture/runtime/advanced-rendering-architecture.md
+++ b/docs/architecture/runtime/advanced-rendering-architecture.md
@@ -40,8 +40,10 @@ Not covered:
 
 ## Core Decisions
 
-- The renderer supports both deferred and forward+ paths. The active path is
-  selected by feature tier and scene requirements.
+- The renderer supports deferred, forward+ and baseline forward paths. The
+  frontend selects a recipe from product preferences, scene requirements and
+  effective feature/format/limit predicates under
+  [ADR-028](../../adr/028-renderer-capability-limits-and-product-profiles.md).
 - Lighting is clustered or tiled by default to scale with many punctual lights.
 - Shadows use a configurable atlas with cascaded directional shadows and
   punctual shadow maps.
@@ -53,10 +55,11 @@ Not covered:
   individual materials.
 - TAA and upscaling are optional but supported through a vendor-neutral
   interface.
-- Ray tracing, mesh shaders, and bindless resources are gated by feature tier
-  and compile-time capability.
-- Every high-end feature has a deterministic raster or CPU-driven fallback;
-  tiers disable features rather than fail.
+- Ray tracing, mesh shaders and bindless resources require implemented backend
+  paths, effective device support and product permission independently.
+- Optional high-end features use declared, implemented and cooked raster or
+  CPU-driven fallbacks. Missing required features fail admission; a profile
+  cannot silently disable content requirements.
 - The render graph owns resource allocation and barrier scheduling; individual
   features declare inputs and outputs.
 
@@ -64,7 +67,9 @@ Not covered:
 
 ### Deferred Lighting
 
-Default path for `dx12_vulkan` and `high_end` tiers.
+Preferred path for High and Ultra when the complete GBuffer attachment, format,
+sample and resource-limit requirements pass. Otherwise the frontend evaluates
+the explicitly allowed fallback recipes before admitting resource work.
 
 Pass flow:
 
@@ -84,7 +89,9 @@ it without per-material negotiation.
 
 ### Forward+ Lighting
 
-Default path for `dx11` and fallback for `es3`.
+Preferred path for Standard when compute preparation and its resource requirements
+are effective. Baseline uses forward raster with bounded CPU light preparation;
+this is also the explicit fallback when compute is unavailable.
 
 Forward+ performs a light culling prepass to produce a per-tile light list,
 then renders opaque and translucent meshes in a forward pass.
@@ -99,16 +106,17 @@ then renders opaque and translucent meshes in a forward pass.
 | Rect        | Optional; area light approximation.                      |
 | Sky         | Ambient contribution and environment cubemap.            |
 
-Rect and Sky light support is tier-dependent. `es3` may support only basic
-approximations; full area-light and dynamic sky contributions are enabled on
-`dx11` and above.
+Rect and Sky light recipes declare their shader/format/limit requirements.
+Baseline may use basic approximations; richer area-light and dynamic-sky paths
+are selected only when their requirements and product budgets pass admission.
 
 ### Clustered / Tiled Culling
 
 Lights are assigned to screen-space tiles or world-space clusters. Each tile
 stores a compact index list. Shaders iterate only over relevant lights.
 
-Culling is performed on CPU or GPU depending on tier and light count.
+Culling is performed on CPU or GPU according to effective support, the selected
+recipe and the product's bounded light/work budget.
 
 ## Shadows
 
@@ -117,7 +125,7 @@ Culling is performed on CPU or GPU depending on tier and light count.
 Directional lights use cascaded shadow maps (CSM).
 
 - cascades are split by logarithmic or mixed partitioning
-- cascade count is tier-dependent
+- cascade count is a validated product budget bounded by effective resource limits
 - cascade blending reduces seams
 - stable cascades reduce shimmer during camera rotation
 
@@ -138,9 +146,9 @@ prioritized by:
 ### Contact Shadows
 
 Optional screen-space contact shadows add fine detail near the camera. They are
-a separate pass that may be disabled on lower tiers. Contact shadows are used on
-`dx12_vulkan` and may be combined with or replaced by virtual shadow maps on
-`high_end`.
+a separate optional pass. High may prefer contact shadows; Ultra may prefer a
+virtual-shadow-map recipe. Both require independent resource/format predicates
+and an explicit fallback to the admitted shadow-atlas recipe.
 
 ## Global Illumination
 
@@ -174,7 +182,7 @@ Optional real-time technique using the depth buffer and GBuffer.
 
 - lower accuracy than baked GI
 - useful for dynamic objects and contact color bleeding
-- tier-gated
+- effective-capability and product-policy gated, with a baked-GI/probe fallback
 
 ## Reflections
 
@@ -200,7 +208,8 @@ mirrors.
 
 ### Ray-Traced Reflections
 
-Available on tiers that support hardware ray tracing.
+Available only when effective support includes the required ray operations and
+resources, the effect implementation is linked, and product policy enables it.
 
 - more accurate than SSR
 - denoising required
@@ -266,13 +275,17 @@ Backends:
 | `FSR`    | AMD spatial/temporal upscaling.  |
 | `XeSS`   | Intel XeSS upscaling.            |
 
-The renderer selects the best available backend based on GPU vendor, tier, and
-user preference. All backends share the same input: jittered low-res color,
-motion vectors, depth, and exposure.
+The frontend selects an upscaler provider from the explicit product/user policy
+and effective support for that provider's requirements. Vendor identity alone
+does not authorize selection; provider selection never switches the renderer API.
+Temporal providers consume jittered low-resolution color, motion vectors, depth
+and exposure. Each provider declares its exact inputs and cooked/runtime support;
+native resolution is the explicit optional-upscaler fallback.
 
 ## Ray Tracing
 
-Ray tracing is gated by feature tier and compile-time capability.
+Ray tracing is gated by effective ray-operation support, implemented/cooked effect
+paths and product policy; an Ultra preference alone does not enable it.
 
 Use cases:
 
@@ -288,7 +301,9 @@ Requirements:
 - shader table management
 - denoising pass
 
-Ray tracing is never required. Every ray-traced effect has a raster fallback.
+Built-in profile recipes do not require ray tracing. Their optional ray-traced
+effects declare raster fallbacks. Content that explicitly requires a ray path
+fails admission on unsupported hardware rather than silently changing its effect.
 
 ## GPU-Driven Rendering
 
@@ -317,7 +332,8 @@ Bindless descriptor indexing reduces descriptor set pressure.
 - materials pass texture indices
 - descriptor heap/array managed by the renderer
 
-Fallback to bound descriptors on tiers without bindless support.
+Fallback to a declared bound-resource variant when effective bindless support is
+absent or product policy disables it; missing required variants fail admission.
 
 ## Mesh Shaders And Meshlets
 
@@ -337,7 +353,8 @@ Virtual texturing allows scenes to use more texture data than GPU memory.
 - runtime requests visible tiles
 - sparse texture arrays or page tables manage residency
 
-Virtual texturing is optional and tier-gated.
+Virtual texturing is optional and admitted through its effective feature/format
+requirements and product residency budgets, not through a profile rank.
 
 ## Occlusion Culling
 
@@ -363,14 +380,16 @@ This document defines the boundary:
 Detailed terrain/foliage architecture is covered in a separate document when
 implemented.
 
-## Feature Tiers
+## Product Profile Policy
 
-| Tier          | Lighting                | Shadows                     | GI                        | Reflections          | Post  | TAA/Upscale   | Ray Tracing | Bindless | Mesh Shaders |
-| ------------- | ----------------------- | --------------------------- | ------------------------- | -------------------- | ----- | ------------- | ----------- | -------- | ------------ |
-| `es3`         | Forward, limited lights | Single cascade, no punctual | Ambient + probes          | Probes only          | Basic | Native        | No          | No       | No           |
-| `dx11`        | Forward+                | Cascaded + atlas            | Lightmaps + probes        | SSR + probes         | Full  | TAA optional  | No          | Limited  | No           |
-| `dx12_vulkan` | Deferred                | Cascaded + atlas + contact  | Lightmaps + probes + SSGI | SSR + RT reflections | Full  | TAA/TAAU/FSR  | Optional    | Yes      | Optional     |
-| `high_end`    | Deferred/clustered      | Virtual shadow maps         | Real-time GI              | SSR + RT + probes    | Full  | All upscalers | Yes         | Yes      | Yes          |
+[ADR-028](../../adr/028-renderer-capability-limits-and-product-profiles.md) owns
+the Baseline through Ultra recipe preferences and the legacy API-tier migration.
+This document owns effect algorithms and their concrete requirements. A profile
+is not a bundle of guaranteed hardware features: every selected pass declares
+required operations, formats, limits, inputs, variants and finite budgets.
+The frontend records optional fallback decisions and rejects missing required
+paths before resource creation. No feature or upscaler selects another renderer
+backend, and no frame-hot path queries the native driver for capability policy.
 
 ## Render Graph Integration
 
@@ -396,7 +415,8 @@ Debug views:
 ## Testing Requirements
 
 - Visual regression tests for representative scenes.
-- Tier fallback tests verifying degraded output without crashes.
+- Profile/feature fallback tests verifying declared degradation, rejection of
+  missing required paths and preservation of the active plan after failed updates.
 - Shader permutation tests for each lighting path.
 - Performance tests measuring draw call scaling.
 - Determinism tests for TAA and motion vector generation.

--- a/docs/architecture/runtime/material-and-shader-model.md
+++ b/docs/architecture/runtime/material-and-shader-model.md
@@ -241,9 +241,16 @@ struct ShaderPermutationKey {
     RenderPassId passId;
     VertexLayoutId vertexLayoutId;
     TargetPlatformId platform;
-    RenderProductProfile profile;
 };
 ```
+
+`RenderProductProfile` is an admission and recipe-selection axis, not a compile
+axis of its own. Profile resolution chooses which declared permutation to bind.
+Compile-time differences that a profile would otherwise imply must appear as
+declared feature flags or as a distinct shader/pass identity. Profile-only
+parameter or uniform overrides stay out of the key and do not duplicate binaries.
+Two admitted profiles that resolve to the same `FeatureMask`, pass, vertex layout
+and platform share the compiled variant.
 
 Feature flags that participate in the key must be declared explicitly in the
 shader manifest. Implicit feature detection from material parameters is not
@@ -291,9 +298,11 @@ typed errors instead of successful degraded conversion.
 
 Cooking uses versioned target requirement manifests, not the cook host's GPU.
 Runtime rechecks every selected recipe against the active effective snapshot.
-Profile fallback follows only the product's explicit ordered list and cannot
-relax material minimums or required content features. Resolution records selected
-variants and reasons even when quality degrades within the same profile name.
+Profile fallback follows ADR-028: an omitted product fallback list uses the
+canonical descending allowed chain; an explicit list is used as written. Fallback
+cannot relax material minimums or required content features. Resolution records
+selected variants and reasons even when quality degrades within the same profile
+name.
 
 ## Pipeline Cache
 

--- a/docs/architecture/runtime/material-and-shader-model.md
+++ b/docs/architecture/runtime/material-and-shader-model.md
@@ -42,9 +42,10 @@ Not covered:
   renderer backend.
 - Shader variants are produced from explicit permutation keys, not from runtime
   string substitution.
-- Feature tiers declare hardware capability sets. Materials and shaders declare
-  which tiers they require; the runtime selects the best available tier and
-  records fallback decisions.
+- Product profiles express quality preferences, not hardware capability sets.
+  Materials and shader variants declare explicit feature, format and limit
+  requirements. The frontend selects an admitted recipe and records every fallback
+  under [ADR-028](../../adr/028-renderer-capability-limits-and-product-profiles.md).
 - Pipeline state objects are cached and reused. Shader compilation may happen
   offline during cook or lazily at runtime, but the cache key format is the same.
 - No gameplay code queries raw shader handles. Gameplay sees only material names,
@@ -177,10 +178,10 @@ shader graph `.horoshadergraph`.
     "depthTest": "LessEqual",
     "depthWrite": true
   },
-  "minTier": "es3",
-  "preferredTier": "dx12_vulkan",
-  "tierOverrides": {
-    "es3": {
+  "minProfile": "baseline",
+  "preferredProfile": "high",
+  "profileOverrides": {
+    "baseline": {
       "features": { "normalMap": false },
       "parameters": { "roughness": 1.0 }
     }
@@ -189,7 +190,10 @@ shader graph `.horoshadergraph`.
 ```
 
 The asset pipeline cooks this into a runtime material descriptor plus a set of
-shader variant requests.
+shader variant requests. The profile fields show the target contract; existing
+`minTier`/`preferredTier`/`tierOverrides` assets require the staged ProjectVersion
+migration in ADR-028 before a parser or writer adopts it. The example does not
+announce a schema implementation or bypass the existing project-version authority.
 
 ## Material Instances
 
@@ -237,13 +241,18 @@ struct ShaderPermutationKey {
     RenderPassId passId;
     VertexLayoutId vertexLayoutId;
     TargetPlatformId platform;
-    QualityTier tier;
+    RenderProductProfile profile;
 };
 ```
 
 Feature flags that participate in the key must be declared explicitly in the
 shader manifest. Implicit feature detection from material parameters is not
 allowed.
+
+The complete cook/cache identity also includes backend shader format, versioned
+profile/recipe policy and shader layout. Runtime plan caches include effective
+capability and settings revisions. A profile name alone cannot select a variant
+whose requirements have not passed admission.
 
 ### Variant Compilation Policy
 
@@ -263,33 +272,28 @@ compilation is disabled.
 - Materials that request unsupported feature combinations produce errors during
   import, not at runtime.
 
-## Feature Tiers
+## Product Profiles And Variant Admission
 
-Feature tiers group renderer capabilities.
+[ADR-028](../../adr/028-renderer-capability-limits-and-product-profiles.md) is the
+single authority for `baseline`, `standard`, `high`, `ultra`, their resolution
+order and migration from API-named tiers. There is no material-local GPU tier
+classifier. The frontend supplies a resolved policy based on effective features,
+typed limits, complete format/usage/sample predicates and allowed cooked variants.
 
-| Tier | Representative capabilities |
-|---|---|
-| `es3` | Forward rendering, limited lights, no compute, no bindless. |
-| `dx11` | Forward+/limited deferred, compute, texture arrays. |
-| `dx12_vulkan` | Full deferred, bindless, compute, ray-tracing optional. |
-| `high_end` | Mesh shaders, hardware ray tracing, virtual texturing, Nanite-style virtual geometry if implemented. |
+A material's `minProfile` restricts profile eligibility; `preferredProfile` records
+author intent without overriding host/user policy. Neither proves hardware support.
+`profileOverrides` patch declared feature choices and parameters for an eligible
+selected profile, with keys restricted to the canonical profile names. A missing
+override retains the base values only when that exact variant passes admission.
+Required features are never silently removed. Optional feature fallbacks must be
+declared and cooked; missing required variants or incompatible requirements produce
+typed errors instead of successful degraded conversion.
 
-Tier selection order:
-
-1. Target platform declares maximum tier.
-2. Cook profile may lower the tier for release builds.
-3. Runtime GPU caps clamp the tier.
-4. User settings may lower the tier further.
-
-A material declares `minTier` and `preferredTier`. The runtime records the
-selected tier and any disabled features.
-
-`minTier` is the lowest tier the material can run on. `preferredTier` is the
-tier the author optimized for. `tierOverrides` patch features and parameters
-when the selected tier is below `preferredTier`; each key in `tierOverrides`
-must match a declared tier name (`es3`, `dx11`, `dx12_vulkan`, `high_end`). If a
-tier lacks an override, the material runs with the base parameters and feature
-set, possibly with degraded quality but without failing conversion.
+Cooking uses versioned target requirement manifests, not the cook host's GPU.
+Runtime rechecks every selected recipe against the active effective snapshot.
+Profile fallback follows only the product's explicit ordered list and cannot
+relax material minimums or required content features. Resolution records selected
+variants and reasons even when quality degrades within the same profile name.
 
 ## Pipeline Cache
 
@@ -391,7 +395,8 @@ Material validation rules:
 - all referenced textures must exist and match expected usage
 - parameter types must match the shader manifest
 - feature flag combinations must be legal
-- `minTier` must not exceed any target platform tier
+- `minProfile` and required variant predicates must be satisfiable by every
+  declared target requirement manifest
 - translucent materials must not request opaque-only passes
 - masked materials must explicitly provide `opacityMaskThreshold`
 
@@ -406,7 +411,8 @@ Cook-time diagnostics:
 - Unit tests for permutation key equality and hash stability.
 - Tests for material instance override inheritance.
 - Cook tests that verify variant emission for each standard feature flag.
-- Runtime tests that verify fallback tier disables features without crashing.
+- Runtime tests for explicit optional-feature fallback, missing required variants,
+  driver restrictions, stale capability revisions and profile-policy rejection.
 - Visual regression tests for standard material spheres under representative
   lighting.
 

--- a/docs/architecture/runtime/render-backend-parity-contract.md
+++ b/docs/architecture/runtime/render-backend-parity-contract.md
@@ -271,6 +271,13 @@ not own scene rendering policy or replace `RenderFrontend`.
 
 ## Required Baseline Capability
 
+This is an interactive-backend lifecycle/parity requirement, not automatic
+qualification for every scene or for the `Baseline` product rendering recipe.
+[ADR-028](../../adr/028-renderer-capability-limits-and-product-profiles.md) defines
+the distinct product profiles and effective support used for resource/plan
+admission. Optional features require both native support and an implemented,
+driver-policy-approved backend path; profile names never grant support.
+
 OpenGL and Metal reach parity only when both provide:
 
 - interactive window presentation;

--- a/docs/architecture/runtime/renderer-distribution-and-availability.md
+++ b/docs/architecture/runtime/renderer-distribution-and-availability.md
@@ -246,6 +246,16 @@ A successful probe is scoped to module version, editor ABI, host OS build,
 architecture, and relevant driver/runtime identity. Changes to those inputs
 invalidate cached availability and require a new probe.
 
+Probe availability is not final project capability admission. Following
+[ADR-028](../../adr/028-renderer-capability-limits-and-product-profiles.md), the
+frontend resolves reported device facts, implemented backend support and driver
+restrictions after the selected device is initialized. Required project/profile
+features and format/limit predicates must pass before scene/GUI resource creation.
+Probe cache identity also includes adapter identity and driver-policy version;
+changed inputs require revalidation. A final mismatch rolls back initialization
+and returns a typed failure, even after a successful helper probe. Only the host's
+explicit fallback list can select another backend; a quality profile cannot.
+
 ## No-Renderer Flow
 
 A graphical editor workspace requires an interactive renderer. `RenderNull`

--- a/docs/architecture/runtime/renderer-module-package-manifest.md
+++ b/docs/architecture/runtime/renderer-module-package-manifest.md
@@ -283,7 +283,9 @@ settings.
 ## Capability Hints
 
 `capabilityHints` exist for catalog presentation and preflight planning only.
-They are not authoritative. The initialized backend's typed capability snapshot
+They are not authoritative. The frontend's effective capability snapshot after
+device initialization and driver-policy adjustment, as defined by
+[ADR-028](../../adr/028-renderer-capability-limits-and-product-profiles.md),
 is authoritative.
 
 A manifest cannot use capability hints to bypass parity requirements or backend

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -156,6 +156,32 @@ capability or platform reason. A fallback to `null` is allowed only for tools,
 tests, and explicitly headless workflows; interactive editor/game hosts must not
 silently switch to `null`.
 
+## Capabilities, Limits And Product Profiles
+
+[ADR-028](../../adr/028-renderer-capability-limits-and-product-profiles.md) owns
+the renderer capability and profile policy. Backend-reported device facts,
+implemented backend operations, driver-adjusted effective support, and requested
+product quality are distinct contracts. The frontend owns the immutable effective
+snapshot; resource and plan admission use it, never a raw report or profile rank.
+
+`Baseline`, `Standard`, `High`, and `Ultra` select rendering recipe preferences.
+They are not graphics APIs, build profiles, hardware guarantees, or gameplay
+budgets. Optional features use declared, implemented and cooked fallback recipes;
+missing required features return typed failures. Limits have explicit units and
+format checks validate the complete usage/sample/view combination. No resource
+API silently substitutes formats or lowers quality.
+
+Final support is established after device initialization, before resource work
+is admitted; module metadata and probe results do not replace that validation.
+Snapshots carry frontend/device/revision identity. Worker plans are revalidated
+on admission, quality changes publish a new policy at a frame boundary, and
+device recreation invalidates old snapshots and resolves policy again before
+resource reconstruction. Profile changes never silently switch a backend.
+
+The existing `RenderBackendCapabilities` booleans are a transitional implementation.
+The richer value contracts, driver-policy provider and profile resolver are
+downstream implementation work; this M0 decision does not claim them as available.
+
 ## Backend Module Registry
 
 Renderer backends are engine-internal modules with separate CMake targets,
@@ -559,7 +585,7 @@ Result<void> DestroyTexture(TextureHandle);
 ```
 
 The frontend validates structure, owner, generation, registry state, referenced
-resources, and reported capabilities before native execution. A resident
+resources, and effective capabilities before native execution. A resident
 generation retains the exact dependency generations named by its descriptor.
 Release prevents new direct use of that handle immediately. Native destruction
 waits until dependents drop their pins and prior GPU work completes on the
@@ -715,6 +741,8 @@ Required tests cover:
 - frontend rejection and cleanup of invalid successful frame tokens
 - frontend resize propagation and exception containment
 - capability-incompatible and malformed execution plans being rejected
+- reported/implemented/driver-adjusted support separation and profile resolution
+  following ADR-028, including stale snapshots and missing required fallback variants
 - installed editor composition loading only the selected verified component while
   development/headless profiles may register explicit static/null modules
 - render graph cycle and invalid-resource rejection


### PR DESCRIPTION
## Summary

Renderer resource admission currently has no documented separation between native
device facts, implemented backend operations, driver restrictions and product quality.
API-named material tiers also imply support that an initialized backend may not provide.

This M0 decision adds ADR-028 and aligns the owning renderer, material/shader,
advanced-rendering, parity, availability and manifest documents with one policy.

## Motivation

RND-001.1 establishes typed renderer resource identity. Its downstream resource,
queue, recovery and cooking work needs a precise capability authority rather than
per-feature API/tier assumptions. HORO-296 requires a reviewable architecture
decision, alternatives, migration impact and a single source of truth.

## Implementation Notes

- Separate reported device facts, backend implementation support, effective support
  after driver restrictions, and resolved product quality policy.
- Define typed limit units, combined format/usage/sample predicates, conservative
  driver restrictions and required versus optional feature admission.
- Define Baseline, Standard, High and Ultra as recipe preferences, with explicit
  fallbacks and no silent backend switching or removal of required content features.
- Specify snapshot generations, stale worker-plan rejection, transactional quality
  changes, recovery, offline cooking and synthetic Null validation boundaries.
- Migrate legacy API-named tier preferences through ProjectVersion while preserving
  required features; document downstream ownership and executable validation cases.
- Branch starts from main after PR #2332 (`11c7f5c`). No runtime code, public header,
  asset parser or persisted schema implementation changes are included.

## Validation

- `git diff --cached --check` passed before commit.
- `python3 scripts/dev.py format --staged --check` passed: no C++ files in scope.
- An ad hoc Python documentation check inspected all nine changed files: 234 local
  links/anchors, balanced fenced blocks and three JSON examples. No new errors.
- Two pre-existing missing links in `docs/architecture/README.md` remain unchanged:
  `editor/localization-implementation-plan.md` and
  `editor/localization-extractor-report.json`.
- Manual contract review covered required-feature rejection, optional cooked
  fallback, driver restrictions, stale capability/settings revisions and device loss.
- Build, runtime tests and GPU smoke tests were not run for this documentation-only
  decision. No runtime behavior or coverage improvement is claimed.

## Risks

The richer capability schema, driver-policy provider, profile resolver and migration
are downstream work. Existing backend booleans and editor tier settings remain
transitional; this PR explicitly does not claim those replacements are implemented.

## Issue Links

- Jira: [HORO-296](https://horo-engine.atlassian.net/browse/HORO-296)
- GitHub: Closes #296
- Milestone: M0 — Architecture Baseline

## Reviewer Notes

Read ADR-028 first, then the Rendering Architecture summary, material/shader
selection and advanced-rendering changes. Focus on whether a profile could
accidentally grant support or silently relax required content. The other document
updates align probe/manifest/parity semantics and indexes with the same authority.


[HORO-296]: https://horo-engine.atlassian.net/browse/HORO-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ