### PR TITLE
docs(render): define GPU memory ownership HORO-358 #358 [RND-010.1]

### DIFF
--- a/docs/adr/034-gpu-memory-and-residency-ownership.md
+++ b/docs/adr/034-gpu-memory-and-residency-ownership.md
@@ -1,0 +1,329 @@
+# ADR-034: GPU Memory and Residency Ownership
+
+- **Status**: proposed
+- **Date**: 2026-08-31
+- **Owners**: Rendering / Application Hosts / World Streaming
+- **Tracking**: HORO-358 / #358 / RND-010.1
+- **Milestone**: M0 — Architecture Baseline
+
+## Context
+
+[ADR-027](027-renderer-resource-identity-and-descriptors.md) defines resident
+identity and retirement, but leaves physical allocation and budget policy to
+RND-010. The current public `IRenderBackend` has lifecycle and execution-plan
+contracts, not a heap allocator or memory ledger. Native viewport and GUI
+allocations still exist in the OpenGL and Metal editor integrations. This ADR
+defines their target ownership; it does not claim those paths already enforce
+the decision or implement new runtime APIs in M0.
+
+GPU memory is shared with other applications and may be shared with the CPU.
+Native allocation sizes, placement, and residency mechanisms differ by backend.
+At the same time, [World Streaming](../architecture/runtime/world-streaming-architecture.md#budget-reservation-and-admission)
+already owns aggregate cell admission and forbids providers from expanding their
+allowances. Independent renderer, cell, and virtual-texture budgets would allow
+overcommit or count the same backing allocation more than once.
+
+## Decision
+
+### 1. Separate policy, accounting, and native allocation
+
+| Responsibility | Owner | Boundary |
+|---|---|---|
+| Finite memory envelopes, emergency headroom, quality/failure policy and distribution between worlds/editor/services | Application host | Explicit composition/configuration; no process-global service discovery or API-name-derived budgets. |
+| Renderer reservation ledger, logical resource readiness, reconstruction records and eviction eligibility | Render frontend | Typed Horo contracts; no native heap values, world-cell selection, or asset I/O. |
+| Allocation requirements, memory pools/heaps, native placement, mapping/coherency, fences and destruction | Selected render backend | Backend-private implementation; cannot invent higher budgets or discard live resources. |
+| Aggregate cell CPU/GPU/staging admission and cell residency/eviction | StreamingPartitionAuthority | Renderer resources consume its reservations; renderer pressure is input to this authority, not permission to evict a cell. |
+| Texture-page/LOD/cache selection within an allowance | Owning feature, such as Virtual Texturing | Uses admitted renderer backing; cannot claim more memory or invalidate required cell content. |
+| Source/cooked identity, storage and asynchronous loading | Asset Pipeline | Supplies reconstruction data; `AssetId` is not a GPU allocation. |
+
+Foundation supplies existing allocation domains, results, jobs and observability
+primitives. It does not acquire a dependency on renderer heaps or world policy.
+Hosts that use several frontends/devices on the same physical memory pool must
+divide one host envelope into non-overlapping allowances. A second preview or
+world cannot receive the full device budget again. Opaque pool identities are
+process-local; native adapter identities stay behind the backend boundary.
+
+### 2. Account backing capacity, not just descriptor payload
+
+Each charged allocation has one owner scope and generation-safe reservation
+identity. The renderer tracks distinct quantities: reserved but unallocated
+capacity, committed backing capacity, live payload, pending upload/readback,
+retiring capacity, and reusable slack. Live payload and retiring/slack breakdowns
+are views of committed capacity, not additional totals. Committed capacity plus
+unallocated reservations must fit the owner allowance and enclosing hard caps.
+
+Whole native heap/block capacity is charged, including padding and unused space.
+A suballocation consumes existing charged slack without charging the block again.
+Releasing a suballocation does not return block capacity to the enclosing budget;
+that happens only when the block is actually destroyed, or ownership is explicitly
+transferred to another admitted scope. Shared pools therefore have a separately
+admitted owner and leases; they cannot hide unused blocks in a departing cell.
+Dedicated allocations follow the same rule. Descriptor bytes, allocation bytes,
+and process/device telemetry are separately named and never summed as though
+they were disjoint allocations.
+
+UMA CPU/GPU mappings of the same physical backing count once in an aggregate
+physical-memory total; CPU/GPU accessibility are attributes. Separate decoded,
+upload and device copies count separately even if they contain identical data.
+Every pool report identifies its accounting domain and whether domains overlap.
+Discrete local/non-local pools have separate constraints; their capacities are
+not interchangeable. Renderer metadata, retained CPU reconstruction data, queue
+storage and emergency reporting storage also consume their host CPU allowances.
+
+For explicit APIs, backend requirement queries supply size/alignment/type
+constraints before allocation. Where native backing size is opaque, the backend
+uses a documented conservative charge model for Horo-requested resource storage
+and marks it estimated. Unknown descriptor cost is rejected, never zero. Hidden
+driver/compositor overhead cannot be given an exact application hard cap: reserve
+host headroom, expose observed process usage when available, and retain failure
+handling. The ledger is an admission guarantee for accounted Horo costs, not a
+promise that every native allocation succeeds or that all driver bytes are known.
+
+### 3. One reservation transaction across streaming and rendering
+
+A world-streaming GPU reservation is a claim against the renderer's host envelope
+as well as a component of the cell aggregate. The two ledgers project the same
+charge identity; they are not additive physical allocations or independent grants.
+Non-streamed resources use an explicit host/editor/service owner scope.
+
+1. A host-composed provider adapter obtains a backend cost plan and reserves the
+   cell aggregate and renderer claim before starting native allocation/upload.
+   No allocation occurs while either admission is missing. A rejected second
+   admission releases the unused first claim; queue and completion capacity are
+   reserved as part of the transaction. Neither owner calls into the other while
+   holding a lock or waits synchronously for its thread.
+2. Claims name the scope incarnation, device owner, resource attempt and budget
+   revision. Issued claims remain charged across revisions; lowering a cap does
+   not erase them. Stale/cancelled attempts cannot publish into a new world/device.
+3. Allocation consumes a claim, rather than adding a second resident charge.
+   Additional requirements, new heap growth, replacement overlap and scratch
+   request growth **before** allocation. If denied, defer within a bounded queue
+   or fail that attempt; never overshoot and report it afterward.
+4. Success publishes only after required uploads and native dependencies are
+   usable. Cancellation/failure releases unused capacity but keeps submitted work,
+   partial native allocations and staging charged until acknowledged retirement.
+5. Shared ownership transfer needs destination admission before source release.
+   Accounting records move once; leases do not multiply charges. Cell retirement
+   follows its existing acknowledgement barrier, including shared-owner transfer.
+
+For example, a charged 64 MiB pool containing 20 MiB of live textures still costs
+64 MiB, not 20 or 84 MiB. Removing one 8 MiB texture produces reusable slack after
+retirement; it does not free 8 MiB of physical capacity from that pool's charge.
+An unrelated cell cannot spend that slack without an admitted lease/transfer.
+
+### 4. Memory classes and allocator strategy
+
+Public descriptors express usage and lifetime, not Vulkan memory-type indices,
+D3D12 heap flags or Metal storage modes. Backend-private pools separate persistent
+device resources, upload, readback, and transient work by compatible requirements
+and charged owner. Mapping never bypasses backend flush/invalidate requirements.
+
+Use backend-owned suballocation for compatible frequent small allocations where
+the API exposes it; use dedicated allocations when required or justified by size,
+lifetime or fragmentation. Exact block sizes and allocator data structures are
+implementation choices to measure in RND-010.2, not public constants. No new
+allocator dependency is selected here. A helper library, if adopted, remains
+private, pinned and subject to the same accounting and lifetime contracts.
+
+Upload/readback arenas are bounded. Reuse waits for the actual last GPU/CPU reader,
+not merely a frame-number modulo. Readback completion produces an owned or leased
+result with a bounded retention policy; forgotten consumers cause backpressure,
+not reuse beneath them. Transient aliasing requires a render-graph lifetime proof
+including asynchronous queues, native compatibility and synchronization. If that
+proof or backend support is absent, allocate non-aliased backing **within budget**
+or reject the plan. Aliasing cannot be assumed to make an otherwise oversized plan
+fit. Persistent resources cannot move silently: compaction/replacement uses the
+new-generation and dependent-rebuild rules of ADR-027, with overlap admitted.
+
+### 5. Dynamic budget observations and backend parity
+
+[ADR-028](028-renderer-capability-limits-and-product-profiles.md) treats available
+memory as dynamic telemetry, not an immutable capability or guaranteed reservation.
+The backend reports pool identity, sample revision/time, estimated usage and
+available budget when known, and explicit unavailable/estimated provenance.
+Observations do not replace the renderer ledger or increase a configured cap.
+
+Admission checks the hard accounting cap and, when a usable native observation
+exists, observed headroom after host emergency margin and reservations not yet
+reflected in that observation. Do not subtract accounted bytes from native usage
+twice. When overlap cannot be established, conservatively withhold that headroom
+until a fresh sample rather than granting speculative capacity. Reclamation is
+not treated as observed native relief before acknowledgement/sample evidence.
+Missing telemetry uses the finite host cap and reserve; it is not unlimited memory
+and does not itself disable the backend. Settings define the sample interval,
+maximum sample age, margins and pressure hysteresis; invalid/missing required
+settings fail composition. No product-tier name supplies an implicit byte count.
+
+| Backend | Required realization of this policy |
+|---|---|
+| OpenGL | Keep allocation/context calls private and honor declared charges and failures. Budget telemetry may be unavailable; baseline cannot require a vendor memory extension or claim an exact physical residency API. |
+| Metal | Charge resources/heaps, distinguish shared backing from duplicate storage, and treat working-set observations as estimates. Do not use a recommendation as reserved memory. |
+| Vulkan | Select compatible memory types/heaps, obey requirement/alignment and allocation-count limits, and suballocate where appropriate. `VK_EXT_memory_budget` is optional telemetry, not an added ADR-031 baseline requirement. |
+| D3D12 | Charge committed allocations/whole placed-resource heaps against their pools and observe DXGI budgets. Native residency readiness is a backend submission prerequisite, not a replacement for Horo logical readiness. |
+| Null | Exercise the same reservations, queue limits, generations and retirement contract using injected costs, pressure and completion ticks. It owns no real GPU heap and proves no hardware capacity or performance claim. |
+
+The Vulkan budget extension describes changing guidelines and estimated usage;
+see [Khronos memory-budget contract](https://docs.vulkan.org/refpages/latest/refpages/source/VK_EXT_memory_budget.html).
+DXGI budgets can change and reservation is not a guarantee; see
+[Microsoft residency guidance](https://learn.microsoft.com/en-us/windows/win32/direct3d12/residency).
+Metal's threshold is approximate; see
+[Apple working-set guidance](https://developer.apple.com/documentation/metal/mtldevice/recommendedmaxworkingsetsize).
+These facts justify conservative admission; the host caps and failure policy here
+are Horo decisions, not vendor guarantees.
+
+### 6. Residency, pressure and failure policy
+
+Logical readiness remains ADR-027's `Pending/Ready/Retiring/Retired/Failed` model.
+An unmaterialized asset/cache key is not a dormant reusable resource handle.
+Eviction logically retires the generation; reloading creates a new one. Native
+paging/mapping is private, but no submission may access inaccessible backing.
+The initial policy keeps required backing accessible until retirement; optional
+native residency optimizations must preserve that contract without CPU waits.
+
+Pressure follows this ordered, bounded policy:
+
+1. Drain already eligible retirements within the per-frame destruction budget.
+2. Stop admitting optional growth and ask owners to trim disposable caches/unused
+   heap blocks. Retiring bytes stay charged; scheduled frees are not new capacity.
+3. Owners select permitted lower-cost cooked/implemented representations and
+   submit admitted replacements. No implicit quality degradation, shader omission,
+   heap-type substitution, CPU spill or renderer switch is allowed.
+4. For activation-critical streamed content, request an admitted fallback or cell
+   eviction through StreamingPartitionAuthority. Pins are not a budget bypass and
+   memory pressure is not permission for a backend to revoke them.
+5. If required work still cannot fit, reject/defer the new attempt with a typed
+   budget/capacity result. If the existing required working set exceeds a reduced
+   target, stop new dependent submissions until the host reduces demand or enters
+   its explicit failure/recovery path; never destroy live backing to meet a counter.
+
+Stopping admission/submissions does not stop completion polling, owner queue
+drains, or already admitted cleanup. These retain reserved capacity so the pressure
+response cannot deadlock the reclamation needed to leave pressure.
+
+Disposable means the owning feature has authorized removal, a valid missing-data
+or reconstruction path exists, and no activation-critical contract is violated.
+Owners order eligible cache candidates by declared priority, oldest accepted-use
+sequence, then stable cache key to break ties. They only request retirement; pins
+and all relevant GPU queues still gate physical release. A hot-path global scan
+of arbitrary scene objects or source-asset deletion is forbidden.
+
+Pressure enters when accounted use reaches the configured high watermark, a fresh
+native sample crosses its margin, or allocation fails. It exits only after the
+configured lower watermark and healthy observations for the configured recovery
+sample count (ledger-only recovery when telemetry is unavailable). Configuration
+requires low < high <= hard cap and finite work/retry limits. An over-cap revision
+is an observable pressure state, not subtraction that underflows the ledger.
+
+Native OOM produces a typed allocation failure with bounded diagnostics and cleans
+up partial state. Retry requires changed admission/pressure evidence and a new
+bounded attempt; no busy retry or normal-frame GPU-idle wait. Budget denial, queue
+exhaustion, unsupported allocation, native OOM and device loss remain distinct.
+Device loss uses ADR-027 reconstruction and new owner generations; a replacement
+device cannot make old work disappear from CPU/retirement accounting. Teardown
+uses documented backend release semantics, not an impossible lost-device fence
+wait. When release cannot be established, retain the charge and report stalled
+retirement rather than promising usable memory.
+
+### 7. Threading, feature and presentation integration
+
+Reservation consumption, registry publication and native mutation run serially
+on the host-declared render-capable thread at its safe points. Other owners submit
+bounded requests and receive completions; worker preparation does not allocate
+native resources through an undocumented exception. Platform/native callbacks
+enqueue observations, not mutate the ledger. Pressure decisions and budget changes
+publish immutable revisioned snapshots to other threads.
+
+[ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md)
+`RenderSafePoint` uses this same owner thread. CPU preparation uses the
+[ADR-010](010-job-waiting-and-operation-store-ownership.md) job contract; resource
+attempts use ADR-027 `ResourceOperationId`, with user-visible operations projected
+through `OperationStore` when appropriate. No second scheduler or blocking poll
+is introduced. Retirement/completion capacity is reserved before admission, so a
+full producer queue cannot prevent cleanup. Normal Null completions are delivered
+at the same owner drain points, never inline solely because no GPU exists.
+
+Virtual Texturing owns page choice, feedback and page-table intent; the renderer
+owns physical atlas/sparse backing and safe mapping execution. Page eviction in
+an allocated atlas frees a slot, not heap bytes. Sparse support requires effective
+capabilities and implementation; an atlas fallback needs its own admitted cost.
+Old page-table readers must retire before remapping/reusing backing. Neither page
+streaming nor renderer eviction changes world-cell residency independently.
+
+Presentation targets, swapchain-related backing estimates, GUI/font textures and
+viewport resources belong to explicit host/editor scopes in the same envelope.
+[ADR-033](033-presentation-and-display-ownership.md) output replacement reserves
+old/new overlap and transient resources before realization. If it cannot fit,
+preserve valid old output or suspend according to that ADR; do not publish the new
+extent as **active** before successful budgeted realization. A pending candidate
+may still be published for layout/extraction under ADR-033; failure skips that
+candidate's output and never submits its plan against mismatched old targets.
+Externally owned
+compositor resources are reported separately with provenance and headroom, not
+destroyed or claimed as renderer-owned allocations.
+
+## Migration And Verification
+
+This is the canonical RND-010 policy. Rendering, world streaming and virtual
+texturing summaries link here; they do not define competing GPU ledgers. Existing
+Foundation allocation-domain and world-cell lifecycle contracts remain intact.
+
+| Delivery | Required next implementation work |
+|---|---|
+| RND-010.2 / #359 | Typed cost plans, finite host configuration, reservation identities, pool accounting, native requirements and private allocator integration; route current viewport/GUI allocations through admitted scopes. |
+| RND-010.3/.4 / #360–361 | Bounded upload/readback arenas, copy accounting, cancellation, consumer leases and completion publication. |
+| RND-010.5/.6 / #362–363 | Graph alias proofs and descriptor/binding storage charged to its actual owner; no unbudgeted helper heaps. |
+| RND-010.7/.8 / #364–365 | Multi-queue retirement, pressure/retry policy, partial failure, device-loss cleanup and allocation-free emergency diagnostics. |
+| RND-010.9/.10 / #366–367 | Capability-gated sparse backing and admitted atlas path; platform qualification, fragmentation/peak/budget/retirement measurements. |
+
+Do not migrate by wrapping a second counter around existing native allocations.
+Replace each path's ownership and charge source, expose unsupported paths honestly,
+and remove its obsolete local budget. No serialized native allocation or resource
+handle is introduced. Future persisted budget settings require the existing
+configuration schema and project migration process; M0 changes no file format.
+
+Implementation acceptance must cover:
+
+- Exact-cap admission, checked arithmetic/alignment, unknown cost, dedicated and
+  pooled growth, block slack, shared transfer, UMA non-duplication and separate
+  discrete pools; two worlds/previews cannot spend the same host allowance.
+- Partial reservation failure, stale scope/device attempts, cancellation before
+  and after submission, replacement peak, retained source copies, bounded queues
+  and readback consumers. Cleanup must progress when producer admission is full.
+- Multi-queue GPU use and dependent pins preventing reuse; no capacity refund on
+  logical release, cell eviction or a frame-index rollover alone.
+- Native budget shrink/unavailable/stale samples, OOM injection, hysteresis,
+  optional versus required content, admitted quality fallback, and stalled
+  retirement without unsafe reclamation. Pressure paths use bounded diagnostics.
+- GL/Metal parity plus future Vulkan/D3D12 native validation; deterministic Null
+  schedules replay the same logical outcomes but do not replace GPU smoke tests.
+- Metrics separating charged capacity, payload, reservations, retired bytes,
+  fragmentation/slack and native estimates, with owner/provenance and failure
+  reason. RND-010.10 records workloads and backend measurements before tuning.
+
+## Consequences
+
+Owners can reject work before allocating and explain where memory remains charged.
+Cell admission and GPU residency compose without competing world authorities.
+Conservative estimates, reserved overlap and whole-block charging may admit less
+content than optimistic byte counts. Shared-pool leases and revisioned transactions
+add bookkeeping, but make cancellation, multiple worlds and pressure reviewable.
+No allocator algorithm, block-size performance claim or hardware qualification is
+proved by this document; downstream implementation and measurements remain required.
+
+## Rejected Alternatives
+
+- **Independent budgets for every feature**: lets their total exceed host/device
+  capacity and duplicates shared allocations.
+- **World Streaming allocates native heaps**: reverses dependencies and conflates
+  cell authority with renderer implementation; non-streamed/editor work still needs
+  admission.
+- **Resource payload size equals GPU cost**: ignores padding, pooled slack, copies,
+  replacement overlap and deferred destruction.
+- **Treat native available-memory telemetry as a guaranteed cap**: observations
+  change and may be estimates or unavailable; native failure remains possible.
+- **Free on logical release or evict the least-used live handle globally**: violates
+  dependency pins, GPU completion and activation-critical cell contracts.
+- **Overcommit then wait for GPU idle on OOM**: turns pressure into frame stalls and
+  cannot guarantee reclamation; use bounded admission and explicit host failure.
+- **Expose one native heap model as the public abstraction**: privileges an API and
+  leaks memory-type/placement policy into feature code.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,6 +45,7 @@ to the replacement.
 | [031](031-vulkan-loader-platform-and-version-baseline.md) | Vulkan Loader, Platform and Version Baseline | proposed | 2026-08-31 |
 | [032](032-d3d12-baseline-and-agility-sdk-policy.md) | D3D12 Baseline and Agility SDK Policy | proposed | 2026-08-31 |
 | [033](033-presentation-and-display-ownership.md) | Presentation and Display Ownership | proposed | 2026-08-31 |
+| [034](034-gpu-memory-and-residency-ownership.md) | GPU Memory and Residency Ownership | proposed | 2026-08-31 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -113,6 +113,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Presentation and Display Ownership](../adr/033-presentation-and-display-ownership.md):
   platform windows/display facts, renderer surface lifetime, host intent,
   resolved output, transition safe points, and multi-surface boundaries.
+- [GPU Memory and Residency Ownership](../adr/034-gpu-memory-and-residency-ownership.md):
+  native allocator ownership, backing-capacity accounting, streaming reservations,
+  bounded pressure policy, and deferred reclamation.
 - [Renderer Distribution And Availability](./runtime/renderer-distribution-and-availability.md):
   optional renderer components, install/repair/probe states, launcher recovery,
   and selection policy.

--- a/docs/architecture/runtime/render-backend-parity-contract.md
+++ b/docs/architecture/runtime/render-backend-parity-contract.md
@@ -269,6 +269,15 @@ may reject unsupported descriptor values through its typed capability/error
 contract; it may not reinterpret them, silently choose a fallback, or weaken
 owner and generation validation.
 
+All backends also obey
+[ADR-034's memory and residency policy](../../adr/034-gpu-memory-and-residency-ownership.md):
+admitted backing-capacity charges, bounded upload/readback work, safe retirement
+and typed pressure/failure results. Native budget telemetry and allocator strategy
+may differ or be unavailable; logical lifetime and owner allowances cannot.
+GUI/private helper allocations are included, not exempted from host accounting.
+Null tests inject costs and completion schedules; native budget and fragmentation
+qualification still requires each actual backend.
+
 In particular:
 
 - OpenGL global state is private to the OpenGL integration.

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -636,6 +636,21 @@ recovery requires a reconstruction source on the residency record
 
 ## Upload And Streaming
 
+The canonical allocator, budget, residency and pressure policy is
+[ADR-034: GPU Memory and Residency Ownership](../../adr/034-gpu-memory-and-residency-ownership.md).
+The host supplies finite envelopes; the frontend owns reservation accounting and
+readiness, while the backend owns native requirements, heaps and release.
+Charge backing capacity, copies and replacement overlap once, including retired
+resources until release acknowledgement. Heap slack is already charged capacity,
+not memory returned merely by destroying a suballocated resource.
+
+Streamed resources consume the World Streaming aggregate reservation through an
+explicit adapter; its GPU claim and the renderer record project the same charge.
+The renderer never selects cells to evict or discards activation-critical resources
+under an Active cell. Non-streamed, GUI, viewport and presentation resources have
+explicit owner scopes within the same host envelope. Native budget observations
+remain estimates, not guaranteed allocation capacity or permission to exceed caps.
+
 CPU asset preparation occurs on workers. GPU upload is queued to the
 render-capable thread with:
 

--- a/docs/architecture/runtime/virtual-texturing-architecture.md
+++ b/docs/architecture/runtime/virtual-texturing-architecture.md
@@ -7,6 +7,24 @@ covers sparse virtual texture pages, page table indirection, page residency
 management, feedback-based streaming, page cache compression, and integration
 with the material system and asset pipeline.
 
+## Memory Ownership Boundary
+
+[ADR-034: GPU Memory and Residency Ownership](../../adr/034-gpu-memory-and-residency-ownership.md)
+owns GPU allocation, reservations and pressure policy. Virtual Texturing selects
+pages and disposable cache entries within its admitted allowance; the renderer
+owns native atlas/sparse backing and safe mapping execution. Page-table updates
+and slot reuse wait for previous GPU readers. Evicting a page from an allocated
+atlas frees a slot, not physical heap capacity from the budget.
+
+For streamed worlds, this allowance consumes World Streaming's aggregate
+reservation through the host-composed adapter. Missing pages may use an explicitly
+admitted feature fallback, but cannot silently invalidate activation-critical cell
+content. Neither page selection nor renderer pressure independently evicts cells.
+Sparse resources require effective backend support; an atlas fallback has a
+separate cost plan that must fit. Page counts below are recipe sizing inputs,
+not extra memory allowances or proof of backend capability. Include atlas backing,
+page tables, feedback, upload and readback copies in peak-cost admission.
+
 ## Virtual Texture Model
 
 Virtual texturing decouples logical texture resolution from physical GPU

--- a/docs/architecture/runtime/world-streaming-architecture.md
+++ b/docs/architecture/runtime/world-streaming-architecture.md
@@ -263,6 +263,16 @@ charged owner and explicit leases; a cell may reference them without charging th
 same allocation twice. Configuration uses checked byte arithmetic (MiB conversion
 is explicit); reservation sums cannot underflow the general pool.
 
+GPU reservation realization follows
+[ADR-034](../../adr/034-gpu-memory-and-residency-ownership.md): the host-composed
+provider adapter obtains a renderer claim against the host GPU envelope before
+native work starts. The cell ledger and renderer record project the same charge
+identity, not two additive physical allocations. Whole backing blocks, padding,
+overlap and copies remain accounted; mapped UMA backing is not counted twice.
+Renderer pools shared across cells require a separately admitted owner and leases.
+Renderer pressure requests enter this authority's existing fallback/eviction path;
+the renderer does not acquire world-cell policy ownership.
+
 1. EstimateCellCost reads validated metadata and returns bounded CPU/GPU/staging
    peak costs. It performs no allocation, I/O or live-world mutation. Where v1
    metadata lacks a provider estimate, use its validated descriptor upper bound or


### PR DESCRIPTION
## Summary

GPU allocation policy was undefined between the renderer's resource registry,
World Streaming's aggregate reservations, and feature-local page caches. That
could allow duplicate budget grants, uncharged heap slack, or unsafe reclamation.

Add ADR-034 as the GPU memory/residency decision and reconcile the rendering,
backend parity, world-streaming and virtual-texturing documents with it.

## Motivation

RND-010 implementation needs one policy for allocator ownership, heaps, admission,
pressure, eviction and retirement without moving cell authority into a backend.

## Implementation Notes

- Hosts supply finite envelopes; the frontend owns accounting/readiness; backends
  own native requirement queries, allocation and release.
- Charge whole backing capacity, copies and old/new overlap. Streaming and renderer
  ledgers project one charge identity; shared pools use admitted owners and leases.
- Keep logical release separate from physical retirement, including all GPU queues,
  readback consumers and native helper allocations.
- Define bounded pressure, cancellation, OOM, budget-observation and Null scheduling
  semantics, plus sparse/atlas and presentation replacement boundaries.
- Record GL/Metal/Vulkan/D3D12 responsibilities and downstream RND-010.2–.10
  implementation/qualification requirements. No runtime allocator or persisted
  schema is introduced in this M0 decision.

## Validation

- Documentation scope: seven Markdown files; 241 local links/anchors and code-fence
  structure checked with a temporary local documentation checker. No new errors.
- Two pre-existing missing editor-document links in the architecture index remain
  unchanged.
- Whitespace and staged format checks pass. No C++ files require formatting.
- Build, runtime tests, coverage and GPU smoke tests were not run for this docs-only
  change. The ADR explicitly lists the meaningful downstream test obligations.

Commands run:
```bash
git diff --check
python3 scripts/dev.py format --staged --check
```

## Risks

Whole-block charging and conservative estimates may admit less content than
optimistic payload counts. Actual allocator tuning, native overhead, budget
telemetry and hardware behavior still require implementation and measurement.

## Issue Links

- Jira: [HORO-358](https://horo-engine.atlassian.net/browse/HORO-358)
- GitHub: Closes #358

## Reviewer Notes

Stacked on #2361; review the incremental diff against that branch. Do not merge
independently of the stack.

Start with ADR-034, then the short owning-document reconciliations. GitHub #358
currently has no native blocked-by issue. Jira has inward links from implementation
tickets (#359/#360/#366 and VTX realization); their scopes consume this decision.
This PR does not change those dependency links or claim their implementation done.


[HORO-358]: https://horo-engine.atlassian.net/browse/HORO-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ