### PR TITLE
docs(extensions): define script module boundary HORO-168 #168 [EXT-005.1]

### DIFF
--- a/docs/adr/059-script-consumable-module-boundary.md
+++ b/docs/adr/059-script-consumable-module-boundary.md
@@ -247,6 +247,13 @@ callback/job/handle quiescence cannot be proven, the update is restart-required.
 Serialized gameplay fields, project assets and tooling configuration cannot depend
 on a live provider pointer and remain inspectable when the API is unavailable.
 
+Retention is bounded to the active generation plus at most one draining predecessor
+per provider. While that predecessor still owns any lease, later candidates may be
+verified and coalesced to the newest compatible candidate, but another generation
+cannot activate. Exceeding the configured drain deadline or retained-code budget
+marks the newest update restart-required; repeated updates never accumulate an
+unbounded chain of loaded native libraries.
+
 Compatibility classification, migration evidence and recovery behavior are owned
 by [EXT-005.6](https://github.com/abdullahbodur/horo-engine/issues/173). Additive
 schema evolution may be compatible only when existing call shapes and semantics

--- a/docs/adr/059-script-consumable-module-boundary.md
+++ b/docs/adr/059-script-consumable-module-boundary.md
@@ -1,0 +1,365 @@
+# ADR-059: Script-Consumable Module Boundary
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Authority, trust, binding, import resolution, marshalling, asynchronous work, permissions, errors, reload and shutdown for module APIs consumed by editor tooling and gameplay scripts
+- **Issue**: [EXT-005.1](https://github.com/abdullahbodur/horo-engine/issues/168)
+- **Jira**: [HORO-168](https://horo-engine.atlassian.net/browse/HORO-168)
+- **Parent**: [EXT-005](https://github.com/abdullahbodur/horo-engine/issues/167)
+- **Related**: [ADR-006](006-lua-5-4-gameplay-runtime.md), [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-010](010-job-waiting-and-operation-store-ownership.md), [ADR-054](054-extension-and-package-authority-boundary.md), [ADR-055](055-extension-manifest-v1-typed-model.md)
+- **Normative documents**: [Extension Capability Roadmap](../architecture/extensions/extension-capability-roadmap.md), [Extension System](../architecture/extensions/plugin-system.md), [Gameplay Behavior Authoring](../architecture/extensions/gameplay-behavior-authoring.md), [Gameplay Module Boundary](../architecture/extensions/gameplay-module-boundary.md), [Package Lifecycle](../architecture/packages/package-lifecycle.md), [Application Security](../architecture/security/application-security.md)
+
+## Context
+
+Backend modules may expose useful services to editor tooling scripts and gameplay
+scripts. The extension manifest already separates a backend service export from a
+script API descriptor, and ADR-006 selects a private Lua 5.4 adapter for gameplay
+behaviors. The architecture does not yet assign one owner for resolving those
+exports into a script runtime, enforcing trust and permissions, marshalling
+values, scheduling asynchronous calls, preserving errors, or revoking bindings.
+
+Without one boundary, a runtime adapter could become a second service locator,
+bind directly to module function pointers, expose different logical APIs per
+language, or keep native callbacks alive after provider shutdown. Tooling scripts
+could acquire runtime scene authority accidentally, while gameplay scripts could
+bypass the behavior lifecycle and create a second startup, tick, reload, or
+serialization model.
+
+The decision must support the selected in-process Lua gameplay runtime without
+making Lua syntax, stack objects, native pointers, or a particular process
+transport part of the public module API. It must also leave a deliberate path to
+isolated providers or future script runtimes without changing service identity or
+project-authored imports.
+
+## Decision
+
+### 1. The supported baseline is a host-mediated in-process binding
+
+The initial supported execution model is:
+
+```text
+script source / generated import declaration
+  -> host-owned ScriptImportResolver
+  -> validated language-neutral ScriptApiDescriptor
+  -> runtime-owned binding adapter
+  -> host-owned ScriptInvocationGateway
+  -> authoritative backend ServiceExport
+```
+
+The script runtime is embedded in-process behind a Horo-owned sandbox adapter.
+The script never calls a provider dynamic library, C function table, C++ object,
+IPC transport, service locator, or application singleton directly. Every call
+passes through the host-owned invocation gateway after import, context, generation
+and permission validation.
+
+An in-process native provider is trusted code only after package verification,
+explicit trust, enablement, compatibility validation and host activation. The
+sandbox protects the host capability surface from scripts; it is not a security
+boundary against a trusted native provider running in the same process.
+
+Provider execution may later move behind an isolated worker or RPC transport.
+That transport remains a private implementation of the same service export and
+invocation gateway. Project metadata, script imports, descriptors, values, errors
+and lifecycle outcomes cannot reveal or depend on provider process location.
+
+### 2. Service, descriptor, adapter and context have separate authority
+
+| Owner | Authoritative responsibility | Must not own |
+| --- | --- | --- |
+| Backend service provider | Business state, typed operations, domain validation, results, provider cancellation and provider shutdown | Script VM objects, script import policy, editor presentation or gameplay lifecycle |
+| Validated service export | Stable backend contract identity, API version, invocation policy, lifetime and required capabilities | Native implementation pointers or runtime-specific syntax |
+| Validated script API descriptor | Stable script API identity/version/namespace and language-neutral mapping to one compatible service export | Provider selection, trust grants, VM handles or executable callbacks |
+| Host import resolver and invocation gateway | Deterministic provider resolution, context admission, effective permissions, generation leases, scheduling, cancellation routing and error preservation | Business logic or language-specific presentation |
+| Script runtime binding adapter | Runtime module/namespace construction, generated glue, VM stack conversion, promise/error projection and VM call-frame containment | Service discovery, permission grants, provider lifetime or a second logical API |
+| Script context | Declared imports, approved capabilities, owner-thread/safe-point policy, cancellation group, diagnostic identity and binding leases | Ambient application access, provider ownership or persistent service state |
+
+Descriptors are inert. Decoding or validating a descriptor cannot load a module,
+activate a service, create a VM, generate live closures, resolve a provider or
+mutate an ambient registry. The application/runtime composition root activates
+providers and creates script contexts explicitly.
+
+### 3. Service and script API identities remain distinct
+
+ADR-055's `ExtensionServiceExportDescriptorV1` names the backend-neutral callable
+contract. `ExtensionScriptApiDescriptorV1` names an independently versioned script
+projection over exactly one compatible service export. Textual namespace equality
+does not make the identities interchangeable.
+
+The complete language-neutral export schema is owned by
+[EXT-005.2](https://github.com/abdullahbodur/horo-engine/issues/169). This ADR fixes
+its boundary requirements:
+
+- the descriptor references stable Horo IDs, semantic versions and registered
+  value/error contracts, never symbols, header names or source-language types;
+- namespace and API conflicts are rejected deterministically before binding;
+- provider choice is resolved from the verified package graph and exact service
+  identity/version constraints, never package load order, filesystem order or
+  first response;
+- required imports fail context creation when missing, denied, ambiguous or
+  incompatible; optional imports remain explicit unavailable results;
+- one canonical descriptor digest is the input to every runtime adapter that
+  declares support for that contract.
+
+A package with several backends or script APIs declares each module, export and
+binding explicitly. A hybrid GUI/backend/script package does not merge their
+lifecycle authorities.
+
+### 4. Generated bindings are derived caches, not authority
+
+Runtime-specific glue is generated or materialized only after the descriptor,
+provider composition, runtime compatibility and effective permissions validate.
+Its cache key includes at least the canonical script API descriptor digest,
+service contract/version, runtime adapter identity/version, target profile and
+effective binding-policy digest.
+
+Generated source, bytecode, closures, runtime tables and reflection caches are
+derived artifacts. They do not become package, API, service or persistence
+identity. Invalidating or deleting the cache must reproduce an equivalent logical
+API from the same validated inputs. Runtime-specific names may improve idiomatic
+syntax, but cannot add functions, relax nullability, change errors or silently
+coerce values beyond the shared descriptor.
+
+### 5. Values cross one bounded language-neutral invocation boundary
+
+Calls use copied or explicitly owned Horo values and generation-safe opaque
+handles. No native pointer, reference, function pointer, VM object, STL container,
+exception, allocator ownership, borrowed module string/view, platform handle or
+unbounded object graph crosses the boundary.
+
+The marshalling contract has explicit encoding, depth, element, byte and work
+limits. Conversion failure returns a typed error before provider invocation or
+before completion reaches the script. Opaque handles name host-owned resources,
+record their type, generation and owning script context, and fail closed after
+revocation; they are not pointer encodings.
+
+The exact value algebra and async call ABI are owned by
+[EXT-005.3](https://github.com/abdullahbodur/horo-engine/issues/170). Runtime
+adapters may project the same values into idiomatic language forms only when the
+round trip preserves the logical value and error semantics.
+
+### 6. Asynchronous work remains host-owned
+
+A script call does not create an untracked provider thread or block the VM owner
+thread waiting for backend work. The invocation descriptor selects a closed host
+policy such as immediate owner-thread work or an admitted asynchronous operation.
+
+An asynchronous invocation receives a host operation identity, cancellation
+source, bounded progress/result channel and exactly one terminal result. The
+adapter maps that operation to the runtime's promise, coroutine or future shape;
+the language object does not become operation authority. Completion is marshalled
+back to the script context's declared owner thread and safe point.
+
+Context destruction revokes delivery first. In-flight work is then cancelled and
+joined when context-owned, or detached only when the service descriptor explicitly
+defines a provider-owned durable operation whose result can outlive the caller.
+Detached completion remains in the host result store and never calls a dead VM.
+Provider disable or shutdown cannot complete an invocation twice or leave a
+pending script promise without a terminal cancellation/unavailable error.
+
+### 7. Effective authority is the intersection of declared policy
+
+Installation makes descriptors available only as inert verified data. A live
+binding requires all of:
+
+1. a verified package/install record and compatible validated extension
+   descriptor;
+2. an enabled and successfully activated backend provider;
+3. approved provider trust and permissions;
+4. a script source/package declaration naming the import and acceptable API
+   version;
+5. a script context profile that permits the service capability and operation;
+6. a compatible runtime adapter and binding schema; and
+7. a live provider generation lease.
+
+The effective permission set is the intersection of product/organization policy,
+package envelope, approved module permissions, script trust, declared import and
+context allowlist. No layer can grant a permission forbidden by an earlier layer.
+Possessing a service/API ID or guessing a namespace never grants import authority.
+
+The detailed permission and context model is owned by
+[EXT-005.5](https://github.com/abdullahbodur/horo-engine/issues/172), but it must
+preserve this intersection and revocation rule.
+
+### 8. Tooling and gameplay contexts are different profiles
+
+Editor tooling scripts run in an application/tooling script context. They may
+import approved headless application capabilities and editor-safe command/query
+adapters. Document or project mutations go through host commands, transactions and
+undo policy. A tooling script receives no `BehaviorContext`, runtime scene pointer,
+renderer backend, editor widget object, unrestricted filesystem/process access or
+ambient extension service graph. Its lifetime is explicitly project, workspace,
+operation or tool-session scoped; closing a panel alone does not own or cancel
+backend work.
+
+Gameplay scripts run only through the gameplay behavior/runtime contract selected
+by ADR-006. A behavior descriptor declares required script APIs alongside its
+other dependencies. Imports resolve before behavior activation against the host
+composition for that scene/play session. The runtime adapter injects binding
+handles into the same behavior instance context that owns lifecycle callbacks.
+
+Calling a module API does not create a second gameplay lifecycle. It cannot add
+module-level script `Start`, `Tick`, `Reload` or `Stop` callbacks outside the
+existing behavior/system/service schedule. Scene reads and mutations continue
+through `BehaviorContext`, declared access and deferred commands; a service API is
+not a shortcut to editor state, unrestricted scene mutation or native globals.
+Behavior fields and scene identity remain serialized independently from provider
+availability.
+
+Shared APIs may be exposed to both context profiles only through one service and
+script API identity with explicit operation-level context compatibility. The host
+does not infer tooling safety from gameplay availability or vice versa.
+
+### 9. Errors preserve one semantic identity
+
+Providers return Horo `Result`/error values whose domains and stable codes are
+declared by the validated extension model. The invocation gateway adds bounded
+package, module, service, script API, script source/context and operation evidence.
+It does not replace the cause with localized text.
+
+Adapters map the same stable error into an idiomatic language error object while
+preserving domain, code, retryability, cancellation and bounded evidence. Native
+exceptions and VM exceptions are caught at their owning adapter boundary and
+translated once. Secrets, arbitrary provider payloads, source contents, native
+addresses and unbounded stack dumps are excluded from ordinary diagnostics.
+
+### 10. Reload replaces immutable generations at safe points
+
+Service exports, script API descriptors and binding sets are immutable generation
+snapshots. A candidate package/provider/API composition is fully decoded,
+cross-reference validated, permission evaluated, activated and binding-generated
+without mutating the current generation.
+
+At a context-appropriate safe point:
+
+- an API-compatible candidate may atomically replace new-import resolution and
+  refresh existing bindings when the runtime adapter proves compatibility;
+- a breaking candidate keeps the previous generation active until consumers are
+  recreated, migrated or report restart required;
+- a failed candidate leaves the previous valid provider and bindings unchanged;
+- removed or denied APIs revoke bindings and make later calls return a typed
+  unavailable/revoked result;
+- the old provider remains loaded until all binding leases, handles, callbacks and
+  operations for that generation drain.
+
+Native code is not unloaded merely because a registry pointer was replaced. If
+callback/job/handle quiescence cannot be proven, the update is restart-required.
+Serialized gameplay fields, project assets and tooling configuration cannot depend
+on a live provider pointer and remain inspectable when the API is unavailable.
+
+Compatibility classification, migration evidence and recovery behavior are owned
+by [EXT-005.6](https://github.com/abdullahbodur/horo-engine/issues/173). Additive
+schema evolution may be compatible only when existing call shapes and semantics
+remain unchanged; breaking changes require a new major API contract and explicit
+consumer migration.
+
+### 11. Shutdown follows the dependency graph in reverse
+
+For every script context and provider generation, shutdown order is:
+
+```text
+close import admission
+  -> revoke context bindings and suppress new VM deliveries
+  -> cancel or detach admitted operations according to descriptor policy
+  -> join context-owned work and terminalize pending promises
+  -> destroy VM binding objects and invalidate opaque handles
+  -> release provider generation leases
+  -> stop authoritative backend services
+  -> destroy provider module objects
+  -> unload native libraries only when quiescence is proven
+```
+
+Project close, scene teardown, Play stop, provider disable, package update and
+process shutdown use the same ownership rule with their appropriate context
+scope. No script finalizer or garbage collector callback is relied on as the
+authoritative release signal.
+
+### 12. Direct-native and runtime-specific shortcuts are unsupported
+
+The supported contract forbids:
+
+- script FFI, `dlopen`/`LoadLibrary`, native package loading, light userdata or
+  pointer-number encodings used to reach module APIs;
+- providers registering Lua/C#/VM closures, stack callbacks or language objects
+  as the authoritative export;
+- runtime adapters discovering services through globals, native symbol names,
+  filesystem scanning or package load order;
+- descriptor schemas whose authoritative type system is Lua tables, C#
+  reflection, C++ headers, arbitrary JSON or another runtime-specific model;
+- synchronous waiting on provider jobs from frame-hot or VM owner-thread paths;
+- script callbacks after context revocation, scene teardown, project close or
+  provider generation release;
+- importing extension GUI objects or renderer/platform native handles;
+- using a script module import to bypass behavior scheduling, document commands,
+  permissions, trust, package authority or host-owned operation stores.
+
+### 13. Conformance is semantic and lifecycle-complete
+
+The same reference service and language-neutral descriptor must produce equivalent
+logical calls, values, errors and cancellation outcomes in every supported runtime
+adapter. Conformance covers tooling and gameplay contexts separately, including
+missing/optional/denied imports, malformed and oversized values, wrong-thread and
+re-entrant calls, provider failure, context revocation, reload, project/scene
+teardown and process shutdown.
+
+No test may pass while leaving a live binding to a released provider generation,
+an orphan operation, a callback into a destroyed VM, or provider-owned serialized
+identity. The full runtime/platform fixture matrix and performance evidence are
+owned by [EXT-005.7](https://github.com/abdullahbodur/horo-engine/issues/174).
+
+## Compatibility And Migration
+
+ADR-055's existing service export and script API records become the manifest-side
+entry to this boundary. The following migration is required before activation is
+enabled:
+
+1. Replace ad hoc runtime module names, manually installed globals and native
+   binding tables with stable service export and script API IDs.
+2. Generate or validate the language-neutral descriptor owned by EXT-005.2 and
+   bind it to the verified package resource and canonical digest.
+3. Declare script imports and version constraints in the owning script/behavior
+   metadata rather than discovering providers at execution time.
+4. Route calls through the invocation gateway and value ABI from EXT-005.3;
+   preserve existing domain error identities where possible.
+5. Place runtime-specific glue behind the registered adapter from EXT-005.4 and
+   delete it from public SDK/service contracts.
+6. Introduce generation leases, permission intersection and ordered revocation
+   before enabling provider reload or disablement.
+
+Legacy names may be accepted only by a bounded, diagnostic migration tool that
+produces explicit stable imports. They are never an alternate live resolution
+path. Current Lua gameplay behavior APIs remain private behavior-context bindings
+under ADR-006 until they are deliberately represented by this service/export
+model; this ADR does not reclassify every existing behavior callback as a module
+API.
+
+## Consequences
+
+- Backend logic remains usable from GUI, CLI, MCP, tooling scripts, gameplay
+  scripts and future isolated hosts without duplicating authority.
+- Script runtimes can expose idiomatic syntax while conformance tests compare one
+  logical descriptor, value and error contract.
+- In-process Lua retains low invocation overhead, but sandboxing and bounded
+  marshalling remain mandatory because process isolation is not the baseline.
+- Host composition owns more machinery: import resolution, invocation admission,
+  operation routing, generation leases, permission intersection and revocation.
+- Provider updates cannot unload eagerly. Safe reload may retain an old generation
+  or require restart, increasing memory and operational complexity.
+- Scripts cannot call arbitrary native libraries or ambient engine services;
+  useful APIs must first become explicit backend service exports and approved
+  script descriptors.
+- Editor tooling and gameplay scripts share infrastructure without sharing
+  authority, lifecycle or mutation privileges.
+
+## Rejected Alternatives
+
+| Alternative | Reason rejected |
+| --- | --- |
+| Bind scripts directly to provider C/C++ functions | Leaks ABI, allocator, lifetime, exception and trust concerns into every runtime and prevents deterministic revocation. |
+| Let each runtime define its own module API descriptor | Produces incompatible logical APIs, duplicate version policy and runtime-specific persistence identity. |
+| Expose the whole backend service object to trusted scripts | Trust does not justify ambient authority; permissions, threading, cancellation and teardown still require per-operation mediation. |
+| Make all scripts and providers out-of-process initially | Stronger fault isolation does not remove the semantic boundary and imposes transport, deployment and latency costs before the in-process Lua baseline is proven. |
+| Treat the script API ID as the backend service ID | The script projection has independent compatibility, namespace, permissions and runtime support. |
+| Resolve imports by package/module load order | Non-deterministic and unsafe under restore, optional providers, updates and parallel activation. |
+| Give gameplay module APIs their own script lifecycle | Duplicates behavior scheduling, serialization, reload and scene ownership and creates inconsistent native/script gameplay. |
+| Keep callbacks alive and fail calls only after unload | Calling unloaded code is not a recoverable error; revocation and generation drain must precede provider destruction. |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -70,6 +70,7 @@ to the replacement.
 | [056](056-external-editor-ui-boundary.md) | External Editor UI Boundary | Proposed | 2026-09-02 |
 | [057](057-package-manifest-v1-typed-model.md) | Package Manifest V1 Typed Model | Proposed | 2026-09-02 |
 | [058](058-package-source-policy.md) | Package Source Policy | Proposed | 2026-09-02 |
+| [059](059-script-consumable-module-boundary.md) | Script-Consumable Module Boundary | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -214,7 +214,9 @@ dependency direction in [System Design](./foundation/system-design.md).
   descriptors, trust/activation hand-off, layouts, and legacy migration.
 - [Extension Capability Roadmap](./extensions/extension-capability-roadmap.md):
   ecosystem capability stages and their separation from product milestones,
-  workstreams, planning horizons, and technical dependencies.
+  workstreams, planning horizons, and technical dependencies. Script-consumable
+  service authority, binding adapters and context lifetimes are defined by
+  [ADR-059](../adr/059-script-consumable-module-boundary.md).
 - [Gameplay Module](./extensions/gameplay-module.md): overview for
   project-owned gameplay modules, behavior authoring, runtime integration, and
   verification.

--- a/docs/architecture/extensions/extension-capability-roadmap.md
+++ b/docs/architecture/extensions/extension-capability-roadmap.md
@@ -61,6 +61,13 @@ capability handles and bounded value marshalling; they never receive native
 pointers, host function tables, or ambient engine services. Provider updates,
 disablement, reload, and shutdown revoke or refresh bindings at safe points.
 
+[ADR-059](../../adr/059-script-consumable-module-boundary.md) makes the backend
+service authoritative, routes imports through a host-owned resolver and
+invocation gateway, confines VM objects to runtime adapters, and separates
+tooling-script contexts from gameplay behavior contexts. The initial runtime is
+an in-process sandbox; isolated providers remain a transport implementation of
+the same semantic service boundary.
+
 Primary initiative: `EXT-005`, supported by `EXT-002`, `GAM-001`, and
 `SDK-001`.
 

--- a/docs/architecture/extensions/gameplay-behavior-authoring.md
+++ b/docs/architecture/extensions/gameplay-behavior-authoring.md
@@ -526,10 +526,10 @@ typed diagnostic.
 ## Scripted Behaviors
 
 Script-authored behavior is a first-class authoring goal because it provides the
-fastest iteration loop for designers and gameplay programmers. The exact first
-runtime, such as Lua, C#, or another embedded runtime, is selected by a separate
-scripting-runtime decision. This document defines the invariants that every
-scripting runtime must satisfy.
+fastest iteration loop for designers and gameplay programmers. ADR-006 selects
+Lua 5.4 as the first private gameplay runtime adapter. Future additional runtime
+adapters must preserve the invariants in this document rather than defining a
+new behavior contract.
 
 Scripted behaviors register `BehaviorDescriptor` records and attach to scene
 objects exactly like native behaviors. Script source files may be interpreted,
@@ -549,6 +549,14 @@ generated descriptors, including bytecode/module lifetime, debug hook ownership,
 state preservation hooks, and how script call frames map to behavior lifecycle
 diagnostics. Those details are runtime-specific, but they cannot add a second
 scene serialization model or a separate editor attachment path.
+
+Gameplay scripts may import approved backend module APIs only through
+[ADR-059](../../adr/059-script-consumable-module-boundary.md). Required imports
+are descriptor dependencies resolved before behavior activation and injected
+into the owning script behavior context. They do not add module-level script
+startup, tick, reload or shutdown callbacks. Scene access and mutation continue
+through `BehaviorContext`, declared access and deferred commands; a service import
+cannot expose editor state, native provider objects or ambient engine services.
 
 The minimum authoring workflow is:
 

--- a/docs/architecture/extensions/plugin-system.md
+++ b/docs/architecture/extensions/plugin-system.md
@@ -1020,6 +1020,11 @@ module API:
 If any invariant cannot be proven, restart remains the only supported unload
 path.
 
+One provider may retain at most its active generation and one draining
+predecessor. Further update candidates are coalesced without activation; a drain
+deadline or retained-code budget breach requires restart instead of accumulating
+loaded libraries.
+
 ## Failure Isolation
 
 Extension callbacks are guarded at host boundaries. A module error disables the

--- a/docs/architecture/extensions/plugin-system.md
+++ b/docs/architecture/extensions/plugin-system.md
@@ -409,6 +409,28 @@ This keeps GUI, CLI, MCP, and headless hosts aligned. The same backend capabilit
 can be invoked from multiple frontends without duplicating business logic or
 requiring ImGui to exist in the process.
 
+### Script-consumable module boundary
+
+Script APIs follow
+[ADR-059](../../adr/059-script-consumable-module-boundary.md). A validated script
+API descriptor is an independently versioned language-neutral projection over
+one compatible service export. The backend service remains authoritative; the
+script runtime adapter owns only VM-specific bindings and value/error projection.
+
+The host resolves declared imports from the verified package graph, trust and
+permission state, context profile and immutable provider generation. Resolution
+never uses package load order, filesystem discovery, native symbol names or
+runtime globals. Calls pass through the host invocation gateway using bounded
+values and host-owned async operations. Provider disablement, reload and shutdown
+revoke bindings before callbacks, jobs, service objects or native code are
+released.
+
+The initial adapter is an in-process sandbox. Script code receives no provider
+function table, native pointer, C++ service object, platform handle or extension
+GUI object. A future isolated provider or runtime must preserve the same service,
+script API, value, error and lifecycle semantics rather than defining a parallel
+transport-specific contract.
+
 ## Discovery And Resolution
 
 Packages are discovered from:

--- a/docs/architecture/packages/package-lifecycle.md
+++ b/docs/architecture/packages/package-lifecycle.md
@@ -223,7 +223,7 @@ Conflicts are contribution-specific:
 - behavior type ID conflict
 - service ID conflict
 - schedule node ID conflict
-- script module name conflict
+- script API ID, namespace, or compatible service-export conflict
 - editor command/menu ID conflict
 - input action ID conflict
 - shader keyword conflict
@@ -248,6 +248,12 @@ Possible resolutions:
 
 Runtime identifiers should not be automatically renamed because serialized scene
 references can break.
+
+Script API conflicts resolve from stable typed identities, compatible version
+constraints and the verified package graph under
+[ADR-059](../../adr/059-script-consumable-module-boundary.md). Package load order,
+runtime globals and automatic namespace renaming are not conflict-resolution
+mechanisms.
 
 ## Package UI Contract
 


### PR DESCRIPTION
## Summary

- Defines the authoritative boundary between backend services, script API descriptors, runtime binding adapters, script contexts, packages, and gameplay behaviors.
- Selects a host-mediated in-process sandbox baseline while keeping future isolated providers transport-private behind the same semantic gateway.
- Defines deterministic import resolution, permission intersection, bounded marshalling, asynchronous operation ownership, generation leases, revocation, reload, and shutdown.

## Why

Script-consumable module APIs need one authority and lifetime model before descriptor, value ABI, adapter, permission, reload, and conformance work proceeds. Without it, runtimes could bind directly to native modules, leak VM/native details, or introduce a second gameplay lifecycle.

## Decision

- Backend services own business state and operations; inert service/script descriptors own stable contracts.
- The host resolves imports, intersects permissions, routes async operations, owns generation leases, revokes access, and orders shutdown.
- Runtime adapters own only VM-specific bindings and value/error projection; no pointer, native handle, borrowed view, or unbounded object graph crosses the boundary.
- Tooling and gameplay contexts use distinct authority profiles; gameplay imports remain dependencies inside the existing behavior lifecycle.
- Provider retention is bounded to the active generation plus one draining predecessor; later candidates coalesce without activation, and deadline/budget failure requires restart.
- EXT-005.2 through EXT-005.7 retain focused ownership of descriptor schema, value ABI, adapters, permission context, reload/recovery, and conformance implementation.

## Validation

- [x] Replayed HORO-168 cleanly onto current `main`; obsolete stack ancestry is absent from the PR.
- [x] `markdownlint-cli` passed for every changed Markdown file.
- [x] `git diff --check` passed.
- [x] All newly added local Markdown links resolve.
- [x] No unresolved TODO/TBD/open-decision marker remains.
- [x] Addressed Codacy's low-confidence memory-pressure concern with an explicit retained-generation bound and acknowledged the decision on the PR.
- [ ] Executable import, marshalling, async-lifetime, reload, and context-isolation tests are downstream implementation work; ADR-059 specifies the required matrix.

## Risk and rollout

Provider unload is intentionally conservative: safety wins over eager unloading. The new generation bound prevents repeated updates from accumulating native libraries, but a stuck generation can still force an editor/process restart.

## Issue links

- Jira: [HORO-168](https://horo-engine.atlassian.net/browse/HORO-168)
- GitHub: Closes #168

## Reviewer notes

Review ADR-059 first, especially the ownership table, tooling/gameplay context split, permission intersection, generation cap, and shutdown order. Companion documents summarize and link the decision without creating alternate policy.


[HORO-168]: https://horo-engine.atlassian.net/browse/HORO-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ