### PR TITLE
docs(render): choose shader source and IR routes HORO-368 #368 [RND-011.1]

### DIFF
--- a/docs/adr/035-shader-source-and-intermediate-representation.md
+++ b/docs/adr/035-shader-source-and-intermediate-representation.md
@@ -1,0 +1,295 @@
+# ADR-035: Shader Source and Intermediate Representation
+
+- **Status**: proposed
+- **Date**: 2026-08-31
+- **Owners**: Rendering / Shader Toolchain / Asset Pipeline
+- **Tracking**: HORO-368 / #368 / RND-011.1
+- **Milestone**: M0 — Architecture Baseline
+
+## Context
+
+The asset-pipeline target describes an unspecified Horo source dialect and one
+canonical SPIR-V representation. That does not define a source language, a D3D12
+DXIL path, or how reflection stays consistent through translation. The current
+OpenGL/Metal viewport integrations embed separate native shader sources; they
+are migration inputs, not an implemented multi-target shader cooker.
+
+This decision owns source language, compiler/IR routes, interface validation and
+diagnostic boundaries. It preserves the target baselines in ADR-029–032, resource
+lifetime in [ADR-027](027-renderer-resource-identity-and-descriptors.md), and asset
+publication in [Asset Pipeline](../architecture/runtime/asset-pipeline.md).
+It does not implement a compiler, change material shading algorithms, or activate
+a desktop cook target in the existing headless-only Phase A contract.
+
+## Decision
+
+### 1. One source contract, target-specific derived artifacts
+
+Use **HLSL with an explicitly selected HLSL 2021 language mode** as the first
+production textual authoring language. Shader graphs generate that same source
+contract plus source maps; they do not own an independent runtime compiler.
+Horo adds a versioned manifest, logical bindings and approved helper library,
+not a new language parser or an API-specific public header.
+
+The portable baseline consists of vertex/fragment entry points, 32-bit scalar,
+vector and matrix arithmetic, bounded uniform data, sampled textures/samplers
+and explicit stage interfaces admitted by every declared target. Boolean material
+values use explicit 32-bit integer storage at buffer boundaries. Compute/storage
+resources, wave operations, 16/64-bit types, advanced stages, unbounded arrays and
+native intrinsics require separate declared capability variants; choosing HLSL
+or Shader Model 6.0 does not make them portable. A shader is portable only over
+its declared target set and tested requirements, not over every compiler backend.
+
+The manifest declares source identity/revision, entry points/stages, logical
+resource IDs, parameter schema, permutation inputs, required features and target
+set. Explicit source bindings must match it; implicit compiler-assigned bindings
+are not authoritative. Generated target annotations/adapters are cook products.
+Portable source cannot branch on a vendor/API macro to silently change material
+semantics. Target-specific implementations are separate named variants with the
+same declared logical interface, explicit requirements and admitted fallback
+policy under [ADR-028](028-renderer-capability-limits-and-product-profiles.md).
+
+### 2. Compiler and intermediate-representation routes
+
+Use DXC for HLSL compilation, SPIRV-Tools validation for SPIR-V artifacts, and
+SPIRV-Cross for the selected GLSL/MSL translation routes. These are toolchain
+components behind private adapters. Exact releases/build hashes, dependencies,
+licenses, host platforms and invocation options must be locked and qualified by
+RND-011.3 before implementation enables a target; this ADR adds no dependency or
+floating tool download. An installed SDK/compiler default is never the lock.
+
+| Target | Selected route and runtime artifact | Baseline constraint |
+|---|---|---|
+| Vulkan | HLSL → DXC SPIR-V → validation/normalization → cooked SPIR-V + Horo reflection | [ADR-031](031-vulkan-loader-platform-and-version-baseline.md): explicit Vulkan 1.3 environment, SPIR-V at most 1.6, only declared/enabled capabilities. |
+| OpenGL | HLSL → validated SPIR-V → SPIRV-Cross → cooked desktop GLSL + Horo binding map | [ADR-029](029-opengl-compatibility-profile-and-platform-policy.md): GLSL 4.10 / desktop 4.1 Core; native compile/link at controlled resource preparation, not a requirement for GL SPIR-V support. |
+| Metal | HLSL → validated SPIR-V → SPIRV-Cross MSL → Apple offline compiler/library → cooked library + Horo binding map | [ADR-030](030-metal-platform-and-feature-baseline.md): explicit MSL 2.4 and macOS 14 deployment/architecture options; no toolchain required by packaged players. |
+| D3D12 | Same HLSL → DXC directly → validated DXIL + Horo binding map | [ADR-032](032-d3d12-baseline-and-agility-sdk-policy.md): explicit stage Shader Model 6.0 profile and baseline root signature 1.0; no SPIR-V → HLSL → DXIL round trip. |
+| Headless Null | Source/manifest validation and normalized reflection fixture/artifact, without native GPU creation | Only declared validation coverage; no claim that an uncompiled native target or visual result passed. |
+
+The GLSL/MSL translation inputs use an explicit locked SPIR-V environment and
+feature allowlist bounded by their **destination** requirements. Vulkan 1.3 is
+the default intermediate validation environment; it is not permission to emit a
+construct GLSL 4.10/MSL 2.4 cannot realize. Unsupported lowering fails the target
+cook instead of raising its shader version, changing the source semantics or
+falling back to another compiler route. Optional routes need separate versioned
+target descriptors and qualification before selection.
+
+SPIR-V is a shared derived intermediate for three routes, **not the universal
+asset authority or required D3D12 interchange format**. Source/manifest/dependency
+identity and the normalized Horo interface are common. Native payloads remain
+target-specific and cannot be substituted merely because reflection looks alike.
+
+DXC documents both DXIL and SPIR-V outputs in its
+[project contract](https://github.com/microsoft/DirectXShaderCompiler).
+SPIRV-Cross documents GLSL/MSL translation and reflection in its
+[README](https://github.com/KhronosGroup/SPIRV-Cross/blob/main/README.md).
+Those capabilities motivate the routes; they do not prove every Horo shader
+translates correctly or establish binary reproducibility across tool versions.
+
+### 3. Explicit target options and portability validation
+
+One validated Horo shader-target descriptor is consumed by offline cooking,
+permitted editor compilation and backend artifact admission. It identifies:
+
+- target OS/architecture/deployment, backend payload format and version;
+- source language version, entry point/stage and explicit compiler profile;
+- intermediate environment, allowed features/extensions, optimization/debug and
+  floating-point options, matrix packing and buffer-layout rules;
+- native language/profile options, binding remap policy and interface-schema
+  versions; compiler, translator and validator build identities.
+
+Missing/conflicting options fail before compiler execution. The baseline uses
+column-major matrix packing explicitly, and the SPIR-V routes use strict GL
+uniform/storage layout selection rather than DXC's relaxed default. The compiler
+adapter selects and tests those options; CPU packing still follows each final
+target layout. No scalar-layout extension is introduced implicitly. See
+[DXC memory-layout rules](https://github.com/microsoft/DirectXShaderCompiler/blob/main/docs/SPIR-V.rst#memory-layout-rules).
+Optimization must not enable unsafe floating-point transformations implicitly;
+explicit fast-math variants record their behavior and are separately qualified.
+Cross-backend numerical agreement uses declared image/numeric tolerances, not a
+claim of bit-identical GPU arithmetic.
+
+SceneMath and renderer projection contracts retain coordinate authority. In
+particular, projection already selects the backend depth range; compiler adapters
+must disable automatic depth remapping that would apply it twice. Any required
+Y/origin/stage-built-in adjustment has one explicit backend lowering policy in the
+target descriptor and fixture tests. Source materials cannot add hidden platform
+flips. Texture origin, front-face orientation and depth tests are qualified
+together, not inferred from a successful shader compile.
+
+### 4. Horo reflection is the binding authority
+
+The shader toolchain normalizes compiler/translator reflection into a versioned
+Horo model. It records logical resource/parameter IDs, stage interfaces, scalar
+types, array extents, access, stage visibility and required feature predicates.
+Each native artifact also carries a target binding/packing map: slots/register
+spaces or indices represented as Horo values, member offsets/strides/matrix order,
+texture-sampler pairing and generated helper resources. Native reflection structs
+and SPIRV-Cross JSON never become the public renderer or material schema.
+
+Manifest validation runs before compilation; final-artifact validation checks
+reflection against that manifest and the complete variant stage interface after
+optimization/translation. D3D12 reflects its actual DXIL; it cannot borrow the
+SPIR-V reflection of a different compilation. GLSL/MSL remaps come from their
+actual translation, with native link/pipeline reflection checks for the fields
+available there. Fields unavailable in native reflection require a validated
+lowering/packing contract and qualification fixture, not invented native evidence.
+An unprovable required interface rejects the artifact/target.
+
+Optimization may remove an unused declared binding: record it as inactive for
+that exact variant, without renumbering logical IDs or treating a missing active
+required binding as optional. Undeclared active resources, incompatible stage I/O,
+overlapping native slots, unbounded dimensions or inconsistent parameter types
+fail validation. Generated combined samplers/helper bindings have explicit mappings
+and count toward actual target limits. OpenGL's flat binding and combined-sampler
+mapping must preserve each logical texture/sampler pair; direct descriptor-set
+numbers are not valid GL bindings by assumption.
+
+Material/Scene code supplies typed semantic values. The renderer packs them through
+the selected target map; it must not memcpy a C++ struct or reuse Vulkan offsets
+as DXIL/MSL offsets. A changed logical parameter schema requires material migration
+or a typed incompatibility. A changed target packing map changes artifact/layout
+identity and pipeline/binding caches even when semantic values remain identical.
+
+### 5. Cook, cache and publication authority
+
+The Asset Pipeline owns trusted source/include resolution, dependency snapshots,
+bounded scheduling, cache keys, staging, manifests and atomic publication. The
+shader compiler adapter consumes immutable inputs and writes bounded logical
+outputs; it does not choose project paths, mutate sources or install tools.
+Compilation includes are resolved only within admitted asset/package/toolchain
+roots, with cycle/depth/size/count limits. No network include, ambient working
+directory search, arbitrary command-line passthrough or timestamp macro may make
+the same declared inputs produce untracked behavior. Toolchain processes use
+host-selected executables and argument arrays, not source-derived shell commands.
+
+The shader artifact key extends the existing dependency-aware cook identity with
+the complete target descriptor, manifest/schema/generator versions, transitive
+source/include digests, canonical defines/permutation and specialization values,
+and all compiler/translator/validator build identities. Debug/optimization options
+participate; the local GPU does not decide a portable cook target. A permutation
+key is a logical lookup index, not the complete artifact compatibility key.
+
+Emit payload, normalized reflection, target map, requirements, dependencies and
+diagnostics as one validated artifact generation. Failure of a required target or
+variant prevents publication of the requested target set; previous good published
+generations remain active. Optional exclusions must be declared before the cook,
+not decided by dropping failed outputs afterward. Tools missing for Metal/DXIL
+production produce a clear unsupported cook-host/toolchain error, not placeholder
+payloads. Cross-host build services, when composed, obey the same input/output
+and cache authority rather than weakening qualification.
+
+Keep three caches distinct: portable cooked shader artifacts owned by Asset
+Pipeline; optional native driver/pipeline binary acceleration blobs owned by the
+backend; and live GPU pipeline objects owned by the renderer registry. Native
+cache keys include the backend/device/driver compatibility identity required by
+the API. Reject stale blobs and rebuild from the cooked artifact at a permitted
+preparation boundary. Never serialize live handles or make a native cache blob the
+only recoverable shader source. Shipping a cache does not guarantee every driver
+can reuse it or avoid all native pipeline compilation.
+
+### 6. Runtime compilation, hot reload and diagnostics
+
+Packaged games require cooked variants: no HLSL compilation, graph evaluation,
+DXC/SPIRV-Cross installation or source-network fetch on a cache miss. OpenGL's
+driver compilation/link of **cooked GLSL** and native pipeline creation are still
+required artifact realization, not an exception enabling arbitrary source cooks.
+Schedule/prewarm them outside frame-hot execution on the required graphics owner
+thread. Pending required pipelines defer dependent work; do not block the core loop
+waiting for compilation or display silently substituted materials.
+
+Editor/development compilation is an explicit bounded request using the same
+target descriptor, diagnostics and artifact validation. CPU compiler work follows
+[ADR-010](010-job-waiting-and-operation-store-ownership.md) `JobId`/`OperationId`
+ownership and cancellation; user-visible status uses `OperationStore`. Native
+realization and publication follow ADR-027 on the render-capable thread. The
+[ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md)
+`RenderSafePoint` is that same owner boundary. Work retains immutable source/input
+leases and project/device generations; cancelled or superseded results cannot
+publish. Queue, source, diagnostics and native resource budgets remain finite.
+
+Hot reload stages and validates an entire candidate, then publishes new shader/
+pipeline generations and compatible dependent bindings at the owner safe point.
+Failure retains the last good generation and reports the failed candidate; it
+does not label an old pipeline as the new successful revision. Old in-flight work
+retires normally, with old/new overlap admitted under
+[ADR-034](034-gpu-memory-and-residency-ownership.md).
+
+Diagnostics use stable Horo categories for source/include errors, unsupported
+features, reflection/layout mismatch, toolchain failure, native compile/link error,
+missing variant, cancellation and stale result. Include source asset/revision,
+entry/stage/variant/target, tool identity and original severity/message. Preserve
+include stacks and graph node/pin-to-generated-line mappings across preprocessing
+and translation; unmappable messages retain their generated location explicitly.
+Bound/truncate payloads with a visible truncation marker. No raw local absolute
+paths or source contents enter remote telemetry by default. Build Output, editor
+and CLI consume the same typed diagnostics, not independently parsed error text.
+
+## Rejected Alternatives
+
+| Option | Decision and reason |
+|---|---|
+| Independent GLSL/HLSL/MSL authoring for every backend | Rejected as the portable default: duplicates material semantics and diagnostics. Backend-private bootstrap code and explicitly target-scoped variants may remain, with declared scope and qualification. |
+| GLSL → SPIR-V as the universal source path | Not selected: fits GL/Vulkan, but adds an HLSL translation/recompile hop for the direct D3D12 target. |
+| HLSL → SPIR-V → HLSL → DXIL for all shaders | Rejected: makes DXIL semantics/reflection depend on an unnecessary round trip. Compile the common source directly for D3D12 and validate both routes. |
+| Hand-author SPIR-V or publish it as the material interface | Rejected: poor authoring diagnostics and does not solve native layout/capability differences. SPIR-V remains a derived artifact. |
+| Slang or WGSL as the first source language | Deferred: would add a different language/toolchain contract before existing backend baselines and material bindings are qualified. Reconsider through an explicit source-contract revision, not a per-project compiler switch. |
+| DXIL → Metal conversion or direct DXC Metal output | Not the selected baseline: would need independent MSL/deployment, binding and device qualification. It cannot silently replace the established MSL 2.4 route. |
+| One byte layout and reflection result reused on all backends | Rejected: compiler layout and translation differences can silently corrupt material data. Use semantic IDs plus checked target maps. |
+
+The selected split needs more than one compiler output path and cross-target
+fixtures. It avoids inventing a language and preserves direct DXIL production,
+but translator coverage is an explicit admission constraint. No M0 claim of full
+HLSL feature portability, bitwise determinism or shader performance is made.
+
+## Migration And Verification
+
+This ADR replaces the unspecified Horo dialect/universal-SPIR-V target prose.
+Existing embedded GLSL/MSL paths must migrate to source manifests and cooked
+artifacts or be explicitly scoped backend bootstrap shaders with the same version,
+diagnostic, budget and lifecycle rules. Keeping them is not evidence that the
+portable compiler exists. Tool versions become pinned dependencies only when
+their owning implementation lands; compiler libraries do not enter public headers.
+
+Persisted source/manifest/target-map schema changes use the existing project and
+asset migration/version authorities. Regenerate derived artifacts after toolchain
+or layout changes; do not silently rewrite authored shader semantics. This PR
+changes no current parser, serialized format, native compilation option or target
+availability.
+
+| Delivery | Required implementation evidence |
+|---|---|
+| RND-011.2 / #369 | Versioned manifest, logical binding/parameter IDs and explicit target descriptor validation. |
+| RND-011.3/.4 / #370–371 | Locked compiler/validator/translator adapters, bounded offline pipeline, final-artifact reflection and source mapping. |
+| RND-011.5/.6 / #373, #372 | Complete permutation/specialization and artifact/native-cache identity; no raw-handle persistence. |
+| RND-011.7/.8 / #374–375 | Prewarm/development policy, nonblocking completion, stale/cancelled candidate rejection and safe replacement. |
+| RND-011.9–.13 / #376–380 | Material packing, graph lowering, typed Build Output diagnostics and cross-backend qualification through those contracts. |
+
+Qualification must test all selected routes, not only one intermediate compiler:
+
+- A shared shader corpus covering material buffers, matrix/array/struct layout,
+  multiple texture/sampler pairs, stage linking, depth/origin/front-face behavior
+  and declared optional-feature rejection; compare outputs with stated tolerances.
+- Minimal-runtime GL 4.1, MSL 2.4/macOS 14, Vulkan 1.3 and DXIL SM 6.0 admission;
+  record exact compiler arguments/options and emitted versions. A cook-host compile
+  alone does not establish runtime support.
+- Malformed/overlapping reflection, optimizer-removed bindings, mismatched DXIL
+  versus SPIR-V layouts, missing native reflection fields and target-limit overflow.
+- Include changes/cycles/root escapes, variant/tool/options changes, corrupted
+  artifacts, native driver-cache mismatch, reproducibility under the same locked
+  inputs and diagnostic mapping to source/graph nodes.
+- Missing required variants, failed multi-target publication, absent tools,
+  bounded queue pressure, cancellation/reload races, project/device replacement,
+  last-good retention and GPU retirement after hot reload.
+- Packaged launch without authoring tools, permitted cooked-GLSL realization and
+  refusal to source-compile missing variants. Null tests cover contracts and error
+  schedules; native validation and image tests remain required for each backend.
+
+## Consequences
+
+Shader authoring has one concrete entry point and downstream teams can implement
+target routes without selecting conflicting languages or reflection authorities.
+Target maps and explicit compiler options expose compatibility differences early.
+The cost is a locked multi-tool pipeline, retained source maps and mandatory native
+qualification. Runtime code and current embedded shader performance are unchanged
+by this M0 architecture decision.

--- a/docs/adr/035-shader-source-and-intermediate-representation.md
+++ b/docs/adr/035-shader-source-and-intermediate-representation.md
@@ -124,8 +124,12 @@ Horo model. It records logical resource/parameter IDs, stage interfaces, scalar
 types, array extents, access, stage visibility and required feature predicates.
 Each native artifact also carries a target binding/packing map: slots/register
 spaces or indices represented as Horo values, member offsets/strides/matrix order,
-texture-sampler pairing and generated helper resources. Native reflection structs
-and SPIRV-Cross JSON never become the public renderer or material schema.
+texture-sampler pairing and generated helper resources. OpenGL 4.1 Core / GLSL
+4.10 does not require explicit `layout(binding = N)` locations, so the OpenGL map
+also records native GLSL resource and uniform-block names for runtime resolution
+through `glGetUniformLocation`, `glGetUniformBlockIndex` and equivalent queries.
+Native reflection structs and SPIRV-Cross JSON never become the public renderer
+or material schema.
 
 Manifest validation runs before compilation; final-artifact validation checks
 reflection against that manifest and the complete variant stage interface after
@@ -143,7 +147,9 @@ overlapping native slots, unbounded dimensions or inconsistent parameter types
 fail validation. Generated combined samplers/helper bindings have explicit mappings
 and count toward actual target limits. OpenGL's flat binding and combined-sampler
 mapping must preserve each logical texture/sampler pair; direct descriptor-set
-numbers are not valid GL bindings by assumption.
+numbers are not valid GL bindings by assumption. The backend binds from the
+recorded native names plus the Horo logical IDs, not from Vulkan/DXIL slot
+numbers copied into GLSL.
 
 Material/Scene code supplies typed semantic values. The renderer packs them through
 the selected target map; it must not memcpy a C++ struct or reuse Vulkan offsets
@@ -171,9 +177,15 @@ participate; the local GPU does not decide a portable cook target. A permutation
 key is a logical lookup index, not the complete artifact compatibility key.
 
 Emit payload, normalized reflection, target map, requirements, dependencies and
-diagnostics as one validated artifact generation. Failure of a required target or
-variant prevents publication of the requested target set; previous good published
-generations remain active. Optional exclusions must be declared before the cook,
+diagnostics as one validated artifact generation. When the target descriptor
+enables debug options, also emit and archive native debug artifacts with that
+generation: DXIL PDBs for D3D12, SPIR-V debug info for Vulkan, and equivalent
+source-mapping data for translated GLSL/MSL. Debug artifacts are companion
+records, not runtime admission inputs; packaged/shipping targets omit them unless
+the product explicitly requests a debug payload set. They must not change the
+public Horo interface schema or the admitted shader payload. Failure of a required
+target or variant prevents publication of the requested target set; previous good
+published generations remain active. Optional exclusions must be declared before the cook,
 not decided by dropping failed outputs afterward. Tools missing for Metal/DXIL
 production produce a clear unsupported cook-host/toolchain error, not placeholder
 payloads. Cross-host build services, when composed, obey the same input/output

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,6 +46,7 @@ to the replacement.
 | [032](032-d3d12-baseline-and-agility-sdk-policy.md) | D3D12 Baseline and Agility SDK Policy | proposed | 2026-08-31 |
 | [033](033-presentation-and-display-ownership.md) | Presentation and Display Ownership | proposed | 2026-08-31 |
 | [034](034-gpu-memory-and-residency-ownership.md) | GPU Memory and Residency Ownership | proposed | 2026-08-31 |
+| [035](035-shader-source-and-intermediate-representation.md) | Shader Source and Intermediate Representation | proposed | 2026-08-31 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -116,6 +116,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [GPU Memory and Residency Ownership](../adr/034-gpu-memory-and-residency-ownership.md):
   native allocator ownership, backing-capacity accounting, streaming reservations,
   bounded pressure policy, and deferred reclamation.
+- [Shader Source and Intermediate Representation](../adr/035-shader-source-and-intermediate-representation.md):
+  HLSL authoring, target-specific SPIR-V/DXIL routes, normalized reflection,
+  compiler identity, source diagnostics, and cooked/runtime boundaries.
 - [Renderer Distribution And Availability](./runtime/renderer-distribution-and-availability.md):
   optional renderer components, install/repair/probe states, launcher recovery,
   and selection policy.

--- a/docs/architecture/runtime/asset-pipeline.md
+++ b/docs/architecture/runtime/asset-pipeline.md
@@ -453,7 +453,7 @@ concerns. It also matches how artists and technical artists think about assets:
 | Setting        | Block | Description                                                                    |
 |----------------|-------|--------------------------------------------------------------------------------|
 | `entryPoints`  | cook  | Map of stage to function name: `{ "vertex": "vsMain", "fragment": "fsMain" }`. |
-| `targetStages` | cook  | Which SPIR-V stages to produce: `Vertex`, `Fragment`, `Compute`.               |
+| `targetStages` | cook  | Declared stages to compile for each admitted target; `Compute` requires explicit capability support. |
 | `defines`      | cook  | Preprocessor macros included in the variant key.                               |
 
 ### Audio Configuration
@@ -784,25 +784,39 @@ remain outside Phase A; the list below does not activate a desktop cook target.
 Shaders require a dedicated pipeline because they are source code that must be
 transpiled and optimized for each target graphics API.
 
+[ADR-035](../../adr/035-shader-source-and-intermediate-representation.md) owns the
+HLSL source contract, compiler/IR routes, normalized Horo reflection and diagnostics.
+SPIR-V is a shared derived intermediate, not a universal D3D12 interchange format.
+The following routes are target architecture; they add no current cook capability.
+
 Pipeline stages:
 
-1. **Preprocess**: resolve `#include`, macros, and shader graph nodes.
-2. **Compile to SPIR-V**: Horo source dialect is compiled to SPIR-V as the
-   canonical intermediate representation.
-3. **Transpile to target**: SPIR-V is translated or packaged for a future
-   typed backend capability; illustrative peers are:
-    - `desktop-vulkan` → SPIR-V with validated reflection metadata
-    - `desktop-opengl` → GLSL or backend-approved translated shader payload
-   - `desktop-metal` → MSL or backend-approved translated shader payload
-   - `headless-null` → reflection-only validation payload
-4. **Variant generation**: produce permutations for static shader keywords
-   (e.g., `USE_NORMAL_MAP`, `SHADOWS_ENABLED`). Each canonical keyword/permutation
-   set is folded into the effective settings digest, whose schema is identified by
-   the effective settings schema version. Variant cache identity derives from the
-   complete `CacheKeyV1`; a keyword hash may be an index or display aid, but is
-   never sufficient cache authority.
-5. **Pack**: cooked shader binaries and variant tables are stored alongside
-   material cooked assets.
+1. **Resolve inputs**: validate source manifests and bounded include/dependency
+   snapshots; graph lowering emits the same HLSL source contract and source maps.
+2. **Enumerate variants**: validate the finite declared keyword/permutation sets
+   before scheduling compilers. Fold each set into the versioned effective settings
+   digest. The complete dependency-aware cook key remains authoritative; a keyword
+   hash is only an index or display aid.
+3. **Compile per target and variant**: locked DXC options produce validated SPIR-V
+   for the Vulkan/GL/Metal routes or validated DXIL directly for D3D12.
+4. **Realize target artifacts**: normalize actual target reflection and validate
+   logical interfaces, binding maps and requirements:
+   - `desktop-vulkan` → SPIR-V for the ADR-031 Vulkan environment
+   - `desktop-opengl` → SPIRV-Cross GLSL 4.10 plus binding map
+   - `desktop-metal` → SPIRV-Cross MSL 2.4, then offline cooked Metal library
+   - `desktop-d3d12` → direct DXIL for the ADR-032 Shader Model baseline
+   - `headless-null` → declared source/interface validation without native GPU proof
+5. **Pack**: validated target payloads, Horo reflection/maps, dependencies and
+   variant tables form the host-published artifact generation. A required target
+   or variant failure cannot be silently omitted to publish a successful cook.
+
+The shader artifact identity includes the complete target descriptor and compiler,
+translator, validator, source-language, layout and generator versions/options.
+Native pipeline acceleration blobs have separate device/driver compatibility keys;
+neither they nor live GPU handles replace the canonical cooked artifact. Required
+missing variants are errors. Packaged games do not install authoring compilers,
+although a backend may realize a cooked payload (for example, GL compile/link of
+cooked GLSL) at its controlled resource preparation boundary.
 
 ```cpp
 struct ShaderCookResult {

--- a/docs/architecture/runtime/material-and-shader-model.md
+++ b/docs/architecture/runtime/material-and-shader-model.md
@@ -47,7 +47,10 @@ Not covered:
   requirements. The frontend selects an admitted recipe and records every fallback
   under [ADR-028](../../adr/028-renderer-capability-limits-and-product-profiles.md).
 - Pipeline state objects are cached and reused. Shader compilation may happen
-  offline during cook or lazily at runtime, but the cache key format is the same.
+  during cook or explicit editor/development preparation under
+  [ADR-035](../../adr/035-shader-source-and-intermediate-representation.md).
+  Portable artifacts, native driver caches and live GPU objects have distinct
+  ownership and compatibility keys.
 - No gameplay code queries raw shader handles. Gameplay sees only material names,
   parameter overrides, and feature flags.
 
@@ -263,14 +266,19 @@ whose requirements have not passed admission.
 
 ### Variant Compilation Policy
 
-- **Cook-time**: all declared permutations are compiled during asset cooking.
-- **Runtime lazy**: missing permutations may be compiled on first use if the
-  platform allows runtime shader compilation.
-- **Headless/server**: only variants requested by the release profile are
-  compiled; no runtime compilation.
+- **Cook-time**: compile all required declared permutations for the selected target
+  set through ADR-035's HLSL/SPIR-V or direct DXIL route. Publish payloads and
+  validated Horo reflection/target maps together.
+- **Editor/development**: explicit bounded compilation requests may build new
+  variants using the same target descriptor and diagnostics. Pending work never
+  blocks the frame loop; stale/failed candidates cannot replace the last good one.
+- **Packaged game/headless/server**: require declared cooked artifacts; no missing
+  variant may trigger HLSL/graph compilation. Controlled native realization of a
+  cooked artifact, such as GL compile/link of cooked GLSL, remains necessary.
 
-The pipeline emits diagnostics when a requested variant is missing and runtime
-compilation is disabled.
+A missing required variant is a typed error. Only predeclared, cooked and admitted
+optional fallback variants may replace it; platform source-compiler availability
+is not permission to invent a runtime variant.
 
 ### Variant Explosion Guard
 
@@ -306,23 +314,21 @@ name.
 
 ## Pipeline Cache
 
-The renderer owns a `ShaderPipelineCache` keyed by `ShaderPermutationKey`. It
-maps to:
+ADR-035 distinguishes Asset Pipeline's cooked shader artifacts, the backend's
+optional native driver/pipeline acceleration blobs, and the renderer registry's
+live GPU objects. `ShaderPermutationKey` is a logical index; full artifact identity
+also includes source/include digests, manifest/target/layout versions, toolchain
+builds and compiler options. Native blob compatibility additionally includes the
+device/driver identity required by the backend.
 
-- compiled shader binaries
-- pipeline state objects
-- descriptor set layouts (or equivalent backend abstractions)
-- root signature / pipeline layout handles
+Live pipelines/layouts/handles are never serialized. A shipped native cache is
+only acceleration: reject incompatible blobs and prepare from the admitted cooked
+artifact at a permitted non-frame-hot boundary. Cache invalidation does not permit
+an implicit source cook or claim that native pipeline creation can never compile.
 
-Cache lifetime:
-
-- process-scoped in development
-- shipped as a cold-start cache in release builds
-- invalidated when shader source, target platform, or renderer backend version
-  changes
-
-The cache must be serializable and reloadable without recompiling if the binary
-is compatible.
+Material parameters remain typed semantic values. Renderer packing uses the
+selected artifact's validated target offsets/strides and binding map; C++ struct
+layout or another backend's reflection cannot substitute for that map.
 
 ## Renderer Integration
 
@@ -412,8 +418,9 @@ Material validation rules:
 Cook-time diagnostics:
 
 - list of emitted variants per shader
-- variants skipped due to caps or profile limits
-- missing variant warnings when runtime compilation is disabled
+- declared optional variants excluded by the requested profile/target policy
+- missing required variants are errors; only declared optional exclusions may be
+  reported without failing publication
 
 ## Testing Requirements
 

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -665,6 +665,15 @@ generation check.
 
 ## Shader And Pipeline Contract
 
+The source language, compiler routes, normalized reflection and diagnostics policy
+is [ADR-035](../../adr/035-shader-source-and-intermediate-representation.md).
+Portable HLSL source feeds validated SPIR-V for Vulkan/GLSL/MSL routes and direct
+DXIL for D3D12. Target-specific binding/packing maps preserve logical material
+interfaces; native compiler defaults and raw reflection structs are not public
+contracts. Packaged builds consume cooked variants, with controlled native
+realization such as GL compile/link of cooked GLSL. Missing variants cannot trigger
+an implicit authoring-source compiler or a blocking frame-hot pipeline build.
+
 Shaders are cooked by the asset pipeline. Runtime loading validates:
 
 - format and version


### PR DESCRIPTION
## Summary

The shader pipeline named an unspecified Horo source dialect and universal SPIR-V
route without a direct DXIL path or a shared reflection authority. Runtime-lazy
compilation and cache wording also blurred authoring, cooked artifacts and native
pipeline realization.

Add ADR-035 selecting HLSL authoring, explicit per-target compiler routes, normalized
Horo interfaces and checked target binding/packing maps. Reconcile the asset,
material and rendering documents with that decision.

## Motivation

RND-011 needs a concrete source/IR policy that respects the existing GL 4.1,
MSL 2.4, Vulkan 1.3 and DXIL SM 6.0 baselines without leaking native reflection
or toolchain defaults into materials.

## Implementation Notes

- HLSL 2021 with explicit portable requirements; graphs emit the same source contract.
- DXC SPIR-V routes for Vulkan and SPIRV-Cross GLSL/MSL; direct DXC DXIL for D3D12.
- Exact tool builds/options must be locked and qualified by the implementation.
  No compiler dependency, parser, target capability or runtime code is added here.
- Validate final target reflection and layouts, generated bindings, source maps,
  cancellation/hot reload generations and bounded diagnostics.
- Separate portable artifact, native driver-cache and live GPU object identities.
  Packaged builds require cooked variants; native compile/link of cooked GLSL is
  distinct from compiling missing HLSL/graph variants.
- Retain Asset Pipeline publication authority and its existing Phase A boundary.

## Validation

- Six Markdown files; 246 local links/anchors, seven JSON blocks and fence structure
  checked with a temporary local documentation checker. No new errors.
- Two pre-existing missing editor-document links in the architecture index remain
  unchanged.
- Whitespace and staged formatting checks pass; no C++ formatting needed.
- Builds, runtime tests, shader compilation, coverage and GPU smoke tests were not
  run for this docs-only M0 decision. The ADR records the required downstream
  multi-target compilation, reflection, minimum-runtime and image qualification.

Commands run:
```bash
git diff --check
python3 scripts/dev.py format --staged --check
```

## Risks

Translator coverage and native packing differences still require implementation
and a shared fixture corpus. Selecting a language does not assert all HLSL features
are portable or that outputs are bit-identical across GPUs.

## Issue Links

- Jira: [HORO-368](https://horo-engine.atlassian.net/browse/HORO-368)
- GitHub: Closes #368

## Reviewer Notes

Stacked on #2362; review only the incremental diff against that branch. Do not
merge independently of the stack. Read ADR-035 first, then the owning-document
reconciliation. Existing embedded backend shaders remain migration inputs and are
not presented as an already implemented portable compiler.


[HORO-368]: https://horo-engine.atlassian.net/browse/HORO-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ