### PR TITLE
docs(render): define OpenGL platform and profile policy HORO-306 #306 [RND-004.1]

### DIFF
--- a/docs/adr/029-opengl-compatibility-profile-and-platform-policy.md
+++ b/docs/adr/029-opengl-compatibility-profile-and-platform-policy.md
@@ -1,0 +1,266 @@
+# ADR-029: OpenGL Compatibility Profile and Platform Policy
+
+- **Status**: proposed
+- **Date**: 2026-08-31
+- **Owners**: Rendering / Platform
+- **Tracking**: HORO-306 / #306 / RND-004.1
+- **Milestone**: M0 — Architecture Baseline
+
+## Context
+
+Horo has an `opengl` backend and matching editor adapters, but a compiled module
+does not establish which contexts, drivers, or platforms the product supports.
+The private `OpenGLContextDescriptor` currently defaults to OpenGL 4.1 Core.
+Without a normative policy, downstream device, surface, shader, and qualification
+work could independently lower that requirement or infer features from it.
+
+“Compatibility renderer” describes OpenGL's product role: maintaining a desktop
+rendering option alongside the other native backends. It does **not** mean the
+OpenGL Compatibility Profile. OpenGL remains an equal backend under the
+[parity contract](../architecture/runtime/render-backend-parity-contract.md).
+
+[ADR-028](028-renderer-capability-limits-and-product-profiles.md) already separates
+native reports, implemented operations, effective support, and product profiles.
+This decision supplies OpenGL's native admission policy; it does not replace
+those contracts or assign a product profile to an API version.
+
+## Decision
+
+### 1. Desktop OpenGL 4.1 Core is the minimum
+
+The `opengl` component requests **desktop OpenGL 4.1 Core**. A context is
+admissible only when its actual API family is desktop OpenGL, its actual version
+is at least 4.1, and its actual profile is Core. A newer Core context may satisfy
+the minimum, subject to the same implementation, driver, and release
+qualification checks. A newer version alone does not qualify a driver or enable
+an optional path.
+
+The following are not admitted under this component's identity:
+
+- OpenGL versions below 4.1, including a 3.3 Core retry;
+- legacy or Compatibility Profile contexts;
+- OpenGL ES, WebGL, or an implicitly substituted translation backend;
+- a context whose required entry points cannot be loaded or whose mandatory
+  interactive parity requirements cannot be satisfied.
+
+There is no fixed-function fallback. Meshes, shader stages, resources, and
+commands still enter through backend-neutral Render API contracts. Core profile
+semantics are defined by the
+[Khronos OpenGL 4.1 Core specification](https://registry.khronos.org/OpenGL/specs/gl/glspec41.core.pdf).
+
+The baseline shader variant must be valid for the admitted 4.1 Core contract.
+The shader/cook pipeline records each variant's language and feature
+requirements; a higher shader requirement needs a separately admitted variant
+and a declared fallback when optional. Existing editor GLSL `150` shaders do not
+lower the context minimum. This ADR does not introduce a new shader compiler,
+asset schema, or public setting for native context versions.
+
+Compute, storage resources, bindless access, and other optional operations are
+not inferred from `opengl`, a version string, an extension string alone, or a
+`Baseline`/`High` product preference. They require the native prerequisites,
+loaded entry points, implemented path, and effective admission from ADR-028.
+
+### 2. Platform scope and qualification
+
+The supported platform families for this component are desktop Windows, Linux,
+and macOS. Support for an individual release is conditional on its published
+qualification matrix; this ADR does not certify every OS, GPU, or driver in
+those families.
+
+| Platform family | Native policy | Qualification boundary |
+|---|---|---|
+| Windows desktop | Desktop OpenGL 4.1 Core or later through the installed driver | Qualify each shipped OS/architecture and driver family; a system loader or successful build alone is insufficient. |
+| Linux desktop | Desktop OpenGL 4.1 Core or later through the installed driver and selected window system | X11 and Wayland are separate qualification entries; success on one does not establish support on the other. |
+| macOS desktop | System OpenGL 4.1 Core where available and qualified | Retained as a compatibility option with a platform deprecation warning; no promise that future macOS versions retain it. |
+| Mobile, browser, and other hosts | Not supported by this component policy | OpenGL ES/WebGL or other providers require their own explicit architecture, package, and qualification decision. |
+
+The current build reference environments are listed in
+[Developer Environment](../architecture/delivery/developer-environment.md).
+Those development baselines are inputs to qualification, not a substitute for
+runtime support evidence. RND-004.8 owns the versioned release matrix, including
+OS version, architecture, window system, GPU/driver identity, component build,
+actual context/profile, and parity/smoke results. An unqualified combination may
+be used by an explicit engineering/test host, but cannot be advertised as a
+qualified product configuration.
+
+Software GL implementations may be used in explicitly identified test lanes.
+Their results do not stand in for hardware GPU qualification or establish
+interactive performance support. `RenderNull` remains the ordinary headless
+test/tool backend; it is not an interactive recovery renderer.
+
+The component packages Horo's adapter and approved private dependencies. It
+does not download arbitrary driver libraries or treat installation of the
+component as installation of a GPU driver. Native loader availability, context
+admission, and effective feature support remain separate checks under
+[Renderer Distribution And Availability](../architecture/runtime/renderer-distribution-and-availability.md).
+
+### 3. Context negotiation has one owner
+
+Rendering owns the native requirements; the selected platform presentation
+adapter realizes them. The host owns selection, window lifetime, and startup
+failure handling. SDL, GLAD, native contexts, and profile constants stay private
+to their backend or platform-adapter targets.
+
+Startup obeys the common component lifecycle with these OpenGL obligations:
+
+1. Resolve and verify the selected component and its immutable pre-window
+   description. A successful availability probe is provisional, not a retained
+   context or a final capability snapshot.
+2. Before creating the OpenGL window, the selected host adapter applies the
+   required context version/profile and presentation attributes. The adapter
+   receives private, immutable setup requirements from the verified component's
+   pre-window metadata; it must not create a second version-policy default.
+   Extend that private metadata/adapter seam during realization without adding
+   native fields to public Render API or project settings.
+3. Create the window and context, make the context current on the designated
+   native owner thread, load the required entry points, and query the actual
+   version, profile, limits, and supported operations. Do not treat requested
+   attributes or the editor's loader initialization as device evidence.
+4. Validate native admission and construct the implemented/effective support
+   snapshot under ADR-028. Only then publish a ready backend. Failure unwinds
+   the context, window, and ownership lease according to their owners, in
+   reverse acquisition order; no partial snapshot becomes active.
+
+SDL requires GL attributes to be set before window creation, allows returned
+attributes to differ from requested ones, and restricts attribute setup to the
+main thread. The SDL host therefore performs this setup on its main thread;
+its declared render-capable ownership and native create/destroy rules must also
+be satisfied. Attribute configuration and window/context creation are serialized
+so two adapters cannot interleave SDL's shared setup state.
+[SDL's attribute contract](https://wiki.libsdl.org/SDL3/SDL_GL_SetAttribute)
+is authoritative for this adapter requirement.
+
+Native context work is not dispatched to arbitrary worker jobs. Rendering and
+native teardown stay on the host-declared owner thread. Context recreation
+invalidates the old device/snapshot identity and resources under
+[ADR-027](027-renderer-resource-identity-and-descriptors.md) and ADR-028; a cached
+probe cannot revive them. Native threading does not weaken the non-blocking
+core-loop rules in [ADR-010](010-job-waiting-and-operation-store-ownership.md).
+
+Debug contexts are diagnostic aids, not baseline availability requirements.
+Normal validation-enabled startup may attempt a debug context and, if that
+attempt fails, retry once without the debug flag after complete rollback of
+that attempt's resources. Both attempts require the same version, Core profile,
+and presentation contract. Report the loss of native debug diagnostics once;
+Horo's own validation remains enabled. A qualification test explicitly requiring
+a debug context fails instead of retrying. There is no retry that lowers the
+API/profile, drops required rendering features, or substitutes another backend.
+
+### 4. Selection and deprecation are explicit
+
+Selection retains the precedence in
+[Rendering Architecture](../architecture/runtime/rendering-architecture.md#backend-selection):
+explicit CLI request, configuration, then host default. The project persists
+`opengl`, not an OS context handle, GL version, driver name, or module path.
+This decision does not change the existing transitional host default or the
+restart requirement for renderer changes.
+
+Apple deprecated OpenGL in macOS 10.14 and recommends Metal for new development;
+Apple also documents its
+[4.1 Core profile](https://developer.apple.com/documentation/appkit/nsopenglprofileversion4_1core).
+See Apple's
+[OpenGL migration guidance](https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/UpdatinganApplicationtoSupportOpenGL3/UpdatinganApplicationtoSupportOpenGL3.html).
+Horo retains qualified macOS OpenGL use without hiding that platform risk.
+
+When OpenGL is selected on macOS, the host presents one localized warning per
+startup, through its existing diagnostics/recovery surface, explaining that
+the platform API is deprecated. It may recommend Metal and offer the existing
+explicit install/probe/switch workflow. It must not claim Metal is available
+without component verification and probe success, change project settings,
+restart, or silently choose Metal merely because the warning was shown.
+Headless diagnostics do not require creating an OpenGL window to show it.
+
+Deprecation is distinct from failure. An admitted macOS context may continue;
+a missing runtime, unsupported profile, failed context creation, or required
+capability failure returns the appropriate typed startup/availability result.
+Diagnostics include the requested backend, required contract, actual context
+facts when available, failure stage, and actionable driver/component guidance.
+No context is manufactured solely to fill an error message.
+
+Any user-authorized fallback follows the common explicit fallback policy and
+is reported. An interactive host cannot recover by selecting `null`. macOS API
+deprecation does not deprecate Horo's Windows/Linux component. Removing macOS
+support, raising the minimum version, or changing host defaults requires a new
+architecture decision, migration guidance, and release notice; no removal date
+is implied here.
+
+### 5. M0 boundary and downstream migration
+
+This is an architecture decision, not a claim that native qualification or the
+complete backend is implemented. Current source defaults align with 4.1 Core,
+but the following gaps remain explicit implementation work:
+
+| Owner | Required realization |
+|---|---|
+| RND-004.2 / #308 — Device, Context and Capability | Validate actual version/profile and required entry points in backend initialization; produce reported and effective facts, typed failures, diagnostic retry handling, and generation invalidation. |
+| RND-004.5 / #311 — Presentation and Surface Lifecycle | Move complete context requirements into the private pre-window setup seam; serialize SDL setup, verify attribute results, and prove rollback/recreation ownership. |
+| RND-004.6 / #310 — Shader, Pipeline and Material | Admit cooked shader variants against the 4.1 Core baseline and optional effective paths without leaking GLSL policy to materials. |
+| RND-004.7 / #312 — Editor GUI and Viewport | Consume the selected backend's readiness; remove reliance on editor-only GL loading for runtime readiness; integrate the macOS warning through the common host workflow. |
+| RND-004.8 / #313 — Compatibility and GPU Qualification | Publish the release matrix and evidence, including actual contexts, platform diagnostics, driver restrictions, and negative admission tests. |
+
+Resource/memory realization (RND-004.3) and command/synchronization adaptation
+(RND-004.4) consume this policy and ADR-027/028; they do not choose another native
+minimum. Other renderer APIs, product profile recipes, package trust, driver
+rule governance, and native shader implementation retain their existing owners.
+
+The current SDL adapter sets version/profile during `CreateContext` after the
+host has created its window. The current backend forwards requested options
+without completing actual-context qualification, while editor integrations
+perform GLAD loading. The migration above must close these gaps before treating
+the component as satisfying this policy. M0 does not silently label the current
+backend production-qualified or add runtime code to simulate completion.
+
+### 6. Verification obligations
+
+Downstream implementation is complete only with evidence for:
+
+- admission of a valid 4.1 Core context and a qualified newer Core context;
+  rejection of a lower version, Compatibility Profile, ES context, missing
+  entry point, and missing required effective capability before readiness;
+- a native extension reported but not implemented remaining unavailable, and
+  required shader variants failing instead of silently lowering requirements;
+- pre-window attribute ordering, actual/requested mismatch, debug retry bounds,
+  strict debug-test rejection, rollback after each failed stage, repeated
+  shutdown, and context recreation rejecting old resources/snapshots;
+- explicit `--renderer opengl`, configuration precedence, unavailable component
+  recovery, macOS warning without implicit switch, and unchanged project state
+  when the user cancels an offered migration;
+- the shared parity and GPU smoke suites on each published platform/driver
+  combination, identifying software-rendered lanes separately.
+
+Fake presentation/query ports cover deterministic negative paths; native GPU
+lanes establish real context and image behavior. Neither replaces the other.
+Docs-only M0 verification checks the decision's links and agreement with the
+owning architecture; it is not GPU coverage evidence.
+
+## Consequences
+
+One desktop native minimum keeps platform negotiation and shader baseline work
+consistent, including the retained macOS path. Older GL hardware and legacy
+contexts are deliberately excluded. Core-only support avoids a second
+fixed-function implementation and keeps backend-neutral rendering contracts
+intact, at the cost of requiring a qualifying driver.
+
+Higher-capability drivers can enable separately implemented optional paths
+without redefining the baseline. This requires honest effective support and
+per-platform qualification rather than treating a version number as readiness.
+macOS compatibility incurs warning, testing, and eventual migration costs;
+retention today is not a guarantee about future Apple platform availability.
+
+## Rejected Alternatives
+
+- **OpenGL 4.6 everywhere:** would exclude the retained macOS 4.1 path and raise
+  the desktop requirement without an M0 need. Optional features belong to
+  effective capability admission.
+- **Lower the baseline to 3.3 or retry legacy/Compatibility contexts:** expands
+  the support and shader matrix and makes startup requirements ambiguous;
+  it is not justified by the current 4.1 Core implementation contract.
+- **Automatically switch macOS projects to Metal:** changes project intent and
+  may select a missing or unqualified component. Offer an explicit migration.
+- **Remove macOS OpenGL immediately:** discards an existing compatibility path
+  without a product migration decision or release notice.
+- **Treat OpenGL ES/WebGL or translation layers as the same component:** hides
+  different API, surface, deployment, and qualification requirements behind one
+  support claim.
+- **Let each host infer a version or hardcode feature tiers:** creates divergent
+  policy and bypasses ADR-028's effective support and product profile separation.

--- a/docs/adr/029-opengl-compatibility-profile-and-platform-policy.md
+++ b/docs/adr/029-opengl-compatibility-profile-and-platform-policy.md
@@ -1,4 +1,4 @@
-# ADR-029: OpenGL Compatibility Profile and Platform Policy
+# ADR-029: OpenGL Core Profile and Platform Policy
 
 - **Status**: proposed
 - **Date**: 2026-08-31

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,7 +40,7 @@ to the replacement.
 | [026](026-large-world-precision-and-floating-origin-strategy.md) | Large-World Precision and Floating Origin Strategy | proposed | 2026-08-28 |
 | [027](027-renderer-resource-identity-and-descriptors.md) | Renderer Resource Identity and Descriptors | proposed | 2026-08-31 |
 | [028](028-renderer-capability-limits-and-product-profiles.md) | Renderer Capability, Limits and Product Profiles | proposed | 2026-08-31 |
-| [029](029-opengl-compatibility-profile-and-platform-policy.md) | OpenGL Compatibility Profile and Platform Policy | proposed | 2026-08-31 |
+| [029](029-opengl-compatibility-profile-and-platform-policy.md) | OpenGL Core Profile and Platform Policy | proposed | 2026-08-31 |
 
 ## Conventions
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,6 +40,7 @@ to the replacement.
 | [026](026-large-world-precision-and-floating-origin-strategy.md) | Large-World Precision and Floating Origin Strategy | proposed | 2026-08-28 |
 | [027](027-renderer-resource-identity-and-descriptors.md) | Renderer Resource Identity and Descriptors | proposed | 2026-08-31 |
 | [028](028-renderer-capability-limits-and-product-profiles.md) | Renderer Capability, Limits and Product Profiles | proposed | 2026-08-31 |
+| [029](029-opengl-compatibility-profile-and-platform-policy.md) | OpenGL Compatibility Profile and Platform Policy | proposed | 2026-08-31 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -98,6 +98,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Renderer Capability, Limits and Product Profiles](../adr/028-renderer-capability-limits-and-product-profiles.md):
   reported versus effective support, driver restrictions, typed format/limit
   admission, and Baseline through Ultra quality policy.
+- [OpenGL Compatibility Profile and Platform Policy](../adr/029-opengl-compatibility-profile-and-platform-policy.md):
+  desktop 4.1 Core admission, platform qualification, context negotiation,
+  and explicit macOS deprecation/migration behavior.
 - [Renderer Distribution And Availability](./runtime/renderer-distribution-and-availability.md):
   optional renderer components, install/repair/probe states, launcher recovery,
   and selection policy.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -98,7 +98,7 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Renderer Capability, Limits and Product Profiles](../adr/028-renderer-capability-limits-and-product-profiles.md):
   reported versus effective support, driver restrictions, typed format/limit
   admission, and Baseline through Ultra quality policy.
-- [OpenGL Compatibility Profile and Platform Policy](../adr/029-opengl-compatibility-profile-and-platform-policy.md):
+- [OpenGL Core Profile and Platform Policy](../adr/029-opengl-compatibility-profile-and-platform-policy.md):
   desktop 4.1 Core admission, platform qualification, context negotiation,
   and explicit macOS deprecation/migration behavior.
 - [Renderer Distribution And Availability](./runtime/renderer-distribution-and-availability.md):

--- a/docs/architecture/runtime/render-backend-parity-contract.md
+++ b/docs/architecture/runtime/render-backend-parity-contract.md
@@ -347,14 +347,14 @@ command-buffer lifetime, but those tests do not weaken the shared contract.
 
 ## Build Matrix
 
-The intended matrix is:
-
 These are qualification obligations, not claims that every lane is already
 passing. For OpenGL, ADR-029 requires a published OS/architecture/window-system
 and GPU/driver matrix backed by actual Core-context and parity/smoke evidence.
 X11 and Wayland qualify separately; software GL test results do not qualify
 hardware. macOS OpenGL remains conditional on a qualified system 4.1 Core path
 and carries the platform deprecation warning without an automatic backend switch.
+
+The intended matrix is:
 
 | Host | OpenGL | Metal | Null |
 |---|---:|---:|---:|

--- a/docs/architecture/runtime/render-backend-parity-contract.md
+++ b/docs/architecture/runtime/render-backend-parity-contract.md
@@ -231,6 +231,13 @@ Required rules:
 OpenGL context behavior and Metal command-buffer behavior are implementation
 details beneath these rules.
 
+[ADR-029](../../adr/029-opengl-compatibility-profile-and-platform-policy.md)
+defines OpenGL's desktop 4.1 Core admission policy. The selected private adapter
+must apply complete context requirements before window creation, and the backend
+must validate the actual context and required entry points before publishing
+readiness. Its compatibility product role does not allow legacy GL contexts,
+weaken parity, or make it another backend's implicit fallback.
+
 ## Required Editor Rendering Lifecycle
 
 The editor uses one backend-neutral ordering regardless of the selected API:
@@ -341,6 +348,13 @@ command-buffer lifetime, but those tests do not weaken the shared contract.
 ## Build Matrix
 
 The intended matrix is:
+
+These are qualification obligations, not claims that every lane is already
+passing. For OpenGL, ADR-029 requires a published OS/architecture/window-system
+and GPU/driver matrix backed by actual Core-context and parity/smoke evidence.
+X11 and Wayland qualify separately; software GL test results do not qualify
+hardware. macOS OpenGL remains conditional on a qualified system 4.1 Core path
+and carries the platform deprecation warning without an automatic backend switch.
 
 | Host | OpenGL | Metal | Null |
 |---|---:|---:|---:|

--- a/docs/architecture/runtime/renderer-distribution-and-availability.md
+++ b/docs/architecture/runtime/renderer-distribution-and-availability.md
@@ -2,6 +2,14 @@
 
 ## Purpose
 
+For the `opengl` component,
+[ADR-029](../../adr/029-opengl-compatibility-profile-and-platform-policy.md)
+owns native admission and platform deprecation: desktop OpenGL 4.1 Core minimum,
+actual-context verification, and release qualification. A packaged component or
+system GL loader alone does not establish availability. The macOS deprecation
+warning is separate from an availability failure and uses the explicit migration
+workflow below; showing it never changes project settings or selects Metal.
+
 This document defines how HoroEditor discovers, installs, verifies, probes,
 selects, repairs, updates, and activates renderer backend components.
 

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -158,6 +158,17 @@ silently switch to `null`.
 
 ## Capabilities, Limits And Product Profiles
 
+[ADR-029](../../adr/029-opengl-compatibility-profile-and-platform-policy.md) owns
+the `opengl` component's native version, platform, and deprecation policy:
+desktop OpenGL 4.1 Core minimum, actual-context validation, and qualified desktop
+Windows/Linux/macOS support. “Compatibility renderer” does not permit the OpenGL
+Compatibility Profile. OpenGL ES/WebGL references elsewhere in this architecture
+describe possible future targets, not support provided by this component.
+The macOS warning never changes backend selection or project settings by itself.
+Context requirements must reach the selected private platform adapter before
+window creation; completing that seam and native admission is downstream
+implementation work, not a claim that today's bootstrap is fully qualified.
+
 [ADR-028](../../adr/028-renderer-capability-limits-and-product-profiles.md) owns
 the renderer capability and profile policy. Backend-reported device facts,
 implemented backend operations, driver-adjusted effective support, and requested


### PR DESCRIPTION
## Summary

Define the OpenGL version, platform, and selection contract before downstream backend implementation invents conflicting policies. ADR-029 establishes desktop OpenGL 4.1 Core as the minimum and distinguishes the compatibility product role from OpenGL's Compatibility Profile.

**Stack:** this PR → #2356 → `main`. The base is `docs/HORO-296_renderer_capability_policy`; review only this layer's six documentation files. Do not merge this PR into the parent feature branch. After #2356 lands, rebase this layer onto `main` and retarget it before merging.

## Motivation

The current backend requests 4.1 Core but does not fully validate the actual context. SDL version/profile setup happens after window creation, and GL loading partly resides in editor integration. The M0 decision must make the required behavior and downstream ownership explicit without presenting these gaps as implemented support.

## Implementation Notes

- Define desktop Windows/Linux/macOS qualification boundaries, Core-only admission, shader requirements, and capability separation under ADR-028.
- Specify private pre-window requirements, actual-context/entry-point validation, bounded diagnostic retry, rollback, and recreation ownership.
- Keep macOS deprecation warnings separate from failures and require explicit migration; preserve current selection precedence and host defaults.
- Assign implementation and qualification obligations to RND-004.2/.5/.6/.7/.8, with resource/command work consuming the same policy.
- Align the ADR index, architecture index, rendering architecture, parity contract, and distribution policy.
- M0 architecture only: no runtime code, public API, build defaults, driver, or shader implementation changes.

## Validation

- [x] `git diff --cached --check` passed before commit.
- [x] `python3 scripts/dev.py format --staged --check` completed: no matching C++ files.
- [x] Local Markdown validation inspected all six changed files, balanced code fences, and 209 relative links/anchors: no new errors.
- [x] Compared policy with current OpenGL backend, SDL presentation adapter, editor startup/loaders, ADR-028, and owning architecture. Verified platform details against official SDL, Apple, and Khronos references linked in ADR-029.
- Build, runtime tests, coverage, and GPU smoke: not run; documentation-only change. Future implementation verification is specified in the ADR, not claimed here.

Two broken architecture-index links already exist in the parent branch (`localization-implementation-plan.md`, `localization-extractor-report.json`); this PR does not introduce or alter them.

## Risks

The current runtime does not yet meet every new admission/qualification obligation. Migration gaps are recorded explicitly; this PR is not a production-support certification. Platform driver coverage remains the responsibility of RND-004.8.

## Issue Links

- Jira: [HORO-306](https://horo-engine.atlassian.net/browse/HORO-306)
- GitHub: Closes #306
- Milestone: M0 — Architecture Baseline
- Parent PR: #2356 (ADR-028, HORO-296)

## Reviewer Notes

Read ADR-029 first, then the small owning-document updates. Check Core-profile terminology, private pre-window ownership, effective capability admission, and explicit macOS migration behavior. Parent ADR-028 changes belong to #2356 and are intentionally excluded from this PR's diff.


[HORO-306]: https://horo-engine.atlassian.net/browse/HORO-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ