### PR TITLE
docs(adr): use domain aliases as Issue link text HORO-306 #306 [RND-004.1]

### DIFF
--- a/docs/adr/007-cross-engine-project-interchange.md
+++ b/docs/adr/007-cross-engine-project-interchange.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-26
 - **Supersedes**: None
 - **Scope**: Import and export of foreign engine projects (Godot, Unity, Unreal) into and out of Horo
-- **Issue**: [#2308](https://github.com/abdullahbodur/horo-engine/issues/2308) ([PEX-001.1])
+- **Issue**: [PEX-001.1](https://github.com/abdullahbodur/horo-engine/issues/2308)
 - **Normative document**: [Cross-Engine Project Interchange](../architecture/foundation/cross-engine-interchange.md)
 
 ## Context

--- a/docs/adr/008-error-model-exception-boundary-and-registry.md
+++ b/docs/adr/008-error-model-exception-boundary-and-registry.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-27
 - **Supersedes**: None
 - **Scope**: Foundation `Result<T,Error>`, `ErrorCode`/`Error`, diagnostics, registry and exception boundaries
-- **Issue**: [#1814](https://github.com/abdullahbodur/horo-engine/issues/1814) ([ERR-001.1])
+- **Issue**: [ERR-001.1](https://github.com/abdullahbodur/horo-engine/issues/1814)
 - **Normative document**: [Error And Diagnostics](../architecture/foundation/error-and-diagnostics.md)
 
 ## Context

--- a/docs/adr/009-configuration-schema-precedence-and-secret-boundary.md
+++ b/docs/adr/009-configuration-schema-precedence-and-secret-boundary.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: Foundation configuration schema, domain ownership, source precedence, environment indirection and credential references
-- **Issue**: [#1821](https://github.com/abdullahbodur/horo-engine/issues/1821) ([CFG-001.1])
+- **Issue**: [CFG-001.1](https://github.com/abdullahbodur/horo-engine/issues/1821)
 - **Jira**: [HORO-1777](https://horo-engine.atlassian.net/browse/HORO-1777)
 - **Normative document**: [Configuration System](../architecture/foundation/configuration-system.md)
 

--- a/docs/adr/010-job-waiting-and-operation-store-ownership.md
+++ b/docs/adr/010-job-waiting-and-operation-store-ownership.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: Job execution, waiting, low-level records, user-facing operation aggregation, observation and submission-captured context
-- **Issue**: [#1828](https://github.com/abdullahbodur/horo-engine/issues/1828) ([JOB-001.1])
+- **Issue**: [JOB-001.1](https://github.com/abdullahbodur/horo-engine/issues/1828)
 - **Jira**: [HORO-1784](https://horo-engine.atlassian.net/browse/HORO-1784)
 - **Normative document**: [Concurrency And Job System](../architecture/foundation/concurrency-and-jobs.md)
 

--- a/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
+++ b/docs/adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: Runtime VFX ownership, per-emitter domain policy, bounded admission, immutable extraction, GPU scheduling, retirement and per-view sorting
-- **Issue**: [#1749](https://github.com/abdullahbodur/horo-engine/issues/1749) ([VFX-001.1])
+- **Issue**: [VFX-001.1](https://github.com/abdullahbodur/horo-engine/issues/1749)
 - **Jira**: [HORO-1706](https://horo-engine.atlassian.net/browse/HORO-1706)
 - **Normative document**: [VFX And Particles Architecture](../architecture/runtime/vfx-and-particles-architecture.md)
 

--- a/docs/adr/012-world-streaming-partition-authority-and-subsystem-boundaries.md
+++ b/docs/adr/012-world-streaming-partition-authority-and-subsystem-boundaries.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: Partition/state ownership, async provider readiness and retirement, reservations, epoch/generation fencing, Scene integration, networking and shutdown
-- **Issue**: [#1528](https://github.com/abdullahbodur/horo-engine/issues/1528) ([WST-001.1])
+- **Issue**: [WST-001.1](https://github.com/abdullahbodur/horo-engine/issues/1528)
 - **Jira**: [HORO-1528](https://horo-engine.atlassian.net/browse/HORO-1528)
 - **Normative document**: [World Streaming Architecture](../architecture/runtime/world-streaming-architecture.md)
 

--- a/docs/adr/013-environment-query-ownership-item-and-scoring-model.md
+++ b/docs/adr/013-environment-query-ownership-item-and-scoring-model.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: EQS orchestration, typed providers, plans/items/contexts, scoring, safe points, deterministic/adaptive budgets, cache identity and cancellation
-- **Issue**: [#1346](https://github.com/abdullahbodur/horo-engine/issues/1346) ([GAI-004.1])
+- **Issue**: [GAI-004.1](https://github.com/abdullahbodur/horo-engine/issues/1346)
 - **Jira**: [HORO-1346](https://horo-engine.atlassian.net/browse/HORO-1346)
 - **Normative document**: [Navigation And AI Architecture — EQS](../architecture/runtime/navigation-and-ai-architecture.md#environment-query-system-eqs)
 

--- a/docs/adr/014-sequencer-ownership-clock-authority-and-binding-boundary.md
+++ b/docs/adr/014-sequencer-ownership-clock-authority-and-binding-boundary.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: Cinematic clock sources and policies, sampling/event phases, domain authority, bindings, origin rebasing and evaluation budgets
-- **Issue**: [#1697](https://github.com/abdullahbodur/horo-engine/issues/1697) ([CIN-001.1])
+- **Issue**: [CIN-001.1](https://github.com/abdullahbodur/horo-engine/issues/1697)
 - **Jira**: [HORO-1656](https://horo-engine.atlassian.net/browse/HORO-1656)
 - **Normative document**: [Cinematic Sequencer Architecture](../architecture/runtime/cinematic-sequencer-architecture.md)
 

--- a/docs/adr/015-accessibility-ownership-typed-transport-and-non-gating-policy.md
+++ b/docs/adr/015-accessibility-ownership-typed-transport-and-non-gating-policy.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: Accessibility state ownership, typed transports, configuration snapshots, DataBus boundaries, non-blocking loops, and semantic availability
-- **Issue**: [#1849](https://github.com/abdullahbodur/horo-engine/issues/1849) ([ACC-001.1])
+- **Issue**: [ACC-001.1](https://github.com/abdullahbodur/horo-engine/issues/1849)
 - **Jira**: [HORO-1805](https://horo-engine.atlassian.net/browse/HORO-1805)
 - **Normative document**: [Accessibility Architecture](../architecture/runtime/accessibility-architecture.md)
 

--- a/docs/adr/016-navigation-target-ownership-and-dependency-boundary.md
+++ b/docs/adr/016-navigation-target-ownership-and-dependency-boundary.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: Navigation target boundaries (`NavigationApi`, `NavigationRuntime`, `NavigationRecastDetour`, `NavigationNull`), third-party encapsulation (Recast/Detour), decoupling from editor viewport navigation and gameplay AI decision graphs, headless/server composition, and compute resource scaling
-- **Issue**: [#1224](https://github.com/abdullahbodur/horo-engine/issues/1224) ([NAV-001.1])
+- **Issue**: [NAV-001.1](https://github.com/abdullahbodur/horo-engine/issues/1224)
 - **Jira**: [HORO-1224](https://horo-engine.atlassian.net/browse/HORO-1224)
 - **Normative document**: [Navigation And AI Architecture](../architecture/runtime/navigation-and-ai-architecture.md)
 

--- a/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
+++ b/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: Prefab asset definition, authoring templates, runtime spawnable templates (`CookedPrefab`), capability tiers (Tier 0, Tier 1, Tier 2), asset identity, project versioning, unknown component preservation, and lifecycle safety
-- **Issue**: [#1008](https://github.com/abdullahbodur/horo-engine/issues/1008) ([PFB-001.1])
+- **Issue**: [PFB-001.1](https://github.com/abdullahbodur/horo-engine/issues/1008)
 - **Jira**: [HORO-1008](https://horo-engine.atlassian.net/browse/HORO-1008)
 - **Normative document**: [Prefab Architecture](../architecture/runtime/prefab-architecture.md)
 

--- a/docs/adr/018-command-registration-permissions-threading-and-packaged-build-policy.md
+++ b/docs/adr/018-command-registration-permissions-threading-and-packaged-build-policy.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: Runtime debug console command registration, `DebugCommandDescriptor`, `CommandPermission` access levels, execution threading rules, packaged-build retail gating, and reconciliation with network administration and world streaming diagnostics
-- **Issue**: [#1842](https://github.com/abdullahbodur/horo-engine/issues/1842) ([DBG-001.1])
+- **Issue**: [DBG-001.1](https://github.com/abdullahbodur/horo-engine/issues/1842)
 - **Jira**: [HORO-1798](https://horo-engine.atlassian.net/browse/HORO-1798)
 - **Normative document**: [Runtime Debug Console And Development Overlays](../architecture/runtime/debug-console-and-overlays.md)
 

--- a/docs/adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
+++ b/docs/adr/019-cli-host-command-ownership-adapter-equivalence-and-horopak-boundary.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None (Amends and extends [ADR-004](004-cli-core-gui-boundary.md))
 - **Scope**: CLI host ownership (`HoroEngine::CliHost`), command descriptor registry, option parsing, execution dispatch, structured presentation, executable responsibilities (`horo-engine`, `HoroEditor`, `horopak`), separation of concerns between CLI, runtime debug console (DBG-001), and MCP (MCP-001), console delegation seam, domain command adapter equivalence (`ICliCommandAdapter`), and `horopak` isolation boundary
-- **Issue**: [#1858](https://github.com/abdullahbodur/horo-engine/issues/1858) ([CLI-001.1])
+- **Issue**: [CLI-001.1](https://github.com/abdullahbodur/horo-engine/issues/1858)
 - **Jira**: [HORO-1814](https://horo-engine.atlassian.net/browse/HORO-1814)
 - **Normative document**: [CLI Architecture](../architecture/interfaces/cli-architecture.md)
 

--- a/docs/adr/020-network-target-ownership-and-dependency-boundary.md
+++ b/docs/adr/020-network-target-ownership-and-dependency-boundary.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: Network target topology, compile-time dependency directions, public API encapsulation, optional linking and composition, threading model, and deterministic lifecycle/shutdown.
-- **Issue**: [#1098](https://github.com/abdullahbodur/horo-engine/issues/1098) ([NET-001.1])
+- **Issue**: [NET-001.1](https://github.com/abdullahbodur/horo-engine/issues/1098)
 - **Jira**: [HORO-1098](https://horo-engine.atlassian.net/browse/HORO-1098)
 - **Normative documents**:
   - [Networking Architecture](../architecture/runtime/networking-architecture.md)

--- a/docs/adr/021-gameplay-ai-ownership-scheduling-and-behavior-boundary.md
+++ b/docs/adr/021-gameplay-ai-ownership-scheduling-and-behavior-boundary.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: Gameplay AI runtime (`HoroAI`), agent brain state, blackboard storage and transactions, perception memory, simulation fixed-tick phases, task scheduler sharing, and separation from editor AI tooling.
-- **Issue**: [#1309](https://github.com/abdullahbodur/horo-engine/issues/1309) ([GAI-001.1])
+- **Issue**: [GAI-001.1](https://github.com/abdullahbodur/horo-engine/issues/1309)
 - **Jira**: [HORO-1309](https://horo-engine.atlassian.net/browse/HORO-1309)
 - **Related**:
   - [ADR-022: AI Fixed-Tick Order, Authority and Simulation Budget](022-ai-fixed-tick-order-authority-and-simulation-budget.md) (fine-grained tick, host authority, profiles)

--- a/docs/adr/022-ai-fixed-tick-order-authority-and-simulation-budget.md
+++ b/docs/adr/022-ai-fixed-tick-order-authority-and-simulation-budget.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: AI simulation tick scheduling, perception-decision-navigation pipeline ordering, multiplayer host authority boundaries, simulation profiles and CPU budget allocation
-- **Issue**: [#1358](https://github.com/abdullahbodur/horo-engine/issues/1358) ([GAI-005.1])
+- **Issue**: [GAI-005.1](https://github.com/abdullahbodur/horo-engine/issues/1358)
 - **Jira**: [HORO-1358](https://horo-engine.atlassian.net/browse/HORO-1358)
 - **Normative documents**:
   - [Navigation And AI Architecture](../architecture/runtime/navigation-and-ai-architecture.md)

--- a/docs/adr/023-world-index-and-cell-format-architecture-decision.md
+++ b/docs/adr/023-world-index-and-cell-format-architecture-decision.md
@@ -19,7 +19,7 @@ Prior to this decision:
 - `docs/adr/003-artifact-identity.md` and `docs/architecture/runtime/asset-pipeline.md` defined general `.horo` package chunk containers and asset IDs, but lacked a normative specification for cooked world index manifests (`world.index`) and spatial cell chunks (`.wcell`).
 - The runtime lacked an explicit binary layout contract, little-endian data guarantees, integrity hash algorithms, version negotiation semantics, feature-provider payload offset tables, and a Foundation-compliant typed error model for corrupted or version-skewed cell artifacts.
 
-Ticket #1564 ([WST-004.1]) requires ratifying the normative specification for:
+[WST-004.1](https://github.com/abdullahbodur/horo-engine/issues/1564) requires ratifying the normative specification for:
 
 1. **Cooked World Index format (`world.index`)**: Manifest containing world bounding volume, partition grid dimensions, spatial cell hierarchy, layer definitions, streaming volumes, and checksum validation table.
 2. **Cooked Cell Archive format (`.wcell` / `horopak` chunk)**: Header with magic number (`HOROCELL`), schema version, little-endian encoding, CRC32/SHA-256 integrity hash, and independently compressed TOC payload blocks for Core ECS, Terrain, Foliage, Physics Mesh, Audio, Navigation Mesh, Destruction, and custom providers.

--- a/docs/adr/023-world-index-and-cell-format-architecture-decision.md
+++ b/docs/adr/023-world-index-and-cell-format-architecture-decision.md
@@ -4,9 +4,9 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: Cooked world index manifest (`world.index`), streaming cell archive format (`.wcell` / `horopak` chunk), binary encoding, versioning, endianness, integrity hashing, feature-provider payloads, typed error model, and cancellation lifecycles
-- **Issue**: [#1564](https://github.com/abdullahbodur/horo-engine/issues/1564) ([WST-004.1])
+- **Issue**: [WST-004.1](https://github.com/abdullahbodur/horo-engine/issues/1564)
 - **Jira**: [HORO-1564](https://horo-engine.atlassian.net/browse/HORO-1564)
-- **Parent**: [#1521](https://github.com/abdullahbodur/horo-engine/issues/1521) ([WST-004])
+- **Parent**: [WST-004](https://github.com/abdullahbodur/horo-engine/issues/1521)
 - **Normative document**: [World Streaming Architecture](../architecture/runtime/world-streaming-architecture.md)
 
 ## Context

--- a/docs/adr/024-perception-ownership-sense-policy-and-budget.md
+++ b/docs/adr/024-perception-ownership-sense-policy-and-budget.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: AI perception subsystem, sensory stimulus emission, line-of-sight query seams, update policies, time-sliced budgets, and bounded memory decay
-- **Issue**: [#1321](https://github.com/abdullahbodur/horo-engine/issues/1321) ([GAI-002.1])
+- **Issue**: [GAI-002.1](https://github.com/abdullahbodur/horo-engine/issues/1321)
 - **Jira**: [HORO-1321](https://horo-engine.atlassian.net/browse/HORO-1321)
 - **Companion decision**: [GAI-003.1 AI Decision Assets and Shared Gameplay Behavior Boundary](https://github.com/abdullahbodur/horo-engine/issues/1333) (ADR-025)
 - **Normative documents**: [Navigation And AI Architecture](../architecture/runtime/navigation-and-ai-architecture.md), [AI Fixed-Tick Order, Authority and Simulation Budget](022-ai-fixed-tick-order-authority-and-simulation-budget.md), [Save Game And Persistence](../architecture/runtime/save-game-and-persistence.md)

--- a/docs/adr/025-ai-decision-assets-and-gameplay-behavior-boundary.md
+++ b/docs/adr/025-ai-decision-assets-and-gameplay-behavior-boundary.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: AI decision graph assets (`BehaviorTreeAsset`, `StateMachineAsset`, `UtilityAiAsset`), runtime execution plan compilation, node hierarchy, UI separation, 1.0 paradigms vs post-1.0 extensions, task execution and lifecycle alignment
-- **Issue**: [#1333](https://github.com/abdullahbodur/horo-engine/issues/1333) ([GAI-003.1])
+- **Issue**: [GAI-003.1](https://github.com/abdullahbodur/horo-engine/issues/1333)
 - **Jira**: [HORO-1333](https://horo-engine.atlassian.net/browse/HORO-1333)
 - **Normative documents**: [Navigation And AI Architecture](../architecture/runtime/navigation-and-ai-architecture.md), [Gameplay Behavior Authoring](../architecture/extensions/gameplay-behavior-authoring.md), [Save Game And Persistence](../architecture/runtime/save-game-and-persistence.md)
 

--- a/docs/adr/026-large-world-precision-and-floating-origin-strategy.md
+++ b/docs/adr/026-large-world-precision-and-floating-origin-strategy.md
@@ -4,9 +4,9 @@
 - **Date**: 2026-08-28
 - **Supersedes**: None
 - **Scope**: Coordinate systems, precision representations (64-bit integer, double-precision floats, camera-relative floats), floating origin rebasing transactions, platform/GPU shader performance boundaries, physics/subsystem authority, and error domains.
-- **Issue**: [#1604](https://github.com/abdullahbodur/horo-engine/issues/1604) ([WST-007.1])
+- **Issue**: [WST-007.1](https://github.com/abdullahbodur/horo-engine/issues/1604)
 - **Jira**: [HORO-1604](https://horo-engine.atlassian.net/browse/HORO-1604)
-- **Parent**: [#1524](https://github.com/abdullahbodur/horo-engine/issues/1524) ([WST-007])
+- **Parent**: [WST-007](https://github.com/abdullahbodur/horo-engine/issues/1524)
 - **Normative documents**:
   - [Coordinate Precision And Origin Rebasing](../architecture/runtime/coordinate-precision-and-origin-rebasing.md)
   - [World Streaming Architecture](../architecture/runtime/world-streaming-architecture.md)

--- a/docs/adr/027-renderer-resource-identity-and-descriptors.md
+++ b/docs/adr/027-renderer-resource-identity-and-descriptors.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-31
 - **Supersedes**: None
 - **Scope**: Backend-neutral resident renderer resources
-- **Issue**: [#290](https://github.com/abdullahbodur/horo-engine/issues/290) ([RND-001.1])
+- **Issue**: [RND-001.1](https://github.com/abdullahbodur/horo-engine/issues/290)
 - **Normative document**: [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
 
 ## Context

--- a/docs/adr/028-renderer-capability-limits-and-product-profiles.md
+++ b/docs/adr/028-renderer-capability-limits-and-product-profiles.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-31
 - **Supersedes**: None
 - **Scope**: M0 renderer capability and product-policy contract; no backend implementation
-- **Issue**: [#296](https://github.com/abdullahbodur/horo-engine/issues/296) ([RND-003.1])
+- **Issue**: [RND-003.1](https://github.com/abdullahbodur/horo-engine/issues/296)
 - **Jira**: [HORO-296](https://horo-engine.atlassian.net/browse/HORO-296)
 - **Normative document**: [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
 

--- a/docs/adr/029-opengl-core-profile-and-platform-policy.md
+++ b/docs/adr/029-opengl-core-profile-and-platform-policy.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-31
 - **Supersedes**: None
 - **Scope**: OpenGL native admission, platform qualification and context negotiation
-- **Issue**: [#306](https://github.com/abdullahbodur/horo-engine/issues/306) ([RND-004.1])
+- **Issue**: [RND-004.1](https://github.com/abdullahbodur/horo-engine/issues/306)
 - **Jira**: [HORO-306](https://horo-engine.atlassian.net/browse/HORO-306)
 - **Normative document**: [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
 

--- a/docs/adr/030-metal-platform-and-feature-baseline.md
+++ b/docs/adr/030-metal-platform-and-feature-baseline.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-31
 - **Supersedes**: None
 - **Scope**: Metal native admission, GPU family, MSL and macOS deployment
-- **Issue**: [#314](https://github.com/abdullahbodur/horo-engine/issues/314) ([RND-005.1])
+- **Issue**: [RND-005.1](https://github.com/abdullahbodur/horo-engine/issues/314)
 - **Jira**: [HORO-314](https://horo-engine.atlassian.net/browse/HORO-314)
 - **Normative document**: [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
 

--- a/docs/adr/031-vulkan-loader-platform-and-version-baseline.md
+++ b/docs/adr/031-vulkan-loader-platform-and-version-baseline.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-31
 - **Supersedes**: None
 - **Scope**: Vulkan loader, 1.3 admission, WSI and Windows/Linux baseline
-- **Issue**: [#322](https://github.com/abdullahbodur/horo-engine/issues/322) ([RND-006.1])
+- **Issue**: [RND-006.1](https://github.com/abdullahbodur/horo-engine/issues/322)
 - **Jira**: [HORO-322](https://horo-engine.atlassian.net/browse/HORO-322)
 - **Normative document**: [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
 

--- a/docs/adr/032-d3d12-baseline-and-agility-sdk-policy.md
+++ b/docs/adr/032-d3d12-baseline-and-agility-sdk-policy.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-31
 - **Supersedes**: None
 - **Scope**: D3D12 native admission, Agility activation and Windows baseline
-- **Issue**: [#330](https://github.com/abdullahbodur/horo-engine/issues/330) ([RND-007.1])
+- **Issue**: [RND-007.1](https://github.com/abdullahbodur/horo-engine/issues/330)
 - **Jira**: [HORO-330](https://horo-engine.atlassian.net/browse/HORO-330)
 - **Normative document**: [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
 

--- a/docs/adr/033-presentation-and-display-ownership.md
+++ b/docs/adr/033-presentation-and-display-ownership.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-31
 - **Supersedes**: None
 - **Scope**: Display facts, surface generations, output negotiation and present ownership
-- **Issue**: [#338](https://github.com/abdullahbodur/horo-engine/issues/338) ([RND-008.1])
+- **Issue**: [RND-008.1](https://github.com/abdullahbodur/horo-engine/issues/338)
 - **Jira**: [HORO-338](https://horo-engine.atlassian.net/browse/HORO-338)
 - **Normative document**: [Runtime Lifecycle](../architecture/runtime/runtime-lifecycle.md)
 

--- a/docs/adr/034-gpu-memory-and-residency-ownership.md
+++ b/docs/adr/034-gpu-memory-and-residency-ownership.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-31
 - **Supersedes**: None
 - **Scope**: GPU backing accounting, reservation transactions and pressure policy
-- **Issue**: [#358](https://github.com/abdullahbodur/horo-engine/issues/358) ([RND-010.1])
+- **Issue**: [RND-010.1](https://github.com/abdullahbodur/horo-engine/issues/358)
 - **Jira**: [HORO-358](https://horo-engine.atlassian.net/browse/HORO-358)
 - **Normative document**: [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
 

--- a/docs/adr/035-shader-source-and-intermediate-representation.md
+++ b/docs/adr/035-shader-source-and-intermediate-representation.md
@@ -4,7 +4,7 @@
 - **Date**: 2026-08-31
 - **Supersedes**: None
 - **Scope**: Shader source language, compiler routes and reflection authority
-- **Issue**: [#368](https://github.com/abdullahbodur/horo-engine/issues/368) ([RND-011.1])
+- **Issue**: [RND-011.1](https://github.com/abdullahbodur/horo-engine/issues/368)
 - **Jira**: [HORO-368](https://horo-engine.atlassian.net/browse/HORO-368)
 - **Normative document**: [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,6 +55,9 @@ to the replacement.
   Supersedes, Superseded by, Scope, Issue, Jira, Parent, Related,
   Companion decision, Normative document(s). Use `Jira` (not `JIRA`). Link the
   Jira key to the work item. Optional fields are omitted rather than left empty.
+- **Issue / Parent**: use the domain alias as the GitHub issue link text
+  (`[RND-011.1](https://github.com/abdullahbodur/horo-engine/issues/368)`).
+  Do not show `#368` as the visible text or in a second parenthesis.
 - **Naming**: `NNN-lowercase-title-with-hyphens.md`
 - **IDs are stable**: a number is assigned once and is never reused for a
   different decision. ADR-008 is the error-model decision


### PR DESCRIPTION
## Summary
- Replace ADR `Issue` (and matching `Parent`) links so the domain alias is the visible GitHub text instead of `#368` plus a second parenthesis.
- Example: `[RND-011.1](https://github.com/abdullahbodur/horo-engine/issues/368)` instead of `[#368](...) ([RND-011.1])`.
- Record the convention in `docs/adr/README.md`.

## Motivation
The `#368 ([RND-011.1])` split is noisy. The GitHub URL still targets the issue; the alias is the label readers need.

## Implementation Notes
- Applied to every ADR `Issue` field that used `[#N](url) ([ALIAS])`.
- Applied the same alias-as-text shape to `Parent` fields (ADR-023, ADR-026).
- `Jira` stays `[HORO-n](browse URL)`.
- Docs-only; no code or test changes.

## Validation
- [x] Inventory of `[#N](...) ([ALIAS])` in `docs/adr` is empty after the rewrite
- [ ] Docs-only: Test jobs are not required

Commands run:
```bash
python3 rewrite of Issue/Parent alias text
git grep leftover `[#N](...) ([ALIAS])` in docs/adr → none
```

## Risks
- None beyond ADR header display. GitHub issue URLs are unchanged.

## Issue Links

- Jira: HORO-306
- GitHub: #306

This is a convention follow-up to the merged ADR metadata work. It does not close HORO-306 / #306.

## Reviewer Notes
- Start with ADR-035 and `docs/adr/README.md`, then spot-check an older ADR and a `Parent` field.