### PR TITLE
docs(render): ratify resident resource model HORO-290 #290 [RND-001.1]

### DIFF
--- a/docs/adr/027-renderer-resource-identity-and-descriptors.md
+++ b/docs/adr/027-renderer-resource-identity-and-descriptors.md
@@ -5,6 +5,8 @@
 - **Supersedes**: None
 - **Scope**: Backend-neutral resident renderer resources
 - **Issue**: [RND-001.1](https://github.com/abdullahbodur/horo-engine/issues/290)
+- **Jira**: [HORO-290](https://horo-engine.atlassian.net/browse/HORO-290)
+- **Parent**: [RND-001](https://github.com/abdullahbodur/horo-engine/issues/13)
 - **Normative document**: [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
 
 ## Context
@@ -22,6 +24,38 @@ resource description independent of backend selection and leave render-graph
 access declarations to the render graph.
 
 ## Decision
+
+### Authority and implementation boundary
+
+This ADR is the single normative owner for resident renderer resource classes,
+identity, immutable creation descriptors, registry states, validation order,
+dependency retention, replacement, and the boundary between persistent asset
+identity and process-local GPU residency. The Resource Model section of
+[Rendering Architecture](../architecture/runtime/rendering-architecture.md)
+summarizes this decision; it does not define a second policy. Generic handle
+guidance in
+[Ownership And Resource Lifetime](../architecture/foundation/ownership-and-resource-lifetime.md)
+is subordinate to this renderer-specific contract.
+
+The implementation tickets consume this decision without reopening it:
+
+- [RND-001.2](https://github.com/abdullahbodur/horo-engine/issues/291)
+  implements the frontend registry, owner/slot/generation validation, state
+  machine, bounded request handling, pins, and retirement;
+- [RND-001.3](https://github.com/abdullahbodur/horo-engine/issues/292)
+  migrates mesh creation, upload, readiness, replacement, and residency onto
+  buffer and mesh resources;
+- [RND-001.4](https://github.com/abdullahbodur/horo-engine/issues/293) and
+  [RND-001.5](https://github.com/abdullahbodur/horo-engine/issues/294) migrate
+  OpenGL and Metal editor viewport resources without exposing native identity;
+- [RND-001.6](https://github.com/abdullahbodur/horo-engine/issues/295) qualifies
+  the shared lifetime and parity contract against Null and supported native
+  backends.
+
+[ADR-028](028-renderer-capability-limits-and-product-profiles.md) owns effective
+capability and limit admission. [ADR-034](034-gpu-memory-and-residency-ownership.md)
+owns backing-memory accounting, reservations, and pressure policy. Neither may
+create another resident identity, descriptor mutability, or lifetime model.
 
 ### Resource taxonomy
 
@@ -67,6 +101,12 @@ Each public resource class has its own named handle and descriptor. Public code
 does not use one untyped `ResourceHandle`, and feature code does not branch on a
 runtime resource-kind tag. Shared implementation behind the named types is
 permitted when it does not widen the public contract.
+
+The renderer-specific owner field does not change or pad the generic
+`Horo::Handle<Tag>` used by owner-local registries in other subsystems. Renderer
+handle types may share a private storage helper, but they remain distinct public
+types with the three-field identity below; a template parameter that optionally
+adds owner identity would obscure that semantic and ABI distinction.
 
 ### Resident handles
 
@@ -380,6 +420,15 @@ The renderer migration proceeds without parallel identity policies:
 5. Parity validation covers malformed, stale, foreign, pending, retiring,
    pinned-dependency release, non-retargeting replacement, reconstruction-source
    recovery, rollback, device-loss, and repeated-shutdown behavior.
+
+Each step replaces its transitional path atomically at the owning boundary.
+Callers do not retain an adapter that accepts both legacy and owner/slot/generation
+handles, and serialized data is not migrated to resident handles. RND-001.2 owns
+the registry implementation consumed by the resource migrations; RND-001.3
+through RND-001.5 cut over callers at their owning boundaries, and RND-001.6
+qualifies the resulting shared behavior. These responsibility boundaries do not
+define delivery order; native blocked-by relationships remain the scheduling
+authority.
 
 The current `RenderTargetHandle {index, generation}` and
 `RenderMeshHandle {MeshResourceId, generation}` are transitional. They migrate

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -92,6 +92,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Rendering Architecture](./runtime/rendering-architecture.md): render
   extraction, frontend/backend boundaries, render graph, GPU resources, and
   null rendering.
+- [Renderer Resource Identity and Descriptors](../adr/027-renderer-resource-identity-and-descriptors.md):
+  resident resource taxonomy, owner/slot/generation handles, immutable
+  descriptors, validation, replacement, and deferred retirement.
 - [Render Backend Parity Contract](./runtime/render-backend-parity-contract.md):
   equal lifecycle, presentation, editor integration, and verification obligations
   for interactive renderer backends.

--- a/docs/architecture/foundation/ownership-and-resource-lifetime.md
+++ b/docs/architecture/foundation/ownership-and-resource-lifetime.md
@@ -89,8 +89,20 @@ using TextureHandle = Handle<TextureTag>;
 using MeshHandle = Handle<MeshTag>;
 ```
 
-Registries validate type, index, generation, and owner domain. Stale handles
-fail safely and never alias a newly allocated object at the same slot.
+The generic handle is meaningful only to its owning registry. That registry
+validates type, index, generation, and the authority boundary at the API entry
+point. Stale handles fail safely and never alias a newly allocated object at the
+same index.
+
+Resident renderer resources cross frontend-registry lifetime boundaries and use
+distinct named handle types whose identity additionally carries a 64-bit renderer
+owner ID. That renderer requirement does not enlarge or parameterize the generic
+`Handle<Tag>` used by other registries. The exact resource taxonomy,
+owner/slot/non-wrapping-generation semantics, registry states, and retirement
+rules are owned by
+[ADR-027](../../adr/027-renderer-resource-identity-and-descriptors.md). The
+generic example above therefore does not authorize a renderer-specific two-field
+handle or a second renderer identity policy.
 
 Serialized project and asset data stores stable logical IDs, not process-local
 handles. The authority that owns the runtime registry resolves those IDs at an

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -1153,6 +1153,8 @@ manually order backend commands around hidden global state.
 
 The canonical identity, descriptor, validation, and lifetime policy is
 [ADR-027: Renderer Resource Identity and Descriptors](../../adr/027-renderer-resource-identity-and-descriptors.md).
+ADR-027 is the sole normative owner of that policy; this section is an
+orientation summary and must not be extended into a parallel resource model.
 Supported resident resource classes are buffers, textures and texture views,
 samplers, shader modules and pipelines, render targets, and meshes. Leaf,
 derived, and composite classes share that model. Material bindings are typed


### PR DESCRIPTION
## Summary

- Establish ADR-027 as the single source of truth for resident renderer resource identity, immutable descriptors, validation, replacement, and deferred retirement.
- Tie the decision to HORO-290 / RND-001.1 and define the implementation responsibilities of RND-001.2 through RND-001.6 without treating ticket order as architecture.
- Keep the generic 64-bit `Horo::Handle<Tag>` unchanged while requiring renderer-only handles to carry owner, slot, and generation identity.

## Why

The renderer migration needs one contract that prevents stale or foreign handles from reaching a backend, keeps persistent asset identity separate from process-local GPU residency, and makes replacement and delayed GPU destruction deterministic. Before this change, ADR-027 held most of that policy, but the architecture index and generic ownership guidance could still be read as competing definitions.

## Decision and boundaries

- Each public resident resource class has a distinct typed handle and immutable Horo-owned descriptor.
- Renderer handle identity contains a non-zero 64-bit frontend owner ID, registry slot, and non-wrapping generation.
- The renderer-specific owner field does not enlarge or parameterize generic handles used by Scene, Physics, or other owner-local registries.
- Asset IDs are persistent logical identities; resident handles are process-local references and are never serialized.
- Replacement publishes a new generation. Existing dependents keep pins to the exact generations they named, and native destruction waits for dependency release and GPU completion.
- ADR-028 remains responsible for capability admission; ADR-034 remains responsible for GPU memory accounting and pressure policy.

## Review findings addressed

Codacy identified that putting a 64-bit owner ID into the generic foundation handle would double every generic handle from 64 to 128 bits. The documentation now preserves the implemented compact `Horo::Handle<Tag>` shape and scopes the larger three-field identity exclusively to named renderer resource handles. This also makes the API and ABI distinction explicit instead of hiding it behind an optional template parameter.

## Validation

- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`
- `npx --yes markdownlint-cli --disable MD013 MD060 -- <changed Markdown files>`
- Added local Markdown links resolve against the repository.
- `git diff origin/main --check`
- Architecture placeholder scan found no unresolved TODO/TBD/open-question markers in the changed contract.

This is a documentation-only architecture change; no runtime or GPU smoke tests apply.

## Risk and rollout

- No runtime behavior changes in this PR.
- The registry and backend migrations remain downstream work in RND-001.2 through RND-001.6.
- Current two-field renderer handles are explicitly transitional and must be replaced atomically at their owning boundaries; no dual identity compatibility path is authorized.

## Issue links

- Jira: HORO-290
- GitHub: Closes #290

## Reviewer notes

Start with the authority and resident-handle sections of ADR-027. Then verify that the foundation ownership guide preserves the generic handle contract while delegating renderer identity semantics to ADR-027.
