### PR TITLE
docs(packages): define source policy HORO-117 #117 [PKG-001.3]

### DIFF
--- a/docs/adr/058-package-source-policy.md
+++ b/docs/adr/058-package-source-policy.md
@@ -55,6 +55,11 @@ enum class PackageSourceKind {
 };
 ```
 
+Canonical serialized kind values are the exact kebab-case projections
+`public-registry`, `private-registry`, `static-index`, `direct-artifact`,
+`vendored-artifact` and `local-development-override`; the generic value
+`registry` is invalid because it loses the public/private policy distinction.
+
 `PackageSourceId` names a logical configured authority such as `horo.public`,
 `team.release` or `project.vendored`. A source owns package/version metadata and a
 stable safe artifact coordinate. One source may have ordered transport endpoints
@@ -135,6 +140,24 @@ Private is not intrinsically higher priority than public, and a registry is neve
 selected merely because it responds first. Namespace routing and source assignment
 are exact policy entries, not prefix guessing. Parallel metadata queries preserve
 the precomputed order; completion timing cannot change selection.
+
+Fresh resolution is not a first-response or first-query match. An explicit source
+assignment, namespace route, vendored assignment or development override is an
+exclusive authority choice and queries only that choice. Otherwise the resolver
+takes a bounded, revision-pinned metadata snapshot from every eligible configured
+source in the applicable ordered tier set before choosing a candidate. It then
+applies the order above and semantic-version rules to that complete snapshot.
+Failure to obtain required metadata for any member of a non-exclusive search set
+returns `SourceMetadataIncomplete`; it does not silently reduce the set and claim
+that identity-conflict checking completed.
+
+Before committing a fresh resolution, the resolver compares the trusted advertised
+artifact/manifest identity for the chosen package ID and exact version across all
+sources in that snapshot. A different digest is `PackageIdentityConflict` even
+when it came from a lower-priority source. Identical identities are one candidate
+with multiple provenance observations. Source priority chooses among versions or
+unique identities only after this cross-source consistency check; it never hides
+a same-ID/version digest conflict.
 
 Within one source, versions are filtered by request range, compatibility, yanked/
 policy state and publisher requirements, then selected by the resolver's canonical
@@ -241,7 +264,7 @@ The resolver returns typed outcomes:
 | Condition | Result |
 |---|---|
 | Same package ID/version and identical verified digest from approved transports of one source | Same artifact; provenance records the successful transport without duplicating a candidate. |
-| Same package ID/version with different digest from any sources | `PackageIdentityConflict`; stop and report both safe source IDs/digests. |
+| Same package ID/version with different digest in any non-exclusive eligible-source snapshot | `PackageIdentityConflict`; stop and report both safe source IDs/digests before selection commits. Explicitly assigned/routed requests have one authority and do not query unrelated sources. |
 | Higher-priority source has no matching version | Continue to the next configured source only when the request does not require the first source exclusively. |
 | Explicitly assigned source unavailable | `AssignedSourceUnavailable`; do not fall through to another authority. |
 | Locked artifact unavailable | `LockedArtifactUnavailable`; do not re-resolve. |

--- a/docs/adr/058-package-source-policy.md
+++ b/docs/adr/058-package-source-policy.md
@@ -1,0 +1,332 @@
+# ADR-058: Package Source Policy
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Public, private, local, vendored and offline package-source identity, deterministic precedence, pinning, mirrors, credential isolation, development overrides and failure behavior
+- **Issue**: [PKG-001.3](https://github.com/abdullahbodur/horo-engine/issues/117)
+- **Jira**: [HORO-117](https://horo-engine.atlassian.net/browse/HORO-117)
+- **Parent**: [PKG-001](https://github.com/abdullahbodur/horo-engine/issues/36)
+- **Related**: [ADR-057](057-package-manifest-v1-typed-model.md), [ADR-002](002-credential-handling.md)
+- **Normative documents**: [Horo Package System](../architecture/packages/package-system.md), [Package Restore](../architecture/packages/package-restore.md), [Package Lifecycle](../architecture/packages/package-lifecycle.md), [Application Security](../architecture/security/application-security.md), [Configuration System](../architecture/foundation/configuration-system.md)
+
+## Context
+
+Horo packages may come from a public registry, an organization/private registry,
+a static index, an exact URL, a vendored project artifact, a user-local development
+directory or an air-gapped mirror. The current package architecture lists these
+possibilities but does not define one source identity model or deterministic
+selection order. It is unclear whether a private registry overrides public
+metadata, whether a mirror becomes a new authority, how a development override
+interacts with a lockfile, or when fallback after a source failure is safe.
+
+Without a policy, two machines with the same project metadata could resolve a
+different artifact because their registries were discovered in another order. A
+malicious or stale mirror could replace a package ID/version, a local override
+could leak into a committed lockfile, and private credentials or URLs could reach
+project files and diagnostics.
+
+ADR-057 separates package author metadata from source/resolution/install state.
+This ADR defines the later source policy and the exact provenance record carried
+by the lockfile and verified install candidate.
+
+## Decision
+
+### 1. Source identity, transport endpoint and artifact identity are separate
+
+The source model uses distinct bounded values:
+
+```cpp
+struct PackageSourceId;
+struct PackageSourceConfigurationDigest;
+struct PackageSourceArtifactId;
+struct PackageIndexRevision;
+struct PackageMirrorId;
+struct CredentialHandle;
+struct ArtifactDigest;
+
+enum class PackageSourceKind {
+    PublicRegistry,
+    PrivateRegistry,
+    StaticIndex,
+    DirectArtifact,
+    VendoredArtifact,
+    LocalDevelopmentOverride,
+};
+```
+
+`PackageSourceId` names a logical configured authority such as `horo.public`,
+`team.release` or `project.vendored`. A source owns package/version metadata and a
+stable safe artifact coordinate. One source may have ordered transport endpoints
+(mirrors and origin). Endpoint URLs are fetch details, not package identity.
+
+`ArtifactDigest` is the immutable byte identity. The tuple of package ID, exact
+version and artifact digest is globally authoritative after verification. A
+source cannot replace an existing locked tuple by winning precedence.
+
+The content-addressed cache is not a source. It may satisfy a fetch only after its
+bytes and provenance are verified against the requested artifact digest.
+
+### 2. Source configuration layers are explicit and canonical
+
+Sources are composed from four layers:
+
+| Layer | Allowed contents | Portability |
+|---|---|---|
+| Product policy | Built-in public source IDs, trusted TLS/signing roots, allowed source/transport kinds and hard security limits | Product-defined |
+| Organization policy | Approved private source IDs, mirrors, allow/deny rules and credential-provider bindings | Organization-managed, not project-authored |
+| Project portable configuration | Named public/static/direct/vendored source references and explicit source choice per dependency | Committed and credential-free |
+| User-local configuration | Explicit development overrides, user mirrors/proxies where policy permits and credential handles | Never committed or locked |
+
+Each layer has a typed schema and deterministic canonical digest. Loading order,
+map iteration, filesystem enumeration and environment-variable order never define
+precedence. A higher layer cannot weaken product/organization TLS, signing,
+redirect, domain, size or source-kind restrictions.
+
+Package manifest files do not configure sources. A package cannot select the
+registry from which its dependencies must be downloaded or supply credentials for
+that registry.
+
+### 3. Locked restore has exactly one authoritative source record
+
+For a dependency already in `.horo/packages.lock`, the lock entry is authoritative
+and contains a credential-free `ResolvedPackageSource`:
+
+```cpp
+struct ResolvedPackageSource {
+    PackageSourceId source;
+    PackageSourceKind kind;
+    PackageSourceArtifactId artifact;
+    std::optional<PackageIndexRevision> indexRevision;
+    HoroPackageId package;
+    PackageVersion version;
+    ArtifactDigest artifactDigest;
+    PackageManifestDigest manifestDigest;
+    PackageFileManifestDigest fileManifestDigest;
+    PublisherId publisher;
+};
+```
+
+Restore may fetch the exact artifact from an approved mirror, origin, vendored
+copy or verified cache entry associated with that logical source, but every byte
+must match the locked digest and signature/publisher policy. It cannot consult
+another registry for a newer version, reinterpret the package ID/version or
+rewrite provenance.
+
+If the locked source ID no longer exists, policy may map that source to an
+approved mirror/archival transport only when the artifact/digests remain exact.
+Otherwise the result is `SourceConfigurationMissing`, not implicit re-resolution.
+
+### 4. Fresh resolution uses an explicit deterministic candidate order
+
+When no accepted lock entry exists, one package request produces candidates in
+this order:
+
+1. An explicitly enabled user-local development override for that exact package
+   and operation profile.
+2. The portable source explicitly named by the project dependency request.
+3. Project-declared vendored/static sources explicitly assigned to that package.
+4. Organization-approved named sources assigned by package/namespace routing.
+5. Project-configured named indexes ordered by numeric priority and then canonical
+   `PackageSourceId`.
+6. The product default public source, when policy allows it.
+
+Private is not intrinsically higher priority than public, and a registry is never
+selected merely because it responds first. Namespace routing and source assignment
+are exact policy entries, not prefix guessing. Parallel metadata queries preserve
+the precomputed order; completion timing cannot change selection.
+
+Within one source, versions are filtered by request range, compatibility, yanked/
+policy state and publisher requirements, then selected by the resolver's canonical
+semantic-version rules. Source precedence chooses where candidates may come from;
+it does not override version/digest conflicts or compatibility.
+
+The ordered canonical source configuration and request inputs produce a
+`PackageSourceConfigurationDigest`. The resolver records it with diagnostics and
+the lock transaction so equal inputs prove equal precedence decisions.
+
+### 5. Development overrides are explicit non-portable graph substitutions
+
+A local development override names one exact package ID and a normalized local
+path stored only in user-local configuration. It is disabled by default in CI,
+release, non-interactive and offline-reproducibility profiles. Enabling it requires
+an explicit development profile or invocation flag permitted by policy.
+
+The override is validated and packaged into a transient ADR-057 bundle before
+use; restore never executes arbitrary build scripts or loads files from an
+unverified working directory. Its provenance is `LocalDevelopmentOverride`, and
+all UI/CLI/diagnostics mark the graph non-portable.
+
+A local path, file identity, digest, credential handle or resolved override result
+never enters committed `packages.json` or `packages.lock`. Lock generation while
+an override is active must either resolve and lock the portable baseline separately
+or fail with `NonPortableOverrideActive`; it cannot lock the override bytes as if
+they came from the assigned portable source. Release ignores overrides and proves
+the locked portable graph.
+
+### 6. Mirrors change transport, not authority or precedence
+
+A logical source owns an ordered list of approved mirrors followed by its origin
+when origin fallback is allowed. Mirror order is explicit numeric priority then
+canonical `PackageMirrorId`. Offline mode may select only endpoints marked
+offline/local.
+
+An availability failure such as unreachable endpoint, DNS failure or policy-
+bounded timeout may advance to the next endpoint for the same logical artifact.
+An integrity, signature, publisher, TLS, redirect-policy, authentication-scope or
+content-identity failure is security-significant: the artifact is quarantined and
+automatic fallback stops. Fallback must not turn an attack into a transient miss.
+
+A mirror cannot add versions, change index metadata or serve different bytes under
+the source's authority unless organization policy explicitly configures it as a
+separate source. Index metadata is signed/pinned or bound to an expected revision/
+digest according to source kind.
+
+### 7. Pinning requirements depend on source capability
+
+| Source kind | Portable pin |
+|---|---|
+| Registry/static index | Source ID + immutable index/package coordinate + exact version + artifact/manifest/file-manifest digests + publisher |
+| Direct artifact URL | Credential-free canonical locator or opaque artifact coordinate + expected artifact digest |
+| Vendored artifact | Project-relative normalized file identity + expected artifact digest |
+| Git source, when enabled later | Canonical repository identity + immutable commit/tree + produced artifact digest; packaging is an explicit trusted operation |
+| Local development override | Never portable or lockable; transient verified bundle only |
+
+Mutable branches, floating tags, unversioned “latest” endpoints, URL artifacts
+without expected hashes and local absolute paths are invalid portable pins. A
+redirect does not change the recorded source/artifact identity and must remain
+within the configured scheme/domain/credential scope.
+
+### 8. Credentials are resolved just in time and never become package data
+
+Private source authentication uses opaque `CredentialHandle` values stored only
+in user/organization credential configuration. Project files, package manifests,
+lockfiles, source configuration digests, cache metadata exported to projects,
+operation history and diagnostic bundles contain neither secret values nor
+credential handles.
+
+The source operation asks the credential service for a short-lived scoped lease
+immediately before one approved network request. The lease is bound to source ID,
+endpoint origin, operation and requested auth mechanism. It is not inherited by a
+redirect to another origin, subprocess, package hook or mirror with a different
+scope. Raw secrets never enter URLs, command-line arguments or environment
+variables when a platform-secure request adapter exists.
+
+Logging/audit records use safe source/mirror IDs, operation IDs, status codes and
+redacted endpoint origins. They do not record query strings, authorization/cookie
+headers, private repository paths, usernames, credential-provider keys or response
+bodies that may contain secrets. Error text from remote servers is bounded and
+redacted before becoming a diagnostic.
+
+### 9. Offline and air-gapped operation filter transports without reordering
+
+Offline mode freezes the same resolver/source policy and removes network-capable
+endpoints. It may use:
+
+- a verified content-addressed cache hit for the locked digest;
+- a project-vendored artifact assigned by portable configuration;
+- an approved local static index/mirror with pinned metadata; or
+- an organization-managed air-gapped source.
+
+Offline does not make arbitrary local directories trusted, relax hash/signature
+checks, reorder package sources or permit a missing lock to select a different
+version. Required unavailability returns `OfflineArtifactUnavailable`. An
+interactive tool may offer a future vendoring plan, but cannot mutate project
+source configuration as a side effect of restore.
+
+### 10. Conflicts are not resolved by precedence
+
+The resolver returns typed outcomes:
+
+| Condition | Result |
+|---|---|
+| Same package ID/version and identical verified digest from approved transports of one source | Same artifact; provenance records the successful transport without duplicating a candidate. |
+| Same package ID/version with different digest from any sources | `PackageIdentityConflict`; stop and report both safe source IDs/digests. |
+| Higher-priority source has no matching version | Continue to the next configured source only when the request does not require the first source exclusively. |
+| Explicitly assigned source unavailable | `AssignedSourceUnavailable`; do not fall through to another authority. |
+| Locked artifact unavailable | `LockedArtifactUnavailable`; do not re-resolve. |
+| Integrity/signature/publisher failure | Quarantine and stop automatic fallback. |
+| Authentication missing/denied | `SourceAuthenticationRequired`/`Denied`; never try another authority to bypass private routing. |
+| Package yanked | Existing exact lock may restore only when policy permits and bytes remain verifiable; fresh resolution excludes it. |
+| Local override invalid | Reject override; do not silently use portable package while presenting a development graph. |
+
+Diagnostics preserve candidate order and safe reasons. Network racing or retry
+timing cannot choose the winner. Retry budgets, backoff and endpoint health affect
+availability only, never source precedence or artifact identity.
+
+### 11. Source resolution is bounded and side-effect disciplined
+
+Index and response parsing uses bounded bytes, entries, versions, redirects,
+headers, diagnostics and time/in-flight request budgets. TLS is mandatory for
+network sources except explicit loopback/local development policy. Domain,
+certificate/pinning, proxy, redirect, maximum artifact size and content-type rules
+are evaluated before accepting bytes.
+
+Metadata query is read-only. Download writes only to a unique staging file,
+verifies size/digest/signature/bundle, then atomically publishes to the content-
+addressed cache. Cancellation or failure removes/quarantines staging and does not
+update the lockfile, source health as authority, install record or active package
+graph. Lockfile publication is a separate journaled resolver transaction.
+
+### 12. Migration normalizes inline sources into named policy
+
+Legacy `.horo/packages.json` entries with inline `url`, `file`, `git` or
+`registry` fields are migration input. Migration creates/reuses canonical named
+portable sources, assigns each dependency explicitly, moves local paths to user-
+local overrides, removes all credentials/query secrets, requires missing hashes/
+immutable revisions and previews the resulting precedence order.
+
+Existing lock entries are accepted only when their source/artifact identity and
+digests can be represented without guessing. Otherwise restore requires explicit
+re-resolution. Migration never uploads, downloads or rewrites a lock merely to
+inspect the old configuration.
+
+## Verification
+
+Contract tests cover:
+
+- identical canonical source configuration/request inputs produce identical
+  ordered candidates and source-configuration digest;
+- public/private/static/direct/vendored resolution with explicit assignment;
+- exact locked restore through origin, approved mirror, verified cache and
+  offline vendored artifact without provenance drift;
+- equal package/version with different digests is a hard identity conflict;
+- assigned/locked source unavailability never falls through to another authority;
+- mirror availability fallback versus integrity/security stop behavior;
+- redirect, TLS, size, index-revision, publisher and artifact-pin enforcement;
+- local override enablement, non-portable diagnostics and lock/release exclusion;
+- offline filtering without reordered candidates or relaxed verification;
+- missing/denied/expired credentials and cross-origin redirect scope rejection;
+- exhaustive log, diagnostic, operation, lockfile and project-file scans proving
+  no secret or credential handle is serialized; and
+- cancellation/failure before and after staging verification with no partial
+  lock, cache publication or install-state mutation.
+
+Determinism fixtures randomize map insertion, filesystem enumeration, request
+completion and mirror response order while expecting the same selection. Private
+source tests use synthetic secrets in URLs, headers, cookies, remote error bodies
+and provider identifiers to verify redaction at every output boundary.
+
+## Consequences
+
+Every resolved artifact has one durable safe source identity and exact digest
+proven in the lockfile. Mirrors improve availability without becoming shadow
+authorities; private/local/offline behavior cannot reorder resolution implicitly;
+credentials remain outside portable and diagnostic data. The cost is explicit
+named source configuration, strict legacy migration, additional provenance types
+and refusal to “helpfully” fall back when assignment, identity or security fails.
+
+## Rejected Alternatives
+
+| Option | Decision and reason |
+|---|---|
+| Search all registries and use the first response | Rejected: network timing would define precedence and reproducibility. |
+| Always prefer private over public | Rejected: privacy classification is not an authority/priority rule; explicit routing owns precedence. |
+| Let mirrors override metadata or versions | Rejected: a mirror is transport for one authority, not a second resolver. |
+| Fall back after hash/signature failure | Rejected: security failures must not be disguised as endpoint availability. |
+| Store authenticated URLs/tokens in project or lock files | Rejected: portable metadata would leak and replay credentials. |
+| Store credential-handle names in the lockfile | Rejected: even opaque provider identifiers are user/organization-local and can disclose infrastructure. |
+| Lock a local development directory | Rejected: it is mutable, non-portable and not a reproducible source artifact. |
+| Treat cache contents as a source | Rejected: cache presence is an optimization and cannot establish provenance or authority. |
+| Let offline mode relax signature/hash policy | Rejected: lack of network does not make local bytes trusted. |
+| Resolve source precedence through generic configuration precedence | Rejected: package assignment, locks, mirrors and conflict semantics require a dedicated typed policy. |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -69,6 +69,7 @@ to the replacement.
 | [055](055-extension-manifest-v1-typed-model.md) | Extension Manifest V1 Typed Model | Proposed | 2026-09-02 |
 | [056](056-external-editor-ui-boundary.md) | External Editor UI Boundary | Proposed | 2026-09-02 |
 | [057](057-package-manifest-v1-typed-model.md) | Package Manifest V1 Typed Model | Proposed | 2026-09-02 |
+| [058](058-package-source-policy.md) | Package Source Policy | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -242,7 +242,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Package System](./packages/package-system.md): core package kinds, contributions,
   manifest, sources, resolver, lockfile, cache, and trust model. The canonical
   typed manifest and verified-bundle boundary is
-  [ADR-057](../adr/057-package-manifest-v1-typed-model.md).
+  [ADR-057](../adr/057-package-manifest-v1-typed-model.md); deterministic source,
+  mirror, credential and override policy is
+  [ADR-058](../adr/058-package-source-policy.md).
 - [Package Restore](./packages/package-restore.md): clean-machine project restore,
   bootstrap, CI, offline restore, dev overrides, and non-interactive policy.
 - [Package Lifecycle](./packages/package-lifecycle.md): install, trust, enable,

--- a/docs/architecture/foundation/configuration-system.md
+++ b/docs/architecture/foundation/configuration-system.md
@@ -44,7 +44,10 @@ validation infrastructure without becoming global configuration.
 Project extension package requests are portable project configuration, but they
 are not a trust grant and do not store resolved package paths. Extension package
 resolution, trust decisions, and development overrides follow
-[Extension System](../extensions/plugin-system.md).
+[Extension System](../extensions/plugin-system.md),
+[Horo Package System](../packages/package-system.md) and the dedicated
+[Package Source Policy](../../adr/058-package-source-policy.md). Generic settings
+precedence does not choose package authorities or resolve source conflicts.
 
 ## Schema
 

--- a/docs/architecture/packages/package-lifecycle.md
+++ b/docs/architecture/packages/package-lifecycle.md
@@ -50,7 +50,9 @@ state, source policy, trust and selected host artifacts remain separate records.
 
 Package install uses the same safety posture as distribution staging:
 
-1. Download into a temporary location.
+1. Resolve one deterministic source/artifact record under
+   [ADR-058](../../adr/058-package-source-policy.md), then download through its
+   ordered approved transports into a temporary location.
 2. Verify expected size and hash.
 3. Extract with path traversal, symlink, depth, file count, and size limits.
 4. Decode and semantically validate the typed package/file manifests, then verify

--- a/docs/architecture/packages/package-restore.md
+++ b/docs/architecture/packages/package-restore.md
@@ -160,6 +160,12 @@ Offline mode:
 - fails on missing packages
 - does not consult network registries, URLs, or Git remotes
 
+Offline mode filters the configured transport endpoints without changing source
+precedence or authority. It may satisfy a locked digest from verified cache,
+vendored content or an approved local/air-gapped mirror. It does not trust
+arbitrary directories, relax hash/signature checks or choose a different package
+version. Missing required bytes return `OfflineArtifactUnavailable`.
+
 ## Development Overrides
 
 Portable dependencies belong in `.horo/packages.json`. Local development
@@ -180,6 +186,10 @@ Overrides:
 - must not appear in committed project metadata
 - are shown in diagnostics so developers know the graph differs from portable
   restore
+- are explicitly enabled only for approved development profiles and validated as
+  transient ADR-057 bundles before use
+- make the active graph non-portable; lock generation resolves the portable
+  baseline separately or fails instead of recording override bytes
 
 ## Package Asset Reference Modes
 

--- a/docs/architecture/packages/package-system.md
+++ b/docs/architecture/packages/package-system.md
@@ -290,7 +290,7 @@ dependency assignments. Map/file enumeration does not define priority:
 {
   "sources": {
     "horo.public": {
-      "kind": "registry",
+      "kind": "public-registry",
       "registry": "official",
       "priority": 100
     },
@@ -324,6 +324,13 @@ dependency assignments. Map/file enumeration does not define priority:
   }
 }
 ```
+
+Fresh resolution with an explicit dependency source queries only that authority.
+An unassigned request snapshots every eligible source in its ordered search set
+before selection and compares the chosen package ID/exact version identity across
+that snapshot. A lower-priority digest mismatch is a hard conflict; unavailable
+required metadata makes the snapshot incomplete rather than silently converting
+resolution into first-match behavior.
 
 Mutable Git branches, unpinned URLs, and local absolute paths are not valid
 portable restore sources.

--- a/docs/architecture/packages/package-system.md
+++ b/docs/architecture/packages/package-system.md
@@ -270,7 +270,8 @@ package composition, trust planning or ExtensionHost.
 
 ## Package Sources
 
-The package system is source-agnostic. A package may come from:
+The package system is source-agnostic, but source identity and precedence follow
+[ADR-058](../../adr/058-package-source-policy.md). A package may come from:
 
 - local `.horopkg` file
 - local package directory
@@ -282,24 +283,42 @@ The package system is source-agnostic. A package may come from:
 Only portable sources may be required for project restore. Local path overrides
 are user-local and must not be required on another machine.
 
-Example `packages.json` source declarations:
+Portable `packages.json` uses named credential-free sources and explicit
+dependency assignments. Map/file enumeration does not define priority:
 
 ```json
 {
+  "sources": {
+    "horo.public": {
+      "kind": "registry",
+      "registry": "official",
+      "priority": 100
+    },
+    "vendor.index": {
+      "kind": "static-index",
+      "url": "https://cdn.vendor.com/horo/index.json",
+      "indexSha256": "...",
+      "priority": 20
+    },
+    "project.vendored": {
+      "kind": "vendored",
+      "root": "vendor/packages/",
+      "priority": 10
+    }
+  },
   "dependencies": {
     "com.vendor.weapon-pack": {
-      "url": "https://cdn.vendor.com/weapon-pack-2.0.0.horopkg",
-      "sha256": "..."
+      "source": "vendor.index",
+      "version": "2.0.0"
     },
     "com.team.vendored-pack": {
-      "file": "vendor/packages/com.team.vendored-pack-1.0.0.horopkg"
-    },
-    "com.example.dialogue": {
-      "git": "https://github.com/example/dialogue-pack.git",
-      "rev": "abc123"
+      "source": "project.vendored",
+      "version": "1.0.0",
+      "artifact": "com.team.vendored-pack-1.0.0.horopkg",
+      "sha256": "..."
     },
     "com.horo.audio": {
-      "registry": "official",
+      "source": "horo.public",
       "version": "^1.0.0"
     }
   }
@@ -335,7 +354,25 @@ Git sources, full registries, and marketplace flows are later extensions.
 
 ### Package Source Policy
 
-Package sources are resolved under package source policy. The policy defines:
+Package source policy separates logical source identity, transport endpoint and
+artifact digest. Locked restore uses exactly the `ResolvedPackageSource` recorded
+in `.horo/packages.lock`; mirrors/cache/vendored copies may supply its exact bytes
+but cannot change authority, version, publisher or digest.
+
+Fresh resolution uses this deterministic order:
+
+1. explicitly enabled user-local development override for the package/profile;
+2. portable source explicitly assigned by the project request;
+3. explicitly assigned project vendored/static source;
+4. organization namespace/package routing;
+5. project named indexes by numeric priority then canonical source ID; and
+6. product default public source when allowed.
+
+Private is not automatically higher priority than public. Completion timing,
+filesystem order and map insertion cannot choose a source. An assigned or locked
+source never falls through to another authority when unavailable.
+
+The policy also defines:
 
 - allowed source types
 - allowed domains and URL schemes
@@ -348,6 +385,9 @@ Package sources are resolved under package source policy. The policy defines:
 
 HTTP without TLS, unbounded redirects, unpinned mutable artifacts, and secrets in
 URLs are rejected unless an explicit local development policy allows them.
+Availability failure may advance through ordered mirrors of the same logical
+source. Hash, signature, publisher, TLS, redirect-scope or authentication-policy
+failure quarantines the artifact and stops automatic fallback.
 
 ## Dependency Request And Lockfile
 
@@ -548,6 +588,12 @@ Private sources use credential handles. Raw secrets must not appear in:
 - diagnostic bundles
 - job history
 
+Credential handles themselves remain in user/organization credential bindings;
+they are also excluded from project files, lockfiles, exported cache metadata,
+diagnostics and operation history. A source request resolves one short-lived
+credential lease just in time, scoped to the source, endpoint origin and
+operation. Redirects, mirrors, subprocesses and package hooks cannot inherit it.
+
 Credential access follows [Application Security](../security/application-security.md)
 and [Release Security](../release/release-security.md).
 
@@ -638,6 +684,10 @@ or sensitive local paths.
 - extension descriptor owner/package binding and undeclared-file rejection
 - extension-only and hybrid packages resolve through the same request/lock graph
 - ExtensionHost cannot load raw directories or resolve/trust package state
+- deterministic source precedence under randomized map/request completion order
+- locked/assigned source unavailability does not re-resolve through another source
+- mirror availability fallback stops on integrity/signature/security failures
+- development overrides never enter committed requests, lockfiles or release
 
 ## Related Documents
 

--- a/docs/architecture/security/application-security.md
+++ b/docs/architecture/security/application-security.md
@@ -26,6 +26,11 @@ editor and CLI hosts.
 - Runtime console and remote-console access are profile-gated, permission-scoped,
   and denied remotely by default.
 - Secrets remain in credential providers and short-lived secure memory.
+- Package source credentials and credential handles never enter package/project
+  manifests, lockfiles, cache provenance exported to projects, logs, diagnostics
+  or operation history. Source adapters resolve one short-lived origin-scoped
+  lease just before an approved request under
+  [ADR-058](../../adr/058-package-source-policy.md).
 - Security decisions are explicit, auditable, and revocable.
 
 ## Trust Domains


### PR DESCRIPTION
## Summary

- Defines one typed policy for public/private registries, static indexes, direct artifacts, vendored artifacts, local development overrides, and offline sources.
- Separates logical source authority, transport mirrors/endpoints, and immutable artifact identity.
- Makes locked restore authoritative and fresh-resolution precedence explicit, deterministic, and conflict-aware.
- Defines pinning, mirror fallback, offline filtering, development-override, credential, and identity-conflict behavior.

## Why

The package architecture listed source kinds but did not define who wins, whether a mirror becomes an authority, how local overrides affect locks, or when fallback is safe. Equal project inputs could otherwise resolve different bytes based on discovery/network order, and a priority rule could accidentally hide dependency-confusion conflicts.

## Decision

- Locked and explicitly assigned/routed sources are exclusive authorities and never fall through to an unrelated source.
- Unassigned fresh resolution takes a bounded metadata snapshot from every eligible configured source before selection; an incomplete required snapshot fails explicitly.
- The resolver checks the chosen package ID/exact-version digest across the full non-exclusive snapshot, so lower-priority conflicts cannot be hidden by precedence.
- Mirrors change transport only; integrity, signature, publisher, TLS, authentication-scope, or content-identity failures quarantine and stop fallback.
- Canonical serialized source kinds exactly distinguish `public-registry`, `private-registry`, `static-index`, `direct-artifact`, `vendored-artifact`, and `local-development-override`.
- Development overrides remain transient verified bundles, mark the graph non-portable, and cannot enter committed requests, locks, or release.
- Credentials and handles remain outside project data, locks, exported provenance, logs, diagnostics, and operation history.

## Validation

- [x] Replayed HORO-117 cleanly onto current `main`; obsolete stack ancestry is absent from the PR.
- [x] `markdownlint-cli` passed for every changed Markdown file.
- [x] `git diff --check` passed.
- [x] All newly added local Markdown links resolve.
- [x] No unresolved TODO/TBD/open-decision marker remains.
- [x] Reconciled priority selection with all-eligible-source conflict scanning and aligned serialized source-kind names; both Codacy threads are resolved.
- [ ] Executable resolver, mirror, redaction, determinism, and failure-injection tests are downstream implementation work; ADR-058 specifies the matrix.

## Risk and rollout

The policy rejects helpful-looking implicit fallback and requires migration from inline source declarations to named credential-free assignments. Missing source identity, pin data, or required conflict-scan metadata must be repaired explicitly rather than guessed.

## Issue links

- Jira: [HORO-117](https://horo-engine.atlassian.net/browse/HORO-117)
- GitHub: Closes #117

## Reviewer notes

Review ADR-058 first, then Package System and Restore. Lifecycle, Application Security, and Configuration System project the same authority/transport separation and credential non-persistence rules.


[HORO-117]: https://horo-engine.atlassian.net/browse/HORO-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ