### PR TITLE
docs(extensions): define external UI boundary HORO-103 #103 [EXT-003.1]

### DIFF
--- a/docs/adr/056-external-editor-ui-boundary.md
+++ b/docs/adr/056-external-editor-ui-boundary.md
@@ -1,0 +1,308 @@
+# ADR-056: External Editor UI Boundary
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Third-party editor UI rendering, input, state, localization, accessibility, compatibility, isolation and teardown across declarative, C ABI and out-of-process extension models
+- **Issue**: [EXT-003.1](https://github.com/abdullahbodur/horo-engine/issues/103)
+- **Jira**: [HORO-103](https://horo-engine.atlassian.net/browse/HORO-103)
+- **Parent**: [EXT-003](https://github.com/abdullahbodur/horo-engine/issues/58)
+- **Related**: [ADR-055](055-extension-manifest-v1-typed-model.md), [ADR-015](015-accessibility-ownership-typed-transport-and-non-gating-policy.md)
+- **Normative documents**: [Extension System](../architecture/extensions/plugin-system.md), [GUI Design System](../architecture/editor/ui-design-system.md), [Editor Panel Host](../architecture/editor/editor-panel-host.md), [Editor Modal Host](../architecture/editor/editor-modal-host.md), [Extension Module Development Guide](../guides/extension-module-development.md)
+
+## Context
+
+Horo needs third-party tabs, panels, settings pages, modal pages, commands and
+tool views without making Dear ImGui, SDL, a concrete renderer or editor internals
+part of its extension SDK. The GUI design contract already says that feature code
+composes Horo-owned components and that ImGui remains an implementation detail.
+The extension architecture nevertheless describes a custom drawer path that hands
+an in-process module an ImGui callback and lets it draw arbitrary content. That
+path would expose toolkit versions, allocators, frame lifetime, global widget
+state, input capture and renderer assumptions through an external binary boundary.
+
+The implemented extension C ABI currently exposes asset-importer registration
+only. The implemented workspace panel interfaces are internal C++ composition
+contracts, not a published third-party ABI. This is the last safe point to choose
+one external UI boundary before accidental examples become compatibility promises.
+
+Three models are plausible:
+
+1. host-rendered declarative surfaces;
+2. a versioned C ABI that gives modules direct rendering callbacks; or
+3. UI/controller work in a separate process.
+
+The decision must preserve theme and DPI behavior, scoped input, localization,
+accessibility semantics, headless inspection, deterministic tests and safe
+teardown. It must also support interactive tools without calling unknown module
+code inside the editor frame or pretending that native in-process code is
+sandboxed.
+
+## Decision
+
+### 1. External editor UI is host-rendered typed presentation
+
+Third-party editor surfaces use a versioned declarative Horo UI schema. The host
+validates and copies the schema and bounded view state, maps them to Horo design-
+system components, owns all rendering and input dispatch, and emits typed actions
+back to the extension capability.
+
+```text
+validated editor contribution
+  -> EditorUiSchemaV1 + declared actions/data bindings
+  -> host-owned ExtensionUiSession
+  -> Horo design-system component tree
+  -> private Dear ImGui/platform/renderer adapters
+
+scoped user interaction
+  -> typed ExtensionUiActionRequest
+  -> approved backend capability/operation
+  -> bounded result or view-state revision
+  -> host validates and applies the next snapshot/patch
+```
+
+The public schema is backend-, toolkit- and process-neutral. It contains typed
+layout nodes, semantic controls, stable IDs, localization keys, accessibility
+metadata, value bindings, validation rules, action IDs and bounded specialized-
+view descriptors. It contains no drawing function, widget pointer, native window,
+GPU resource, dock ID, borrowed editor object or arbitrary property map.
+
+The same schema and action protocol are used by trusted in-process modules and
+isolated helpers. Isolation changes the transport, not the UI contract.
+
+### 2. Supported models have distinct responsibilities
+
+| Model | Policy | Responsibility |
+|---|---|---|
+| Host-rendered declarative/typed UI | Supported and required for embedded third-party editor surfaces | Defines semantics, layout intent, view state and typed actions; Horo owns pixels and interaction. |
+| Versioned extension C ABI | Supported for in-process schema publication, state snapshots, actions and lifecycle | Transports bounded copied data and opaque handles; it is not a drawing or C++ widget ABI. |
+| Out-of-process controller/helper | Supported when isolation, dependency separation or crash containment is required | Uses the same schema/action model over bounded authenticated IPC; Horo still renders embedded UI. |
+| Separate external application window | Explicit opt-in tool launch only | The external application owns its window and accessibility; it is not embedded, docked or represented as a Horo editor surface. |
+| Direct ImGui/SDL/native-renderer callback | Forbidden for external packages | Toolkit/global state, ABI, input, accessibility and teardown cannot be contained or kept compatible. |
+
+First-party GUI code compiled into the product may use internal Horo component and
+panel interfaces. Those interfaces remain target-private and carry no third-party
+compatibility promise. Built-in and external surfaces share visual and behavioral
+rules, not a binary widget ABI.
+
+### 3. The UI schema is closed, semantic and capability-negotiated
+
+`EditorUiSchemaV1` is a validated typed tree with bounded depth, node count, text,
+choice count, table rows, binary/resource references and serialized state size.
+Core node alternatives cover layout, text, buttons, toggles, numeric/text fields,
+choices, lists, tables, progress, diagnostics, images and host-owned navigation.
+Every interactive node references a declared typed action; it cannot contain code.
+
+Complex tools use registered specialized view schemas such as plot, timeline,
+node graph, image/canvas annotation or property inspector. Each schema owns its
+data limits, semantic accessibility projection, input vocabulary and performance
+budget. An extension cannot request a generic immediate-mode command stream or
+upload arbitrary executable shaders as a substitute for a missing view schema.
+
+The host advertises supported UI schema and specialized-view versions during
+activation. Required unsupported nodes or features reject the contribution.
+Optional unsupported features produce an explicit unavailable/fallback outcome;
+they are never silently dropped when doing so could change an action or meaning.
+
+### 4. Rendering, theme and layout are host authority
+
+The GUI host owns:
+
+- design-token and theme resolution, including high-contrast and user overrides;
+- DPI scaling, font selection, shaping, bidirectional text and icon rendering;
+- component implementation, hover/active/disabled/focus visuals and tooltips;
+- docking, panel chrome, modal layering, clipping, scroll and popup placement;
+- renderer resources, texture upload, draw ordering and frame lifetime; and
+- narrow-width behavior, localization expansion and component test coverage.
+
+Extensions express semantic intent and bounded placement preferences. They do not
+select colors, fonts or absolute screen coordinates except where a registered
+specialized view explicitly accepts theme-relative data. Package resources such
+as icons and images are verified, decoded and uploaded by the host; modules never
+receive or return renderer handles.
+
+No extension callback runs during ImGui traversal, draw-list construction or
+renderer submission. The frame consumes a host-owned immutable UI snapshot. State
+refresh and action handling run through scheduled extension operations outside the
+render traversal, with deadlines, cancellation and stale-revision rejection.
+
+### 5. Input is scoped and actions are typed
+
+The host performs hit testing, pointer capture, focus traversal, shortcut
+arbitration, drag/drop admission, clipboard policy and modal exclusion. A surface
+receives only semantic actions for its active controls and registered specialized
+view. It does not receive the global input stream, keys typed in other surfaces,
+raw SDL events or unrestricted native window messages.
+
+Action requests contain the contribution/session/node/action IDs, the schema and
+view-state revisions, a typed bounded payload, cancellation and an invocation ID.
+The host rejects stale, duplicate, unauthorized or structurally invalid actions.
+Actions call declared application capabilities or module operations; they do not
+mutate project files, registries, selection, layout or modal state directly.
+
+Global shortcuts, file drops, clipboard reads, external URL/process launch and
+credential prompts require separate declared host capabilities. Modal pages
+cannot close or commit their owning workflow except through the owning modal's
+typed result contract.
+
+### 6. Localization and accessibility remain host-verifiable
+
+Visible strings, descriptions, tooltips, errors and accessibility labels use
+verified package localization message IDs with typed arguments. The host resolves
+locale, fallback, shaping and truncation. Technical text is explicitly tagged and
+cannot be used to bypass localization for ordinary user-facing copy.
+
+Every UI node has a semantic role, stable identity, accessible name source,
+state/value metadata and focus policy where applicable. Registered specialized
+views provide an equivalent semantic tree, keyboard operations and non-color
+state cues. The host builds test-visible accessibility snapshots even when the
+current native backend cannot expose a complete OS accessibility tree.
+
+An extension cannot hide essential controls inside an unlabeled image, depend on
+color alone, trap focus, bypass the active modal scope or replace host focus
+restoration. Invalid accessibility structure rejects the surface schema rather
+than degrading silently.
+
+### 7. State ownership is explicit
+
+| State | Owner |
+|---|---|
+| Layout, docking, focus, open/closed state and active modal scope | GUI/editor hosts |
+| Control draft values, validation display and bounded transient presentation state | Host-owned `ExtensionUiSession` under the contribution ID |
+| Domain/business state, jobs, cache keys and operation results | Backend capability or authoritative application service |
+| User/workspace/project settings | Typed configuration authorities |
+| Extension-owned durable data | Declared package/application storage capability, never the UI tree |
+
+The UI snapshot is a projection, not a second domain authority. Events only
+invalidate projections; the host or extension controller re-queries the owning
+store. Workspace presentation state is versioned and bounded. It contains no
+permission, trust decision, executable payload, pointer, credential or renderer
+resource and cannot activate an unavailable provider when restored.
+
+### 8. The C ABI carries copied values, handles and lifecycle only
+
+The external UI C ABI follows the extension ABI rules: sized append-only tables,
+fixed-width types, byte-counted UTF-8, explicit schema versions, opaque generation-
+checked handles, status values and host-owned output sinks. The host copies and
+validates module-owned schema/state/action-result data before returning from the
+call that borrowed it.
+
+The ABI does not expose C++ interfaces, STL containers, exceptions, RTTI,
+allocators, `std::function`, ImGui contexts, draw lists or Horo internal component
+objects. Callback context is opaque and callable only under a live module/session
+lease. ABI version negotiation and UI-schema negotiation are separate: binary
+transport compatibility does not imply support for every surface feature.
+
+Unknown required ABI/table fields, schema nodes, action payloads or specialized
+view versions fail before attach. Compatible optional tail fields use `structSize`
+and explicit capability bits; consumers never guess based on engine version text.
+
+### 9. Out-of-process helpers use the same contract with stronger isolation
+
+Packages that need crash containment, conflicting dependencies or lower trust run
+their controller/backend in a host-supervised helper process. Activation supplies
+one authenticated bounded channel scoped to the package, contribution and granted
+capabilities. Messages carry canonical schema/state/action protocol values with
+length, depth, rate and in-flight-operation limits.
+
+The host owns process launch, environment filtering, credentials, cancellation,
+timeouts, restart policy and termination. The helper cannot map editor memory,
+receive renderer handles, inject native child windows or use IPC as a service
+locator. Loss of the helper replaces its surfaces with a host-owned unavailable/
+recovery state without corrupting layout or blocking the GUI frame.
+
+An extension may explicitly launch a separate external application through the
+process capability. That application's native/web UI is outside Horo: it is not
+docked, cannot claim Horo theme/accessibility equivalence and communicates only
+through approved application APIs. Embedded arbitrary HTML/Electron/WebView UI is
+not a supported shortcut around the typed surface contract.
+
+### 10. Teardown is admission-first and callback-safe
+
+Surface lifetime is an explicit host state machine:
+
+```text
+Declared -> Validated -> Attached -> Active
+                         |            |
+                         +-> Detaching -> Detached -> Released
+```
+
+Detach first closes interaction and state-update admission, invalidates the
+session generation and renders no further module-provided snapshot. The host then
+cancels outstanding actions/refreshes, releases subscriptions, removes registry
+entries transactionally, drains queued callbacks, destroys copied presentation
+state and releases the module/helper lease. Late results are rejected by session
+generation and cannot resurrect a surface.
+
+In-process native disable, update and removal remain restart-applied by default.
+The editor must not unload a dynamic library until every callback, job, borrowed
+view, deleter and lease is proven gone. Out-of-process helpers may be terminated
+after bounded graceful shutdown because no executable helper pointers exist in
+the GUI host. A failed/crashed helper never requires editor-process teardown.
+
+### 11. Migration removes the documented raw-ImGui external path
+
+No supported public UI ABI exists in the current implementation, so this policy
+does not break a released extension contract. Migration proceeds as follows:
+
+1. Mark `IWorkspacePanel`, internal component types and ImGui adapters as
+   first-party/private; public extension headers do not expose them.
+2. Replace the documented custom ImGui drawer path with declarative fields and
+   registered specialized typed views.
+3. Model UI contributions in ADR-055 with explicit UI schema/resource/action and
+   required-feature versions; reject old arbitrary callback payloads.
+4. Add a versioned C ABI adapter and out-of-process protocol over the same
+   validated model, with headless schema/action contract tests.
+5. Convert first-party packaged examples to typed UI projections. First-party
+   product panels may remain internal, but cannot be cited as external ABI.
+6. Migrate a third-party custom tool to existing typed nodes, request a focused
+   specialized-view extension point, or run as a separately launched application.
+   It cannot retain raw ImGui rendering as a compatibility fallback.
+
+Compatibility is additive within one schema major version. Removing or changing
+node/action semantics requires a new schema version and an explicit pure migration
+of stored presentation state. Packages declare required versions/features in the
+manifest; the host never silently emulates unsupported direct drawing behavior.
+
+## Verification
+
+Contract coverage must include:
+
+- schema bounds, duplicate IDs, invalid references and required-feature rejection;
+- deterministic render-model snapshots in normal, hovered, active, disabled,
+  focused, modal, narrow, long-localized and high-contrast states;
+- keyboard-only traversal, semantic accessibility snapshots and non-color cues;
+- theme/DPI/locale changes without module callbacks inside frame rendering;
+- stale action, permission denial, cancellation, timeout and replay rejection;
+- GUI-only, mixed-role and out-of-process surfaces using the same schema/actions;
+- helper crash/restart and unavailable-surface layout/state preservation;
+- detach with queued events/actions and proof of no callback after release; and
+- compile-only public-header checks with no ImGui, SDL, renderer or editor-private
+  dependency.
+
+Performance evidence records schema size, update frequency, frame cost, action
+latency, IPC payload/rate and memory bounds. An extension cannot require synchronous
+IPC or module work on the GUI frame to meet correctness.
+
+## Consequences
+
+Horo can theme, localize, test and reason about accessibility for third-party
+surfaces while keeping toolkit and renderer choices private. In-process and
+isolated modules share one semantic contract, and unknown code never executes in
+the draw traversal. The cost is that arbitrary custom widgets require a reviewed
+specialized view schema or a separate application. The host must build a capable
+typed UI catalog, bounded state/action protocol and tooling for authoring and
+previewing schemas.
+
+## Rejected Alternatives
+
+| Option | Decision and reason |
+|---|---|
+| Publish raw ImGui callbacks/contexts | Rejected: toolkit/global state, memory ABI, input, accessibility, renderer and frame lifetime become an unsafe compatibility surface. |
+| Publish C++ panel/widget interfaces | Rejected: compiler, STL, RTTI, exception, allocator and ownership compatibility cannot be maintained for third parties. |
+| Treat the C ABI as an immediate-mode draw-command API | Rejected: it preserves per-frame foreign execution and recreates a poorly typed toolkit ABI. |
+| Embed arbitrary HTML/Electron/WebView packages | Rejected: it duplicates theme, input, accessibility, resource and security authorities and adds a second GUI platform. |
+| Allow native child windows inside editor docking | Rejected: focus, DPI, renderer composition, modal exclusion and cross-platform teardown are not portable or host-verifiable. |
+| Require every extension UI to be out-of-process | Rejected: isolation is valuable but transport location does not remove the need for one semantic host-rendered UI contract. |
+| Allow only basic forms forever | Rejected: registered specialized typed views support advanced tools without exposing a generic drawing escape hatch. |
+| Promise live native unload for declarative UI | Rejected: host-owned pixels do not prove that backend callbacks, jobs and leases into module code are gone. |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -67,6 +67,7 @@ to the replacement.
 | [053](053-renderer-module-manifest-parser.md) | Renderer Module Manifest Parser | Proposed | 2026-09-02 |
 | [054](054-extension-and-package-authority-boundary.md) | Extension and Package Authority Boundary | Proposed | 2026-09-02 |
 | [055](055-extension-manifest-v1-typed-model.md) | Extension Manifest V1 Typed Model | Proposed | 2026-09-02 |
+| [056](056-external-editor-ui-boundary.md) | External Editor UI Boundary | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -233,7 +233,9 @@ dependency direction in [System Design](./foundation/system-design.md).
   C ABI, typed v1 manifests, permissions, registration, and lifecycle. Package
   authority and manifest-model decisions are recorded in
   [ADR-054](../adr/054-extension-and-package-authority-boundary.md) and
-  [ADR-055](../adr/055-extension-manifest-v1-typed-model.md).
+  [ADR-055](../adr/055-extension-manifest-v1-typed-model.md); external editor UI
+  uses the host-rendered boundary in
+  [ADR-056](../adr/056-external-editor-ui-boundary.md).
 
 ## Packages
 

--- a/docs/architecture/editor/editor-modal-host.md
+++ b/docs/architecture/editor/editor-modal-host.md
@@ -524,23 +524,30 @@ settings, or publish committed authority events.
 
 ```mermaid
 sequenceDiagram
-    participant Ext as Extension Page
+    participant Ext as Extension Controller
     participant Settings as Settings Modal
+    participant Session as Host UI Session
     participant Draft as Settings Draft
     participant Store as Settings Store
     participant Bus as EditorDataBus
 
-    Settings->>Ext: Construct with page context
-    Ext->>Draft: Bind fields to validated draft keys
-    Ext-->>Settings: Return validation diagnostics
+    Settings->>Session: Attach copied schema/state + scoped actions
+    Session->>Draft: Bind declared keys through host capability
+    Session->>Bus: Subscribe through host-owned token
+    Session->>Ext: Request typed refresh outside render traversal
+    Ext-->>Session: Return copied state + validation snapshot
+    Session-->>Settings: Emit typed page action/validation result
     Settings->>Store: Apply typed settings transaction
     Store->>Bus: Publish committed settings notification
-    Bus-->>Ext: Invalidate page view if still open
+    Bus-->>Session: Deliver allowlisted invalidation hint
+    Session->>Session: Invalidate projection if still open
 ```
 
-Extension pages may subscribe to `EditorDataBus` for the same invalidation model
-as built-in pages. They receive only page-scoped capabilities and must release
-subscriptions before the page or provider module is destroyed.
+External extension code never subscribes directly to the C++ `EditorDataBus`.
+The host-owned UI session holds the subscription token and delivers only
+allowlisted invalidation hints through the versioned schema/state protocol or the
+extension's scoped capability context. The session re-queries authoritative state
+and releases its subscription before the page or provider module is destroyed.
 
 ## Build And Release Modal
 

--- a/docs/architecture/editor/editor-modal-host.md
+++ b/docs/architecture/editor/editor-modal-host.md
@@ -498,7 +498,10 @@ points. This allows an add-on package to contribute a settings section, import
 wizard page, diagnostics page, or tool-specific configuration page without
 forking the owning modal.
 
-Page contributions are descriptors, not imperative UI mutations:
+Page contributions are descriptors and host-rendered typed UI schemas, not
+imperative UI mutations. External pages follow
+[ADR-056](../../adr/056-external-editor-ui-boundary.md): they do not implement a
+C++ modal/page interface or receive ImGui, input, renderer or modal-host objects.
 
 ```cpp
 struct EditorModalPageContribution {
@@ -512,11 +515,12 @@ struct EditorModalPageContribution {
 };
 ```
 
-The owning modal validates and orders pages, constructs page instances through
-registered factories, and controls navigation, validation, dirty state, preview,
-apply, cancel, and close policy. Extension pages cannot directly close the root
-modal, bypass confirmation policy, commit settings, or publish committed
-authority events.
+The owning modal validates and orders pages. A host-owned page session renders
+the copied schema and binds its declared actions/fields to approved capabilities;
+first-party pages may still use internal factories. The modal controls navigation,
+validation, dirty state, preview, apply, cancel, focus and close policy. Extension
+pages cannot directly close the root modal, bypass confirmation policy, commit
+settings, or publish committed authority events.
 
 ```mermaid
 sequenceDiagram

--- a/docs/architecture/editor/editor-panel-host.md
+++ b/docs/architecture/editor/editor-panel-host.md
@@ -492,9 +492,10 @@ sequenceDiagram
 ```
 
 Requested event subscriptions are advisory for validation, diagnostics, and
-permission review. A tab still performs subscription through the typed
-`EditorDataBus` API at attach time. Event payloads remain invalidation hints;
-the tab queries the authoritative model or store for the data it needs.
+permission review. The host-owned UI session performs subscription through the
+typed `EditorDataBus` API at attach time; external module/controller code never
+receives the C++ bus. Event payloads remain invalidation hints, and the session
+queries the authoritative model or store through approved capabilities.
 
 Extensions may contribute new editor-local event types only under their stable
 module prefix. Those events are visible only to the active editor session unless

--- a/docs/architecture/editor/editor-panel-host.md
+++ b/docs/architecture/editor/editor-panel-host.md
@@ -464,29 +464,31 @@ Extension tab descriptors declare:
   log queries, metric queries, or specific editor commands;
 - workspace-state schema version and byte limits.
 
-The host validates the descriptor, resolves capabilities, creates the surface
-factory, and then calls the ordinary `RegisterTab()` or `RegisterPanel()` path.
-The factory receives an extension-scoped context; it does not receive the whole
-`EditorLayer`, raw ImGui dock IDs, renderer backend objects, or process-global
-services.
+The host validates the descriptor and resolves capabilities. First-party product
+code may create an internal surface factory and call the ordinary `RegisterTab()`
+or `RegisterPanel()` path. An external package instead supplies the validated
+typed UI schema/state/action contract from
+[ADR-056](../../adr/056-external-editor-ui-boundary.md); a host-owned adapter
+registers that projection through the same layout path. External code does not
+implement `IWorkspacePanel` or receive the whole `EditorLayer`, raw ImGui dock
+IDs, renderer backend objects, C++ component objects or process-global services.
 
 ```mermaid
 sequenceDiagram
     participant EM as Extension Manager
     participant Registry as Editor Surface Registry
     participant Host as EditorPanelHost
-    participant Tab as Extension Tab
+    participant Tab as Host UI Session
     participant Bus as EditorDataBus
 
     EM->>Registry: Commit editor.tab descriptor
-    Registry->>Host: Register factory + fallback placement
-    Host->>Tab: Construct with extension-scoped context
-    Host->>Tab: OnAttach(EditorTabContext)
-    Tab->>Bus: Subscribe with RAII tokens
+    Registry->>Host: Register schema + fallback placement
+    Host->>Tab: Attach copied schema/state + scoped actions
+    Tab->>Bus: Subscribe through host-owned tokens
     Bus-->>Tab: Notify selected allowlisted events
     Tab->>Tab: Invalidate local presentation cache
     Tab->>Host: Save bounded workspace state
-    Host->>Tab: OnDetach before provider shutdown
+    Host->>Tab: Close admission and detach before provider shutdown
 ```
 
 Requested event subscriptions are advisory for validation, diagnostics, and

--- a/docs/architecture/editor/ui-design-system.md
+++ b/docs/architecture/editor/ui-design-system.md
@@ -70,6 +70,23 @@ ImGui wrapper must define its typed props/result contract, token usage,
 accessibility behavior, and component-gallery coverage before feature code
 depends on it.
 
+### External Package Boundary
+
+External packages do not implement that low-level integration point. Embedded
+extension tabs, panels, drawers, modal pages and settings pages publish bounded
+typed UI schemas and state; the GUI host renders them with the same components,
+tokens, localization, focus and accessibility rules as built-in surfaces. A
+versioned extension C ABI may carry copied schemas, action requests and lifecycle
+values, but never an ImGui context, draw list, SDL event, renderer handle, native
+child window or C++ component object.
+
+Advanced external tools use registered host-owned schemas for plots, timelines,
+node graphs, image/canvas annotation and other reviewed specialized views. There
+is no generic immediate-mode drawing escape hatch. Isolation-sensitive modules
+may put their controller in a supervised helper process while retaining the same
+host-rendered schema/action contract. See
+[ADR-056](../../adr/056-external-editor-ui-boundary.md).
+
 ## Editor Platform And Renderer Boundary
 
 The graphical editor uses SDL3 for platform windowing and multimedia

--- a/docs/architecture/extensions/plugin-system.md
+++ b/docs/architecture/extensions/plugin-system.md
@@ -736,15 +736,16 @@ state.
 
 ### Data Bus Participation
 
-Extension surfaces are normal `EditorDataBus` subscribers. They may observe
-allowlisted editor-session notifications, invalidate local presentation caches,
-and query authoritative stores. They may publish only event types they own or
-notifications for transient state they own.
+Host-owned surface sessions are normal `EditorDataBus` subscribers. They may
+observe allowlisted editor-session notifications, invalidate copied presentation
+snapshots, and query authoritative stores through approved capabilities. External
+controller/module code never receives the C++ bus; it receives versioned bounded
+invalidation hints through its UI session or capability context.
 
 Rules:
 
-- Extension tabs and panels subscribe through move-only RAII tokens and release
-  them during detach.
+- Host UI sessions for extension tabs and panels subscribe through move-only RAII
+  tokens and release them during detach.
 - An extension does not subscribe directly to `EngineDataBus` from a GUI surface;
   process events enter the editor through `EditorEngineEventBridge` allowlists.
 - Extension event types use the extension's stable module ID as a prefix and are
@@ -757,13 +758,13 @@ Rules:
 - Subscriber order is not part of the contract. Coordination that requires a
   result uses typed commands or use cases, not event ordering.
 
-GUI surfaces use `EditorDataBus` rather than direct `EngineDataBus`
+Host UI sessions use `EditorDataBus` rather than direct `EngineDataBus`
 subscriptions because their lifetime is tied to one editor session, not the
 whole process. Process-level events that matter to UI are imported through an
 allowlisted bridge so payloads can be permission-checked, redacted, normalized,
 and scoped to the active workspace. Add-ons that need true process-level
 observation declare a separate process-observer contribution or event-import
-request instead of hiding that dependency inside a tab factory.
+request instead of hiding that dependency inside a surface schema.
 
 ### Modal And Settings Page Contributions
 
@@ -777,9 +778,10 @@ cancel, and close policy. Extension pages provide page content, validation
 diagnostics, and draft-field bindings; they do not commit settings directly or
 close the root modal by mutating modal-host state.
 
-Extension modal pages may subscribe to `EditorDataBus` through their provided
-context. They follow the same interaction and focus rules as built-in modal
-content and cannot bypass the active modal scope.
+The host UI session for an extension modal page may subscribe to `EditorDataBus`;
+the external controller receives only allowlisted invalidation hints through its
+versioned session/capability contract. Extension pages follow the same interaction
+and focus rules as built-in modal content and cannot bypass the active modal scope.
 
 ### Activity Bar Contributions
 

--- a/docs/architecture/extensions/plugin-system.md
+++ b/docs/architecture/extensions/plugin-system.md
@@ -88,6 +88,10 @@ Use these names deliberately:
   backend- and GUI-neutral v1 model from
   [ADR-055](../../adr/055-extension-manifest-v1-typed-model.md). Only that
   validated value may enter package composition, trust planning or activation.
+- Embedded third-party editor surfaces are host-rendered typed schemas under
+  [ADR-056](../../adr/056-external-editor-ui-boundary.md). The extension C ABI
+  carries copied schema/state/action values and lifecycle, never ImGui, SDL,
+  renderer handles or C++ panel objects.
 - Extension packages may be backend-only, frontend-only, or hybrid. GUI support
   is optional presentation over host-approved backend capabilities; it is not
   the definition of an extension.
@@ -828,64 +832,55 @@ drawer or main view) to deliver a complete side-panel tool.
 ### Drawer Content (Panel UI)
 
 When the activity bar icon is clicked, the bound drawer opens. The module owns
-the entire content area of that drawer. Horo provides two paths for building the
-panel UI:
+the backend behavior and semantic view projection; Horo owns the content area's
+rendering, interaction and presentation state. External packages use two typed
+composition paths:
 
-#### 1. Declarative field layout (preferred for data-driven panels)
+#### 1. Declarative component layout
 
-Modules register a typed field schema. The host renders standard Horo form
-controls — text inputs, dropdowns, checkboxes, sliders, color pickers — without
-the module writing any ImGui code. The schema supports conditional visibility,
-read-only states, and validation.
+Modules register a bounded `EditorUiSchemaV1`. The host renders standard Horo
+layout, text, input, choice, list, table, progress, diagnostics, image and action
+components without module drawing code. The schema owns stable semantic IDs,
+localization keys, accessibility metadata, typed value bindings and actions.
 
-```cpp
-// Module registers field descriptors — host handles layout and rendering
-struct CurveEditorFields {
-    static constexpr std::string_view PanelId = "com.vendor.curve-tools.drawer";
-
-    static std::vector<EditorFieldDescriptor> Describe() {
-        return {
-            EditorFieldDescriptor::Float("tension", 0.5f, 0.0f, 1.0f),
-            EditorFieldDescriptor::Float("bias", 0.0f, -1.0f, 1.0f),
-            EditorFieldDescriptor::Bool("closedLoop", false),
-            EditorFieldDescriptor::Enum("interpolation", {"Linear","CatmullRom","Bezier"}, 1),
-        };
-    }
-};
+```json
+{
+  "schemaVersion": 1,
+  "root": {
+    "type": "column",
+    "children": [
+      { "type": "number-field", "id": "tension", "label": "curve.tension" },
+      { "type": "number-field", "id": "bias", "label": "curve.bias" },
+      { "type": "toggle", "id": "closed-loop", "label": "curve.closed_loop" },
+      { "type": "action", "id": "preview", "label": "curve.preview" }
+    ]
+  }
+}
 ```
 
-#### 2. Custom ImGui rendering (for graphical or interactive panels)
+User interaction becomes a typed action request to an approved backend capability.
+The GUI frame renders the latest host-owned immutable snapshot and does not call
+module code during widget traversal or draw submission.
 
-Modules receive an `EditorDrawerContext` with a dedicated ImGui container.
-They can draw any ImGui content — plots, node graphs, custom widgets — inside
-that region. The host owns the window, scroll, focus, and teardown; the module
-owns the pixels inside the content area.
+#### 2. Registered specialized typed views
 
-```cpp
-// Module receives a render callback inside the drawer
-class CurveEditorDrawer : public IEditorDrawerSurface {
-public:
-    void OnDraw(EditorDrawerContext& ctx) override {
-        ImGui::Text("Curve Editor");
-        ImGui::SliderFloat("Tension", &mTension, 0.0f, 1.0f);
-        ImGui::PlotLines("##curve", mSamples.data(), mSamples.size());
-        // ... custom ImGui content
-    }
-private:
-    float mTension = 0.5f;
-    std::vector<float> mSamples;
-};
-```
+Graphical tools use registered plot, timeline, node-graph, image/canvas annotation
+or property-inspector schemas. Each view defines bounded data, semantic keyboard/
+accessibility behavior, input actions and a performance budget. Missing advanced
+semantics require a reviewed extension-point/schema revision; they do not grant a
+generic drawing callback.
 
-Modules can mix both approaches — use declarative fields for simple property
-editing and reserve custom ImGui for visualization or bespoke interaction.
-The host guarantees that only the active drawer receives render calls, and that
-drawers are detached cleanly on disable, update, or unload.
+External modules never receive `ImGuiContext`, draw lists, SDL events, native
+windows, dock IDs, GPU textures or Horo internal panel/component objects. A
+separate external application may be launched through an approved process
+capability, but its window is not embedded or docked and it does not inherit Horo
+theme/accessibility guarantees. The complete in-process, C ABI and isolated-helper
+policy is [ADR-056](../../adr/056-external-editor-ui-boundary.md).
 
 Users discover and install these modules through the Plugin Manager
 (`Window → Plugin Manager`), which fetches package metadata from the
-[registry](#marketplace-and-github-registry). After install, trust, and enable,
-the activity bar icon appears without restarting the editor.
+[registry](#marketplace-and-github-registry). Install, trust and enable follow the
+package lifecycle; native contribution activation is restart-applied by default.
 
 ### Layout, State, And Teardown
 
@@ -894,8 +889,10 @@ workspace-state byte limits, and safe teardown. Extension surfaces persist only
 bounded presentation state under their contribution ID. State for a missing
 provider remains opaque and cannot grant capabilities when the provider returns.
 
-GUI modules do not draw outside their assigned surface, bypass modal interaction
-exclusivity, install process-global shortcuts, or retain direct editor internals.
+GUI modules do not draw directly, bypass modal interaction exclusivity, install
+process-global shortcuts, or retain direct editor internals. The host performs
+all hit testing, focus, accessibility traversal and rendering from copied typed
+state.
 During disable, update, shutdown, or future live unload, contributed surfaces are
 detached before module shutdown and all subscriptions, callbacks, jobs, and
 queued continuations into module code are drained or rejected.

--- a/docs/guides/extension-module-development.md
+++ b/docs/guides/extension-module-development.md
@@ -56,8 +56,10 @@ permission checks, result storage, and teardown.
    `horo-package.toml`.
 4. Declare module ABI/entries, permissions, settings, errors, events, and UI
    contributions in the package-scoped `extension.json`.
-5. Implement the native module behind the Horo extension C ABI.
-6. Register factories for the declared contributions.
+5. Implement the native module behind the Horo extension C ABI or an approved
+   isolated helper protocol.
+6. Publish typed backend implementations and host-rendered UI schemas/actions for
+   the declared contributions; do not register external drawing callbacks.
 7. Read engine and IDE data through approved query capabilities.
 8. Mutate engine/editor state only through typed commands or application use
    cases.
@@ -283,6 +285,12 @@ Frontend contribution
 External native editor/tool modules cross a C ABI. C++ STL types, exceptions,
 RTTI-dependent ownership, allocator ownership, and C++ object deletion do not
 cross this boundary.
+
+The C ABI also does not expose ImGui contexts, draw lists, SDL events, renderer
+handles, native child windows or C++ panel/component interfaces. Embedded UI is a
+copied typed schema/state/action contract rendered by Horo; complex tools use
+registered specialized view schemas or a separately launched application. See
+[ADR-056](../adr/056-external-editor-ui-boundary.md).
 
 Use the concrete SDK declaration in
 `include/Horo/Extensions/ExtensionAbi.h`; do not reproduce private copies of
@@ -658,6 +666,8 @@ Each extension package should have contract tests for:
 ## Common Mistakes
 
 - Adding a tab by editing `EditorLayer` instead of contributing `editor.tab`.
+- Implementing external editor UI with raw ImGui, native child windows or a C++
+  panel interface instead of the typed host-rendered UI contract.
 - Reading another tab's state directly instead of querying an authority.
 - Subscribing a GUI surface directly to `EngineDataBus`.
 - Sending commands through the data bus.
@@ -671,6 +681,7 @@ Each extension package should have contract tests for:
 ## Related Architecture
 
 - [Extension System](../architecture/extensions/plugin-system.md)
+- [External Editor UI Boundary](../adr/056-external-editor-ui-boundary.md)
 - [Editor Panel Host](../architecture/editor/editor-panel-host.md)
 - [Editor Modal Host](../architecture/editor/editor-modal-host.md)
 - [Editor Data Bus](../architecture/editor/editor-data-bus.md)


### PR DESCRIPTION
## Summary

- Chooses host-rendered typed presentation as the only embedded third-party editor UI boundary.
- Limits the versioned C ABI to copied schema, state, action, and lifecycle values rather than rendering callbacks.
- Uses the same bounded UI/action contract over IPC for isolated helpers and keeps separately launched applications outside editor docking.
- Assigns rendering, input, theme, localization, accessibility, state, event delivery, and teardown ownership explicitly.
- Replaces the documented custom ImGui drawer path with declarative components and registered specialized typed views.

## Why

The GUI design contract keeps ImGui private, while the extension documentation previously offered external modules raw callbacks and direct event-bus participation. Publishing those paths would expose toolkit/global state, memory ABI, renderer, input, and frame-lifetime details that Horo cannot safely version, isolate, or unload.

## Decision

- External embedded surfaces provide validated `EditorUiSchemaV1` plus copied state and typed actions; Horo owns pixels and interaction.
- First-party internal panel/component interfaces remain private and are not an external ABI promise.
- No extension callback runs during widget traversal or renderer submission; frames consume immutable host-owned snapshots.
- Host UI sessions own `EditorDataBus` subscriptions and send external controllers only allowlisted, bounded invalidation hints.
- Input, focus, accessibility, localization, clipboard/drop/process capabilities, and modal exclusion remain host-controlled.
- Native detach closes admission, cancels/drains work, destroys copied state, and releases callbacks/leases before module teardown.

## Validation

- [x] Replayed HORO-103 cleanly onto current `main`; obsolete stack ancestry is absent from the PR.
- [x] `markdownlint-cli` passed for every changed Markdown file.
- [x] `git diff --check` passed.
- [x] All newly added local Markdown links resolve.
- [x] No unresolved TODO/TBD/open-decision marker remains.
- [x] Replaced the legacy modal sequence with a host-session/typed-action flow and aligned modal, panel, and extension-system event-subscription wording.
- [x] Replied to and resolved the Codacy line thread; separately acknowledged and fixed its out-of-diff review-summary concern.
- [ ] Executable schema, action, IPC, accessibility, and teardown contract tests are downstream implementation work; ADR-056 specifies the matrix.

## Risk and rollout

This documentation policy intentionally removes raw custom widget rendering as an external compatibility option. Advanced third-party tools must migrate to existing typed nodes, request a focused host-owned specialized-view schema, or run as a separately launched application.

## Issue links

- Jira: [HORO-103](https://horo-engine.atlassian.net/browse/HORO-103)
- GitHub: Closes #103

## Reviewer notes

Review ADR-056 first, then the modal and panel host projections. The Extension System, GUI Design System, and author-guide changes enforce the same no-ImGui/no-direct-bus/no-frame-callback boundary.


[HORO-103]: https://horo-engine.atlassian.net/browse/HORO-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ