### PR TITLE
test(render): define reference image gates HORO-442 #442 [RND-017.10]

### DIFF
--- a/docs/adr/050-cross-backend-reference-image-tests.md
+++ b/docs/adr/050-cross-backend-reference-image-tests.md
@@ -125,15 +125,16 @@ A versioned baseline key is:
 ```text
 case ID + scene revision + capture point + image-contract revision
 + backend ID + platform/architecture + effective profile/capability fingerprint
-+ baseline schema revision
++ baseline hardware scope + baseline schema revision
 ```
 
 Backend/platform baselines account for qualified implementation differences.
 Vendor/device/driver is recorded in provenance but does not create a new baseline
-automatically. A narrower hardware-class baseline requires a reviewed descriptor
-with evidence that one common backend/platform reference cannot satisfy the
-declared semantic tolerance. Unknown hardware still runs against the nearest
-applicable reviewed key only when matching is exact under that descriptor;
+automatically. `baseline hardware scope` is `BackendPlatformCommon` by default.
+A narrower stable adapter hardware-class ID is written into that key only through
+a reviewed descriptor with evidence that one common backend/platform reference
+cannot satisfy the declared semantic tolerance. Unknown hardware still runs
+against a baseline only when its scope match is exact under that descriptor;
 otherwise the result is `BaselineUnavailable`, never pass.
 
 Cross-backend parity is checked separately through descriptor-owned invariants:
@@ -227,12 +228,16 @@ atomic manifest-last commit. Interrupted output is reported and quarantined.
 
 ### 7. Work, storage and retries are finite
 
-Default case limits are 4096x4096, four channels, two captured frames, 256 MiB
-readback/intermediate memory, 512 MiB artifacts and 60 seconds after warm-up. Hard
-maxima are 8192x8192, four channels, eight frames, 1 GiB memory, 2 GiB artifacts
-and five minutes. The suite validates aggregate parallel-case memory, staging and
-GPU submission budgets before admission; individually valid cases cannot
-oversubscribe a lane.
+Default case limits are 2048x2048, four channels, one captured frame, 256 MiB
+peak readback/intermediate memory, 512 MiB artifacts and 60 seconds after warm-up.
+Hard maxima are 4096x4096, four channels, two frames, 1 GiB peak memory, 2 GiB
+artifacts and five minutes. Multi-frame cases capture, compare and release each
+frame's working buffers sequentially; all retained canonical outputs still count
+against the artifact limit. Before admission, checked format/dimension/frame math
+must prove that reference, actual, diff and required scratch buffers fit the peak
+memory bound and that worst-case retained outputs fit the artifact bound. The
+suite also validates aggregate parallel-case memory, staging and GPU submission
+budgets; individually valid cases cannot oversubscribe a lane.
 
 At most one capture per device is in flight by default and at most two at the hard
 limit. CPU comparison runs on cancellable bounded workers over owned buffers.

--- a/docs/adr/050-cross-backend-reference-image-tests.md
+++ b/docs/adr/050-cross-backend-reference-image-tests.md
@@ -1,0 +1,333 @@
+# ADR-050: Cross-Backend Reference Image Tests
+
+- **Status**: Proposed
+- **Date**: 2026-09-01
+- **Supersedes**: None
+- **Scope**: Renderer reference scenes, canonical image capture, comparison policy, artifacts and qualification lanes
+- **Issue**: [RND-017.10](https://github.com/abdullahbodur/horo-engine/issues/442)
+- **Jira**: [HORO-442](https://horo-engine.atlassian.net/browse/HORO-442)
+- **Companion decisions**: [ADR-028](028-renderer-capability-limits-and-product-profiles.md), [ADR-041](041-backend-neutral-renderer-diagnostics-model.md), [ADR-044](044-render-markers-and-debug-labels.md), [ADR-047](047-renderdoc-pix-and-metal-capture-integration.md)
+- **Normative documents**: [Rendering Architecture](../architecture/runtime/rendering-architecture.md), [Render Backend Parity Contract](../architecture/runtime/render-backend-parity-contract.md), [Testing Architecture](../architecture/delivery/testing-architecture.md), [Quality And CI](../architecture/delivery/quality-and-ci.md)
+
+## Context
+
+Unit and Null-backend tests prove renderer contracts but cannot prove that native
+backends produce the intended pixels. A single shared golden image is also not a
+sound oracle: platform rasterization, shader compiler routes, presentation
+transforms and effective capabilities may legitimately differ while preserving
+the same Horo semantics. Conversely, unrestricted per-machine baselines and broad
+tolerances would hide actual regressions.
+
+Reference-image validation needs reproducible scene inputs, an exact capture
+boundary, bounded objective comparisons, reviewable baseline provenance and
+artifacts that identify the backend/capability/operation which failed. Native GPU
+availability is not guaranteed on every pull-request runner, so unsupported and
+unqualified lanes must remain explicit rather than silently passing.
+
+## Decision
+
+### 1. One application-owned qualification service coordinates the suite
+
+The test host composes `RendererReferenceImageService` from narrow scene-fixture,
+renderer lifecycle, canonical readback, image codec, diagnostics and artifact
+publication capabilities. It does not expose native devices, command objects or
+image handles to generic test code.
+
+```text
+reference test runner -> RendererReferenceImageService -> typed case result
+                                  |
+                                  +-> deterministic scene fixture
+                                  +-> render frontend + selected backend
+                                  +-> canonical readback adapter
+                                  +-> bounded comparator/artifact writer
+```
+
+Descriptors are inert metadata. Discovering or validating a scene/case cannot
+install a backend, create a surface, register services, mutate global settings or
+write a baseline. Host/application composition selects one explicit backend and
+adapter before renderer activation. There is no fallback to another backend,
+device, software rasterizer, scene or baseline.
+
+### 2. Cases declare exact inputs and expected capability outcomes
+
+```cpp
+struct RendererReferenceImageCaseDescriptor {
+    RendererReferenceCaseId id;
+    ReferenceSceneRevision scene;
+    ReferenceCapturePoint capturePoint;
+    ReferenceImageContract image;
+    ReferenceComparisonPolicy comparison;
+    EffectiveCapabilityPredicate requirements;
+    ReferenceCaseLimits limits;
+};
+```
+
+Every case uses a stable registered ID and immutable cooked fixture. The fixture
+declares scene/assets/materials/shader variants, camera/projection, viewport and
+sample count; fixed simulation step/frame count; random seeds; exposure, color
+space and output transform; product/quality profile; required and optional
+capabilities; warm-up frames; capture frames; and expected resource/frame budgets.
+Assets and shader outputs are content-addressed in the result manifest.
+
+Adaptive resolution, temporal jitter sequences, animation time, particle seeds,
+streaming residency, automatic exposure and other history inputs are fixed by the
+case. A case that intentionally validates one adaptive feature declares its exact
+input trace and convergence window. It cannot inherit editor focus, wall clock,
+current project, display ICC profile or ambient driver settings.
+
+Capability resolution produces one of:
+
+- `RequiredAndSupported`: run the required path;
+- `OptionalPathSelected`: run the explicitly declared path and record selection;
+- `ExpectedUnsupported`: pass only when admission rejects with the declared typed
+  capability reason before rendering; or
+- `UnexpectedUnsupported`: fail with the missing/restricted capability and
+  provenance.
+
+An unsupported case never compares a blank image or reuses another profile's
+reference.
+
+### 3. Capture occurs at a named canonical render-graph boundary
+
+Reference images use a Horo `ReferenceCapturePoint`, not a native render-target
+handle or ADR-047 graphics capture. Initial points are:
+
+- `SceneLinearBeforeOutputTransform`: RGBA16F-equivalent finite linear scene
+  values after the declared scene/post-process path but before display encoding;
+- `FinalSdrAfterOutputTransform`: the final logical SDR image after the declared
+  Horo output transform, before platform compositor scaling/color management; and
+- a registered feature checkpoint only when its resource semantics, format and
+  lifetime are part of the test descriptor.
+
+The render graph admits one bounded transfer/readback for the exact real frame,
+graph execution, renderer/device/surface generation and capture point. The
+backend-private adapter maps native format, swizzle, row pitch, orientation,
+sample resolve and origin convention into the declared Horo contract. Generic
+code never guesses these from backend names.
+
+Normalization validates dimensions and checked byte sizes, resolves multisampling
+through the production-declared resolve semantics, converts channel order, removes
+row padding, flips only when the adapter declares a native origin difference and
+canonicalizes negative zero. HDR non-finite values fail before comparison with
+pixel/channel coordinates. SDR comparison uses exact 8-bit canonical sRGB bytes;
+HDR comparison uses finite IEEE binary32 linear RGBA values decoded from the
+captured contract. No lossy image codec is an oracle input.
+
+Readback cannot wait for global GPU idle. It uses the normal submission/fence
+lifecycle, a finite timeout and generation-safe resource ownership. Capture does
+not alter pass policy, shader variants, quality, validation or compatibility
+rules beyond the descriptor's explicit readback operation.
+
+### 4. Backend-specific baselines and cross-backend invariants are distinct
+
+A versioned baseline key is:
+
+```text
+case ID + scene revision + capture point + image-contract revision
++ backend ID + platform/architecture + effective profile/capability fingerprint
++ baseline schema revision
+```
+
+Backend/platform baselines account for qualified implementation differences.
+Vendor/device/driver is recorded in provenance but does not create a new baseline
+automatically. A narrower hardware-class baseline requires a reviewed descriptor
+with evidence that one common backend/platform reference cannot satisfy the
+declared semantic tolerance. Unknown hardware still runs against the nearest
+applicable reviewed key only when matching is exact under that descriptor;
+otherwise the result is `BaselineUnavailable`, never pass.
+
+Cross-backend parity is checked separately through descriptor-owned invariants:
+same admitted feature path, frame/capture identity, dimensions, alpha semantics,
+required visible regions and feature-specific measurements. A cross-backend
+aggregate report may compare canonical images diagnostically, but it does not
+replace each backend/platform golden gate or require bit identity where the
+renderer contract allows implementation variance.
+
+Baselines store canonical lossless oracle data, a human-viewable preview and a
+manifest containing all key fields, source commit, producing lane, environment,
+effective capabilities, shader/compiler identity and checksums. Baseline lookup
+verifies schema and hashes before use. Corrupt, duplicate, ambiguous or newer
+unknown schemas fail as typed baseline errors.
+
+### 5. Comparison thresholds are explicit, bounded and reviewed
+
+The default required SDR policy for non-masked RGB channels is:
+
+- dimensions and alpha bytes match exactly;
+- per-channel absolute difference is at most `2/255`;
+- RGB root-mean-square error is at most `0.5/255`; and
+- pixels with any RGB difference greater than `1/255` are at most `0.10%`.
+
+The default required linear-HDR policy is:
+
+- dimensions match and alpha absolute difference is at most `1e-6`;
+- each finite RGB channel satisfies absolute difference `<= 1e-3` or relative
+  difference `<= 1e-3`, with relative denominator
+  `max(abs(reference), 1e-3)`;
+- RGB root-mean-square error is at most `2.5e-4`; and
+- pixels exceeding both RGB absolute and relative limits are at most `0.10%`.
+
+All calculations use a specified deterministic binary64 accumulator and fixed
+row-major/channel order. Checked 64-bit counts precede allocation and arithmetic.
+NaN/Infinity, dimension mismatch, missing channels or integer overflow are hard
+failures, not outliers. Perceptual metrics such as SSIM may be included as
+diagnostic evidence only until their exact implementation, parameters and gate
+are versioned in the comparison policy.
+
+A case may tighten thresholds. Loosening any default requires a case-local reason,
+owner, metric values from at least two qualified runs and review in the same
+change; no global “update tolerance” switch exists. Thresholds cannot vary from a
+runtime environment variable or be learned from the candidate image.
+
+Static masks are permitted only for a registered, deterministic region whose
+semantic value is independently asserted (for example a timestamp overlay that
+the case intentionally includes). A mask is content-addressed, reviewed and may
+exclude at most `1.0%` of pixels by default; higher coverage requires an explicit
+case limit and owner approval. Runtime-generated difference masks, dilation around
+failed pixels and blanket edge suppression are forbidden. Reports show masked
+area and still publish masked-pixel differences diagnostically.
+
+### 6. Results and artifacts preserve actionable identity
+
+```cpp
+struct RendererReferenceImageResult {
+    ReferenceRunId run;
+    RendererReferenceCaseId testCase;
+    RendererEnvironmentIdentity environment;
+    RendererGeneration renderer;
+    DeviceGeneration device;
+    RealRenderFrameId frame;
+    GraphExecutionId graph;
+    ReferenceBaselineKey baseline;
+    ReferenceImageOutcome outcome;
+    ReferenceComparisonMetrics metrics;
+    ReferenceArtifactManifest artifacts;
+};
+```
+
+Outcomes are `Passed`, `ExpectedUnsupported`, `UnexpectedUnsupported`,
+`BaselineUnavailable`, `BaselineInvalid`, `CaptureFailed`, `TimedOut`,
+`DeviceLost`, `ComparisonFailed`, `BudgetExceeded`, `Cancelled` and
+`InfrastructureFailed`, plus `NonDeterministic` when identical run identity
+produces disagreeing results. A process exit and JUnit case derive from this
+result; log text is not parsed to decide success.
+
+Every non-pass identifies case, backend, adapter/device/environment, effective
+capability revision, capture operation/state and stable actionable cause. When an
+image exists, failure artifacts include reference, actual canonical image,
+human-viewable previews, absolute-difference image, threshold heatmap, bounded top
+pixel/channel differences and the complete comparison/result manifest. ADR-041
+diagnostics and ADR-044 markers join only by exact generation/frame/graph context.
+
+Artifact paths use generated names under the CI/test result root. Manifests use
+relative allowlisted paths and checksums; no machine-absolute path or native
+handle/address is published. Image artifacts are untrusted data, decoded with
+dimension/byte limits and never executed. Publication uses temporary files and an
+atomic manifest-last commit. Interrupted output is reported and quarantined.
+
+### 7. Work, storage and retries are finite
+
+Default case limits are 4096x4096, four channels, two captured frames, 256 MiB
+readback/intermediate memory, 512 MiB artifacts and 60 seconds after warm-up. Hard
+maxima are 8192x8192, four channels, eight frames, 1 GiB memory, 2 GiB artifacts
+and five minutes. The suite validates aggregate parallel-case memory, staging and
+GPU submission budgets before admission; individually valid cases cannot
+oversubscribe a lane.
+
+At most one capture per device is in flight by default and at most two at the hard
+limit. CPU comparison runs on cancellable bounded workers over owned buffers.
+Backpressure queues finite work or returns `BudgetExceeded`; it never grows an
+unbounded image queue or blocks a renderer owner thread on encoding/upload.
+
+The same commit/environment case may retry once only after an explicitly typed
+infrastructure interruption such as runner loss. Image mismatch, timeout, device
+loss, unsupported capability and crash are test outcomes and are not retried into
+a pass. Repeat disagreement on identical identity is classified `NonDeterministic`
+by lane orchestration and emits both result sets. It fails the current
+qualification; later quarantine may make the job non-blocking under CI policy but
+cannot convert either run to `Passed` or mark that backend tuple `Qualified`.
+
+### 8. CI uses explicit native hardware lanes
+
+Pull-request fast lanes always run Null/service/comparator/schema fixtures and
+affected CPU-side tests. A native reference subset runs only on a documented,
+stable GPU lane whose backend/platform/device class, driver policy, color path and
+artifact capacity satisfy the case matrix. Absence of a required protected lane
+is `InfrastructureFailed` or a blocked required check, not success.
+
+Protected-branch lanes cover every supported production backend/platform tuple
+with representative scenes for opaque/masked/translucent materials, geometry and
+depth, lighting/shadows, texture sampling, post-processing/output transform,
+resource lifetime/aliasing boundaries and supported presentation paths.
+Capability-specific scenes run only where their predicate is admitted; every
+required profile has at least one success and expected-unsupported case.
+
+Scheduled qualification expands device/driver classes, cold caches and exhaustive
+scenes. The matrix records `Qualified`, `Failed`, `ExpectedUnsupported`,
+`NotScheduled` and `InfrastructureFailed` independently. `NotScheduled` may be
+non-blocking only when the protected matrix assigns another required lane; it
+never means a backend passed.
+
+Artifacts are uploaded on failure and retained under CI policy. Passing runs keep
+manifests/metrics and may omit duplicate previews. Baseline promotion is a
+separate maintainer-reviewed operation showing old/new/reference/diff metrics and
+provenance. Tests and bots cannot overwrite repository baselines, accept the
+candidate output automatically or mix baseline updates with unrelated changes.
+
+### 9. Lifecycle and Null behavior are explicit
+
+Cancellation stops future frames/readbacks, waits only for already submitted work
+through its bounded fence token, releases owned buffers and publishes
+`Cancelled`. Device loss closes admission for the old generation, records exact
+coverage and releases readback resources through normal deferred destruction. A
+surface/backend replacement cannot satisfy an old request with a new generation.
+
+Shutdown rejects new cases, cancels queued work, drains or abandons bounded
+submitted readbacks under renderer policy, joins comparison/publication workers,
+releases artifact staging and then destroys backend/test-host services. It is
+idempotent after partial initialization and performs no global GPU-idle wait.
+
+Null provides deterministic canonical images and injected success, unsupported,
+malformed, timeout, cancellation, device-loss and publication failures. It proves
+service state, normalization, comparison math, manifests, budgets and lifecycle,
+but cannot qualify native rasterization, shader compilation, readback mapping,
+color conversion or driver behavior.
+
+## Migration And Verification
+
+Existing ad hoc visual checks migrate to registered descriptors and canonical
+baselines. Material, advanced-rendering, animation and editor screenshot suites
+may share comparator/artifact infrastructure, but editor UI baselines remain a
+separate domain and cannot serve as renderer scene references.
+
+Tests must cover descriptor/schema/hash validation; exact baseline-key matching;
+canonical swizzle/pitch/origin/resolve and SDR/HDR conversion; dimensions,
+non-finite values and checked overflow; exact threshold boundaries, outlier counts,
+RMSE/relative math and masks; success/expected and unexpected unsupported paths;
+capture failure/timeout/device loss/cancel/shutdown; aggregate admission and
+backpressure; interrupted atomic artifacts; diagnostic/marker correlation;
+baseline promotion authorization; deterministic Null fixtures; and native
+backend/platform scenes on documented hardware lanes.
+
+## Consequences
+
+Renderer changes gain reproducible pixel evidence with explicit backend,
+capability and artifact provenance. Legitimate implementation variation is kept
+separate from semantic parity, and unsupported/infrastructure states cannot look
+like success. The cost is curated deterministic scenes, reviewed per-platform
+baselines, stable hardware lanes, storage and ongoing triage/promotion ownership.
+
+## Rejected Alternatives
+
+| Option | Decision and reason |
+|---|---|
+| One golden image for all backends/platforms | Rejected: legitimate compiler/rasterization/output differences create noise and encourage broad tolerances. |
+| One baseline per arbitrary driver/machine | Rejected: baseline explosion can bless regressions and makes coverage irreproducible. |
+| Compare native swapchain screenshots | Rejected: compositor scaling/color management and window state are outside the canonical renderer oracle. |
+| Use JPEG or another lossy oracle | Rejected: codec error contaminates objective renderer differences. |
+| Automatically accept current output after failure | Rejected: converts regressions into baselines without review. |
+| Retry image mismatches until one passes | Rejected: hides nondeterminism and produces non-reproducible gates. |
+| Treat unsupported/no-GPU as pass | Rejected: absence of native evidence is not qualification. |
+| Mask all edges or generate masks from the diff | Rejected: systematically hides rasterization and geometry regressions. |
+| Run unbounded full-resolution captures in parallel | Rejected: can exhaust GPU/CPU memory, artifact storage and CI time. |
+| Use Null results as native image qualification | Rejected: synthetic images prove orchestration/comparison, not drivers or native rendering. |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,6 +61,7 @@ to the replacement.
 | [047](047-renderdoc-pix-and-metal-capture-integration.md) | RenderDoc, PIX and Metal Capture Integration | Proposed | 2026-09-01 |
 | [048](048-gpu-crash-and-device-loss-diagnostic-bundles.md) | GPU Crash and Device-Loss Diagnostic Bundles | Proposed | 2026-09-01 |
 | [049](049-render-graph-and-resource-inspector-ui.md) | Render Graph and Resource Inspector UI | Proposed | 2026-09-01 |
+| [050](050-cross-backend-reference-image-tests.md) | Cross-Backend Reference Image Tests | Proposed | 2026-09-01 |
 
 ## Conventions
 

--- a/docs/architecture/delivery/quality-and-ci.md
+++ b/docs/architecture/delivery/quality-and-ci.md
@@ -224,6 +224,21 @@ GUI quality is measured through:
 
 Visual baselines are versioned strictly per renderer and platform. Screenshot tolerances are explicit and kept narrow.
 
+Renderer scene references follow
+[ADR-050](../../adr/050-cross-backend-reference-image-tests.md) and remain
+separate from editor screenshots. Pull-request fast lanes run comparator/schema/
+Null fixtures and an affected native subset only when a stable documented GPU
+lane is available. Protected branches require the bounded backend/platform scene
+matrix; scheduled qualification expands device/driver classes and cold-cache
+coverage.
+
+Required lane absence is an infrastructure failure or blocked check, never a
+visual pass. Image mismatch, timeout, device loss and unexpected unsupported
+capability are not retried. Failure artifacts include canonical reference/actual,
+diff/heatmap and a manifest identifying case, backend, environment, capability,
+capture operation and thresholds. Baseline promotion is a separate reviewed
+change; CI cannot overwrite or automatically approve candidate output.
+
 ### Flaky Test Policy
 
 GUI and visual tests are susceptible to flakiness. The CI policy is strict:
@@ -231,6 +246,12 @@ GUI and visual tests are susceptible to flakiness. The CI policy is strict:
 - Flaky tests are immediately **quarantined** (they run, but do not fail the pipeline).
 - A tracking ticket is automatically generated for the owning team.
 - Quarantined tests must be fixed within 7 days. If a test proves consistently unreliable and cannot be stabilized within this window, it must be permanently deleted rather than left rotting in quarantine.
+
+For ADR-050 native renderer references, quarantine is explicit missing
+qualification rather than a pass. The affected backend/platform tuple remains
+`NotScheduled`/unqualified in packaged qualification reports until a stable
+required case replaces or restores the quarantined case. CI never retries an
+image mismatch to choose a passing sample or promotes either sample as a baseline.
 
 ### Performance Regression Testing
 

--- a/docs/architecture/delivery/quality-and-ci.md
+++ b/docs/architecture/delivery/quality-and-ci.md
@@ -242,6 +242,7 @@ change; CI cannot overwrite or automatically approve candidate output.
 ### Flaky Test Policy
 
 GUI and visual tests are susceptible to flakiness. The CI policy is strict:
+
 - Any test that flips between pass/fail on the same commit is automatically marked as **Flaky** by the CI runner.
 - Flaky tests are immediately **quarantined** (they run, but do not fail the pipeline).
 - A tracking ticket is automatically generated for the owning team.
@@ -256,6 +257,7 @@ image mismatch to choose a passing sample or promotes either sample as a baselin
 ### Performance Regression Testing
 
 CI tracks numerical regressions on protected branches against a **7-day rolling average baseline** to prevent noise from temporary infrastructure spikes:
+
 - **Build Time**: Alerts if a CMake target's compilation time increases by >10%.
 - **Test Duration**: Alerts if integration suites degrade in execution time.
 - **Frame Time / Memory**: Automated headless scenes run with observability metrics enabled. If `engine.frame.cpu_time` or `process.memory.resident` regressions exceed 5%, the build is flagged for review.

--- a/docs/architecture/delivery/testing-architecture.md
+++ b/docs/architecture/delivery/testing-architecture.md
@@ -630,7 +630,7 @@ python3 scripts/dev.py test --all --coverage
 python3 scripts/dev.py coverage-report
 ```
 
-Coverage reports are merged across compatible jobs. Coverage data is exclusively collected from **Unit**, **Integration**, and **Contract (CLI/MCP)** test layers. 
+Coverage reports are merged across compatible jobs. Coverage data is exclusively collected from **Unit**, **Integration**, and **Contract (CLI/MCP)** test layers.
 
 GUI test coverage is intentionally excluded from official metrics to prevent flaky line-hit variance (due to frame timings) and to avoid artificially inflating coverage numbers with UI layout execution.
 

--- a/docs/architecture/delivery/testing-architecture.md
+++ b/docs/architecture/delivery/testing-architecture.md
@@ -263,6 +263,26 @@ capability interfaces without constructing ImGui. GUI tests verify the thin
 adapter mapping, interaction behavior, and rendered result rather than
 re-testing the full business rule only through pixels.
 
+### Renderer Reference Image Tests
+
+[ADR-050](../../adr/050-cross-backend-reference-image-tests.md) owns renderer
+scene reference tests. They are distinct from editor GUI screenshots: renderer
+tests capture a named pre-compositor Horo render-graph point, while GUI tests
+exercise a windowed editor surface and interaction state.
+
+Every renderer case registers an immutable scene revision, fixed time/seeds/
+history, image contract, capability predicate, exact baseline key and bounded
+comparison policy. Canonical lossless SDR/HDR data is the oracle; preview images
+are artifacts only. Unsupported, missing/invalid baseline, capture failure,
+timeout, device loss, comparison failure, cancellation and infrastructure failure
+are separate typed results.
+
+CPU/Null fixtures cover normalization, comparator boundary math, manifests,
+budgets and lifecycle in default test runs. Native pixel qualification is opt-in
+locally and required only on the documented protected/scheduled GPU lanes. A
+developer must not report native reference tests as passed when only Null fixtures
+or compilation ran.
+
 Performance-sensitive event paths have focused microbenchmarks. Benchmarks
 report subscriber count, event type, allocation count, and dispatch duration;
 release thresholds are maintained per supported platform instead of relying on

--- a/docs/architecture/runtime/render-backend-parity-contract.md
+++ b/docs/architecture/runtime/render-backend-parity-contract.md
@@ -383,6 +383,20 @@ explicit; a backend cannot fabricate parity with names, zeros or latest values.
 Null validates logical fixtures and all service/UI states but cannot qualify native
 barriers, memory observations or measurement accuracy.
 
+[ADR-050 reference-image parity](../../adr/050-cross-backend-reference-image-tests.md)
+requires the same case identity, scene/capture/image contract, capability outcome,
+typed result and bounded artifact schema across backends. Backend-private adapters
+may normalize format, swizzle, pitch, origin and resolve semantics only as declared
+by the canonical Horo capture point; they cannot change scene policy, quality,
+shader variants or comparison thresholds.
+
+Each backend/platform uses an exact reviewed baseline key while cross-backend
+reports separately assert semantic feature/capture invariants. No backend may
+substitute another baseline/device/software route, treat unsupported or absent
+hardware as pass, retry an image mismatch into success or auto-promote its output.
+Null proves orchestration and comparison fixtures but cannot qualify native
+pixels, compiler routes, color conversion or driver behavior.
+
 In particular:
 
 - OpenGL global state is private to the OpenGL integration.

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -828,6 +828,26 @@ Hidden tabs perform no polling/layout/formatting or instrumentation. Null suppli
 deterministic logical fixtures but cannot qualify native synchronization, timing
 or memory realization.
 
+### Cross-backend reference images
+
+[ADR-050](../../adr/050-cross-backend-reference-image-tests.md) defines native
+reference-image qualification at named Horo render-graph capture points. Cases
+own immutable scene/content revisions, fixed time/seeds/history, exact capability
+predicates and canonical SDR/HDR image contracts. Backend-private readback
+adapters normalize native format, swizzle, row pitch, orientation and resolve
+semantics without exposing native objects.
+
+Backend/platform golden gates and cross-backend semantic invariants are separate.
+Every result preserves backend, environment, capability revision, real frame,
+graph execution and baseline provenance. Unsupported, missing-baseline, timeout,
+device-loss and infrastructure outcomes remain typed and cannot fall back to
+another backend/reference or compare a blank image. Readback follows normal
+submission/deferred-destruction ownership and never requires global GPU idle.
+
+Null validates deterministic service, normalization, comparator, artifact,
+budget, cancellation and shutdown fixtures. Only documented native hardware
+lanes qualify rasterization, shader compilation, readback and driver behavior.
+
 ## Backend Implementation Boundary
 
 Each concrete backend owns its API dependencies, context/device objects,


### PR DESCRIPTION
## Summary

- Defines deterministic cross-backend renderer reference scenes and named canonical SDR/HDR capture points.
- Separates reviewed backend/platform golden gates from cross-backend semantic invariants.
- Specifies objective thresholds, bounded masks, typed outcomes, actionable artifacts and native hardware qualification lanes.

## Motivation

Null and contract tests cannot prove native pixels, while one universal golden image or unrestricted per-machine baselines would either create noise or hide regressions. Reference validation needs exact capability, environment, capture and baseline provenance.

## Implementation Notes

- This is stacked on #2380 and should be reviewed after that PR.
- Readback uses normal renderer submission/fence ownership and never global GPU idle.
- Native scene implementation, baseline generation and CI hardware-lane provisioning remain downstream realization work.

## Validation

- [x] Documentation formatting and whitespace passed
- [x] Repository layout configure passed
- [x] Local Markdown links resolved
- [ ] Native backend image lanes (documentation-only decision; deferred to implementation)

## Risks

Driver variation can cause baseline explosion or permissive tolerances. The decision keeps vendor/driver as provenance by default, requires reviewed baseline keys and case-local evidence for any loosened threshold or hardware-class split.

## Issue Links

- Jira: [HORO-442](https://horo-engine.atlassian.net/browse/HORO-442)
- GitHub: Closes #442

## Reviewer Notes

Review ADR-050 first, then Rendering Architecture, Backend Parity, Testing Architecture and Quality/CI projections.


[HORO-442]: https://horo-engine.atlassian.net/browse/HORO-442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ