### PR TITLE
docs(render): define renderer component scope HORO-152 #152 [RND-002.1]

### DIFF
--- a/docs/adr/052-first-party-renderer-component-scope.md
+++ b/docs/adr/052-first-party-renderer-component-scope.md
@@ -134,7 +134,7 @@ The dimensions mean:
 | Verification | `Unchecked`, `Verifying`, `Verified`, `AbiMismatch`, `SignatureInvalid`, `Quarantined` | verifier/trust and ABI policy |
 | Host support | `Unknown`, `Supported`, `UnsupportedOs`, `UnsupportedArchitecture`, `UnsupportedOsVersion` | signed manifest + platform facts |
 | Runtime availability | `Unknown`, `ProbeRequired`, `Probing`, `Available`, `MissingRuntime`, `ProbeFailed`, `ProbeTimedOut`, `ProbeCrashed`, `Stale` | probe service result/identity |
-| Selection | `NotSelected`, `Requested`, `SelectedForNextStart` | command/project/user/host policy resolver |
+| Selection | `NotSelected`, `Selected`, `SelectedForNextStart` | command/project/user/host policy resolver |
 | Activation | `Inactive`, `Loading`, `Negotiating`, `Initializing`, `Active`, `Failed`, `Stopping` | current host composition instance |
 
 Installed means an install record exists; it does not imply verified, supported,

--- a/docs/adr/052-first-party-renderer-component-scope.md
+++ b/docs/adr/052-first-party-renderer-component-scope.md
@@ -1,0 +1,293 @@
+# ADR-052: First-Party Renderer Component Scope
+
+- **Status**: Proposed
+- **Date**: 2026-09-01
+- **Supersedes**: None
+- **Scope**: Independently distributable first-party renderer artifacts, lifecycle ownership and no-renderer recovery
+- **Issue**: [RND-002.1](https://github.com/abdullahbodur/horo-engine/issues/152)
+- **Jira**: [HORO-152](https://horo-engine.atlassian.net/browse/HORO-152)
+- **Companion decisions**: [ADR-028](028-renderer-capability-limits-and-product-profiles.md), [ADR-029](029-opengl-core-profile-and-platform-policy.md), [ADR-030](030-metal-platform-and-feature-baseline.md), [ADR-031](031-vulkan-loader-platform-and-version-baseline.md), [ADR-032](032-d3d12-baseline-and-agility-sdk-policy.md)
+- **Normative documents**: [Renderer Distribution And Availability](../architecture/runtime/renderer-distribution-and-availability.md), [Renderer Module Package Manifest](../architecture/runtime/renderer-module-package-manifest.md), [Rendering Architecture](../architecture/runtime/rendering-architecture.md), [Render Backend Parity Contract](../architecture/runtime/render-backend-parity-contract.md), [System Design](../architecture/foundation/system-design.md)
+
+## Context
+
+Horo renderer implementations need independent installation and update without
+turning backend-native APIs into public contracts or making projects load native
+plugins. “Renderer component” is currently used for several different things:
+backend code, package archives, installed records, system drivers and optional
+developer SDKs. Treating those as one unit would give installation authority to
+runtime rendering, duplicate shared runtimes or imply that a file on disk is
+available and active.
+
+Installation, host compatibility, runtime probing, user/project selection and
+live activation also change independently. A single linear lifecycle enum cannot
+honestly represent, for example, an installed component that is host-unsupported,
+a selected component awaiting restart, or an active old version while a new
+version is staged.
+
+## Decision
+
+### 1. One first-party component owns one interactive backend identity
+
+The independently distributable unit is a signed Horo product component with one
+stable `RenderBackendId`, for example:
+
+```text
+horo.renderer.opengl  -> opengl
+horo.renderer.metal   -> metal
+horo.renderer.vulkan  -> vulkan
+horo.renderer.d3d12   -> d3d12
+```
+
+One component version may contain multiple OS/architecture variants of that same
+backend but cannot contain multiple backend identities, select another backend or
+declare a fallback. Package version and private module ABI are independent of the
+stable backend ID selected by a project.
+
+The component's signed file allowlist may contain only artifacts required to
+realize that backend:
+
+- the backend implementation and private renderer C-ABI entry module;
+- matching backend-private presentation, editor GUI/viewport and host adapter
+  code/data when those are dynamically delivered with the module;
+- backend-owned immutable shader/runtime tables and generated mapping data;
+- declared backend-local runtime libraries whose redistribution policy permits
+  component ownership;
+- signed metadata, platform variants, licenses/notices and bounded diagnostics
+  schemas.
+
+Every executable/library file is variant-declared, hashed and signed. The package
+does not contain project assets, user configuration, machine probe results,
+arbitrary tools, another renderer, an editor executable or unrestricted scripts.
+Optional developer validation/capture tools remain separate toolchains/system
+software and are not runtime availability prerequisites unless an explicit
+feature operation requests them.
+
+### 2. Core renderer contracts and product services are not components
+
+The editor/engine installation owns and versions:
+
+- public `RenderApi`, backend-neutral `RenderFrontend` and graph/resource models;
+- private `RenderModuleHost`, C-ABI host tables/adapters and ABI negotiation;
+- product component catalog/manager, trust roots, installer, probe orchestrator,
+  selection policy and bootstrap recovery surface;
+- platform path/window/process primitives and shared application composition;
+- `RenderNull` for headless tools/tests; and
+- the public extension SDK, which does not expose or promise the renderer module
+  ABI.
+
+These artifacts cannot be replaced by a renderer package. A component implements
+host-owned contracts but does not ship its own copy as authority. ABI negotiation
+may accept compatible table revisions; duplicate core libraries cannot override
+the running host.
+
+Application-owned shared runtimes, such as an executable-selected D3D12 Agility
+SDK payload, remain product/runtime dependencies with one coordinated version.
+A renderer manifest references their exact compatibility record; it cannot bundle
+a private competing copy or mutate application runtime selection during load.
+System drivers/loaders/frameworks remain host runtime facts, never installed Horo
+renderer files unless a separate approved product-runtime component explicitly
+owns redistribution.
+
+### 3. Renderer components are product state, not project dependencies or plugins
+
+Installation records live in verified Horo product component roots and are scoped
+to the machine/user plus editor ABI. Projects persist only a stable backend ID and
+explicit fallback policy. They never persist package paths/versions, signatures,
+trust decisions, probe results or native runtime identity.
+
+A project `.horopkg`, imported asset, extension or gameplay module cannot supply,
+install, update, select or activate native renderer code. Opening a project cannot
+expand trusted component roots or approve a package. Local developer components
+require explicit developer policy and visible development provenance; they are
+not portable project state or Shipping support evidence.
+
+This private first-party module boundary is not a third-party renderer SDK. Any
+future external renderer ecosystem requires a separate trust, compatibility,
+support, distribution and ABI decision. The current private ABI may change with
+coordinated first-party packages.
+
+### 4. Lifecycle facts are orthogonal immutable snapshots
+
+`RendererComponentSnapshot` contains separate dimensions:
+
+```cpp
+struct RendererComponentSnapshot {
+    RenderBackendId backend;
+    RendererCatalogState catalog;
+    RendererInstallState install;
+    RendererVerificationState verification;
+    RendererHostSupportState hostSupport;
+    RendererRuntimeAvailabilityState runtime;
+    RendererSelectionState selection;
+    RendererActivationState activation;
+    RendererComponentRevision revision;
+};
+```
+
+The dimensions mean:
+
+| Dimension | Representative states | Authority |
+|---|---|---|
+| Catalog | `Unknown`, `Known`, `Retired` | signed product catalog/release channel |
+| Install | `NotInstalled`, `Downloading`, `Staged`, `Installed`, `RepairRequired`, `Removing` | component manager/install record |
+| Verification | `Unchecked`, `Verifying`, `Verified`, `AbiMismatch`, `SignatureInvalid`, `Quarantined` | verifier/trust and ABI policy |
+| Host support | `Unknown`, `Supported`, `UnsupportedOs`, `UnsupportedArchitecture`, `UnsupportedOsVersion` | signed manifest + platform facts |
+| Runtime availability | `Unknown`, `ProbeRequired`, `Probing`, `Available`, `MissingRuntime`, `ProbeFailed`, `ProbeTimedOut`, `ProbeCrashed`, `Stale` | probe service result/identity |
+| Selection | `NotSelected`, `Requested`, `SelectedForNextStart` | command/project/user/host policy resolver |
+| Activation | `Inactive`, `Loading`, `Negotiating`, `Initializing`, `Active`, `Failed`, `Stopping` | current host composition instance |
+
+Installed means an install record exists; it does not imply verified, supported,
+available, selected or active. Host-supported is metadata compatibility, not a
+driver/device claim. Runtime-available requires a current successful bounded
+probe for exact package/host/runtime identity. Selected means policy chose an
+exact candidate for a startup attempt. Active means the current process completed
+module negotiation and backend initialization for an exact generation.
+
+Snapshots are immutable/revisioned and may describe multiple installed versions
+plus one active instance. Derived UI actions come from the dimensions but do not
+replace them with one lossy status. Impossible combinations are rejected at
+transaction boundaries; asynchronous work commits only if its source revision is
+still current.
+
+### 5. Ownership follows product/application/runtime boundaries
+
+| Responsibility | Owner | Must not own it |
+|---|---|---|
+| Catalog/release metadata and signed archives | Delivery/product distribution | render frontend, project |
+| Download/install/verify/repair/update/rollback/remove | application component manager | backend module, editor tab |
+| Host metadata compatibility | component resolver + Platform facts | native probe/device |
+| Bounded runtime/device probe | application probe service + helper process | editor workspace, render frontend |
+| Selection/fallback resolution | application startup policy | package, backend, render feature/profile |
+| Exact module load/private ABI negotiation | `RenderModuleHost` at composition root | `RenderFrontend`, project/plugin |
+| Device initialization and reported capabilities | selected backend instance | installer/catalog |
+| Effective capability admission | `RenderFrontend` policy over initialized facts | package hints/probe alone |
+| No-renderer recovery UI/CLI | HoroEditor bootstrap/application services | Null or another interactive backend |
+
+Module metadata and registration descriptors remain inert. Reading a manifest,
+constructing a provider or registering it cannot create windows/devices, inspect
+ambient service locators, activate lifecycle callbacks or mutate component state.
+Side effects occur in explicit install/probe/startup operations.
+
+### 6. Selection precedes presentation-capable window creation
+
+Startup resolves one exact candidate in this order:
+
+1. command-line request;
+2. project backend setting;
+3. user preference; then
+4. deterministic host recommendation.
+
+The resolver evaluates only exact installed versions whose verification,
+host-support and current probe dimensions permit activation. It reads signed
+backend-neutral window requirements before native module load. Interactive window
+and renderer creation begin only after selection commits.
+
+Selection does not make the component active. The composition root loads the
+exact verified path, negotiates the private ABI, attaches the matching private
+presentation/editor integration, registers/seals one provider, constructs the
+frontend and initializes the device. Every step has a typed result and rollback;
+failure releases completed steps in reverse order without mutating project files.
+
+Dynamic device capabilities are authoritative only after initialization. Manifest
+hints and probe results may reject impossibility early but cannot grant a feature,
+format or limit. ADR-028 effective capability admission remains required before
+scene/editor renderer resources are created.
+
+### 7. Fallback is explicit policy, never component behavior
+
+A failed/missing requested backend returns its exact state dimensions and action:
+install, verify, repair, update, re-probe, choose another backend or open
+diagnostics. It does not silently select the platform-default API or load a library
+found on `PATH`.
+
+An ordered fallback list may be evaluated only when the initiating host/profile
+explicitly owns one. Each candidate goes through the full independent resolution
+and startup sequence, and diagnostics retain every attempt. A renderer package,
+shader/material quality fallback, probe helper or backend cannot append/reorder
+that list. Interactive editor/game hosts never fall back to Null. Headless tools
+may request Null explicitly or include it in an explicit headless policy.
+
+Changing project/user selection while a renderer is active records
+`SelectedForNextStart`; it does not hot-swap the active device or unload code still
+leased by the process. Device-loss recovery within the same active backend follows
+renderer lifecycle policy and does not imply selecting another product component.
+
+### 8. No-renderer recovery remains inside HoroEditor without RenderApi
+
+If no interactive candidate can activate, HoroEditor does not create a renderer-
+specific window, enter the workspace or modify project selection. It publishes a
+typed aggregate containing requested ID, candidate dimensions, attempted versions,
+safe causes and allowed actions.
+
+The HoroEditor bootstrap/Welcome component-manager surface provides install,
+offline install, verify, repair, update, re-probe, diagnostics and explicit backend
+selection. CLI exposes equivalent application operations. This minimal surface
+uses a bounded platform-native/software bootstrap presentation path outside
+RenderApi; it cannot render project/editor workspace content and does not privilege
+OpenGL, Metal, Vulkan or D3D12.
+
+Recovery actions are transactional and cancellable. Failure preserves the last
+verified installed version and active selection record. Restart into the workspace
+occurs only after an exact candidate reaches activation prerequisites; the recovery
+surface cannot claim success from installation alone.
+
+### 9. Resource limits, concurrency and shutdown are bounded
+
+Catalog/install snapshots, installed versions, variants, files and diagnostics
+have schema count/byte limits. Component operations use one writer transaction per
+component ID and bounded global download/extract/probe concurrency. Checked size
+and path validation precede allocation/extraction. Native code is never loaded
+from staging or quarantined roots.
+
+Install/probe/activation each own cancellation tokens and explicit leases. Remove/
+rollback cannot delete a version held by an active/probe/module lease. Cancellation
+before commit removes private staging; after publication it cannot pretend the
+committed record did not exist. Probe or activation timeout terminates/rolls back
+through its owner, not by leaking a worker or module callback.
+
+Shutdown rejects new operations, cancels queued work, terminates bounded helpers,
+waits for component transactions, stops/deinitializes the active backend, releases
+module callbacks/leases and then destroys registries/services. It is idempotent
+after partial startup and never waits for network, editor UI or global GPU idle.
+
+## Migration And Verification
+
+The existing linear availability state migrates to orthogonal snapshot dimensions.
+UI and CLI may derive one summary badge/action, but persistence and control flow use
+the full typed snapshot/revision. Current statically linked developer/test backends
+remain explicit composition fixtures; installed products load only verified
+component records through the same provider lifecycle.
+
+Tests must cover component file classification; one-backend package identity;
+forbidden core/project/plugin/native leakage; every state dimension and stale-
+revision commit; installed-but-unverified/unsupported/unavailable/selected-
+inactive combinations; selection priority and explicit fallback attempts; pre-
+window metadata; activation rollback at each step; no-renderer bootstrap and CLI
+equivalence; Null headless-only policy; active leases during remove/update;
+cancellation, timeout, helper crash, partial startup and shutdown; OpenGL-only,
+Metal-only where supported, combined and no-interactive-component installations.
+
+## Consequences
+
+Renderer implementations can ship independently without weakening backend-neutral
+contracts or giving projects native loading authority. Product health, policy and
+live runtime truth stay distinguishable, and zero-renderer recovery is possible
+without a privileged fallback API. The cost is a richer state snapshot, private
+module/adapter packaging, explicit composition and coordinated product-runtime/
+ABI versioning.
+
+## Rejected Alternatives
+
+| Option | Decision and reason |
+|---|---|
+| Bundle every renderer permanently into HoroEditor | Rejected: forces unused native dependencies and prevents independent repair/update. |
+| Put multiple backends in one renderer component | Rejected: couples lifecycle/trust and enables hidden selection/fallback. |
+| Let projects or plugins ship renderer modules | Rejected: project content would gain native product-code authority. |
+| Publish the private renderer C ABI as the extension SDK | Rejected: freezes an unsupported trust/support boundary. |
+| Treat installed as available/active | Rejected: files do not prove host support, runtime/device health, selection or initialization. |
+| Model all lifecycle facts as one enum | Rejected: independent install, health, policy and process states cannot be represented honestly. |
+| Search `PATH` or project folders for renderer libraries | Rejected: bypasses signed records, deterministic resolution and trust roots. |
+| Silently choose the platform-default backend | Rejected: hides failures and privileges one backend. |
+| Use Null as the editor recovery renderer | Rejected: Null is headless and cannot satisfy interactive parity. |
+| Create a separate launcher solely for recovery | Rejected: HoroEditor owns one bootstrap/application recovery surface without RenderApi. |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -63,6 +63,7 @@ to the replacement.
 | [049](049-render-graph-and-resource-inspector-ui.md) | Render Graph and Resource Inspector UI | Proposed | 2026-09-01 |
 | [050](050-cross-backend-reference-image-tests.md) | Cross-Backend Reference Image Tests | Proposed | 2026-09-01 |
 | [051](051-renderer-benchmark-and-regression-gates.md) | Renderer Benchmark and Regression Gates | Proposed | 2026-09-01 |
+| [052](052-first-party-renderer-component-scope.md) | First-Party Renderer Component Scope | Proposed | 2026-09-01 |
 
 ## Conventions
 

--- a/docs/architecture/foundation/system-design.md
+++ b/docs/architecture/foundation/system-design.md
@@ -622,6 +622,11 @@ Renderer component lifecycle follows
 [Renderer Distribution And Availability](../runtime/renderer-distribution-and-availability.md).
 Equal backend behavior follows
 [Render Backend Parity Contract](../runtime/render-backend-parity-contract.md).
+Component scope and lifecycle ownership follow
+[ADR-052](../../adr/052-first-party-renderer-component-scope.md): one signed
+first-party component realizes one backend identity, while component management,
+selection/fallback, module-host composition and no-renderer recovery remain
+application/product responsibilities outside `RenderFrontend` and projects.
 
 The null renderer is a supported implementation for headless execution and
 tests.

--- a/docs/architecture/runtime/render-backend-parity-contract.md
+++ b/docs/architecture/runtime/render-backend-parity-contract.md
@@ -59,6 +59,13 @@ These sibling build targets produce independently packageable renderer
 components. An installed editor may contain any supported subset; runtime loading
 does not change the dependency direction.
 
+[ADR-052](../../adr/052-first-party-renderer-component-scope.md) restricts each
+first-party component to one backend identity and its matching private module/
+presentation/editor artifacts. Host-neutral contracts, component management,
+trust, selection/fallback policy and Null remain outside every interactive
+component. Installed, verified, host-supported, runtime-available, selected and
+active are separate snapshot dimensions and cannot be collapsed to claim parity.
+
 Editor integrations follow the same rule:
 
 ```text

--- a/docs/architecture/runtime/renderer-distribution-and-availability.md
+++ b/docs/architecture/runtime/renderer-distribution-and-availability.md
@@ -83,6 +83,15 @@ systems, but they have separate ownership and activation rules:
 Third-party renderer extensibility is outside this contract. It requires a
 separate security, compatibility, and support policy.
 
+[ADR-052](../../adr/052-first-party-renderer-component-scope.md) limits one
+component to one stable interactive backend identity. Its signed allowlist may
+contain that backend's private module, matching presentation/editor integration,
+backend-owned immutable runtime data, declared redistributable local libraries,
+metadata and notices. It cannot replace `RenderApi`, `RenderFrontend`,
+`RenderModuleHost`, component/trust services, Platform, `RenderNull`, the editor
+executable or public extension SDK. Shared application-owned runtimes remain one
+coordinated product dependency rather than competing copies inside components.
+
 ## Component Roots
 
 Renderer discovery is restricted to roots owned by the Horo product component
@@ -105,56 +114,34 @@ component record. That record is visibly untrusted/development state, is never
 portable project configuration, and is disabled in release or managed-policy
 builds unless policy allows it.
 
-## Availability State Model
+## Component State Model
 
-A renderer component has one discovery/health state at a time:
+[ADR-052](../../adr/052-first-party-renderer-component-scope.md) forbids one
+lossy linear lifecycle enum. A revisioned `RendererComponentSnapshot` carries
+orthogonal dimensions:
 
-```text
-NotInstalled
-    -> Downloading
-    -> Staged
-    -> InstalledUnchecked
-    -> Verifying
-    -> Verified
-    -> Probing
-    -> Available
-    -> Selected
-    -> Active
-```
+| Dimension | Representative states | Authority |
+|---|---|---|
+| Catalog | `Unknown`, `Known`, `Retired` | signed product catalog |
+| Install | `NotInstalled`, `Downloading`, `Staged`, `Installed`, `RepairRequired`, `Removing` | component manager/install record |
+| Verification | `Unchecked`, `Verifying`, `Verified`, `AbiMismatch`, `SignatureInvalid`, `Quarantined` | verifier/trust/ABI policy |
+| Host support | `Unknown`, `Supported`, `UnsupportedOs`, `UnsupportedArchitecture`, `UnsupportedOsVersion` | signed manifest + Platform facts |
+| Runtime availability | `Unknown`, `ProbeRequired`, `Probing`, `Available`, `MissingRuntime`, `ProbeFailed`, `ProbeTimedOut`, `ProbeCrashed`, `Stale` | probe service |
+| Selection | `NotSelected`, `Requested`, `SelectedForNextStart` | startup policy resolver |
+| Activation | `Inactive`, `Loading`, `Negotiating`, `Initializing`, `Active`, `Failed`, `Stopping` | current host composition |
 
-Failure and maintenance states:
+Installed means only that an install record exists. It does not imply verified,
+host-supported, runtime-available, selected or active. Host support is package/
+platform metadata compatibility; it is not a driver/device claim. Availability
+requires a current successful bounded probe for the exact component and host
+runtime identity. Selection is startup policy, while activation is live process
+truth after module negotiation and backend initialization.
 
-```text
-HostUnsupported
-MissingRuntime
-AbiMismatch
-SignatureInvalid
-ProbeFailed
-Quarantined
-UpdateRequired
-RepairRequired
-```
-
-State meanings:
-
-| State | Meaning |
-|---|---|
-| `NotInstalled` | No verified installation record exists for the backend ID and active editor ABI. |
-| `InstalledUnchecked` | Files are present, but current integrity and compatibility checks have not completed. |
-| `Verified` | Manifest, layout, hashes, signatures, ABI metadata, and platform identity are valid. No device claim has been made. |
-| `HostUnsupported` | Package metadata excludes the current OS, architecture, or minimum OS version. |
-| `MissingRuntime` | Required system loader, driver capability, or runtime dependency is absent. |
-| `AbiMismatch` | Module ABI is incompatible with the active editor/engine ABI. |
-| `ProbeFailed` | The helper process returned a typed failure, timed out, crashed, or produced invalid output. |
-| `Quarantined` | Security or repeated health failure prevents loading until repair or explicit policy action. |
-| `Available` | Verification and the current host probe succeeded. |
-| `Selected` | Startup policy chose the backend; no live device is implied yet. |
-| `Active` | The editor successfully loaded and initialized the selected backend. |
-| `UpdateRequired` | A compatible module update is required before activation. |
-| `RepairRequired` | Installed state is incomplete, corrupted, or inconsistent with its install record. |
-
-`Compiled`, `installed`, `verified`, `available`, and `active` are not synonyms.
-Capability hints in a manifest are not authoritative device capabilities.
+Snapshots may describe multiple installed versions and one active instance.
+Asynchronous verification/probe/install operations commit only against their
+source revision. UI/CLI may derive one summary badge/action but control flow and
+persistence retain all dimensions. Capability hints in a manifest and probe
+success are not authoritative initialized-device capabilities.
 
 ## Resolution And Selection
 
@@ -173,7 +160,7 @@ A requested backend that is missing or unavailable does not silently become a
 different backend. The result is an actionable typed diagnostic containing:
 
 - requested backend ID;
-- component lifecycle state;
+- component snapshot revision and relevant install/verification/host/runtime state;
 - editor and renderer ABI versions;
 - host OS and architecture;
 - safe failure category;
@@ -301,7 +288,8 @@ horo renderer select <id> --scope user|project
 
 Command names are architectural intent, not a statement that the current CLI
 already implements them. The Welcome/component-manager surface and CLI call the
-same application services and produce the same lifecycle states and diagnostics.
+same application services and produce the same component snapshots and
+diagnostics.
 
 Removing the active or selected backend requires explicit resolution. Uninstall
 is blocked while a running process holds a module lease. Project references do
@@ -315,7 +303,7 @@ paths. Each backend entry shows at least:
 
 - display name and stable ID;
 - installed version;
-- lifecycle/health state;
+- install, verification, host-support and runtime-availability summary;
 - host support result;
 - last probe result and safe diagnostic summary;
 - install, repair, update, diagnostics, or remove actions;

--- a/docs/architecture/runtime/renderer-distribution-and-availability.md
+++ b/docs/architecture/runtime/renderer-distribution-and-availability.md
@@ -127,7 +127,7 @@ orthogonal dimensions:
 | Verification | `Unchecked`, `Verifying`, `Verified`, `AbiMismatch`, `SignatureInvalid`, `Quarantined` | verifier/trust/ABI policy |
 | Host support | `Unknown`, `Supported`, `UnsupportedOs`, `UnsupportedArchitecture`, `UnsupportedOsVersion` | signed manifest + Platform facts |
 | Runtime availability | `Unknown`, `ProbeRequired`, `Probing`, `Available`, `MissingRuntime`, `ProbeFailed`, `ProbeTimedOut`, `ProbeCrashed`, `Stale` | probe service |
-| Selection | `NotSelected`, `Requested`, `SelectedForNextStart` | startup policy resolver |
+| Selection | `NotSelected`, `Selected`, `SelectedForNextStart` | startup policy resolver |
 | Activation | `Inactive`, `Loading`, `Negotiating`, `Initializing`, `Active`, `Failed`, `Stopping` | current host composition |
 
 Installed means only that an install record exists. It does not imply verified,

--- a/docs/architecture/runtime/renderer-module-package-manifest.md
+++ b/docs/architecture/runtime/renderer-module-package-manifest.md
@@ -17,6 +17,19 @@ This format packages Horo-owned renderer modules that are versioned and released
 with a known Horo renderer ABI. It is not the public third-party plugin manifest
 and does not grant arbitrary projects permission to load native code.
 
+[ADR-052](../../adr/052-first-party-renderer-component-scope.md) limits one
+package to one stable `RenderBackendId`. In addition to its private renderer entry
+module, the signed allowlist may carry only matching backend-private presentation/
+editor adapters, backend-owned immutable runtime data, declared redistributable
+local libraries, metadata and notices. Another renderer, host core contracts,
+component/trust services, editor executable, project content and unrestricted
+tools/scripts are forbidden.
+
+`RenderApi`, `RenderFrontend`, `RenderModuleHost`, Platform, `RenderNull` and the
+public extension SDK are host-owned and cannot be replaced by package files.
+Application-owned shared runtimes use exact compatibility records and one product
+version; a renderer package cannot ship a competing private copy.
+
 The manifest is readable without loading the native library and contains no
 native pointers, process-local handles, credentials, absolute installation paths,
 or machine-local probe results.

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -500,6 +500,13 @@ uses only the installed, verified, ABI-compatible, successfully probed set. This
 keeps the editor core and headless/CLI installations free of unused GPU
 dependencies.
 
+[ADR-052](../../adr/052-first-party-renderer-component-scope.md) assigns one
+signed first-party component to one backend identity and keeps install,
+verification, host support, runtime probe, selection and activation as orthogonal
+application/product facts. `RenderFrontend` owns none of those facts. Components
+cannot replace host renderer contracts or supply fallback policy; they implement
+one selected backend behind the private module boundary.
+
 ```text
 Resolve component record
     -> verify manifest/signature/ABI/probe state


### PR DESCRIPTION
## Summary

- Defines one independently distributable, signed first-party component per interactive renderer backend identity.
- Replaces the lossy linear lifecycle with revisioned, orthogonal catalog, install, verification, host-support, runtime-availability, selection, and activation facts.
- Keeps component management, trust, probing, selection/fallback, module-host composition, and no-renderer recovery at explicit product/application boundaries.

## Why

A renderer file being present does not prove that it is trusted, compatible with the host, usable with the current driver/device, selected by policy, or active in the process. The prior linear lifecycle could not represent staged updates, selected-but-inactive components, or an active old version alongside a candidate update without conflating independent facts.

## Decision

- A package realizes exactly one stable `RenderBackendId`; it cannot select or fall back to another backend.
- `RenderApi`, `RenderFrontend`, `RenderModuleHost`, Platform, `RenderNull`, trust/component services, and the public extension SDK remain host-owned.
- Projects persist only a backend ID and explicit fallback policy; project content and plugins cannot install or activate native renderer code.
- Startup selects an exact verified candidate before presentation-capable window creation, then performs typed module negotiation and rollback-safe activation.
- HoroEditor retains a minimal bootstrap recovery path that does not depend on `RenderApi` when no interactive renderer can activate.

## Validation

- [x] Replayed the two HORO-152 commits onto current `main`; the PR now contains only ADR-052 and its six architecture projections plus the ADR index.
- [x] `markdownlint-cli` passed for every changed Markdown file.
- [x] `git diff --check` passed.
- [x] All newly added local Markdown links resolve.
- [x] No unresolved TODO/TBD/open-decision marker remains in the decision or projections.
- [x] All Codacy review threads are resolved; the post-rebase Codacy analysis passed.

## Risk and rollout

This is a documentation-only contract change. The richer state model intentionally increases implementation surface, but prevents UI summaries or package presence from becoming a second control-flow authority. Manifest parsing, installer/registry behavior, probing, ABI loading, and lifecycle tests remain traceable downstream RND-002 work.

## Issue links

- Jira: [HORO-152](https://horo-engine.atlassian.net/browse/HORO-152)
- GitHub: Closes #152

## Reviewer notes

Review ADR-052 first, then the distribution/availability projection. The remaining projections only establish ownership and dependency boundaries in the manifest, rendering, parity, and system-design contracts.


[HORO-152]: https://horo-engine.atlassian.net/browse/HORO-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ