### PR TITLE
docs(extensions): define package authority boundary HORO-69 #69 [EXT-001.1]

### DIFF
--- a/docs/adr/054-extension-and-package-authority-boundary.md
+++ b/docs/adr/054-extension-and-package-authority-boundary.md
@@ -1,0 +1,283 @@
+# ADR-054: Extension and Package Authority Boundary
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Durable package identity, extension descriptors, trust and activation hand-off for extension-only and hybrid packages
+- **Issue**: [EXT-001.1](https://github.com/abdullahbodur/horo-engine/issues/69)
+- **Jira**: [HORO-69](https://horo-engine.atlassian.net/browse/HORO-69)
+- **Normative documents**: [Horo Package System](../architecture/packages/package-system.md), [Package Lifecycle](../architecture/packages/package-lifecycle.md), [Extension System](../architecture/extensions/plugin-system.md), [Desired Project Trees](../architecture/desired-project-tree.md), [Application Security](../architecture/security/application-security.md)
+
+## Context
+
+Horo currently describes two overlapping distribution models. The package system
+uses `horo-package.toml`, `files.manifest.json`, `.horopkg`,
+`.horo/packages.json` and a verified package cache. The implemented extension
+inventory instead discovers directories containing a top-level `extension.json`,
+copies them under `~/.horo/extensions`, stores separate enable/trust state and may
+download a ZIP through a separate marketplace path. `extension.json` repeats
+package identity, version, compatibility, dependencies and permissions.
+
+Keeping both models as durable authorities would make identity, dependency
+resolution, trust, update, rollback and uninstall disagree. A hybrid package
+could be resolved at one version by `PackageService` while `ExtensionHost` loads a
+different directory/version. A project could also request the same add-on through
+both `.horo/packages.json` and `.horo/plugins.json`, with no canonical lock or
+transaction owner.
+
+Extension modules still need their own ABI version, entry artifacts,
+contributions and permissions. Those facts belong to a module descriptor, but do
+not require a second package manager. This ADR assigns every durable fact and
+lifecycle transition to one authority and defines migration from the current
+extension-directory layout.
+
+## Decision
+
+### 1. Every installable extension is a Horo package
+
+`.horopkg` is the only portable installable distribution artifact for asset,
+game-library, extension-only, hybrid and template packages. A package containing
+one or more `EditorExtension` or other approved extension contribution descriptors
+is an extension package; it is not a separate artifact kind or package authority.
+
+`horo-package.toml` owns the durable package ID, package version, kind, source-
+independent compatibility, package dependency edges, contribution roots and
+license/security declarations. `files.manifest.json` owns the canonical signed
+file allowlist, normalized paths, sizes, modes and hashes. Together with the
+archive signature and trusted source metadata they produce one immutable
+`VerifiedPackageInstallRecord`.
+
+Neither a directory name, registry entry, marketplace card, `extension.json`,
+module return value nor dynamic-library filename may replace or amend that
+identity. Duplicate `(packageId, version)` values with different artifact or
+manifest digests are conflicts, not alternate extension installations.
+
+### 2. Manifest roles do not overlap
+
+| Artifact/value | Authority |
+|---|---|
+| `.horo/packages.json` | Portable project request, source and requested contribution groups |
+| `.horo/packages.lock` | Exact resolved package graph and artifact/manifest identities |
+| `horo-package.toml` | Durable package identity, version, kind, compatibility, dependencies and contribution descriptor paths |
+| `files.manifest.json` | Exact package file allowlist, ownership, sizes, modes and digests |
+| `extensions/<module-id>/extension.json` | One extension module ABI/entry descriptor plus its contributions and requested permissions |
+| `VerifiedPackageInstallRecord` | Runtime authority that binds all verified manifests, digests, extracted roots and selected host variants |
+| local/organization trust record | Approval for a specific verified publisher/package/artifact identity and capability set |
+| package lifecycle state | Durable enablement intent, pending restart/update and activation outcome |
+| `ExtensionHost` activation generation | Live module, registry and callback leases for one exact install record |
+
+`extension.json` schema v1 contains a canonical module ID/version, extension ABI
+range, platform/architecture entry variants, contribution descriptors, requested
+permissions and optional package-owner binding. An owner package ID/version in the
+descriptor is a defensive assertion and must exactly equal the install record; it
+is not another source of truth. Cross-package dependencies, source locations,
+package trust decisions, update channels and package enablement do not appear in
+the extension descriptor.
+
+The package manifest lists every extension descriptor as a typed contribution
+with stable contribution ID and package-relative descriptor path. The file
+manifest lists the descriptor and every referenced binary/resource. An extension
+descriptor cannot discover another file by scanning its directory, broaden its
+declared root or introduce an undeclared executable.
+
+Module-to-module ordering within one package may use bounded local module IDs in
+the package contribution graph. Any dependency on another package is declared
+only in `horo-package.toml`, resolved once by `PackageResolver` and pinned once in
+`.horo/packages.lock`.
+
+### 3. Extension-only and hybrid layouts are explicit
+
+An extension-only package has no special top-level manifest:
+
+```text
+com.vendor.fbx-importer-1.2.0.horopkg
+├── horo-package.toml
+├── files.manifest.json
+├── publisher.cert.json
+├── signature.sig
+├── extensions/
+│   └── com.vendor.fbx-importer.native/
+│       ├── extension.json
+│       ├── bin/
+│       │   ├── macos-arm64/libhoro_fbx_importer.dylib
+│       │   ├── linux-x64/libhoro_fbx_importer.so
+│       │   └── windows-x64/horo_fbx_importer.dll
+│       └── resources/icons/fbx.svg
+├── licenses/
+└── NOTICE.md
+```
+
+A hybrid package uses the same package manifests and adds ordinary content plus
+one or more extension descriptors:
+
+```text
+com.vendor.weapon-tools-2.0.0.horopkg
+├── horo-package.toml
+├── files.manifest.json
+├── assets/
+├── scripts/
+├── behaviors/
+├── services/
+├── extensions/
+│   ├── com.vendor.weapon-tools.backend/extension.json
+│   └── com.vendor.weapon-tools.editor/extension.json
+├── samples/
+├── docs/
+└── NOTICE.md
+```
+
+Backend, GUI, CLI and MCP contributions may share a module or use separate
+modules, but the package manifest declares each descriptor and contribution root.
+The backend capability remains authoritative for behavior; presentation
+contributions remain adapters. Asset/runtime contribution activation can be
+portable project intent while native editor activation remains locally trusted.
+
+### 4. Package services hand an exact activation candidate to ExtensionHost
+
+The ordered hand-off is:
+
+```text
+PackageService / PackageResolver
+    -> resolve one package graph and exact artifacts
+PackageLifecycleService
+    -> verify archive, manifests, files, signature and compatibility
+TrustService
+    -> compute required trust and match explicit local/organization approval
+PackageLifecycleService
+    -> resolve enabled contribution groups and build activation candidates
+ExtensionHost
+    -> validate descriptor/ABI binding and build a candidate registry batch
+ExtensionHost
+    -> atomically publish live registrations and return generation leases
+PackageLifecycleService
+    -> publish activation outcome against the same install-record revision
+```
+
+`ExtensionActivationCandidate` is immutable and contains an install-record ID and
+lease, package ID/version/digests, one validated descriptor value, the selected
+declared module artifact, approved capability/permission set, host compatibility
+result and target activation generation. It contains no caller-selected absolute
+path. `ExtensionHost` resolves only package-relative identities through the
+leased verified install record.
+
+`ExtensionHost` does not download, resolve, install, update, trust, enable or
+uninstall packages. It validates the extension ABI and module-returned identity,
+loads only the selected declared artifact, builds candidate contributions and
+owns live module/registry/callback leases. It cannot write package lifecycle
+state directly.
+
+`PackageLifecycleService` owns durable enablement intent and coordinates restart,
+update, rollback and uninstall. It cannot mark a native extension active until
+`ExtensionHost` returns a committed generation. Failed activation records a typed
+outcome without changing the verified install record or trusting the package.
+Deactivation first closes/detaches contributions and drains leases; cache removal
+waits for all live activation and content leases.
+
+### 5. Trust is computed outside both manifests
+
+Install and verification grant no execution trust. `TrustService` computes the
+required level from verified files, package contribution kinds, extension module
+kind, native/script artifacts, requested permissions, publisher/signature,
+source policy and product/organization rules. Package and extension manifests may
+declare risk and requested permissions, but cannot lower the computed result.
+
+A trust record binds the publisher identity, package ID, artifact/manifest digest
+or an explicit bounded update policy, approved capability set and policy revision.
+Changing executable bytes, publisher, requested permissions or trust class makes
+the prior decision insufficient until policy explicitly accepts the transition.
+Portable project metadata can request an extension contribution but cannot carry
+the local trust grant.
+
+### 6. One project request and lock graph owns package dependencies
+
+`.horo/packages.json` is the only portable package request file and
+`.horo/packages.lock` is the only exact resolution. A request may select required
+or optional contribution groups such as `runtime`, `editor`, `tools` or a stable
+package-defined feature. Editor-only edges are still represented in this graph so
+restore, release exclusion, license closure and conflicts see the same dependency
+truth.
+
+`.horo/plugins.json` is deprecated and is not consulted as a second resolver after
+migration. User-local development overrides live under the package-system local
+override policy and still require a valid `horo-package.toml`, file inventory and
+synthetic verified development install record. Arbitrary extension-root or
+current-directory scanning is not a production discovery path.
+
+### 7. Legacy extension directories migrate transactionally
+
+The current layout is recognized only by an explicit bounded legacy migration:
+
+```text
+~/.horo/extensions/<legacy-id>/extension.json
+.horo/plugins.json
+```
+
+Migration performs these steps without loading code:
+
+1. inventory each direct child once, rejecting links, escapes, duplicate IDs,
+   oversized files/trees and invalid legacy manifests;
+2. map the legacy package ID/version to `horo-package.toml`, move module facts to
+   `extensions/<module-id>/extension.json` and generate a complete
+   `files.manifest.json` in private staging;
+3. show identity, file, dependency, permission, trust and project-request diffs;
+4. validate the generated package exactly like a local development package;
+5. atomically publish one package install record and migrate project requests to
+   `.horo/packages.json` in the project transaction;
+6. retain the original directory and metadata as a recoverable backup until the
+   transaction commits, then quarantine or archive it under bounded policy.
+
+Legacy `extension.json` package fields are migration input only. The generated
+package manifest becomes authoritative after commit; the legacy file is never
+read again for activation. Existing enabled state becomes pending enablement, not
+an automatic native-code activation. Unsigned/directory content requires trust
+review against the generated digest; the migration does not silently copy a trust
+grant to changed bytes.
+
+The compatibility reader may exist for one documented migration window, but it
+can only produce a migration plan. New installs, marketplace downloads, project
+creation and authoring tools write the canonical package layout immediately.
+Rollback restores the old project request/state metadata and leaves legacy files
+untouched; it cannot leave both authorities active.
+
+### 8. Verification proves authority and hand-off boundaries
+
+Required coverage includes:
+
+- extension-only and hybrid package fixtures with one and multiple modules;
+- package/descriptor owner ID and version mismatch rejection;
+- undeclared descriptor, binary, resource and executable rejection;
+- cross-package dependency in `extension.json` rejection;
+- one deterministic packages request/lock graph for editor and runtime groups;
+- install without trust, trust without enablement and enablement without host
+  compatibility remaining inactive;
+- activation candidate digest/lease, path containment and stale-generation tests;
+- all-or-nothing contribution registration and activation-outcome publication;
+- update/uninstall waiting for module, registry, callback and content leases;
+- legacy inventory limit, duplicate, traversal, link and malformed-manifest
+  rejection;
+- dry-run migration diff, trust reapproval, project request conversion, rollback
+  and idempotent resume after interruption; and
+- proof that production `ExtensionHost` cannot activate a raw directory or fetch,
+  resolve, trust or mutate package state.
+
+## Consequences
+
+Package identity, files, dependencies, signatures, source resolution, update and
+rollback now have one authority for every package shape. ExtensionHost becomes a
+narrow live-code host rather than a second package manager, while extension
+descriptors retain independent module/ABI/contribution identity. The cost is a
+breaking authoring-layout migration, removal of `.horo/plugins.json` as an active
+resolver and new activation-candidate/install-record plumbing before the current
+directory loader can become a production path.
+
+## Rejected Alternatives
+
+| Option | Decision and reason |
+|---|---|
+| Keep `extension.json` and `horo-package.toml` as peer package manifests | Rejected: identity, dependencies, trust and updates would have competing authorities. |
+| Treat extension packages as ZIPs outside `.horopkg` | Rejected: duplicates source, verification, cache, lock, transaction and rollback machinery. |
+| Put module ABI and every contribution directly in `horo-package.toml` | Rejected: package and module schemas evolve at different boundaries and multi-module packages need bounded independent descriptors. |
+| Let ExtensionHost scan package directories for descriptors/binaries | Rejected: undeclared files and caller-selected paths could bypass the verified install record. |
+| Store native extension trust in `.horo/packages.json` | Rejected: cloning a project must not grant code-execution trust on another machine. |
+| Preserve `.horo/plugins.json` indefinitely as an overlay | Rejected: dependency resolution, restore and release closure would still have two graphs. |
+| Auto-activate migrated legacy directories | Rejected: migration changes the verified identity and old directory installs may be unsigned or insufficiently bounded. |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -65,6 +65,7 @@ to the replacement.
 | [051](051-renderer-benchmark-and-regression-gates.md) | Renderer Benchmark and Regression Gates | Proposed | 2026-09-01 |
 | [052](052-first-party-renderer-component-scope.md) | First-Party Renderer Component Scope | Proposed | 2026-09-01 |
 | [053](053-renderer-module-manifest-parser.md) | Renderer Module Manifest Parser | Proposed | 2026-09-02 |
+| [054](054-extension-and-package-authority-boundary.md) | Extension and Package Authority Boundary | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -16,7 +16,7 @@ For a first architecture review, read:
 6. [Concurrency And Job System](./foundation/concurrency-and-jobs.md)
 7. [Runtime Lifecycle](./runtime/runtime-lifecycle.md)
 8. [Scene Runtime](./runtime/scene-runtime.md)
-8. the host or subsystem documents relevant to the change
+9. the host or subsystem documents relevant to the change
 
 `system-design.md` defines the map and dependency direction. Detailed documents
 own their specific contracts; the overview does not override them.
@@ -209,6 +209,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 
 ## Extensions
 
+- [Extension and Package Authority Boundary](../adr/054-extension-and-package-authority-boundary.md):
+  one package identity/file/dependency authority, package-scoped extension
+  descriptors, trust/activation hand-off, layouts, and legacy migration.
 - [Extension Capability Roadmap](./extensions/extension-capability-roadmap.md):
   ecosystem capability stages and their separation from product milestones,
   workstreams, planning horizons, and technical dependencies.

--- a/docs/architecture/desired-project-tree.md
+++ b/docs/architecture/desired-project-tree.md
@@ -846,7 +846,6 @@ MyGame/
 │   ├── project.json
 │   ├── packages.json
 │   ├── packages.lock
-│   ├── plugins.json
 │   ├── release-profiles.json
 │   ├── editor_workspace.json
 │   ├── asset_index.json
@@ -1111,9 +1110,15 @@ com.vendor.weapon-pack-2.0.0.horopkg
 │   └── recoil_behavior.horo-behavior.json
 ├── services/
 │   └── recoil_service.horo-service.json
-├── editor/
-│   ├── weapon_stats_panel.horo-extension.json
-│   └── inspectors/
+├── extensions/
+│   └── com.vendor.weapon-tools.editor/
+│       ├── extension.json
+│       ├── bin/
+│       │   ├── linux-x64/libweapon_tools.so
+│       │   ├── macos-arm64/libweapon_tools.dylib
+│       │   └── windows-x64/weapon_tools.dll
+│       └── resources/
+│           └── icons/weapon-stats.svg
 ├── samples/
 │   ├── scenes/
 │   │   └── weapon_demo.horo
@@ -1124,6 +1129,11 @@ com.vendor.weapon-pack-2.0.0.horopkg
 │   └── README.md
 └── NOTICE.md
 ```
+
+`horo-package.toml` and `files.manifest.json` remain authoritative for the whole
+archive. Each `extensions/<module-id>/extension.json` describes only that module,
+its entry variants and contributions as defined by
+[ADR-054](../adr/054-extension-and-package-authority-boundary.md).
 
 ## Global Package Cache
 

--- a/docs/architecture/editor/project-model.md
+++ b/docs/architecture/editor/project-model.md
@@ -54,7 +54,8 @@ A Horo project is a directory with a `.horo/` metadata folder:
 MyGame/
     .horo/
         project.json           # project identity and settings
-        plugins.json           # portable requested plugin dependencies
+        packages.json          # portable package and extension requests
+        packages.lock          # exact resolved package graph
         input.json             # portable project input defaults
         editor_workspace.json  # last editor layout and UI state
         asset_index.json       # derived asset lookup registry
@@ -76,11 +77,14 @@ paths are resolved from this root.
 Durable portable metadata, machine-local state, and derived output remain
 separate:
 
-- `.horo/project.json`, `.horo/plugins.json`, `.horo/input.json`, and asset sidecars are portable
-  source-controlled inputs
+- `.horo/project.json`, `.horo/packages.json`, `.horo/packages.lock`,
+  `.horo/input.json`, and asset sidecars are portable source-controlled inputs
 - `.horo/editor_workspace.json`, `.horo/local/`, and `.horo/asset_index.json`
   are local or derived state
 - `build/` contains generated build outputs and content-addressed asset caches
+
+Legacy `.horo/plugins.json` is read only by the transactional ADR-054 migration
+into `.horo/packages.json`; it is not a second package request authority.
 
 ## Project Format And Identity
 
@@ -619,8 +623,9 @@ never mutates GUI route state directly. Stateful open requests return typed
   CI credential provider.
 - Workspace state is user-specific and should not be committed to version
   control.
-- `.horo/project.json`, `.horo/plugins.json`, `.horo/input.json`, and asset metadata sidecars are
-  portable and may be committed. `.horo/editor_workspace.json`,
+- `.horo/project.json`, `.horo/packages.json`, `.horo/packages.lock`,
+  `.horo/input.json`, and asset metadata sidecars are portable and may be
+  committed. `.horo/editor_workspace.json`,
   `.horo/asset_index.json`, `.horo/local/`, and generated build/cache output
   should be ignored.
 

--- a/docs/architecture/extensions/plugin-system.md
+++ b/docs/architecture/extensions/plugin-system.md
@@ -47,7 +47,7 @@ how installable packages contribute modules and extension-point descriptors.
 
 | Term | Meaning |
 |---|---|
-| Extension package | Installable distribution artifact with a manifest, binaries or scripts, resources, licenses, and contribution descriptors. |
+| Extension package | A `.horopkg` whose package manifest declares one or more extension contribution descriptors. |
 | Module | A code/lifecycle boundary inside a package or project. Native modules may be dynamic libraries; script modules may be interpreted or compiled by a host runtime. |
 | Contribution | A manifest-declared item added to a typed extension point, such as an asset importer or editor panel. |
 | Extension point | A host-owned slot with a public descriptor contract and registry validation rules. |
@@ -80,6 +80,10 @@ Use these names deliberately:
   contribution and registry concepts.
 - An extension package may contain one or more modules and one or more
   contributions.
+- `horo-package.toml`, `files.manifest.json` and the verified package install
+  record own package identity, files and cross-package dependencies;
+  `extension.json` is only a module/contribution descriptor. See
+  [ADR-054](../../adr/054-extension-and-package-authority-boundary.md).
 - Extension packages may be backend-only, frontend-only, or hybrid. GUI support
   is optional presentation over host-approved backend capabilities; it is not
   the definition of an extension.
@@ -103,14 +107,17 @@ Use these names deliberately:
 
 ```text
 User / Project
-  -> declares package requirements in .horo/plugins.json
+  -> declares package requirements in .horo/packages.json
 
-Extension Manager
-  -> discovers packages
-  -> validates manifests and package integrity
-  -> resolves versions and dependencies
-  -> checks local trust and permissions
-  -> loads modules through the proper ABI boundary
+PackageService / PackageLifecycleService / TrustService
+  -> resolve one package graph
+  -> verify package and file manifests, integrity and compatibility
+  -> evaluate local trust and contribution enablement
+  -> produce exact immutable extension activation candidates
+
+ExtensionHost
+  -> validates the selected module descriptor and ABI binding
+  -> loads only the artifact named by the verified install record
   -> builds a candidate contribution set
 
 Typed Registries
@@ -132,43 +139,63 @@ explicitly grants that authority.
 ## Package Layout
 
 ```text
-FbxImporter/
-  extension.json
-  bin/
-    macos-arm64/libhoro_fbx_importer.dylib
-    linux-x64/libhoro_fbx_importer.so
-    windows-x64/horo_fbx_importer.dll
-  resources/
-    icons/fbx.svg
+com.vendor.fbx-importer-1.2.0.horopkg
+  horo-package.toml
+  files.manifest.json
+  extensions/
+    com.vendor.fbx-importer.native/
+      extension.json
+      bin/
+        macos-arm64/libhoro_fbx_importer.dylib
+        linux-x64/libhoro_fbx_importer.so
+        windows-x64/horo_fbx_importer.dll
+      resources/
+        icons/fbx.svg
   licenses/
 ```
 
-Paths in the manifest are normalized and must remain inside the package root.
-Symlinks, `..` traversal, absolute paths, and platform-specific path tricks do
-not bypass containment checks.
+The package manifest declares the extension descriptor path and contribution
+root. The signed file manifest declares the descriptor, binaries and resources.
+Paths are normalized and must remain inside the verified package root. Symlinks,
+`..` traversal, absolute paths, undeclared executable files and platform-specific
+path tricks do not bypass containment checks.
 
-## Manifest Schema
+## Module Descriptor Schema
 
-The manifest separates package identity, modules, contributions, permissions,
-and marketplace metadata:
+`extension.json` separates one module's ABI/entry variants, contributions and
+requested permissions. Package identity, dependencies, sources, trust and
+enablement remain in the package system:
 
 ```json
 {
-  "id": "com.vendor.fbx-importer",
-  "displayName": "FBX Importer",
-  "version": "1.2.0",
-  "apiVersion": 1,
-  "engineVersion": ">=0.8 <0.9",
-  "publisher": "Vendor",
-
-  "modules": [
-    {
-      "id": "com.vendor.fbx-importer.native",
-      "version": "2.0.0",
-      "kind": "native",
-      "entry": "bin/${platform}-${arch}/horo_fbx_importer"
-    }
-  ],
+  "schemaVersion": 1,
+  "ownerPackage": {
+    "id": "com.vendor.fbx-importer",
+    "version": "1.2.0"
+  },
+  "module": {
+    "id": "com.vendor.fbx-importer.native",
+    "version": "2.0.0",
+    "kind": "native",
+    "abi": "horo-extension-1",
+    "entries": [
+      {
+        "platform": "macos",
+        "architecture": "arm64",
+        "path": "bin/macos-arm64/libhoro_fbx_importer.dylib"
+      },
+      {
+        "platform": "linux",
+        "architecture": "x86_64",
+        "path": "bin/linux-x64/libhoro_fbx_importer.so"
+      },
+      {
+        "platform": "windows",
+        "architecture": "x86_64",
+        "path": "bin/windows-x64/horo_fbx_importer.dll"
+      }
+    ]
+  },
 
   "contributions": [
     {
@@ -189,29 +216,28 @@ and marketplace metadata:
   "permissions": [
     "project.read",
     "project.write.generated"
-  ],
-
-  "licenses": ["licenses/LICENSE.txt"]
+  ]
 }
 ```
 
-Every module has its own canonical semantic version. When `version` is omitted
-from a module entry, the package version is inherited and becomes the module's
-effective version. Contribution registries snapshot both contribution version
-and effective module version; durable asset provenance records both so a module
-upgrade is distinguishable from an importer-contract upgrade.
+Every module has its own canonical semantic version. The package contribution
+points to exactly one descriptor; packages with multiple modules declare multiple
+descriptor paths. Contribution registries snapshot package, module and
+contribution versions so a module upgrade remains distinguishable from an
+importer-contract upgrade.
 
 Validation rules:
 
-- Package IDs, module IDs, and contribution IDs are globally canonical and
-  stable.
+- Package IDs come only from the verified package install record. Module and
+  contribution IDs are globally canonical and stable.
+- An optional `ownerPackage` binding must exactly match that install record.
 - Module IDs belong to exactly one package.
 - Contribution IDs are unique across all active packages and built-in
   contributions.
-- A contribution may only reference a module in the same package unless the
-  extension point explicitly allows cross-package composition.
-- Required permissions must be declared at package level and approved by trust
-  policy before load.
+- A contribution references the descriptor's module. Cross-package dependencies
+  are declared only in `horo-package.toml` and the resolved package graph.
+- Descriptor-requested permissions must be a subset of the package contribution
+  capability envelope and approved by trust policy before load.
 - Unknown manifest fields are preserved only in documented extension namespaces;
   unknown required fields reject the package.
 
@@ -357,37 +383,35 @@ requiring ImGui to exist in the process.
 
 Packages are discovered from:
 
-1. packaged built-in extension directory
-2. user-installed extension directory
-3. project-declared package requirements after trust approval
-4. explicit development package path
+1. built-in package install records composed by the product host
+2. verified user-installed package records
+3. the project package graph after restore and trust approval
+4. explicit package-system development overrides
 
-Arbitrary current-directory scanning is forbidden.
+Arbitrary current-directory and raw extension-root scanning are forbidden in the
+production activation path.
 
-Project requirements live in `.horo/plugins.json`:
+Project requirements live in `.horo/packages.json`:
 
 ```json
 {
-  "required": [
-    {
-      "id": "com.vendor.fbx-importer",
-      "version": "^1.2.0"
+  "dependencies": {
+    "com.vendor.fbx-importer": {
+      "registry": "official",
+      "version": "^1.2.0",
+      "contributions": ["editor", "tools"]
     }
-  ],
-  "optional": [
-    {
-      "id": "com.horo.network.enet",
-      "version": ">=0.3 <0.4"
-    }
-  ]
+  }
 }
 ```
 
 This file is portable project intent, not a trust grant and not a resolved local
-path. The Extension Manager resolves package IDs and versions against installed
-packages, development overrides, and optional marketplace metadata. Duplicate
-package IDs, conflicting version ranges, missing dependencies, or incompatible
-platform assets fail before any binary loads.
+path. `PackageResolver` resolves package IDs and versions once and pins the exact
+graph in `.horo/packages.lock`. `PackageLifecycleService` and `TrustService`
+produce activation candidates; ExtensionHost does not resolve another graph.
+Duplicate package IDs, conflicting version ranges, missing dependencies, owner
+binding mismatches or incompatible platform artifacts fail before any binary
+loads. Legacy `.horo/plugins.json` is migration input only under ADR-054.
 
 ## Trust And Permissions
 
@@ -781,7 +805,7 @@ When the activity bar icon is clicked, the bound drawer opens. The module owns
 the entire content area of that drawer. Horo provides two paths for building the
 panel UI:
 
-**1. Declarative field layout (preferred for data-driven panels)**
+#### 1. Declarative field layout (preferred for data-driven panels)
 
 Modules register a typed field schema. The host renders standard Horo form
 controls — text inputs, dropdowns, checkboxes, sliders, color pickers — without
@@ -804,7 +828,7 @@ struct CurveEditorFields {
 };
 ```
 
-**2. Custom ImGui rendering (for graphical or interactive panels)**
+#### 2. Custom ImGui rendering (for graphical or interactive panels)
 
 Modules receive an `EditorDrawerContext` with a dedicated ImGui container.
 They can draw any ImGui content — plots, node graphs, custom widgets — inside
@@ -872,8 +896,7 @@ Each package entry points to immutable GitHub Release artifacts:
   "latest": "1.2.0",
   "versions": {
     "1.2.0": {
-      "manifestUrl": "https://github.com/vendor/horo-fbx/releases/download/v1.2.0/extension.json",
-      "packageUrl": "https://github.com/vendor/horo-fbx/releases/download/v1.2.0/horo-fbx-1.2.0.zip",
+      "packageUrl": "https://github.com/vendor/horo-fbx/releases/download/v1.2.0/com.vendor.fbx-importer-1.2.0.horopkg",
       "sha256": "...",
       "signature": "...",
       "engineVersion": ">=0.8 <0.9",
@@ -925,7 +948,7 @@ private registry mirror with the same metadata schema.
 ## Lifecycle
 
 ```text
-Discovered -> Resolved -> Validated -> Trusted -> Loaded -> Registered -> Active
+Resolved -> Verified -> Installed -> Trusted -> Enabled -> Loaded -> Registered -> Active
 ```
 
 Disable, update, and removal operations are staged and applied on restart by
@@ -1008,6 +1031,15 @@ Artifact signatures, updates, dependency resolution, per-project requirements,
 removal, private-registry credentials, and live-safe contribution types remain
 future work.
 
+This inventory/manager is transitional and does not define the target package
+authority. The ADR-054 migration inventories top-level legacy `extension.json`
+directories without loading them, generates canonical package and file manifests
+in staging, obtains trust review for the generated digest, publishes one verified
+package install record and converts `.horo/plugins.json` requests into the package
+graph transactionally. After that cutover ExtensionHost accepts only immutable
+activation candidates from verified install records; direct directory loading is
+retained only in an explicitly marked development/test adapter until removed.
+
 ## Testing
 
 Required tests cover:
@@ -1038,6 +1070,10 @@ Required tests cover:
 - shutdown ordering and no host callbacks after module teardown
 - no STL, exceptions, or cross-allocator ownership in ABI fixtures
 - marketplace registry schema, SHA-256, signature, and release URL validation
+- extension-only and hybrid `.horopkg` authority fixtures
+- raw directory and undeclared descriptor/binary activation rejection
+- legacy directory and `.horo/plugins.json` migration dry-run, rollback and
+  idempotent resume
 
 The repository's executable reference fixture lives under
 `examples/extensions/asset-importer-basic`. Its automated contract test loads

--- a/docs/architecture/extensions/plugin-system.md
+++ b/docs/architecture/extensions/plugin-system.md
@@ -164,7 +164,8 @@ path tricks do not bypass containment checks.
 
 `extension.json` separates one module's ABI/entry variants, contributions and
 requested permissions. Package identity, dependencies, sources, trust and
-enablement remain in the package system:
+enablement remain in the package system. Every path in the descriptor is relative
+to the verified package root, not to the descriptor directory:
 
 ```json
 {
@@ -182,17 +183,17 @@ enablement remain in the package system:
       {
         "platform": "macos",
         "architecture": "arm64",
-        "path": "bin/macos-arm64/libhoro_fbx_importer.dylib"
+        "path": "extensions/com.vendor.fbx-importer.native/bin/macos-arm64/libhoro_fbx_importer.dylib"
       },
       {
         "platform": "linux",
         "architecture": "x86_64",
-        "path": "bin/linux-x64/libhoro_fbx_importer.so"
+        "path": "extensions/com.vendor.fbx-importer.native/bin/linux-x64/libhoro_fbx_importer.so"
       },
       {
         "platform": "windows",
         "architecture": "x86_64",
-        "path": "bin/windows-x64/horo_fbx_importer.dll"
+        "path": "extensions/com.vendor.fbx-importer.native/bin/windows-x64/horo_fbx_importer.dll"
       }
     ]
   },

--- a/docs/architecture/foundation/configuration-system.md
+++ b/docs/architecture/foundation/configuration-system.md
@@ -32,7 +32,7 @@ Configuration is divided by ownership:
 | Engine defaults | fixed timestep, default backend | packaged resources |
 | User preferences | theme, editor behavior, log filters | user config directory |
 | Project settings | default scene, physics, target profiles | `.horo/project.json` |
-| Project extension package requests | desired package IDs, versions, permission intent | `.horo/plugins.json` |
+| Project package and extension requests | desired package IDs, versions, sources and contribution groups | `.horo/packages.json` |
 | Workspace settings | panel layout, local editor state | editor workspace file |
 | Session overrides | temporary profiling or preview options | memory only |
 | Invocation overrides | CLI and environment overrides | process launch |

--- a/docs/architecture/foundation/system-design.md
+++ b/docs/architecture/foundation/system-design.md
@@ -395,6 +395,14 @@ leased resources and consumes committed revisions. Background jobs publish via
 and implementation gates are defined by
 [ADR-016](../../adr/016-navigation-target-ownership-and-dependency-boundary.md).
 
+[ADR-054](../../adr/054-extension-and-package-authority-boundary.md) keeps
+extension package composition in the application boundary. Package resolution,
+verified install records, trust and durable enablement are application/package
+services. `ExtensionHost` consumes an immutable exact activation candidate,
+loads the declared module through `ExtensionApi`, and owns only live module and
+registry leases. It cannot scan raw directories, resolve dependencies, grant
+trust or mutate package lifecycle state.
+
 ## Dependency Direction
 
 Arrows point from the dependent target to the target that defines the contract:

--- a/docs/architecture/packages/package-lifecycle.md
+++ b/docs/architecture/packages/package-lifecycle.md
@@ -35,6 +35,11 @@ Resolve
 Install does not imply trust. Trust does not imply activation. Activation does
 not bypass contribution validation.
 
+[ADR-054](../../adr/054-extension-and-package-authority-boundary.md) applies this
+same lifecycle to extension-only and hybrid packages. `ExtensionHost` is the
+live module/contribution host for an exact verified activation candidate; it does
+not own a parallel install, dependency, trust or enablement lifecycle.
+
 ## Transactional Install
 
 Package install uses the same safety posture as distribution staging:
@@ -66,6 +71,25 @@ safe merely by reducing permissions.
 In non-interactive mode, new trust requirements fail unless a policy allowlist or
 previous user-local trust state exists.
 
+### Extension Activation Hand-Off
+
+For each enabled extension descriptor, `PackageLifecycleService` lends
+ExtensionHost one immutable candidate containing the verified install-record
+identity/lease, package and manifest digests, selected declared module artifact,
+approved permissions/capabilities and target activation generation. The host
+cannot accept a caller-selected raw directory or scan for another descriptor.
+
+ExtensionHost validates the descriptor/ABI/artifact binding, builds the complete
+candidate contribution batch and commits live registrations atomically. Its
+returned generation/leases prove live activation; only then may the package
+lifecycle snapshot publish `Active`. Failure leaves the package installed and
+records a typed activation outcome without granting trust or partial registry
+state.
+
+Disable, update, rollback and uninstall first detach contributed surfaces and
+registries, reject/drain callbacks and jobs, and release module leases. Verified
+cache content is not removed while an activation or content lease can still call
+or read it.
 
 ## Enablement State
 
@@ -140,7 +164,6 @@ If required references remain, policy may:
 
 Silent dangling references are forbidden.
 
-
 ## Rollback Contract
 
 Package lifecycle operations write a transaction journal before mutating project
@@ -171,6 +194,14 @@ requiresUserReview = true
 
 Migration plans must be previewable. Any migration that changes project-owned
 scene or asset files uses editor document commands/transactions where applicable.
+
+Legacy extension directories and `.horo/plugins.json` use the bounded ADR-054
+migration. It parses legacy metadata only to build a preview, generates a
+canonical `horo-package.toml`, `files.manifest.json` and package-scoped extension
+descriptor in staging, revalidates the result as one package, requests trust for
+the generated digest and atomically converts project requests to
+`.horo/packages.json`. The old directory/request state remains recoverable until
+commit and is never active at the same time as the new package authority.
 
 ## Conflict Policy
 
@@ -244,6 +275,9 @@ The modal must show:
 - transaction journal restores metadata and activation state on failed update
 - runtime enablement is portable while trust remains user-local
 - editor contribution deactivation closes panels safely
+- exact install-record/descriptor binding and stale activation generation
+- no raw-directory ExtensionHost activation
+- legacy extension migration preview, trust review, rollback and resume
 
 ## Related Documents
 

--- a/docs/architecture/packages/package-system.md
+++ b/docs/architecture/packages/package-system.md
@@ -17,13 +17,19 @@ Detailed restore, lifecycle, and release behavior is defined by:
 A Horo project must be restorable, verifiable, portable, releasable, and secure
 from committed project metadata plus declared package sources.
 
+[ADR-054](../../adr/054-extension-and-package-authority-boundary.md) makes this
+package model authoritative for extension-only and hybrid packages as well as
+asset, game-library and template packages. ExtensionHost consumes verified
+activation candidates; it is not a second resolver, installer or trust store.
+
 The package system is not a replacement for the asset importer or the extension
 system:
 
 - Asset importers convert individual source assets into project assets.
 - Packages distribute resolved sets of assets, scripts, behaviors, services,
   samples, templates, and optional editor contributions.
-- Editor/IDE addons remain high-trust Extension System contributions.
+- Editor/IDE addons are high-trust Extension System contributions carried by the
+  same package manifest, verification, lock and lifecycle model.
 
 ## Core Distinctions
 
@@ -48,6 +54,7 @@ and require separate trust approval.
 enum class HoroPackageKind {
     AssetPackage,
     GameLibrary,
+    ExtensionPackage,
     HybridPackage,
     TemplatePackage,
 };
@@ -71,6 +78,11 @@ enum class PackageContributionKind {
 Contribution kinds are validated independently. A `HybridPackage` may declare
 runtime and editor contributions, but editor contributions are not activated
 unless the extension trust flow succeeds.
+
+An `ExtensionPackage` contains one or more extension descriptors and may include
+only their declared binaries, scripts, resources, schemas, licenses and
+documentation. A package that also contributes project assets, gameplay code or
+services is a `HybridPackage`; both shapes use the same package authority.
 
 ## Package Operations
 
@@ -115,7 +127,7 @@ scripts = ["scripts/"]
 behaviors = ["behaviors/"]
 services = ["services/"]
 samples = ["samples/"]
-editor = ["editor/"]
+extensions = ["extensions/"]
 documentation = ["docs/"]
 
 [[contribution]]
@@ -128,7 +140,8 @@ capabilities = ["runtime.assets", "runtime.input"]
 [[contribution]]
 kind = "EditorExtension"
 id = "com.example.horo.gun-pack.editor-tools"
-root = "editor/"
+root = "extensions/com.example.horo.gun-pack.editor-tools/"
+descriptor = "extensions/com.example.horo.gun-pack.editor-tools/extension.json"
 required = false
 capabilities = ["editor.panel", "asset.inspect"]
 
@@ -156,7 +169,7 @@ package.horopkg
   scripts/
   behaviors/
   services/
-  editor/
+  extensions/
   samples/
   docs/
   NOTICE.md
@@ -186,6 +199,21 @@ activation, the verifier expands them into typed descriptors that declare:
 
 Activation, release inclusion, conflict checks, and dependency resolution use the
 expanded descriptors, not raw folder names.
+
+### Extension Descriptor Boundary
+
+An extension contribution points to one package-relative
+`extensions/<module-id>/extension.json`. The descriptor owns only module ABI,
+entry variants, contributions and requested permissions. It may defensively bind
+the owner package ID/version, but the binding must equal the parsed package
+manifest and verified install record.
+
+Package identity, version, source, cross-package dependencies, update channel,
+trust and enablement remain outside `extension.json`. Every descriptor, binary
+and resource is present in `files.manifest.json`; ExtensionHost receives an exact
+validated descriptor and install-record lease rather than scanning a directory.
+The complete authority and activation hand-off are defined by
+[ADR-054](../../adr/054-extension-and-package-authority-boundary.md).
 
 ## Package Sources
 
@@ -267,7 +295,6 @@ Package sources are resolved under package source policy. The policy defines:
 
 HTTP without TLS, unbounded redirects, unpinned mutable artifacts, and secrets in
 URLs are rejected unless an explicit local development policy allows them.
-
 
 ## Dependency Request And Lockfile
 
@@ -389,7 +416,6 @@ Rules:
 - editor extensions activate through the Extension System
 - trust approval, denial, revocation, and activation are audit events
 
-
 ### Trust Metadata Is Not Authoritative
 
 Declared package security metadata is advisory. The host computes required trust
@@ -509,7 +535,7 @@ Validation checks:
 | `PackageLifecycleService` | Install, enable, activate, update, uninstall, migrate |
 | `AssetImportService` | Imports individual assets from packages |
 | `GameplayModuleBoundary` | Registers game library modules, behaviors, services |
-| `ExtensionHost` | Activates trusted editor extension contributions |
+| `ExtensionHost` | Activates exact trusted extension candidates from verified install records and owns live module/registry leases |
 | `TrustService` | Evaluates signature, trust level, and user/policy approval |
 
 Editor modals, CLI commands, MCP tools, and CI jobs are adapters. They call these
@@ -534,7 +560,6 @@ type, phase, duration, byte count, cache hit, verification result, and trust
 requirement. They must not include URL query tokens, auth headers, raw secrets,
 or sensitive local paths.
 
-
 ## Required Tests
 
 - manifest schema validation
@@ -552,6 +577,9 @@ or sensitive local paths.
 - package-scoped asset identity resolves through lockfile
 - package-declared low trust cannot bypass computed trust requirement
 - package signature requires a trusted publisher root
+- extension descriptor owner/package binding and undeclared-file rejection
+- extension-only and hybrid packages resolve through the same request/lock graph
+- ExtensionHost cannot load raw directories or resolve/trust package state
 
 ## Related Documents
 

--- a/docs/guides/extension-module-development.md
+++ b/docs/guides/extension-module-development.md
@@ -26,15 +26,19 @@ compile previews through the approved backend capability.
 
 ```text
 com.vendor.shader-tools
-  extension.json
-  bin/
-    macos-arm64/libhoro_shader_tools.dylib
-    linux-x64/libhoro_shader_tools.so
-    windows-x64/horo_shader_tools.dll
-  schemas/
-    compile-preview.schema.json
-  resources/
-    icons/shader-tools.svg
+  horo-package.toml
+  files.manifest.json
+  extensions/
+    com.vendor.shader-tools.native/
+      extension.json
+      bin/
+        macos-arm64/libhoro_shader_tools.dylib
+        linux-x64/libhoro_shader_tools.so
+        windows-x64/horo_shader_tools.dll
+      schemas/
+        compile-preview.schema.json
+      resources/
+        icons/shader-tools.svg
 ```
 
 The package does not patch `EditorLayer`, does not subscribe directly to
@@ -47,16 +51,18 @@ permission checks, result storage, and teardown.
 
 1. Choose whether the package is backend-only, frontend-only, or hybrid.
 2. Choose the extension points.
-3. Declare package, module, permissions, settings, errors, events, and UI
-   contributions in `extension.json`.
-4. Implement the native module behind the Horo extension C ABI.
-5. Register factories for the declared contributions.
-6. Read engine and IDE data through approved query capabilities.
-7. Mutate engine/editor state only through typed commands or application use
+3. Declare package identity, dependencies and the extension descriptor path in
+   `horo-package.toml`.
+4. Declare module ABI/entries, permissions, settings, errors, events, and UI
+   contributions in the package-scoped `extension.json`.
+5. Implement the native module behind the Horo extension C ABI.
+6. Register factories for the declared contributions.
+7. Read engine and IDE data through approved query capabilities.
+8. Mutate engine/editor state only through typed commands or application use
    cases.
-8. Observe changes through `EditorDataBus` or approved process-event imports.
-9. Store only bounded presentation state under the contribution ID.
-10. Test registration, permission denial, event handling, workspace persistence,
+9. Observe changes through `EditorDataBus` or approved process-event imports.
+10. Store only bounded presentation state under the contribution ID.
+11. Test registration, permission denial, event handling, workspace persistence,
    and teardown.
 
 Every module and every importer contribution declares an independent canonical
@@ -68,25 +74,54 @@ unversioned contribution instead of publishing ambiguous provenance.
 
 ## Manifest
 
-A minimal manifest for the Shader Tools package:
+A minimal package manifest contribution points to the module descriptor:
+
+```toml
+[package]
+id = "com.vendor.shader-tools"
+version = "1.0.0"
+kind = "extension"
+
+[[contribution]]
+kind = "EditorExtension"
+id = "com.vendor.shader-tools.native"
+root = "extensions/com.vendor.shader-tools.native/"
+descriptor = "extensions/com.vendor.shader-tools.native/extension.json"
+required = false
+```
+
+The package-scoped module descriptor is:
 
 ```json
 {
-  "id": "com.vendor.shader-tools",
-  "displayName": "Shader Tools",
-  "version": "1.0.0",
-  "apiVersion": 1,
-  "engineVersion": ">=0.8 <0.9",
-  "publisher": "Vendor",
-
-  "modules": [
-    {
-      "id": "com.vendor.shader-tools.native",
-      "version": "1.0.0",
-      "kind": "native",
-      "entry": "bin/${platform}-${arch}/horo_shader_tools"
-    }
-  ],
+  "schemaVersion": 1,
+  "ownerPackage": {
+    "id": "com.vendor.shader-tools",
+    "version": "1.0.0"
+  },
+  "module": {
+    "id": "com.vendor.shader-tools.native",
+    "version": "1.0.0",
+    "kind": "native",
+    "abi": "horo-extension-1",
+    "entries": [
+      {
+        "platform": "macos",
+        "architecture": "arm64",
+        "path": "bin/macos-arm64/libhoro_shader_tools.dylib"
+      },
+      {
+        "platform": "linux",
+        "architecture": "x86_64",
+        "path": "bin/linux-x64/libhoro_shader_tools.so"
+      },
+      {
+        "platform": "windows",
+        "architecture": "x86_64",
+        "path": "bin/windows-x64/horo_shader_tools.dll"
+      }
+    ]
+  },
 
   "contributions": [
     {
@@ -276,12 +311,15 @@ already validated from the manifest.
 For a complete compiling implementation, use
 `examples/extensions/asset-importer-basic`. It registers an `.hraw` importer,
 one preset-compatible boolean setting, a versioned editor payload, and an RGBA8
-preview callback. Its `extension.json` declares the same package, module, and
-contribution IDs returned through the binary boundary.
+preview callback. Its current top-level `extension.json` is a legacy development
+fixture; ADR-054 migration moves package identity into `horo-package.toml` and
+the module descriptor below `extensions/<module-id>/` without changing the
+module/contribution IDs returned through the binary boundary.
 
-Build it with `-DHORO_BUILD_EXAMPLES=ON`. CMake places `extension.json` beside
-the platform library, so the resulting absolute directory can be passed
-directly to `ExtensionManager::LoadExtension`.
+Build it with `-DHORO_BUILD_EXAMPLES=ON`. Until the package activation-candidate
+path is implemented, CMake places the legacy descriptor beside the platform
+library for the explicit development/test `ExtensionManager::LoadExtension`
+adapter. Production activation must not use that raw-directory path.
 
 Activation receives a module context containing only the capabilities approved by
 manifest, trust, project policy, and host availability.

--- a/docs/guides/extension-module-development.md
+++ b/docs/guides/extension-module-development.md
@@ -90,7 +90,8 @@ descriptor = "extensions/com.vendor.shader-tools.native/extension.json"
 required = false
 ```
 
-The package-scoped module descriptor is:
+The package-scoped module descriptor is below. Every path inside it is relative
+to the verified package root, not to the descriptor directory.
 
 ```json
 {
@@ -108,17 +109,17 @@ The package-scoped module descriptor is:
       {
         "platform": "macos",
         "architecture": "arm64",
-        "path": "bin/macos-arm64/libhoro_shader_tools.dylib"
+        "path": "extensions/com.vendor.shader-tools.native/bin/macos-arm64/libhoro_shader_tools.dylib"
       },
       {
         "platform": "linux",
         "architecture": "x86_64",
-        "path": "bin/linux-x64/libhoro_shader_tools.so"
+        "path": "extensions/com.vendor.shader-tools.native/bin/linux-x64/libhoro_shader_tools.so"
       },
       {
         "platform": "windows",
         "architecture": "x86_64",
-        "path": "bin/windows-x64/horo_shader_tools.dll"
+        "path": "extensions/com.vendor.shader-tools.native/bin/windows-x64/horo_shader_tools.dll"
       }
     ]
   },


### PR DESCRIPTION
## Summary

- Makes `.horopkg`, `horo-package.toml`, `files.manifest.json`, and the verified install record the single durable authority for extension-only and hybrid packages.
- Narrows `extension.json` to a package-scoped module ABI, entry, contribution, and permission descriptor.
- Defines the exact hand-off between package resolution/lifecycle/trust services and `ExtensionHost`.
- Adds canonical package layouts and a transactional migration from legacy extension directories and `.horo/plugins.json`.

## Why

The package and extension documents previously described competing identities, dependency graphs, trust stores, installers, and update paths. A hybrid add-on could therefore resolve through one package graph while `ExtensionHost` loaded a different raw directory or version.

## Decision

- Every installable extension is a Horo package; package identity, dependency resolution, files, signatures, source, updates, and rollback have one authority.
- `extension.json` owns only module-local ABI/entry variants, contributions, and requested permissions; cross-package dependencies and trust decisions are forbidden there.
- Every descriptor path is relative to the verified package root and must resolve through the leased install record.
- `ExtensionHost` accepts an immutable activation candidate, validates ABI/identity, and owns live leases; it cannot scan, install, trust, enable, or mutate package state.
- Portable requests move to `.horo/packages.json` and the common lock graph; local execution trust remains non-portable.
- Legacy migration is previewable, transactional, trust-aware, recoverable, and never auto-activates native code.

## Validation

- [x] Replayed the HORO-69 change onto current `main`; obsolete stack ancestry is absent from the PR.
- [x] `markdownlint-cli` passed for every changed Markdown file.
- [x] `git diff --check` passed.
- [x] All newly added local Markdown links resolve.
- [x] No unresolved TODO/TBD/open-decision marker remains.
- [x] Corrected all six entry examples to use package-root-relative paths and resolved both Codacy threads.
- [ ] Executable migration and activation-candidate tests are downstream implementation work; ADR-054 specifies the required matrix.

## Risk and rollout

This documentation decision intentionally breaks the top-level `extension.json` install layout and removes `.horo/plugins.json` as an active resolver after migration. Rollout therefore requires generated package/file manifests, a visible dry-run diff, trust reapproval against the generated digest, atomic project-request conversion, and recoverable rollback.

## Issue links

- Jira: [HORO-69](https://horo-engine.atlassian.net/browse/HORO-69)
- GitHub: Closes #69

## Reviewer notes

Review ADR-054 first, then Package System, Package Lifecycle, and Extension System. The project-tree, project-model, configuration, system-design, and development-guide changes project the same single-authority boundary.


[HORO-69]: https://horo-engine.atlassian.net/browse/HORO-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ