### PR TITLE
docs(render): define render inspector UI HORO-441 #441 [RND-017.9]

### DIFF
--- a/docs/adr/049-render-graph-and-resource-inspector-ui.md
+++ b/docs/adr/049-render-graph-and-resource-inspector-ui.md
@@ -1,0 +1,320 @@
+# ADR-049: Render Graph and Resource Inspector UI
+
+- **Status**: Proposed
+- **Date**: 2026-09-01
+- **Supersedes**: None
+- **Scope**: Editor renderer-inspection snapshots, projection model and dockable UI ownership
+- **Issue**: [RND-017.9](https://github.com/abdullahbodur/horo-engine/issues/441)
+- **Jira**: [HORO-441](https://horo-engine.atlassian.net/browse/HORO-441)
+- **Companion decisions**: [ADR-027](027-renderer-resource-identity-and-descriptors.md), [ADR-041](041-backend-neutral-renderer-diagnostics-model.md), [ADR-042](042-cpu-gpu-timestamps-and-pipeline-statistics.md), [ADR-043](043-gpu-memory-and-resource-inspection.md), [ADR-044](044-render-markers-and-debug-labels.md)
+- **Normative documents**: [Rendering Architecture](../architecture/runtime/rendering-architecture.md), [Editor Panel And Tab Architecture](../architecture/editor/editor-panel-host.md), [Editor UI Design System](../architecture/editor/ui-design-system.md), [Metrics And Profiling](../architecture/observability/observability-performance.md)
+
+## Context
+
+Passes, resources, lifetime intervals, barriers, queues, GPU timing and memory are
+owned by different renderer models and may become available at different times.
+A UI that walks live frontend/backend state during `Draw()` would race mutation,
+leak native identities, change collection cadence and keep GPU resources alive.
+Simply combining the latest graph, timing and memory values could also present a
+convincing but false view assembled from unrelated frames or generations.
+
+The inspector is a persistent engineering workspace, not a renderer authority or
+a modal workflow. It needs a bounded immutable projection, explicit capture,
+typed absence/partial coverage and presentation that remains useful on Null and
+across backend capability differences.
+
+## Decision
+
+### 1. A dockable tab consumes an application query service
+
+HoroEditor registers one `RenderInspectorTab` with `EditorPanelHost`. It is closed
+by default and may be placed in any tab stack; opening it never changes renderer
+instrumentation. `PerformanceTab` remains the metrics/profiler surface. The
+inspector may link to matching performance/capture sessions but does not absorb
+their service ownership.
+
+The application composition creates `RendererInspectionService` over narrow
+frontend graph-inspection, ADR-043 memory-inspection, ADR-042 measurement and
+ADR-041 diagnostic query capabilities. The tab receives only this service and
+immutable operation snapshots. It does not depend on `RenderFrontend`, concrete
+backends, native APIs, resource registries, memory ledgers or observability stores.
+
+```text
+Editor tab -> RendererInspectionService -> immutable inspection bundle/pages
+                         |
+                         +-> frontend graph projection
+                         +-> ADR-043 memory/resource snapshot
+                         +-> ADR-042 matching result batches
+                         +-> ADR-041 bounded correlated diagnostics
+```
+
+The service and source descriptors are inert until composed. Tab construction,
+layout restore or visibility changes cannot capture a graph, enable timestamps,
+walk resources or register backend callbacks.
+
+### 2. Inspection is an explicit typed operation
+
+```cpp
+struct RendererInspectionRequest {
+    RendererInspectionTarget target;
+    RendererInspectionDetail detail;
+    RendererInspectionFilters filters;
+    RendererInspectionLimits limits;
+    RendererInspectionCorrelationPolicy correlation;
+    Duration retention;
+};
+```
+
+Targets are `NextRealRenderFrame`, an admitted future `RealRenderFrameId`, a
+retained exact `GraphExecutionId`, or a completed ADR-048 incident graph manifest.
+The request carries exact renderer/device generations and optional surface/view.
+It never infers current target from editor focus, selected scene object or backend
+enumeration. Synthetic presentation without a real graph is explicitly
+unsupported.
+
+Detail independently requests graph topology, resource uses/lifetimes, barrier/
+queue transitions, ADR-043 allocation/resource records, ADR-042 CPU/GPU timing and
+pipeline statistics, marker labels and correlated diagnostics. Unsupported detail
+returns typed availability or `Partial` only when the caller allowed it. Opening a
+collapsed UI section does not issue a new native query; recapture is explicit.
+
+Operation states are `Queued`, `Arming`, `CapturingGraph`,
+`AwaitingMeasurements`, `Materializing`, `Ready`, `Partial`, `Cancelled`,
+`StaleGeneration`, `DeviceLost` and `Failed`. The tab observes these states and can
+cancel or request another capture. Rendering success/failure never depends on the
+inspection result.
+
+### 3. The base graph snapshot is immutable and self-consistent
+
+The frontend captures one post-compilation, post-culling/merge/queue-assignment
+graph execution projection before native submission. Capturing the projection does
+not mutate graph semantics:
+
+```cpp
+struct RendererGraphInspectionSnapshot {
+    RendererGraphInspectionSnapshotId id;
+    RendererGeneration renderer;
+    DeviceGeneration device;
+    RealRenderFrameId frame;
+    GraphExecutionId graph;
+    RenderPlanGeneration plan;
+    EffectiveCapabilitiesRevision capabilities;
+    RendererGraphInspectionCoverage coverage;
+    RendererGraphInspectionPageManifest pages;
+};
+```
+
+Records use stable Horo identities and contain:
+
+- passes: pass ID/kind, registered display identity, queue, compile/execution
+  order, cull/merge provenance and marker scope;
+- resources: exact ADR-027 typed identity/class/generation, transient/imported/
+  persistent class, descriptor summary/fingerprint and optional redacted label;
+- uses: pass/resource, read/write/access/stage/usage semantics and subresource range;
+- dependencies: producer/consumer pass and typed reason;
+- lifetimes: first/last admitted use, queue intervals and alias-group proof;
+- synchronization: logical transition/hazard reason, source/destination queue,
+  stage/access semantics and ownership transfer; and
+- submissions/presentation: queue batch, dependency and exact surface/frame link.
+
+Native barrier enums, pointers, handles, command-list indices and GPU addresses do
+not cross the adapter. A backend may add a bounded normalized realization record
+only when mapped to the Horo logical transition. The UI never infers a barrier
+solely because two passes are adjacent.
+
+Snapshot capture uses pre-reserved fixed graph metadata already produced by
+compilation plus optional finite inspection projection. It performs no native
+enumeration, resource-content mapping, device idle or full registry walk. Values
+are copied/owned until snapshot expiry and cannot retain graph/resource lifetimes.
+
+### 4. Memory and timing join only by proven identity
+
+The service coordinates graph and ADR-043 requests at one render safe point. A
+memory/resource snapshot joins only when renderer/device generations match and its
+resource records prove the graph identities/revision requested. If exact revision
+alignment cannot be obtained, memory detail is `Unavailable` or separately labeled
+`NearestAggregate` with source revision/time; it is never shown as exact per-graph
+allocation truth.
+
+ADR-042 measurement batches may arrive after the base graph snapshot. The bundle
+retains an immutable base and publishes a new overlay revision only for results
+whose renderer/device, real frame, graph, queue, scope and clock generations match.
+Pending, unsupported, disjoint, partial and stale timings remain explicit. The UI
+does not display zero or reuse a same-named pass from another frame. Pipeline
+statistics preserve their canonical semantic/availability and are never compared
+across unsupported scopes as if equivalent.
+
+ADR-041 diagnostics join by exact generation/frame/graph/pass/resource context.
+Uncorrelated device-wide messages appear in a separate device section and are not
+attached to a selected pass heuristically. ADR-044 registered labels are
+presentation metadata only, never join identity.
+
+```cpp
+struct RendererInspectionBundle {
+    RendererInspectionBundleId id;
+    RendererGraphInspectionSnapshot graph;
+    std::optional<RendererMemoryInspectionSnapshotId> memory;
+    RendererInspectionOverlayRevision overlays;
+    RendererInspectionCoverage coverage;
+};
+```
+
+Every overlay update preserves source identity/provenance and notifies one
+coalesced bundle revision. Existing returned page values remain immutable; clients
+request pages for the new overlay revision explicitly.
+
+### 5. Pages, filters and budgets are finite
+
+Graph projection defaults to 1,024 passes, 8,192 resources, 32,768 uses/edges,
+16,384 synchronization records and 16 MiB encoded data. Hard limits are 8,192
+passes, 65,536 resources, 262,144 uses/edges, 131,072 synchronization records and
+128 MiB. ADR-043 resource/allocation limits remain independently authoritative;
+the composite request cannot widen them. Checked arithmetic validates all counts,
+subresource ranges and bytes before admission.
+
+One page defaults to 256 rows or 256 KiB and has hard maxima of 1,024 rows and
+1 MiB. Pages are move-only owned immutable values with identity/position cursors,
+the same lifetime rule as ADR-043. A tab may hold eight pages by default and at
+most 32; further reads return backpressure. Expiry rejects new reads but does not
+invalidate already returned owned pages.
+
+Filters use finite typed sets, exact IDs, bounded registered-name search and
+numeric ranges. Free-text search is applied on a worker to already materialized
+bounded safe display strings; regex/native message/path search is not evaluated on
+the renderer owner thread. Sorting and graph layout run on cancellable workers over
+owned pages and have finite output/time budgets.
+
+By default one bundle may arm and two completed bundles may be retained per
+renderer; hard maxima are two arming and eight retained. Retention defaults to
+60 seconds and cannot exceed 10 minutes unless pinned by an explicit developer
+session within the same byte/count budgets. A pinned bundle never pins GPU state.
+
+If limits truncate data, coverage records total-known/returned counts, omitted
+stable-ID intervals and whether graph topology is still closed. A topology view is
+`Complete` only when every included edge endpoint is present. Partial data never
+draws an edge to a fabricated “unknown pass”; it uses an explicit omitted boundary.
+
+### 6. The view model is a read-only projection
+
+`RenderInspectorViewModel` owns only presentation state: selected bundle/pass/
+resource, expanded groups, typed filters, search draft, table sort, graph pan/zoom,
+column widths and chosen timeline scale. Selection uses bundle-scoped stable IDs.
+It cannot destroy/relabel resources, change barriers/queues/pass order, force
+residency, recook shaders, alter graph culling or enable capabilities.
+
+Primary views are:
+
+- **Graph**: passes/submissions as accessible nodes with typed dependency/use edges;
+- **Passes**: virtualized table and detail for queue, inputs/outputs, transitions,
+  markers, measurements and diagnostics;
+- **Resources**: virtualized table and detail for descriptor, lifecycle, graph
+  uses, allocation references and lifetime/alias intervals;
+- **Timeline**: per-queue CPU/GPU spans with explicit unavailable/pending/disjoint;
+- **Memory**: ADR-043 aggregate/pool/allocation relationships without resumming
+  overlapping values; and
+- **Capture**: operation status, coverage, source revisions and recapture/export
+  actions.
+
+Clicking a graph node and selecting the same pass row are one view-model command.
+Links to `PerformanceTab`, Console or an ADR-047/048 artifact route through typed
+application/editor commands carrying exact session/bundle/context IDs. The tab
+does not parse URLs, log text or filenames to correlate.
+
+### 7. UI behavior follows editor design and accessibility contracts
+
+The tab uses shared editor tables, tree rows, splitters, search fields, badges,
+empty/error states, design tokens and localization. It does not draw raw ImGui
+controls where a shared control exists. No meaning relies on color alone: queue,
+access, availability and hazard states include text/icon/pattern semantics.
+
+The graph supports keyboard node traversal in stable execution/ID order, focus
+indication, zoom controls, “fit selection/all”, list-view equivalence and screen-
+reader labels. Tooltips supplement rather than replace table/detail values.
+Minimum typography and hit targets remain valid at narrow widths and translated
+text. Large graphs default to clustered/virtualized rendering and never shrink
+text below design-system roles merely to fit.
+
+Loading, no-renderer, Null, unsupported-detail, awaiting-timing, partial,
+cancelled, stale-generation, device-loss and expired states are distinct localized
+surfaces with actionable recapture/open-provider guidance. An unavailable value is
+not rendered as `0`, blank success or disabled checkbox implying user control.
+
+The visible tab may request page/layout work at a throttled bounded cadence after
+a committed revision. A hidden/collapsed tab performs no polling, page prefetch,
+layout, search formatting or measurement capture. Coalesced revision notifications
+only mark the view model dirty; `Draw()` never changes source collection cadence.
+
+### 8. Threading, cancellation and shutdown are explicit
+
+Graph/source revision capture and final admission occur on the render-capable
+owner thread at safe points. Projection preparation, joins, sorting, search,
+layout and export run on cancellable workers over owned immutable values. GUI
+state changes occur on the GUI thread. No worker captures a tab, backend, registry,
+ledger or page reference beyond its ownership token.
+
+Closing the tab cancels its unpublished UI requests and releases page values but
+does not cancel another client's operation or GPU work. Cancelling a bundle before
+capture removes reservations; after source capture it suppresses remaining
+materialization/overlays and releases service storage. Already published pages
+remain valid under bounded ownership.
+
+Device/backend replacement stops old-generation admission and marks retained
+bundles historical/stale. They remain inspectable only with a visible source-
+generation badge and cannot issue current renderer actions. Shutdown rejects new
+requests, cancels workers, expires cursors, releases service storage and then
+destroys the tab/view model. It is idempotent after partial initialization and
+never waits for UI, GPU idle or external capture tools.
+
+### 9. Export and parity preserve the same model
+
+An explicit export writes the already captured Horo bundle manifest/pages to the
+Platform diagnostics state root or user-selected validated path with atomic
+publication, schemas, source revisions, coverage, byte sizes and checksums. It
+does not export resource/shader contents, native handles, graphics-capture payloads
+or unrestricted labels/paths. Export cannot trigger recapture silently.
+
+OpenGL, Metal, Vulkan and D3D12 provide the same logical graph/resource/use/
+lifetime/synchronization schema. Normalized realization and measurements may be
+unavailable. Null generates deterministic synthetic graph, barrier, timing and
+memory fixtures and validates all UI/service states, but cannot qualify native
+barrier realization, timing accuracy or memory observations.
+
+## Migration And Verification
+
+Existing Performance views keep metrics/profiler ownership. Ad hoc backend debug
+windows migrate to `RenderInspectorTab` and immutable service bundles. No backend
+debug UI or editor-side registry walk remains. The initial graph authoring model
+must add typed resource uses/dependencies before claiming complete barrier/lifetime
+inspection; until then unsupported detail is explicit.
+
+Tests must cover exact frame/graph/surface/generation targeting; complete/partial/
+omitted topology; pass/resource/use/lifetime/barrier/queue fixtures; delayed,
+disjoint and stale measurement joins; exact/nearest/unavailable memory joins;
+diagnostic/marker correlation without text heuristics; all count/byte/page/lease/
+retention limits; cancellation, hidden-tab zero work, device loss, historical
+bundles and shutdown; virtualized tables/large graphs; keyboard/focus/list-view/
+non-color accessibility; narrow/localized layouts and all empty/error states;
+atomic safe export; deterministic Null fixtures; and native backend qualification.
+
+## Consequences
+
+Engineers can inspect one evidence-backed graph execution across passes, resources,
+barriers, queues, timings and memory without the editor touching live renderer
+state. Delayed and partial sources remain honest, UI work is bounded/virtualized,
+and the tool cannot mutate rendering. The cost is a graph inspection projection,
+composite snapshot coordination, paging/layout infrastructure and substantial UI/
+backend fixture coverage.
+
+## Rejected Alternatives
+
+| Option | Decision and reason |
+|---|---|
+| Walk live frontend/backend state from `Draw()` | Rejected: races lifetime, leaks native details and couples UI cadence to rendering. |
+| Put all inspector detail in `PerformanceTab` metrics | Rejected: topology/resource identity is high-cardinality snapshot data, not metrics. |
+| Join the latest graph, memory and timing values by name | Rejected: produces false cross-frame/generation correlation. |
+| Let the inspector mutate barriers/resources/residency | Rejected: a diagnostic projection is not renderer policy or authoring authority. |
+| Copy an entire large graph every UI frame | Rejected: unbounded frame/GUI work; explicit paged snapshots own detail. |
+| Show unavailable values as zero | Rejected: confuses unsupported/pending/disjoint with measured zero. |
+| Use native handles/enums in UI rows | Rejected: breaks backend parity, privacy and generation safety. |
+| Keep hidden tabs polling for freshness | Rejected: presentation visibility cannot create instrumentation/formatting cost. |
+| Treat Null rendering as native qualification | Rejected: fixtures prove contracts/UI, not driver realization or measurement accuracy. |

--- a/docs/adr/049-render-graph-and-resource-inspector-ui.md
+++ b/docs/adr/049-render-graph-and-resource-inspector-ui.md
@@ -69,8 +69,9 @@ Targets are `NextRealRenderFrame`, an admitted future `RealRenderFrameId`, a
 retained exact `GraphExecutionId`, or a completed ADR-048 incident graph manifest.
 The request carries exact renderer/device generations and optional surface/view.
 It never infers current target from editor focus, selected scene object or backend
-enumeration. Synthetic presentation without a real graph is explicitly
-unsupported.
+enumeration. UI-fabricated presentation in the absence of a renderer-provided
+projection is explicitly unsupported; deterministic Null renderer projections
+remain valid contract fixtures.
 
 Detail independently requests graph topology, resource uses/lifetimes, barrier/
 queue transitions, ADR-043 allocation/resource records, ADR-042 CPU/GPU timing and
@@ -176,13 +177,23 @@ One page defaults to 256 rows or 256 KiB and has hard maxima of 1,024 rows and
 1 MiB. Pages are move-only owned immutable values with identity/position cursors,
 the same lifetime rule as ADR-043. A tab may hold eight pages by default and at
 most 32; further reads return backpressure. Expiry rejects new reads but does not
-invalidate already returned owned pages.
+invalidate already returned owned pages. This client cache limit does not limit
+the records considered by a service query.
 
 Filters use finite typed sets, exact IDs, bounded registered-name search and
-numeric ranges. Free-text search is applied on a worker to already materialized
-bounded safe display strings; regex/native message/path search is not evaluated on
-the renderer owner thread. Sorting and graph layout run on cancellable workers over
-owned pages and have finite output/time budgets.
+numeric ranges. The snapshot-owning service applies filter/search/sort queries on
+cancellable workers across the full bounded immutable dataset, then exposes the
+matching ordered result through pages. Free-text search examines only already
+materialized bounded safe display strings; regex/native message/path search is not
+evaluated on the renderer owner thread. A query builds at most one checked bounded
+record-index permutation charged to the bundle byte budget and returns typed
+timeout/cancellation/backpressure instead of silently searching only cached pages.
+The UI page cache holds result windows, not query truth.
+
+Graph layout likewise consumes the full included closed topology from service-
+owned immutable storage and emits a finite clustered/virtualized projection. It
+does not infer omitted edges or require all source records to reside in the tab's
+page cache. Search, sorting and layout have explicit finite output/time budgets.
 
 By default one bundle may arm and two completed bundles may be retained per
 renderer; hard maxima are two arming and eight retained. Retention defaults to

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,6 +60,7 @@ to the replacement.
 | [046](046-gpu-driver-compatibility-and-workaround-registry.md) | GPU Driver Compatibility and Workaround Registry | Proposed | 2026-09-01 |
 | [047](047-renderdoc-pix-and-metal-capture-integration.md) | RenderDoc, PIX and Metal Capture Integration | Proposed | 2026-09-01 |
 | [048](048-gpu-crash-and-device-loss-diagnostic-bundles.md) | GPU Crash and Device-Loss Diagnostic Bundles | Proposed | 2026-09-01 |
+| [049](049-render-graph-and-resource-inspector-ui.md) | Render Graph and Resource Inspector UI | Proposed | 2026-09-01 |
 
 ## Conventions
 

--- a/docs/architecture/editor/editor-panel-host.md
+++ b/docs/architecture/editor/editor-panel-host.md
@@ -67,6 +67,7 @@ EditorLayer
     |                       +-- ConsoleTab
     |                       +-- McpTab
     |                       +-- PerformanceTab
+    |                       +-- RenderInspectorTab (registered, closed by default)
     |
     +-- EditorModalHost          exclusive modal workflows above the workspace
 ```
@@ -117,6 +118,14 @@ The bottom Console tab is a presentation consumer of the foundation
 `IStructuredLogQuery` capability. It does not parse terminal text or own a second
 logger. Terminal, persistent JSONL, and Console delivery fan out from the same
 accepted structured record.
+
+The optional dockable `RenderInspectorTab` follows
+[ADR-049](../../adr/049-render-graph-and-resource-inspector-ui.md). It consumes an
+application-owned immutable renderer-inspection query service and owns only
+selection, filters, graph pan/zoom and other presentation state. It does not reach
+into the render frontend/backend, resource registry, memory ledger or metrics
+stores. It is closed by default; restoring/opening/closing it cannot arm
+instrumentation, and a hidden tab performs no capture, paging, layout or polling.
 
 `EditorModalHost` is a separate overlay owner. Settings, Build & Release, import,
 and confirmation workflows are not tabs or layout nodes. While a modal is open,

--- a/docs/architecture/observability/observability-performance.md
+++ b/docs/architecture/observability/observability-performance.md
@@ -439,6 +439,7 @@ governs concurrency, data retention, and event propagation as follows:
 ### Concurrency And Write Semantics
 
 To prevent lock contention on hot engine threads (e.g., render, update):
+
 - **Thread-Local Accumulators**: Hot-path metrics (such as draw calls, frames, and allocation counters) write directly to thread-local or sharded atomic slots.
 - **Periodic Aggregation**: The central `MetricsStore` aggregates these sharded buffers at a fixed rate (e.g., once per frame for frame metrics, or every 500ms for system/process counters) using a readers-writer lock (`std::shared_mutex`).
 - **Query Path**: Reads and presentation queries acquire a shared lock (`shared_lock`), while the aggregator thread acquires a unique write lock (`unique_lock`) only during flush phases.
@@ -764,6 +765,7 @@ Python timers use `time.perf_counter_ns()` to guarantee high-resolution monotoni
 ### Registry Thread Safety
 
 To support concurrent scripts and parallel task executions (e.g. `multiprocessing` or `threading` wrappers in release jobs):
+
 - **Locking**: The Python metrics registry in `horo_metrics.py` implements a global `threading.Lock` protecting the creation and updating of instrument handles.
 - **Process Sampler Platform Behavior**: Process CPU and resident memory usage collection uses `psutil` if available. On Linux systems where `psutil` is absent, it parses `/proc/self/stat` directly. On macOS systems without `psutil`, CPU and memory stats default to `Unavailable`. The script will gracefully mark them unavailable without raising import or runtime errors.
 

--- a/docs/architecture/observability/observability-performance.md
+++ b/docs/architecture/observability/observability-performance.md
@@ -713,6 +713,14 @@ Profiler capture control is a typed observability operation. Starting or
 stopping a capture is not encoded as a data-bus command. Capture state is owned
 by `ProfilerCaptureService`; notifications publish state changes after commit.
 
+[ADR-049](../../adr/049-render-graph-and-resource-inspector-ui.md) keeps the
+high-cardinality render graph/resource inspector separate from this metrics view.
+`PerformanceTab` may open an exact matching inspection bundle through a typed
+application command, but it does not own graph capture, page storage or inspector
+layout. Conversely, `RenderInspectorTab` may link to an exact profiler/capture
+session but never treats metrics as graph/resource identity or changes metric
+sampling from its draw cadence.
+
 Editor Settings may configure safe defaults for metric history, graph windows,
 and available capture channels. Settings cannot enable a channel compiled out of
 the active product profile.

--- a/docs/architecture/runtime/render-backend-parity-contract.md
+++ b/docs/architecture/runtime/render-backend-parity-contract.md
@@ -371,6 +371,18 @@ perform no backend traversal/query. Null proves shared rings, partial coverage,
 interrupted staging and stale-generation behavior but cannot qualify native fault
 APIs, dumps, driver accuracy or signal safety.
 
+[ADR-049 inspector parity](../../adr/049-render-graph-and-resource-inspector-ui.md)
+requires the same logical pass/resource/use/dependency/lifetime/synchronization
+schema, stable Horo identities, immutable pages and typed coverage. Backends may
+provide optional normalized realization facts but never expose native handles,
+addresses or enums to the application/editor.
+
+Memory, timing, statistics, diagnostics and markers join only through exact source
+generation/frame/graph/queue/scope identities. Unavailable or delayed facts remain
+explicit; a backend cannot fabricate parity with names, zeros or latest values.
+Null validates logical fixtures and all service/UI states but cannot qualify native
+barriers, memory observations or measurement accuracy.
+
 In particular:
 
 - OpenGL global state is private to the OpenGL integration.

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -807,6 +807,27 @@ tasks cannot hold device/resources alive beyond one bounded native safe-point.
 Null validates freeze/generation/budget/publication semantics synthetically but
 cannot qualify native fault evidence or crash-handler safety.
 
+### Render graph and resource inspector
+
+[ADR-049](../../adr/049-render-graph-and-resource-inspector-ui.md) defines an
+explicit immutable inspection bundle for one exact renderer/device/frame/graph
+generation. The frontend projects post-compilation pass/resource/use/dependency/
+lifetime/synchronization data into bounded owned pages. The editor never walks
+live frontend/backend state or exposes native handles/enums.
+
+ADR-043 memory/resource detail and ADR-042 delayed measurements join only through
+proven generation, frame, graph, queue and scope identities. Pending, disjoint,
+partial, nearest-aggregate and unavailable data remain explicit; same names or
+latest values never establish correlation. Diagnostics and markers likewise join
+by typed context, not text.
+
+The application query service owns capture, paging, overlays, retention,
+cancellation and safe export. `RenderInspectorTab` owns presentation state only
+and cannot mutate barriers, queues, resources, residency, labels or graph policy.
+Hidden tabs perform no polling/layout/formatting or instrumentation. Null supplies
+deterministic logical fixtures but cannot qualify native synchronization, timing
+or memory realization.
+
 ## Backend Implementation Boundary
 
 Each concrete backend owns its API dependencies, context/device objects,


### PR DESCRIPTION
## Summary

- Defines a dockable, read-only render graph and resource inspector over immutable backend-neutral snapshots.
- Correlates passes, resources, lifetimes, barriers, queues, timings, memory, diagnostics and markers only through proven identities.
- Bounds capture, paging, retention, worker layout, cancellation, export and hidden-tab behavior.

## Motivation

Walking live renderer state from the editor would race lifetimes, expose native identities and couple UI cadence to instrumentation. Combining unrelated latest values would also create convincing but false graph, timing and memory views.

## Implementation Notes

- This is stacked on #2379 and should be reviewed after that PR.
- `RenderInspectorTab` owns presentation state only; application services own capture and immutable projections.
- Native implementation and visual interaction qualification remain downstream realization work.

## Validation

- [x] Documentation formatting and whitespace passed
- [x] Repository layout configure passed
- [x] Local Markdown links resolved
- [ ] Native backend and editor interaction tests (documentation-only decision; deferred to implementation)

## Risks

Large graphs can create high-cardinality CPU and UI work. The decision enforces count, byte, page, retention and worker-time limits, plus explicit partial topology coverage and zero hidden-tab polling.

## Issue Links

- Jira: [HORO-441](https://horo-engine.atlassian.net/browse/HORO-441)
- GitHub: Closes #441

## Reviewer Notes

Review ADR-049 first, then the Rendering Architecture, Editor Panel Host, parity and Metrics/Profiling projections.


[HORO-441]: https://horo-engine.atlassian.net/browse/HORO-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ