### PR TITLE
docs(render): define Vulkan loader and platform baseline HORO-322 #322 [RND-006.1]

### DIFF
--- a/docs/adr/031-vulkan-loader-platform-and-version-baseline.md
+++ b/docs/adr/031-vulkan-loader-platform-and-version-baseline.md
@@ -1,0 +1,263 @@
+# ADR-031: Vulkan Loader, Platform and Version Baseline
+
+- **Status**: proposed
+- **Date**: 2026-08-31
+- **Owners**: Rendering / Platform
+- **Tracking**: HORO-322 / #322 / RND-006.1
+- **Milestone**: M0 — Architecture Baseline
+
+## Context
+
+The renderer architecture reserves the `vulkan` identity, but the active runtime
+has no Vulkan backend target or platform adapter yet. Loader installation, API
+version, device features, presentation support, and engine implementation must
+not become one ambiguous “Vulkan available” flag during realization.
+
+This ADR defines native admission and deployment policy. It consumes
+[ADR-028](028-renderer-capability-limits-and-product-profiles.md) for effective
+capabilities and product profiles, and the common
+[parity](../architecture/runtime/render-backend-parity-contract.md) and
+[distribution](../architecture/runtime/renderer-distribution-and-availability.md)
+contracts for lifecycle and selection. It does not choose a new shader source
+language, allocator, render-graph scheduler, or public extension ABI.
+
+## Decision
+
+### 1. Vulkan 1.3 core with explicit enabled features
+
+The initial native backend requires **Vulkan 1.3** at both instance and selected
+physical-device level. Query loader instance-version support before instance
+creation and request `VK_API_VERSION_1_3`; a missing version-query entry point or
+a reported version below 1.3 fails admission. Check the selected device's API
+version independently. Newer compatible implementations may satisfy the floor,
+but do not raise the requested API version merely because newer headers or a
+newer loader are installed. Only the standard Vulkan API variant is admitted.
+
+The required device feature bits are `dynamicRendering`, `synchronization2`,
+and `timelineSemaphore`. Query them through the appropriate features structures
+and explicitly enable them at device creation. The initial command path uses
+the core 1.3 dynamic-rendering and synchronization2 commands. There is no hidden
+1.2-plus-extensions or legacy-render-pass retry. This bounds the initial native
+implementation matrix and must be reflected in RND-006.2/.4 realization.
+
+Instance and device versions differ, and promotion to core does not replace
+feature enablement. These distinctions follow the Khronos
+[version guidance](https://docs.vulkan.org/guide/latest/versions.html) and
+[feature enablement contract](https://docs.vulkan.org/guide/latest/enabling_features.html).
+Device creation enables only required features and admitted optional features,
+not every feature reported by the driver.
+
+Timeline support is an internal synchronization prerequisite, not permission to
+wait on the normal frame thread. Presentation still uses the required WSI binary
+semaphores and their separate lifetime rules; a graphics submission's completion
+does not by itself prove a presentation wait semaphore is reusable. RND-006.4/.5
+own that synchronization under the
+[Khronos swapchain semaphore guidance](https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html).
+
+Shader artifacts target the Vulkan 1.3 environment with SPIR-V no newer than
+1.6. Individual SPIR-V capabilities/extensions must also match enabled device
+features and the cooked variant requirements. The SPIR-V version ceiling alone
+does not admit arbitrary shader operations. RND-006.6 and the canonical shader
+toolchain record/validate the target environment and features; they do not add
+a Vulkan-specific asset registry or silently recompile failed packaged assets.
+
+### 2. Required extensions and surface-specific admission
+
+| Scope | Required contract |
+|---|---|
+| Interactive instance | `VK_KHR_surface` and the selected host adapter's WSI instance extensions. |
+| Windows Win32 WSI | `VK_KHR_win32_surface`. |
+| Linux X11 WSI | The adapter's selected `VK_KHR_xlib_surface` or `VK_KHR_xcb_surface` path; do not require both when only one is used. |
+| Linux Wayland WSI | `VK_KHR_wayland_surface`. |
+| Interactive device | `VK_KHR_swapchain`, the required core feature bits above, and compatible graphics/presentation queues for the actual surface. |
+| Explicit diagnostics | `VK_EXT_debug_utils` and `VK_LAYER_KHRONOS_validation` when the corresponding native diagnostic mode is requested; absence is a typed diagnostic-unavailable failure, not silent disablement. |
+
+Enumerate and validate required instance/device extensions in their respective
+scopes before creating the corresponding object. Optional extension groups
+must declare all dependencies and associated feature bits. Promoted core paths
+do not require the former extension name to remain advertised. Ray tracing,
+descriptor indexing/bindless, mesh shaders, HDR, timestamp queries, and engine
+compute execution remain individually optional under ADR-028; API version and
+the backend ID do not grant them.
+
+The selected adapter supplies native WSI requirements through a private Horo
+seam after host video initialization and before Vulkan instance creation. For
+SDL, consume [SDL's required extension list](https://wiki.libsdl.org/SDL3/SDL_Vulkan_GetInstanceExtensions)
+rather than guessing from an OS name. Deduplicate the list, validate it against
+the supported platform paths above, and reject missing or unsupported WSI
+requirements with a typed startup diagnostic. Native window handles and Vulkan
+extension strings do not enter project settings or public Render API types.
+
+Select a graphics-capable queue and validate presentation support against the
+actual surface. A common queue family is preferred; a separate present family
+is allowed with explicit ownership/sharing and synchronization in RND-006.4/.5.
+Do not assume graphics capability implies present capability or require a
+dedicated compute/transfer queue. Validate surface formats, usages, extents,
+image counts, and presentation modes before swapchain creation. FIFO is the
+required parity mode; unsupported explicit alternatives return typed results.
+Output color/HDR policy remains with the display/presentation owners.
+
+### 3. Platform and portability scope
+
+The initial product scope is native **Windows 11 x86_64** and **Linux x86_64**
+desktop. Ubuntu 24.04 LTS is the Linux reference qualification distribution,
+matching [Developer Environment](../architecture/delivery/developer-environment.md).
+Other distributions require their own package/runtime compatibility evidence;
+an OS-family label is not a universal ABI or driver guarantee. X11 and Wayland
+are separate qualification lanes. Additional architectures and platforms need
+an explicit scope/migration decision before being advertised.
+
+macOS/iOS MoltenVK and other portability-subset implementations are **deferred**
+from this initial component. The baseline does not enable
+`VK_KHR_portability_enumeration` or its enumeration flag, and rejects a selected
+device advertising `VK_KHR_portability_subset`. An engineering host may test a
+separate experimental configuration but cannot label it native qualification.
+
+Future portability support must explicitly enable enumeration, enable the
+device subset extension when advertised, inspect subset features/limits, and
+qualify each required engine operation. Khronos documents those obligations in
+[portability enumeration](https://docs.vulkan.org/refpages/latest/refpages/source/VK_KHR_portability_enumeration.html)
+and [portability subset](https://docs.vulkan.org/refpages/latest/refpages/source/VK_KHR_portability_subset.html).
+It also needs a verified package/runtime policy; the manifest's `horo.moltenvk`
+identifier is a vocabulary example, not current product support. Metal remains
+the explicit Apple backend governed by
+[ADR-030](030-metal-platform-and-feature-baseline.md); no Vulkan failure silently
+switches the project to Metal or OpenGL.
+
+### 4. One loader lease and private dispatch ownership
+
+Use the platform-installed Vulkan loader and ICD discovery for native product
+variants. The component does not bundle a second loader or GPU driver, search a
+project directory for native libraries, or require a Vulkan SDK at runtime.
+Pinned Vulkan headers and optional validation/shader tools are build/toolchain
+dependencies private to their owning targets. Package metadata declares
+`khronos.vulkan-loader` as a system-loader requirement; actual version/device
+admission still occurs at probe and initialization.
+
+The host platform adapter owns a loader lease. The backend receives its
+`vkGetInstanceProcAddr` through a private interface, builds instance/device
+dispatch tables with the correct dispatch owner, and rejects missing required
+entry points. No backend-wide mutable global device dispatch table, implicit
+static loader initialization, or cross-device function-pointer reuse is allowed.
+The loader lease outlives instances, devices, surfaces, and callbacks created
+through it; release it last. The backend does not load a second library behind
+the adapter's back. See the
+[Khronos loader architecture](https://github.com/KhronosGroup/Vulkan-Loader/blob/main/docs/LoaderInterfaceArchitecture.md).
+
+For SDL, load the library explicitly after video initialization and before the
+first Vulkan window, and obtain the entry point from the same SDL loader.
+Serialize load/unload operations and pair each successful load with its unload;
+do not let the first window implicitly select a different library.
+[SDL's loader contract](https://wiki.libsdl.org/SDL3/SDL_Vulkan_LoadLibrary)
+defines its reference counting and lack of thread safety. Platform library
+resolution uses the controlled system-loader path, not a user-supplied project
+or Toolchains path. Any alternative development loader is an explicit,
+machine-local engineering configuration, outside product qualification.
+
+System loader discovery can involve native ICDs and layers, including externally
+configured layers. This is not a sandbox or a claim that all driver code is
+verified by Horo's package signature. Probes use the existing isolation policy;
+qualification records loader/ICD/layer identities and relevant overrides.
+Unexpected or modified configurations require re-probe and cannot inherit a
+different environment's qualification result. Horo does not change process-wide
+loader environment variables during a live renderer session.
+
+### 5. Admission, failures, and driver policy
+
+Composition retains CLI/configuration/host-default precedence and verified
+component selection before graphics-window creation. Metadata reading and
+provider registration remain inert; an isolated availability probe may acquire
+temporary native objects but releases them before returning its provisional
+result. The final surface/device admission must be repeated at initialization.
+
+Enumerate candidate devices, record typed rejection reasons, and apply the host's
+explicit adapter preference only among eligible devices. An explicit requested
+adapter must match or fail. With no preference, use a documented stable ordering
+of eligible machine-local device identities; do not depend on loader enumeration
+order or infer support from vendor/model strings. Adapter identity is not
+portable project data. RND-006.2 realizes selection without changing the shared
+backend-selection policy or creating implicit multi-GPU execution.
+
+Driver qualification is per OS/window system, GPU/device/driver identity, loader,
+component build, and effective capabilities. ADR-028's versioned driver rules
+may restrict support, never invent it. If a restriction removes a required
+feature, the backend becomes unavailable; do not downgrade to a different
+native contract. Software ICD and virtual GPU test results are labeled fixtures,
+not hardware/performance qualification.
+
+Publish readiness only after required dispatch, feature enablement, queue,
+surface, and effective-support checks succeed. Failures identify the requested
+backend, failed stage, required versus observed contract, and repair guidance.
+Missing loader, no compatible ICD/device, missing extension/feature, validation
+unavailability, and surface incompatibility remain distinguishable typed results.
+No normal frame blocks for GPU idle; bounded recovery/teardown/test exceptions
+remain those of the renderer architecture and
+[ADR-010](010-job-waiting-and-operation-store-ownership.md).
+
+Partial failure unwinds acquired native objects in reverse ownership order and
+clears borrowed editor access. Device loss invalidates resource owner/generation
+and effective snapshots under
+[ADR-027](027-renderer-resource-identity-and-descriptors.md) and ADR-028. Recovery
+rebuilds state explicitly, including dispatch ownership, without reusing old
+resources/plans. Runtime/window ownership stays with its established host,
+backend, and platform-adapter layers.
+
+### 6. M0 realization and verification
+
+This decision adds no runtime backend, dependency, or build option. The current
+`vulkan` catalog ID, future target diagram, and SDK path examples are planning
+contracts, not evidence of implemented support. Downstream owners are:
+
+| Ticket | Required realization |
+|---|---|
+| RND-006.2 / #323 | Loader/dispatch seams with Platform, independent version queries, candidate admission, explicit feature enablement, queue/device ownership and diagnostics. |
+| RND-006.3 / #324 | Required resource/format/descriptor paths and retirement using effective support, without a mandatory bindless implementation. |
+| RND-006.4 / #326 | Core dynamic-rendering/synchronization2 path, timeline completion, queue ownership, and non-blocking frame execution. |
+| RND-006.5 / #325 | Private WSI requirements, actual-surface checks, swapchain binary-semaphore lifetime, resize and recovery. |
+| RND-006.6 / #327 | Vulkan 1.3 SPIR-V target validation, required shader capabilities, cooked variants and pipeline diagnostics. |
+| RND-006.7 / #328 | Matching GUI/viewport integration that borrows the admitted backend, never creates an independent loader/device. |
+| RND-006.8 / #329 | Windows/Linux X11/Wayland qualification, validation layers, loss/rollback tests, and package/runtime evidence with release owners. |
+
+Deterministic tests must cover independent loader/device version failures,
+missing entry points, wrong API variant, missing instance/device extensions,
+queried-but-not-enabled required features, portability rejection, adapter
+selection independent of enumeration order, separate graphics/present families,
+and required driver-rule restrictions. Also verify dispatch/loader lifetime,
+partial rollback, stale generations, and unchanged project selection on failure.
+
+Native lanes must cover each shipped WSI path, shared parity/GPU smoke, actual
+surface-format support, clean validation results for the synchronization path,
+resize/suspension, device loss where inducible, and packaged launch with a
+system loader/driver but without the SDK. Validate shader target/features and
+archive metadata during cook. Pure fake-runtime and software-ICD lanes do not
+replace those tests. M0 verifies documentation consistency; it does not report
+future runtime/GPU tests as passed.
+
+## Consequences
+
+A 1.3 core path avoids maintaining parallel extension/legacy implementations of
+the initial rendering and synchronization model. It excludes older drivers
+even when some extensions could emulate that path; this is an explicit product
+trade-off. Windows/Linux WSI and package compatibility still require distinct
+evidence, rather than one cross-platform availability claim.
+
+Using a single system loader keeps driver ownership with the platform and
+avoids SDK installation as a gameplay prerequisite. Driver/layer configuration
+remains a native trust boundary and must be reflected in diagnostics. Deferring
+portability avoids silently weakening required semantics while preserving a
+clear future admission/packaging route.
+
+## Rejected Alternatives
+
+- **Vulkan 1.2 plus assorted extensions:** expands startup and command-path
+  combinations before the first backend exists; rejected for this baseline.
+- **Require the latest Vulkan release:** raises driver requirements without an
+  M0 feature need and makes SDK updates change product policy.
+- **Accept loader presence or version alone:** cannot establish device, feature,
+  enabled-operation, or actual-surface support.
+- **Bundle an SDK/driver or load arbitrary project libraries:** confuses tools,
+  system runtime ownership, and trusted component activation.
+- **Enable every extension or infer features from vendor names:** bypasses typed
+  effective support and unnecessarily expands the backend's promised contract.
+- **Silently use MoltenVK on Apple hosts:** conceals portability restrictions,
+  packaging, and qualification work; Metal selection remains explicit.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -42,6 +42,7 @@ to the replacement.
 | [028](028-renderer-capability-limits-and-product-profiles.md) | Renderer Capability, Limits and Product Profiles | proposed | 2026-08-31 |
 | [029](029-opengl-compatibility-profile-and-platform-policy.md) | OpenGL Core Profile and Platform Policy | proposed | 2026-08-31 |
 | [030](030-metal-platform-and-feature-baseline.md) | Metal Platform and Feature Baseline | proposed | 2026-08-31 |
+| [031](031-vulkan-loader-platform-and-version-baseline.md) | Vulkan Loader, Platform and Version Baseline | proposed | 2026-08-31 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -104,6 +104,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Metal Platform and Feature Baseline](../adr/030-metal-platform-and-feature-baseline.md):
   macOS 14, native GPU-family admission, MSL 2.4, effective feature support,
   and deployment/qualification policy.
+- [Vulkan Loader, Platform and Version Baseline](../adr/031-vulkan-loader-platform-and-version-baseline.md):
+  Vulkan 1.3 core, required enabled features, system-loader ownership,
+  Windows/Linux WSI qualification, and deferred portability scope.
 - [Renderer Distribution And Availability](./runtime/renderer-distribution-and-availability.md):
   optional renderer components, install/repair/probe states, launcher recovery,
   and selection policy.

--- a/docs/architecture/runtime/render-backend-parity-contract.md
+++ b/docs/architecture/runtime/render-backend-parity-contract.md
@@ -363,11 +363,17 @@ and carries the platform deprecation warning without an automatic backend switch
 
 The intended matrix is:
 
-| Host | OpenGL | Metal | Null |
-|---|---:|---:|---:|
-| macOS | Build + parity + GPU smoke | Build + parity + GPU smoke | Build + headless tests |
-| Linux | Build + parity; GPU smoke on display-capable CI | Not compiled | Build + headless tests |
-| Windows | Build + parity; GPU smoke on display-capable CI | Not compiled | Build + headless tests |
+| Host | OpenGL | Metal | Vulkan | Null |
+|---|---|---|---|---|
+| macOS | Build + parity + GPU smoke | Build + parity + GPU smoke | Portability deferred | Build + headless tests |
+| Linux | Build + parity; GPU smoke on display-capable CI | Not compiled | Planned: build + parity + GPU smoke per shipped X11/Wayland path | Build + headless tests |
+| Windows | Build + parity; GPU smoke on display-capable CI | Not compiled | Planned: build + parity + Win32 GPU smoke | Build + headless tests |
+
+[ADR-031](../../adr/031-vulkan-loader-platform-and-version-baseline.md) defines
+Vulkan's initial Windows 11/Linux x86_64 scope and independent loader, device,
+feature, and WSI checks. No Vulkan target is implemented by that M0 decision;
+its matrix cells describe future acceptance obligations. Software ICDs and
+headless tests cannot qualify the native interactive lanes.
 
 Metal being Apple-only is a host availability constraint, not a lower or higher
 architectural rank.

--- a/docs/architecture/runtime/renderer-distribution-and-availability.md
+++ b/docs/architecture/runtime/renderer-distribution-and-availability.md
@@ -439,6 +439,13 @@ features. They do not change the selected renderer module or bypass component
 verification. A Vulkan SDK is not required merely because the Vulkan renderer is
 selected unless a documented runtime packaging policy explicitly says so.
 
+[ADR-031](../../adr/031-vulkan-loader-platform-and-version-baseline.md) fixes that
+policy for the initial `vulkan` component: use the platform-installed loader and
+driver, with no SDK runtime prerequisite and no bundled replacement loader.
+Loader presence, supported instance version, compatible device, enabled features,
+and actual WSI support are separate admission stages. The initial component does
+not package or silently select an Apple portability backend.
+
 ## Security And Platform Policy
 
 Renderer modules execute native code with editor-process privileges. Required

--- a/docs/architecture/runtime/renderer-module-package-manifest.md
+++ b/docs/architecture/runtime/renderer-module-package-manifest.md
@@ -258,6 +258,12 @@ validation fails.
 
 ## Runtime Requirements
 
+For Vulkan, [ADR-031](../../adr/031-vulkan-loader-platform-and-version-baseline.md)
+requires the system loader plus separately validated Vulkan 1.3 device/features
+and the selected WSI path. A `khronos.vulkan-loader` requirement cannot stand in
+for an ICD, GPU, or surface probe. `horo.moltenvk` below is a reserved runtime
+vocabulary example; portability packages are outside the initial product scope.
+
 Runtime requirements use known typed IDs and kinds. Examples:
 
 ```text

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -158,6 +158,14 @@ silently switch to `null`.
 
 ## Capabilities, Limits And Product Profiles
 
+[ADR-031](../../adr/031-vulkan-loader-platform-and-version-baseline.md) owns the
+planned `vulkan` component's native baseline: Vulkan 1.3 instance/device support,
+explicit dynamic-rendering/synchronization2/timeline feature enablement, a single
+system loader, and actual-surface admission on Windows/Linux desktop. It defers
+portability-subset product support. These are downstream requirements, not a
+claim that a Vulkan backend target exists or that optional engine features are
+already implemented.
+
 [ADR-030](../../adr/030-metal-platform-and-feature-baseline.md) owns the `metal`
 component's native baseline: macOS 14.0+, Apple7 on native arm64 or Mac2 on native
 x86_64, explicit MSL 2.4 shaders, and conventional command-buffer/encoder APIs.


### PR DESCRIPTION
## Summary

Define the native Vulkan admission contract in ADR-031 before implementing the backend. The baseline separates loader, instance/device versions, enabled features, and actual WSI support, and aligns the owning architecture and package documents.

**Stack:** this PR → #2358 → #2357 → #2356 → `main`. Base: `docs/HORO-314_metal_platform_baseline`. Review this layer's seven documentation files only. Do not merge into the parent feature branch; rebase/retarget remaining layers after ancestors land.

## Motivation

Vulkan is currently a planned backend identity with no active runtime target. Downstream implementation needs one supported version, loader owner, extension policy, WSI scope, and portability decision rather than inventing these independently.

## Implementation Notes

- Require Vulkan 1.3 at instance/device level with explicit dynamicRendering, synchronization2, and timelineSemaphore enablement; no hidden 1.2/legacy retry.
- Define instance/device extension scopes, same-loader dispatch ownership, Windows 11/Linux x86_64 WSI qualification, and actual-surface checks.
- Defer portability-subset/MoltenVK product support with explicit future admission obligations.
- Keep optional engine features under ADR-028, native runtime distinct from the SDK, and driver policy restrictive only.
- Assign realization, failure/lifecycle coverage, and native qualification to RND-006.2 through RND-006.8.
- M0 documentation only: no runtime code, build option, dependency, or advertised implementation status added.

## Validation

- `git diff --check`: passed.
- `python3 scripts/dev.py format --staged --check`: no matching C++ files.
- Local Markdown validator: seven changed files, 230 relative links/anchors, balanced fences, one JSON block; no new errors.
- Compared repository implementation/build state, ADR-027/028/030, and owning renderer documents. Official Khronos and SDL references are linked in ADR-031.
- Runtime tests/build/coverage/GPU smoke not run for this docs-only change. Future native qualification is specified, not claimed as completed.

Two existing architecture-index localization links remain broken in the base branch and are unchanged here.

## Risks

Vulkan 1.3 intentionally excludes older driver/extension combinations. None of the new backend obligations are implementation evidence. Jira currently reverses the #322/#323 dependency compared with GitHub's native relationship; the M0 decision precedes device realization according to both ticket scopes. No dependency metadata was changed.

## Issue Links

- Jira: [HORO-322](https://horo-engine.atlassian.net/browse/HORO-322)
- GitHub: Closes #322
- M0 — Architecture Baseline
- Parent PR: #2358

## Reviewer Notes

Read ADR-031, then the small parity/build-matrix and package/runtime updates. Check version versus feature enablement, dispatch/lifetime ownership, per-surface WSI validation, and explicit portability exclusion. Parent ADR changes belong to earlier stack layers.


[HORO-322]: https://horo-engine.atlassian.net/browse/HORO-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ