### PR TITLE
docs(extensions): define typed manifest model HORO-70 #70 [EXT-001.2]

### DIFF
--- a/docs/adr/055-extension-manifest-v1-typed-model.md
+++ b/docs/adr/055-extension-manifest-v1-typed-model.md
@@ -256,7 +256,6 @@ struct ExtensionSettingDescriptorV1 {
     ExtensionSettingId id;
     ExtensionModuleId owner;
     ExtensionSettingScope scope;
-    ExtensionSettingValueKind kind;
     ExtensionSettingValue defaultValue;
     ExtensionSettingConstraints constraints;
     ExtensionSettingReloadPolicy reload;
@@ -268,9 +267,11 @@ struct ExtensionSettingDescriptorV1 {
 
 Scope is one of user, workspace, project, project-profile or session under the
 configuration contract. Reload policy is a closed enum such as `ImmediateSafe`,
-`NextOperation`, `NextActivation` or `RestartRequired`. Kind, default and
-constraints must match exactly. Secret values are not manifest defaults; settings
-that need credentials use typed credential-reference capability contracts.
+`NextOperation`, `NextActivation` or `RestartRequired`. The serialized `kind`
+selects the `defaultValue` variant during decoding and is not retained as a second
+typed-model discriminator; constraints must match that active variant exactly.
+Secret values are not manifest defaults; settings that need credentials use typed
+credential-reference capability contracts.
 
 Settings are declared once and referenced by ID from contributions or service
 exports. Prefix/string convention is not used to infer ownership. Preset opt-in is
@@ -347,6 +348,14 @@ package resource with bounded typed signatures; it cannot expose raw host/module
 pointers, C++ names, arbitrary reflection or undeclared functions. A
 `ScriptProvider` role without a script API, or a script API referencing a missing/
 incompatible service/runtime/permission, is invalid.
+
+The script API permission set is additive to its referenced service export, not a
+replacement or subset constraint. Validation computes the effective requirement
+as the set union of both declarations, requires every member of that union to be
+declared by the descriptor and remain inside the package capability envelope, and
+records the union in the activation candidate. Trust approval and every script
+invocation are gated on that complete effective set, so a binding cannot hide or
+subtract a permission required by its underlying service.
 
 ### 10. Cross-reference validation is complete before activation
 

--- a/docs/adr/055-extension-manifest-v1-typed-model.md
+++ b/docs/adr/055-extension-manifest-v1-typed-model.md
@@ -1,0 +1,463 @@
+# ADR-055: Extension Manifest V1 Typed Model
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Backend- and GUI-neutral typed model for package-scoped extension modules, contributions, permissions, settings, events, errors, service exports and script bindings
+- **Issue**: [EXT-001.2](https://github.com/abdullahbodur/horo-engine/issues/70)
+- **Jira**: [HORO-70](https://horo-engine.atlassian.net/browse/HORO-70)
+- **Related**: [ADR-054](054-extension-and-package-authority-boundary.md)
+- **Normative documents**: [Extension System](../architecture/extensions/plugin-system.md), [Horo Package System](../architecture/packages/package-system.md), [Extension Module Development Guide](../guides/extension-module-development.md), [System Design](../architecture/foundation/system-design.md)
+
+## Context
+
+The current public `ExtensionManifest` stores package, module, contribution,
+compatibility and platform facts as unrelated strings. It accepts implicit module
+defaults, carries an absolute `rootPath`, knows only three contribution fields and
+cannot represent permissions, settings, events, errors, service exports or script
+bindings. Callers must interpret values such as `kind`, `type`, `sdkAbi` and
+platform names after parsing. Invalid references can therefore survive until a
+dynamic library is selected or a contribution callback registers.
+
+ADR-054 removes the larger ambiguity: package identity, files, dependencies,
+trust and enablement belong to the package system, while each package-scoped
+`extension.json` describes one module and its contributions. A complete typed v1
+model must now bind that module descriptor to the exact verified package record,
+represent GUI-only, backend-only, script-consumable and mixed roles without
+inference, and validate every reference before ExtensionHost may activate code.
+
+The model is a public Horo contract used by package validation, trust planning,
+ExtensionHost, CLI/MCP/UI projections and tests. It cannot expose JSON-library
+nodes, filesystem/native paths, ImGui types, backend handles, dynamic-library
+objects or mutable registry state.
+
+## Decision
+
+### 1. Parsing, validation and activation use distinct immutable values
+
+The boundary exposes three stages:
+
+```text
+bounded syntax/schema decode
+    -> DecodedExtensionModuleManifestV1
+semantic and cross-reference validation against VerifiedPackageInstallRecord
+    -> ValidatedExtensionModuleManifestV1
+package graph composition and trust/host resolution
+    -> ExtensionActivationCandidate
+```
+
+Only `ValidatedExtensionModuleManifestV1` may enter package contribution indexes
+or trust planning. Only an `ExtensionActivationCandidate` may enter
+ExtensionHost. A decoded value is never “partially valid” and cannot expose an
+entry artifact or register a contribution.
+
+All values own their data. Validation returns a new immutable value and indexes;
+it does not mutate the decoded object in place. The result retains the canonical
+descriptor digest and exact package install-record revision used for validation.
+
+### 2. Identity types are not interchangeable strings
+
+V1 uses distinct bounded canonical value types:
+
+```cpp
+struct ExtensionManifestSchemaVersion;
+struct ExtensionManifestDigest;
+struct ExtensionModuleId;
+struct ExtensionContributionId;
+struct ExtensionSettingId;
+struct ExtensionEventId;
+struct ExtensionErrorDomainId;
+struct ExtensionErrorCode;
+struct ExtensionServiceExportId;
+struct ExtensionScriptApiId;
+struct ExtensionPointSchemaId;
+struct ExtensionPermissionId;
+struct ExtensionCapabilityId;
+struct LocalizationMessageId;
+struct PackageResourceId;
+```
+
+Package ID/version, package file identity, semantic versions/ranges, operating
+system, CPU architecture, hashes and install-record IDs reuse the package and
+foundation typed contracts from ADR-054. A module ID cannot be passed where a
+contribution, service, event or script API ID is required even when the canonical
+text is identical.
+
+Canonical IDs use registered domain-specific grammar and bounds. Human labels,
+descriptions and localization keys are presentation metadata, never identity.
+Paths are validated package-relative resource/file identities from the verified
+file manifest; the public model contains no absolute path and never joins paths.
+
+### 3. One descriptor owns exactly one explicitly role-tagged module
+
+The module envelope is:
+
+```cpp
+enum class ExtensionModuleRuntimeKind {
+    NativeCAbi,
+    Lua54,
+    Declarative,
+};
+
+enum class ExtensionModuleRole {
+    BackendCapability,
+    EditorPresentation,
+    HeadlessTooling,
+    ScriptProvider,
+    RuntimeParticipant,
+};
+
+struct ExtensionModuleDescriptorV1 {
+    ExtensionModuleId id;
+    SemanticVersion version;
+    ExtensionModuleRuntimeKind runtimeKind;
+    EnumSet<ExtensionModuleRole> roles;
+    ExtensionAbiRequirement abi;
+    std::vector<ExtensionEntryVariant> entries;
+    ExtensionLifecyclePolicy lifecycle;
+};
+```
+
+`roles` is non-empty and explicit. Runtime kind answers how code/data executes;
+roles answer what the module is allowed to contribute. They are orthogonal:
+
+| Shape | Required roles | Typical contributions |
+|---|---|---|
+| GUI-only | `EditorPresentation` | panel, tab, settings page over an existing capability |
+| Backend/library-only | `BackendCapability` and optionally `HeadlessTooling` | importer, cooker, validator, command provider |
+| Script-consumable | `BackendCapability` + `ScriptProvider` | typed service export plus approved script API binding |
+| Mixed-role | explicit union of its real roles | backend service plus GUI/CLI/MCP adapters |
+
+A module cannot gain a role because an unknown contribution string resembles a
+GUI or runtime type. Contributions, service exports and script bindings must be
+permitted by the declared role set. `RuntimeParticipant` remains restricted by
+gameplay/runtime policy; declaring the role does not grant activation.
+
+Native entry variants contain typed host OS, architecture, build/ABI profile,
+minimum platform version and one `PackageFileId`. Lua/declarative entries use
+their matching typed artifact/schema identity. Duplicate or overlapping selector
+keys are invalid. A validated descriptor may have no current-host entry, but host
+resolution must return typed `UnsupportedHost`; it cannot choose another variant.
+
+### 4. The complete manifest is a typed aggregate
+
+```cpp
+struct ExtensionPackageBindingV1 {
+    HoroPackageId packageId;
+    SemanticVersion packageVersion;
+    PackageManifestDigest packageManifest;
+    PackageInstallRecordId installRecord;
+    PackageInstallRecordRevision revision;
+};
+
+struct ValidatedExtensionModuleManifestV1 {
+    ExtensionManifestSchemaVersion schema;
+    ExtensionPackageBindingV1 package;
+    ExtensionModuleDescriptorV1 module;
+    std::vector<ExtensionPermissionRequirement> permissions;
+    std::vector<ExtensionContributionDescriptorV1> contributions;
+    std::vector<ExtensionServiceExportDescriptorV1> serviceExports;
+    std::vector<ExtensionScriptApiDescriptorV1> scriptApis;
+    std::vector<ExtensionSettingDescriptorV1> settings;
+    std::vector<ExtensionEventDescriptorV1> events;
+    std::vector<ExtensionErrorDescriptorV1> errors;
+    std::vector<ExtensionManifestExtensionV1> extensions;
+    ExtensionManifestDigest digest;
+};
+```
+
+The JSON descriptor may contain an `ownerPackage` ID/version assertion. The
+validator replaces no package data from that assertion: it checks equality and
+builds `ExtensionPackageBindingV1` exclusively from the leased verified install
+record. Package display name, author, source, dependencies, trust and enablement
+are not extension-manifest fields.
+
+A package with multiple modules owns multiple validated descriptor values.
+`ValidatedExtensionPackageComposition` binds them to one package record, rejects
+duplicate IDs across descriptors and builds immutable lookup indexes. No “default
+module” is synthesized and module version never inherits silently from package
+version in canonical v1.
+
+### 5. Contributions use typed payload variants and registered schemas
+
+Every contribution has a common envelope:
+
+```cpp
+struct ExtensionContributionDescriptorV1 {
+    ExtensionContributionId id;
+    SemanticVersion version;
+    ExtensionModuleId owner;
+    ExtensionPointSchemaId point;
+    ExtensionContributionRequirement requirement;
+    EnumSet<ExtensionCapabilityId> requiredCapabilities;
+    EnumSet<ExtensionPermissionId> requiredPermissions;
+    ExtensionContributionPayloadV1 payload;
+};
+```
+
+`ExtensionContributionPayloadV1` is a closed `std::variant` of the typed payload
+models supported by schema v1, including asset importer/cooker/preview, project
+validator, application capability, process observer, pipeline step, toolchain
+provider, command, MCP tool and approved editor-surface descriptors. A payload
+contains Horo resource IDs, placement enums/IDs, localization keys, field schemas,
+operation/thread policies and other typed values required by its extension point.
+It contains no ImGui callback, renderer/native handle, service locator, arbitrary
+property map or backend enum.
+
+The host owns a versioned `ExtensionPointSchemaCatalog`. The manifest names the
+exact schema ID/version represented by the payload. A known point with a wrong
+payload alternative/version is invalid. An unsupported required point rejects the
+package; an optional unavailable point remains an explicit inactive outcome and
+never becomes an opaque live contribution.
+
+Backend/library behavior is exposed as an application capability, provider,
+operation or service export. GUI, command, CLI and MCP contributions are separate
+adapters that reference that typed authority. A GUI contribution cannot hide a
+backend operation in arbitrary UI payload data.
+
+### 6. Permissions are typed requirements, not grants
+
+```cpp
+enum class ExtensionPermissionRequirementKind {
+    Required,
+    Optional,
+};
+
+struct ExtensionPermissionRequirement {
+    ExtensionPermissionId id;
+    ExtensionPermissionRequirementKind requirement;
+    LocalizationMessageId rationale;
+};
+```
+
+Permission IDs resolve through the host's sealed/versioned permission catalog.
+Unknown required IDs reject the descriptor; optional IDs make only their dependent
+contributions unavailable. A descriptor's permission set must be a subset of the
+package contribution capability envelope from ADR-054. The validated model records
+requests and dependency edges, not trust approval. `TrustService` supplies the
+approved subset later in the activation candidate.
+
+Every contribution, service export and script binding names the permissions it
+requires. A top-level unused permission is rejected rather than silently granting
+future authority, and a referenced undeclared permission is invalid.
+
+### 7. Settings are typed, scoped and reload-aware
+
+```cpp
+using ExtensionSettingValue = std::variant<
+    bool,
+    std::int64_t,
+    double,
+    BoundedUtf8String,
+    RegisteredChoiceId,
+    PackageResourceId>;
+
+struct ExtensionSettingDescriptorV1 {
+    ExtensionSettingId id;
+    ExtensionModuleId owner;
+    ExtensionSettingScope scope;
+    ExtensionSettingValueKind kind;
+    ExtensionSettingValue defaultValue;
+    ExtensionSettingConstraints constraints;
+    ExtensionSettingReloadPolicy reload;
+    LocalizationMessageId label;
+    std::optional<LocalizationMessageId> description;
+    bool includeInPresets;
+};
+```
+
+Scope is one of user, workspace, project, project-profile or session under the
+configuration contract. Reload policy is a closed enum such as `ImmediateSafe`,
+`NextOperation`, `NextActivation` or `RestartRequired`. Kind, default and
+constraints must match exactly. Secret values are not manifest defaults; settings
+that need credentials use typed credential-reference capability contracts.
+
+Settings are declared once and referenced by ID from contributions or service
+exports. Prefix/string convention is not used to infer ownership. Preset opt-in is
+explicit and false by default for paths, credentials and instance-specific data.
+
+### 8. Events and errors use host-owned semantic contracts
+
+```cpp
+struct ExtensionEventDescriptorV1 {
+    ExtensionEventId id;
+    ExtensionModuleId owner;
+    ExtensionEventScope scope;
+    ExtensionEventPayloadSchema payload;
+    DiagnosticPrivacyClass privacy;
+    ExtensionEventDeliveryPolicy delivery;
+};
+
+struct ExtensionErrorDescriptorV1 {
+    ExtensionErrorDomainId domain;
+    ExtensionErrorCode code;
+    ErrorSeverity defaultSeverity;
+    LocalizationMessageId summary;
+    bool userActionable;
+    bool retryable;
+    DiagnosticPrivacyClass privacy;
+};
+```
+
+Event scope, delivery, payload schema and privacy are typed. Events are
+notifications, not mutation or lifecycle authority. Payloads use registered
+bounded Horo schemas and cannot carry arbitrary JSON, native pointers or borrowed
+views into module memory.
+
+Error `(domain, code)` identities are unique within the package composition and
+map to the foundation error model. Runtime diagnostic evidence is bounded and
+separate from manifest localization metadata. An error cannot smuggle an
+undeclared remediation command, URL or permission.
+
+### 9. Service exports and script APIs preserve separate identities
+
+```cpp
+struct ExtensionServiceExportDescriptorV1 {
+    ExtensionServiceExportId id;
+    ExtensionModuleId owner;
+    ExtensionCapabilityId capability;
+    ExtensionApiContractId contract;
+    SemanticVersion apiVersion;
+    ExtensionInvocationPolicy invocation;
+    ExtensionServiceLifetime lifetime;
+    EnumSet<ExtensionPermissionId> requiredPermissions;
+};
+
+struct ExtensionScriptApiDescriptorV1 {
+    ExtensionScriptApiId id;
+    ExtensionModuleId owner;
+    ExtensionServiceExportId service;
+    ScriptRuntimeId runtime;
+    ScriptNamespaceId nameSpace;
+    SemanticVersion apiVersion;
+    PackageResourceId bindingSchema;
+    EnumSet<ExtensionPermissionId> requiredPermissions;
+};
+```
+
+A service export identifies a backend-neutral callable contract; it is not a
+process-global C++ service object. Invocation policy declares operation ownership,
+thread affinity, cancellation/result-store behavior and lifecycle. Concrete
+function tables or adapters remain private to the C ABI/host implementation.
+
+A script API is an explicit binding over one compatible declared service export.
+It has independent stable identity/version because script compatibility may
+evolve separately from the native service. The binding schema is a verified
+package resource with bounded typed signatures; it cannot expose raw host/module
+pointers, C++ names, arbitrary reflection or undeclared functions. A
+`ScriptProvider` role without a script API, or a script API referencing a missing/
+incompatible service/runtime/permission, is invalid.
+
+### 10. Cross-reference validation is complete before activation
+
+Validation builds finite indexes and rejects at least:
+
+- owner package assertion or descriptor digest not bound to the install record;
+- duplicate package/module/contribution/setting/event/error/service/script IDs;
+- missing, duplicate or ambiguous entry variants and undeclared package files;
+- contribution payload/schema mismatch or contribution forbidden by module role;
+- GUI contribution without `EditorPresentation`, backend export without
+  `BackendCapability`, script API without `ScriptProvider`, or restricted runtime
+  participation without the matching role/policy;
+- undeclared/unknown permission, capability, extension point, runtime, event
+  payload, setting kind, reload policy or lifecycle enum;
+- permission use outside the package envelope or unused privilege requests;
+- references to missing settings, events, errors, services, script APIs,
+  resources or foreign modules;
+- service/script API version or runtime incompatibility;
+- duplicate/cyclic local module/service ordering; and
+- required optional-feature edges whose target is unavailable.
+
+Indexes use checked bounded counts and deterministic duplicate reporting. No
+validation path loads a library, resolves an absolute filesystem path, registers
+a service, invokes a module or consults GUI/backend ambient state.
+
+### 11. Schema v1 fails closed and has one extension envelope
+
+Canonical descriptors use integer `schemaVersion: 1`. Every v1 top-level and
+nested field has an exact type, required/optional rule and owner in the typed
+model. Unknown fields reject the descriptor except inside the explicit bounded
+`extensions` array:
+
+```json
+{
+  "id": "com.vendor.example.metadata",
+  "schemaVersion": 1,
+  "required": false,
+  "payload": {}
+}
+```
+
+Known extensions use registered inert schemas and produce typed extension values.
+Unknown required extensions reject the descriptor. Unknown optional extensions
+are retained as bounded canonical opaque data for digest/round-trip fidelity but
+cannot add files, entries, permissions, capabilities, contributions, services,
+script bindings, settings, events, errors or activation behavior.
+
+A newer core schema is not accepted as v1 by dropping fields. Migration is an
+explicit pure transformation between fully validated typed models. Serialization
+emits one deterministic canonical form and never serializes install-record IDs,
+absolute paths, trust decisions, resolved host variants or activation state back
+into `extension.json`.
+
+### 12. Public headers remain Horo-owned and presentation-neutral
+
+The public declaration owns typed IDs, enums, immutable descriptors, validation
+results and serialization contracts. JSON decoding and package/install-record
+adapters remain implementation-private. Public headers do not include
+`nlohmann::json`, `std::filesystem`, dynamic-loader/native API, ImGui, editor
+widget, renderer backend or service-locator types.
+
+Editor, CLI and MCP surfaces project the same validated descriptors into their own
+view models. They may render registered labels/icons/forms, but cannot reinterpret
+unknown strings or activate a contribution that typed validation rejected.
+
+## Migration And Verification
+
+The current `ExtensionManifest`, `ExtensionModuleManifest` and
+`ExtensionContributionManifest` string carriers are transitional. The legacy
+ADR-054 converter maps package fields to `horo-package.toml`, requires explicit
+module IDs/versions/roles, maps known kinds/types to v1 enums/schema payloads and
+reports every lossy or unknown field. It removes `rootPath`; package resources and
+entry artifacts bind through the verified file manifest. No compatibility model
+silently defaults module identity/version/kind from the package.
+
+Canonical fixtures cover:
+
+- GUI-only module over a built-in backend capability;
+- backend/headless asset importer with settings, events and errors;
+- script-consumable service export with a Lua 5.4 binding schema;
+- mixed backend plus editor/CLI/MCP adapters in one module;
+- hybrid package containing separate backend and editor module descriptors; and
+- multi-module package composition with local ordering and no role ambiguity.
+
+Every fixture round-trips to the same typed value and canonical bytes/digest.
+Negative tests cover every ID domain, enum, variant, permission/capability edge,
+payload alternative, setting value/constraint, resource/file reference,
+service/script version and required/optional unknown-field path. Compile-only
+consumer tests prove public headers remain backend- and GUI-neutral. Activation
+tests prove decoded/unvalidated values cannot construct an
+`ExtensionActivationCandidate` or reach ExtensionHost.
+
+## Consequences
+
+Package, module, contribution, service and script identities remain distinct and
+role intent becomes explicit. Trust planning, UI/CLI/MCP inspection and
+ExtensionHost consume the same immutable model, so invalid cross-references fail
+before native code runs. The cost is a larger public type vocabulary, versioned
+payload variants/catalogs, canonical migration of every legacy manifest and
+deliberate schema revisions when new core fields or extension points are added.
+
+## Rejected Alternatives
+
+| Option | Decision and reason |
+|---|---|
+| Keep strings and validate in each consumer | Rejected: consumers would disagree and invalid references could reach activation. |
+| Use one map of arbitrary contribution properties | Rejected: field ownership, types, permissions and GUI/backend neutrality would be unprovable. |
+| Infer module roles from contribution names | Rejected: unknown/new points and mixed modules would be ambiguous and could gain authority accidentally. |
+| Put all package modules in one `extension.json` | Rejected: ADR-054 gives each module a bounded independently versioned descriptor and package composition index. |
+| Let module versions default to package version | Rejected: package and module compatibility evolve independently and provenance must remain explicit. |
+| Expose JSON DOM or filesystem paths in the public model | Rejected: parser behavior and machine-local/native types would leak across the stable boundary. |
+| Treat script API as the service export identity | Rejected: script and backend contracts have separate compatibility and permission surfaces. |
+| Ignore unknown fields | Rejected: typos and future security fields could silently lose effect. |
+| Reject all optional future metadata | Rejected: the bounded inert extension envelope permits round-trip-compatible evolution without granting behavior. |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -66,6 +66,7 @@ to the replacement.
 | [052](052-first-party-renderer-component-scope.md) | First-Party Renderer Component Scope | Proposed | 2026-09-01 |
 | [053](053-renderer-module-manifest-parser.md) | Renderer Module Manifest Parser | Proposed | 2026-09-02 |
 | [054](054-extension-and-package-authority-boundary.md) | Extension and Package Authority Boundary | Proposed | 2026-09-02 |
+| [055](055-extension-manifest-v1-typed-model.md) | Extension Manifest V1 Typed Model | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -229,8 +229,11 @@ dependency direction in [System Design](./foundation/system-design.md).
     lifecycle, and component persistence.
   - [Gameplay Module Verification](./extensions/gameplay-module-verification.md):
     contract and regression coverage.
-- [Extension System](./extensions/plugin-system.md): editor/tool extension packages, C ABI,
-  manifests, permissions, registration, and lifecycle.
+- [Extension System](./extensions/plugin-system.md): editor/tool extension packages,
+  C ABI, typed v1 manifests, permissions, registration, and lifecycle. Package
+  authority and manifest-model decisions are recorded in
+  [ADR-054](../adr/054-extension-and-package-authority-boundary.md) and
+  [ADR-055](../adr/055-extension-manifest-v1-typed-model.md).
 
 ## Packages
 

--- a/docs/architecture/extensions/plugin-system.md
+++ b/docs/architecture/extensions/plugin-system.md
@@ -84,6 +84,10 @@ Use these names deliberately:
   record own package identity, files and cross-package dependencies;
   `extension.json` is only a module/contribution descriptor. See
   [ADR-054](../../adr/054-extension-and-package-authority-boundary.md).
+- The descriptor is decoded and then cross-reference validated into the immutable,
+  backend- and GUI-neutral v1 model from
+  [ADR-055](../../adr/055-extension-manifest-v1-typed-model.md). Only that
+  validated value may enter package composition, trust planning or activation.
 - Extension packages may be backend-only, frontend-only, or hybrid. GUI support
   is optional presentation over host-approved backend capabilities; it is not
   the definition of an extension.
@@ -162,10 +166,13 @@ path tricks do not bypass containment checks.
 
 ## Module Descriptor Schema
 
-`extension.json` separates one module's ABI/entry variants, contributions and
-requested permissions. Package identity, dependencies, sources, trust and
-enablement remain in the package system. Every path in the descriptor is relative
-to the verified package root, not to the descriptor directory:
+`extension.json` separates one module's ABI/entry variants, explicit roles,
+contributions, service/script surfaces and requested permissions. Package
+identity, dependencies, sources, trust and enablement remain in the package
+system. The JSON below is a readable projection of the typed v1 model; consumers
+do not retain a JSON DOM or reinterpret its strings after validation. Every path
+in the descriptor is relative to the verified package root, not to the descriptor
+directory:
 
 ```json
 {
@@ -177,7 +184,8 @@ to the verified package root, not to the descriptor directory:
   "module": {
     "id": "com.vendor.fbx-importer.native",
     "version": "2.0.0",
-    "kind": "native",
+    "kind": "native-c-abi",
+    "roles": ["backend-capability", "editor-presentation"],
     "abi": "horo-extension-1",
     "entries": [
       {
@@ -231,6 +239,9 @@ Validation rules:
 
 - Package IDs come only from the verified package install record. Module and
   contribution IDs are globally canonical and stable.
+- Package, module, contribution, permission, setting, event, error, service
+  export and script API identities are distinct bounded types; textual equality
+  does not make their domains interchangeable.
 - An optional `ownerPackage` binding must exactly match that install record.
 - Module IDs belong to exactly one package.
 - Contribution IDs are unique across all active packages and built-in
@@ -239,8 +250,19 @@ Validation rules:
   are declared only in `horo-package.toml` and the resolved package graph.
 - Descriptor-requested permissions must be a subset of the package contribution
   capability envelope and approved by trust policy before load.
-- Unknown manifest fields are preserved only in documented extension namespaces;
-  unknown required fields reject the package.
+- Module roles are non-empty and explicit. GUI, backend, script-provider and
+  runtime contributions cannot grant their matching role by inference.
+- Contribution payloads are closed typed variants selected by a registered
+  extension-point schema ID/version. Arbitrary property maps cannot enter a live
+  registry.
+- Settings, events, errors, service exports and script APIs are declared as typed
+  records and every reference resolves within the validated package composition.
+- Unknown fields reject schema v1 except inside its bounded extension envelope;
+  unknown required extensions reject the descriptor and unknown optional
+  extensions remain inert canonical data.
+- Decoded or partially validated descriptors cannot construct an activation
+  candidate. Complete rules and the migration contract are defined by
+  [ADR-055](../../adr/055-extension-manifest-v1-typed-model.md).
 
 ## Extension Point Catalog
 
@@ -339,16 +361,17 @@ and allocator ownership do not cross the binary ABI. The C ABI adapter validates
 and copies module-owned descriptor data into the host-owned typed registry before
 the module can participate in import operations.
 
-## Backend, Frontend, And Hybrid Packages
+## GUI, Backend, Script-Consumable, And Mixed Modules
 
-An add-on is not synonymous with an editor panel. Packages fall into three
-normal shapes:
+An add-on is not synonymous with an editor panel. Each module declares the exact
+roles needed by its shape; packages may compose multiple modules:
 
 | Shape | Examples | Required boundary |
 |---|---|---|
-| Backend-only | asset importer, cooker, project validator, network transport, build pipeline step, toolchain provider | Declares backend contribution, capability, permissions, errors, settings, observability, and optional process-event imports. |
-| Frontend-only | diagnostics tab over existing stores, command-palette shortcut, Settings page for built-in capability | Declares editor contribution and consumes existing approved capabilities. |
-| Hybrid | shader tools with compile service plus inspector tab, network transport plus connection diagnostics panel, importer plus import-settings page | Declares backend contribution and separate GUI/MCP/CLI-facing contributions over the backend capability. |
+| GUI-only | diagnostics tab over existing stores, command-palette shortcut, Settings page for built-in capability | Declares `EditorPresentation`, contributes presentation only and consumes existing approved capabilities. |
+| Backend-only | asset importer, cooker, project validator, network transport, build pipeline step, toolchain provider | Declares `BackendCapability` and optional `HeadlessTooling`, plus typed capabilities, permissions, errors, settings and observability. |
+| Script-consumable | backend service with an approved Lua 5.4 binding | Declares `BackendCapability` and `ScriptProvider`; the script API references a compatible typed service export. |
+| Mixed-role | shader tools with compile service plus inspector tab, network transport plus connection diagnostics panel, importer plus import-settings page | Declares the explicit union of its real roles and separate GUI/CLI/MCP adapters over the backend authority. |
 
 The backend side is authoritative. It owns state transitions, jobs, cache keys,
 generated outputs, and operation results through host APIs. The frontend side is

--- a/docs/architecture/extensions/plugin-system.md
+++ b/docs/architecture/extensions/plugin-system.md
@@ -257,6 +257,8 @@ Validation rules:
   registry.
 - Settings, events, errors, service exports and script APIs are declared as typed
   records and every reference resolves within the validated package composition.
+- A script API adds its permissions to those of its referenced service export;
+  validation, trust approval and invocation enforce the complete set union.
 - Unknown fields reject schema v1 except inside its bounded extension envelope;
   unknown required extensions reject the descriptor and unknown optional
   extensions remain inert canonical data.

--- a/docs/architecture/foundation/system-design.md
+++ b/docs/architecture/foundation/system-design.md
@@ -403,6 +403,14 @@ loads the declared module through `ExtensionApi`, and owns only live module and
 registry leases. It cannot scan raw directories, resolve dependencies, grant
 trust or mutate package lifecycle state.
 
+[ADR-055](../../adr/055-extension-manifest-v1-typed-model.md) makes the descriptor
+boundary a public Horo-owned typed model. Syntax decoding is implementation-private;
+package/install-record validation produces an immutable backend- and GUI-neutral
+value with distinct module, contribution, permission, setting, event, error,
+service-export and script-API identities. Only a fully validated package
+composition can become an activation candidate, so no consumer may repair or
+reinterpret manifest strings during activation.
+
 ## Dependency Direction
 
 Arrows point from the dependent target to the target that defines the contract:

--- a/docs/architecture/packages/package-system.md
+++ b/docs/architecture/packages/package-system.md
@@ -213,7 +213,12 @@ trust and enablement remain outside `extension.json`. Every descriptor, binary
 and resource is present in `files.manifest.json`; ExtensionHost receives an exact
 validated descriptor and install-record lease rather than scanning a directory.
 The complete authority and activation hand-off are defined by
-[ADR-054](../../adr/054-extension-and-package-authority-boundary.md).
+[ADR-054](../../adr/054-extension-and-package-authority-boundary.md). The
+descriptor is decoded and cross-reference validated against the leased install
+record into the immutable typed model defined by
+[ADR-055](../../adr/055-extension-manifest-v1-typed-model.md). A decoded value,
+unknown required field, unresolved typed identity or mismatched role cannot enter
+package composition, trust planning or ExtensionHost.
 
 ## Package Sources
 

--- a/docs/guides/extension-module-development.md
+++ b/docs/guides/extension-module-development.md
@@ -49,7 +49,8 @@ permission checks, result storage, and teardown.
 
 ## Development Flow
 
-1. Choose whether the package is backend-only, frontend-only, or hybrid.
+1. Choose explicit module roles for GUI-only, backend-only, script-consumable or
+   mixed behavior.
 2. Choose the extension points.
 3. Declare package identity, dependencies and the extension descriptor path in
    `horo-package.toml`.
@@ -103,7 +104,8 @@ to the verified package root, not to the descriptor directory.
   "module": {
     "id": "com.vendor.shader-tools.native",
     "version": "1.0.0",
-    "kind": "native",
+    "kind": "native-c-abi",
+    "roles": ["backend-capability", "editor-presentation"],
     "abi": "horo-extension-1",
     "entries": [
       {
@@ -230,6 +232,9 @@ to the verified package root, not to the descriptor directory.
 
 Rules:
 
+- Treat the JSON as the serialized form of the typed v1 model in
+  [ADR-055](../adr/055-extension-manifest-v1-typed-model.md). Only the fully
+  cross-reference validated value may reach registration or activation.
 - IDs are stable contracts. Do not rename or repurpose them after release.
 - Contributions are inert descriptors. Loading the package must not mutate host
   registries through static initialization.
@@ -247,15 +252,16 @@ Rules:
   resources, or mutate the project. Returning a failure selects the declared
   mesh, image, audio, or generic host fallback.
 
-## Package Shapes
+## Module Shapes
 
 Horo add-ons are not necessarily GUI add-ons:
 
 | Shape | Example | Rule |
 |---|---|---|
-| Backend-only | asset importer, cooker, project validator, pipeline step, toolchain provider | Must run without `HoroEditor` or ImGui. Exposes typed capabilities, diagnostics, settings, and observability. |
-| Frontend-only | inspector tab over existing scene/asset/log stores, command-palette shortcut, Settings page for built-in service | Owns presentation only. Reads existing authorities and calls existing capabilities. |
-| Hybrid | shader compile service plus inspector tab and MCP tool | Backend contribution is authoritative; GUI/MCP/command contributions are adapters over it. |
+| Backend-only | asset importer, cooker, project validator, pipeline step, toolchain provider | Declares `BackendCapability` and optional `HeadlessTooling`; it must run without `HoroEditor` or ImGui. |
+| GUI-only | inspector tab over existing scene/asset/log stores, command-palette shortcut, Settings page for built-in service | Declares `EditorPresentation`, owns presentation only and calls existing capabilities. |
+| Script-consumable | backend service with an approved Lua 5.4 binding | Declares `BackendCapability` plus `ScriptProvider`; a typed script API binds to one compatible service export. |
+| Mixed-role | shader compile service plus inspector tab and MCP tool | Declares the explicit union of its roles; GUI/MCP/command contributions remain adapters over the backend authority. |
 
 When a feature has real behavior, put that behavior behind a backend contribution
 first. The GUI then becomes optional presentation. This keeps the same add-on


### PR DESCRIPTION
## Summary

- Defines the immutable, backend- and GUI-neutral Extension Manifest v1 typed model.
- Separates bounded syntax decoding, complete cross-reference validation, package composition/trust resolution, and activation-candidate construction.
- Preserves distinct package, module, contribution, permission, setting, event, error, service-export, and script-API identity domains.
- Defines explicit GUI-only, backend-only, script-consumable, and mixed module roles with fail-closed schema evolution.

## Why

The current public extension manifest is a collection of loosely related strings. Consumers can reinterpret kinds, contribution payloads, permissions, and compatibility data after parsing, allowing invalid references or hidden authority to survive until activation or registration.

## Decision

- Only a fully validated manifest bound to an exact verified package install record may enter composition, trust planning, or `ExtensionHost`.
- Contribution payloads are closed typed variants selected by registered extension-point schema versions; identities from different domains are not interchangeable.
- Module runtime kind and allowed roles are explicit and orthogonal; contributions cannot infer or grant a missing role.
- The serialized setting kind selects one typed `defaultValue` variant during decoding and is not retained as a second discriminator.
- A script API's permissions are additive to its referenced service export; validation, trust approval, activation, and invocation enforce their complete set union.
- Unknown v1 fields fail closed outside one bounded inert extension envelope.
- Public contracts exclude JSON DOM, filesystem, native-loader, renderer, and GUI types.

## Validation

- [x] Replayed HORO-70 onto current `main`; resolved one documentation conflict by retaining ADR-054's package-root-relative paths while integrating the typed-model wording.
- [x] `markdownlint-cli` passed for every changed Markdown file.
- [x] `git diff --check` passed.
- [x] All newly added local Markdown links resolve.
- [x] No unresolved TODO/TBD/open-decision marker remains.
- [x] Addressed both Codacy findings: explicit permission-union semantics and removal of the redundant typed setting discriminator; both threads are resolved.
- [ ] Executable model, round-trip, role-gate, and activation-gate tests are downstream implementation work; ADR-055 specifies the required matrix.

## Risk and rollout

This documentation decision removes implicit module defaults and stringly compatibility behavior. Existing development manifests require explicit diagnostic migration before the typed activation path can replace the transitional direct-directory loader.

## Issue links

- Jira: [HORO-70](https://horo-engine.atlassian.net/browse/HORO-70)
- GitHub: Closes #70

## Reviewer notes

Review ADR-055 first, then Extension System and Package System. The system-design and author-guide changes project the same identity, role, permission, and validation boundaries.


[HORO-70]: https://horo-engine.atlassian.net/browse/HORO-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ