### PR TITLE
docs(render): ratify shader source routes HORO-368 #368 [RND-011.1]

### DIFF
--- a/docs/adr/035-shader-source-and-intermediate-representation.md
+++ b/docs/adr/035-shader-source-and-intermediate-representation.md
@@ -1,11 +1,12 @@
 # ADR-035: Shader Source and Intermediate Representation
 
-- **Status**: Proposed
+- **Status**: Accepted
 - **Date**: 2026-08-31
 - **Supersedes**: None
 - **Scope**: Shader source language, compiler routes and reflection authority
 - **Issue**: [RND-011.1](https://github.com/abdullahbodur/horo-engine/issues/368)
 - **Jira**: [HORO-368](https://horo-engine.atlassian.net/browse/HORO-368)
+- **Parent**: [RND-011](https://github.com/abdullahbodur/horo-engine/issues/283)
 - **Normative document**: [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
 
 ## Context
@@ -24,6 +25,37 @@ It does not implement a compiler, change material shading algorithms, or activat
 a desktop cook target in the existing headless-only Phase A contract.
 
 ## Decision
+
+### Authority and adjacent ownership
+
+This ADR is the single normative owner of the production shader source language,
+compiler and intermediate-representation routes, target-descriptor requirements,
+normalized reflection boundary, artifact identity inputs, source diagnostic
+provenance, and packaged-versus-development compilation policy. Summaries in
+[Asset Pipeline](../architecture/runtime/asset-pipeline.md),
+[Rendering Architecture](../architecture/runtime/rendering-architecture.md), and
+[Material And Shader Model](../architecture/runtime/material-and-shader-model.md)
+consume this decision and cannot introduce another source language, universal
+intermediate, reflection authority, or implicit runtime compiler path.
+
+Adjacent owners remain separate:
+
+- Asset Pipeline owns admitted source/include resolution, bounded cook
+  orchestration, cache lookup, staging, and atomic artifact publication.
+- Renderer resource and capability contracts own live shader-module/pipeline
+  generations and target admission under [ADR-027](027-renderer-resource-identity-and-descriptors.md)
+  and [ADR-028](028-renderer-capability-limits-and-product-profiles.md).
+- ADR-029 through ADR-032 own native backend baselines; they constrain this
+  decision's target descriptors but do not select a different engine-wide
+  language or reflection model.
+- Material and shader-graph work owns semantic material/graph schemas and emits
+  this source contract plus mappings; it does not create another compiler or IR
+  authority.
+
+RND-011.2 through RND-011.13 consume this decision within their assigned
+implementation, adjacent-decision, or qualification scopes. Their issue numbers
+and roadmap milestones do not imply delivery order; native blocked-by relationships
+remain the scheduling authority.
 
 ### 1. One source contract, target-specific derived artifacts
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -46,7 +46,7 @@ to the replacement.
 | [032](032-d3d12-baseline-and-agility-sdk-policy.md) | D3D12 Baseline and Agility SDK Policy | Proposed | 2026-08-31 |
 | [033](033-presentation-and-display-ownership.md) | Presentation and Display Ownership | Proposed | 2026-08-31 |
 | [034](034-gpu-memory-and-residency-ownership.md) | GPU Memory and Residency Ownership | Proposed | 2026-08-31 |
-| [035](035-shader-source-and-intermediate-representation.md) | Shader Source and Intermediate Representation | Proposed | 2026-08-31 |
+| [035](035-shader-source-and-intermediate-representation.md) | Shader Source and Intermediate Representation | Accepted | 2026-08-31 |
 | [036](036-raster-render-path-and-quality-architecture.md) | Raster Render Path and Quality Architecture | Proposed | 2026-09-01 |
 | [037](037-scene-color-and-hdr-architecture.md) | Scene Color and HDR Architecture | Proposed | 2026-09-01 |
 | [038](038-gpu-scene-and-instance-data-model.md) | GPU Scene and Instance Data Model | Proposed | 2026-09-01 |

--- a/docs/architecture/runtime/asset-pipeline.md
+++ b/docs/architecture/runtime/asset-pipeline.md
@@ -786,6 +786,9 @@ transpiled and optimized for each target graphics API.
 
 [ADR-035](../../adr/035-shader-source-and-intermediate-representation.md) owns the
 HLSL source contract, compiler/IR routes, normalized Horo reflection and diagnostics.
+It is the sole normative owner of those choices; this section projects them onto
+Asset Pipeline's cook, cache, staging, and publication authority without defining
+a second shader language or artifact route.
 SPIR-V is a shared derived intermediate, not a universal D3D12 interchange format.
 The following routes are target architecture; they add no current cook capability.
 

--- a/docs/architecture/runtime/material-and-shader-model.md
+++ b/docs/architecture/runtime/material-and-shader-model.md
@@ -49,6 +49,9 @@ Not covered:
 - Pipeline state objects are cached and reused. Shader compilation may happen
   during cook or explicit editor/development preparation under
   [ADR-035](../../adr/035-shader-source-and-intermediate-representation.md).
+  ADR-035 is the sole source-language, compiler-route, reflection, and packaged
+  compilation authority; this material model only supplies semantic inputs and
+  consumes its validated artifacts.
   Portable artifacts, native driver caches and live GPU objects have distinct
   ownership and compatibility keys.
 - No gameplay code queries raw shader handles. Gameplay sees only material names,

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -1224,6 +1224,8 @@ generation check.
 
 The source language, compiler routes, normalized reflection and diagnostics policy
 is [ADR-035](../../adr/035-shader-source-and-intermediate-representation.md).
+ADR-035 is the sole normative owner of that policy; the renderer consumes its
+validated target artifacts and must not select an alternate source or IR route.
 Portable HLSL source feeds validated SPIR-V for Vulkan/GLSL/MSL routes and direct
 DXIL for D3D12. Target-specific binding/packing maps preserve logical material
 interfaces; native compiler defaults and raw reflection structs are not public


### PR DESCRIPTION
## Summary

- Accept ADR-035 as Horo’s authoritative shader source, compiler-route, intermediate-representation, reflection, and packaged-compilation policy.
- Standardize production authoring on HLSL 2021 while retaining target-specific cooked outputs: SPIR-V for Vulkan, SPIR-V-to-GLSL/MSL routes for OpenGL and Metal, and direct DXC-to-DXIL for D3D12.
- Align Asset Pipeline, Rendering Architecture, and Material and Shader Model as consumers of ADR-035 instead of parallel policy owners.

## Why

The renderer roadmap cannot implement shader cooking, material packing, hot reload, or backend qualification safely while source language, reflection authority, and artifact routes are ambiguous. ADR-035 already contained the detailed design, but its parent traceability, ownership boundary, consumer references, and lifecycle status did not yet express a ratified decision.

## Decision and boundaries

- HLSL 2021 is the first production textual authoring contract; shader graphs emit that contract plus source maps rather than defining a second language.
- SPIR-V is a shared derived intermediate for Vulkan, OpenGL, and Metal routes, not a universal asset or D3D12 interchange format.
- D3D12 compiles the same HLSL directly to validated DXIL.
- Versioned normalized Horo reflection and per-target binding/packing maps are public authority; raw compiler/native reflection is not.
- Asset Pipeline owns trusted inputs, bounded cooking, cache identity, staging, and atomic publication.
- ADR-027 owns live GPU resource generations, ADR-028 owns capability admission, and ADR-029 through ADR-032 own backend baselines.
- Packaged builds consume cooked artifacts and cannot silently invoke authoring compilers on cache misses.

## Review finding addressed

Codacy noted that a PR titled “ratify” still left ADR-035 as `Proposed`. The ADR and its index entry now move together to `Accepted`, matching the PR’s purpose and removing lifecycle ambiguity for downstream implementation tickets.

## Validation

- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`
- `npx --yes markdownlint-cli --disable MD013 MD060 -- <changed Markdown files>`
- Added local Markdown links resolve against the repository.
- `git diff origin/main --check`
- Architecture placeholder scan found no unresolved TODO/TBD/open-question markers in the changed contract.

This is a documentation-only architecture decision; native shader compiler and GPU tests belong to RND-011.2 through RND-011.13.

## Risk and rollout

- No runtime behavior or dependency changes in this PR.
- Toolchain versions are deliberately not floated into this decision; RND-011.3 must lock exact builds, licenses, host support, and compiler arguments before enabling a route.
- Existing embedded GLSL/MSL remains migration input only and does not prove the portable pipeline exists.

## Issue links

- Jira: HORO-368
- GitHub: Closes #368

## Reviewer notes

Review ADR-035’s authority section and target-route table first. Then verify each architecture consumer retains only its adjacent ownership and cannot select an alternate source, IR, reflection, or runtime compilation policy.
