### PR TITLE
docs(animation): define clock and pose ownership HORO-454 #454 [ANI-001.1]

### DIFF
--- a/docs/adr/014-sequencer-ownership-clock-authority-and-binding-boundary.md
+++ b/docs/adr/014-sequencer-ownership-clock-authority-and-binding-boundary.md
@@ -64,7 +64,9 @@ enum class SequenceDilationPolicy : uint8_t { SourceNative, ApplyGameplayScale }
 ```
 
 - **CommittedSimulation** consumes `FixedStepContext::fixedDelta * playbackSpeed`
-  once per committed tick. Supplied simulation dilation is not multiplied twice.
+  once per committed tick. Host simulation rate is already represented by fixed-
+  tick production under [ADR-061](061-animation-ownership-update-order-and-clock.md)
+  and is not multiplied into `fixedDelta` again.
   Cursor, values and events are staged for the attempted tick and discarded if it
   fails. No render-interpolated delta advances this authoritative clock.
 - **UnscaledFixedControl** consumes host-owned unscaled fixed service quanta even
@@ -140,8 +142,9 @@ requirements are rejected instead of creating a second scheduler.
 For AI entities, movement is an admitted NavIntentCommit intent, followed by
 CharacterControllerLocomotion and AnimationRigUpdate under ADR-022. Cinematics do
 not insert another AI mutation phase or let clients control server-owned actors.
-The non-AI presentation/root-motion path in Animation Architecture retains its
-separate ordering; it is not a render-rate-independent simulation guarantee.
+The non-AI animation/root-motion path follows ADR-061's authoritative fixed-tick
+ordering. Sequencer inputs that can affect movement are staged through that owner
+seam; optional presentation samples remain render-only.
 Optional interpolated values target immutable presentation/preview output only.
 
 Physics/controller transforms, velocity and collider state cannot be directly

--- a/docs/adr/061-animation-ownership-update-order-and-clock.md
+++ b/docs/adr/061-animation-ownership-update-order-and-clock.md
@@ -1,0 +1,358 @@
+# ADR-061: Animation Ownership, Update Order and Clock
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Runtime pose ownership, animation clock domains, fixed-tick ordering, and physics/render handoff
+- **Issue**: [ANI-001.1](https://github.com/abdullahbodur/horo-engine/issues/454)
+- **Jira**: [HORO-454](https://horo-engine.atlassian.net/browse/HORO-454)
+- **Parent**: [ANI-001](https://github.com/abdullahbodur/horo-engine/issues/447)
+- **Related**: [ADR-014](014-sequencer-ownership-clock-authority-and-binding-boundary.md)
+- **Normative documents**: [Animation Architecture](../architecture/runtime/animation-architecture.md), [Runtime Lifecycle](../architecture/runtime/runtime-lifecycle.md), [Character Controller Architecture](../architecture/runtime/character-controller-architecture.md)
+
+## Context
+
+The existing Animation Architecture says that a non-AI animation pose is sampled
+once per rendered frame before zero or more fixed physics steps. Runtime Lifecycle,
+however, runs all fixed ticks before variable update and render extraction. The
+render-rate path can therefore feed one root-motion delta into several simulation
+ticks, skip authoritative advancement when no frame is presented, or produce
+different movement and event results at different render cadences.
+
+Pose ownership is also incomplete. Animation, IK, physics overrides, character
+movement, editor preview, and rendering are described as sequential consumers,
+but the documents do not define who owns mutable pose storage, when physics may
+replace joints, or how a frame snapshot remains valid. Pause, single-step, time
+scaling, reverse playback, and large traversal intervals need one clock contract
+before clip, graph, pose-pool, root-motion, and physics integration tickets can
+implement compatible behavior.
+
+This decision covers the authoritative non-AI path. ADR-022 continues to own its
+AI phase graph. ADR-014 continues to own cinematic player clocks and bindings,
+but any cinematic input that affects animation, movement, or physics enters the
+owner seams defined here.
+
+## Decision
+
+### 1. Authority and ownership
+
+This ADR is the single normative owner of animation clock domains, authoritative
+update order, pose mutation/publication, root-motion timing, and animation/physics/
+render handoff. Animation Architecture summarizes this contract; Runtime Lifecycle
+owns host phases and fixed-tick production; Character Controller Architecture owns
+collision-aware movement resolution. None defines a second animation clock or
+pose owner.
+
+| State or operation | Owner | Boundary |
+|---|---|---|
+| Skeleton, clip, graph, retarget, and compression artifacts | Animation model plus Asset Pipeline publication | Immutable, versioned assets; no live pose or instance identity |
+| Graph instance, player cursors, transition/event state, and pose working memory | Animation runtime | One scene/runtime generation; mutation only through admitted animation stages |
+| Mutable local/model pose buffers and palette preparation | Animation runtime | Never shared for external mutation; allocated from bounded instance/frame storage |
+| Gameplay parameters and movement intent | Gameplay owner | Typed per-tick snapshot committed before animation evaluation |
+| Character transform and collision result | Character controller / physics owner | Root motion is a request; animation never writes the authoritative transform |
+| Ragdoll/body transforms | Physics runtime | Published as a typed post-physics override; physics never writes animation storage |
+| Render pose and joint palette view | Render extraction snapshot | Immutable, frame-owned projection of committed pose state |
+| Timeline preview pose | Editor preview runtime | Separate instance/storage; cannot mutate play/runtime animation state |
+
+The exact IDs and handle layouts belong to ANI-001.2. They must distinguish
+persistent asset identity, scene animation-instance identity, committed pose
+generation, and frame-local presentation views. A pose handle is process-local,
+generation-checked, non-serializable identity. Copying it does not own or extend
+the pose lifetime. External systems receive immutable snapshots or leases, never
+mutable arrays or cached pointers into a recyclable pose pool.
+
+### 2. Evaluation domains and clocks
+
+Animation has three explicit evaluation domains:
+
+```cpp
+enum class AnimationEvaluationDomain : std::uint8_t {
+    AuthoritativeSimulation,
+    Presentation,
+    EditorPreview,
+};
+```
+
+`AuthoritativeSimulation` advances exactly once for every attempted fixed tick
+in which its scene participates. It consumes `FixedStepContext::fixedDelta`, the
+committed parameter/input snapshot, immutable asset revisions, and versioned
+per-instance settings. Its state, root motion, and events are staged until that
+tick commits. It never reads render delta, interpolation alpha, presentation
+timestamps, audio-device time, or wall time.
+
+`Presentation` does not advance an authoritative cursor. It reads the previous
+and current committed pose generations plus interpolation alpha, then may apply
+explicit presentation-only overlays. It cannot emit gameplay events, produce
+root motion, update colliders, write animation parameters, or feed a later fixed
+tick. Rendering the same committed tick more than once does not advance animation.
+
+`EditorPreview` owns an isolated preview instance. Play, pause, manual step, seek,
+scrub, and optional clamped monotonic preview playback affect only that instance.
+Seek/scrub samples values without gameplay callbacks, root motion, physics writes,
+or event replay. Host suspension freezes preview advancement and resume establishes
+a zero-delta baseline. Editor preview cannot borrow mutable play-session pose or
+player state.
+
+### 3. Simulation rate, player rate, pause, and reverse
+
+Runtime owns a positive bounded rational `simulationRate`. It scales the clamped
+elapsed contribution to the fixed-step accumulator; the fixed quantum supplied to
+physics and animation remains unchanged. The baseline rate is `1/1`. Rate changes
+commit at the owner-thread command boundary before fixed-step scheduling, preserve
+their fractional remainder, carry a revision for replay evidence, and cannot be
+negative. Animation and physics never multiply the host rate into `fixedDelta`
+again.
+
+Gameplay pause is a separate composed host state, not `simulationRate == 0`.
+While paused, no fixed tick is attempted, so authoritative animation holds its
+cursor, pose, transition timers, events, and root motion. Single-step attempts
+exactly one ordinary fixed tick at the unchanged quantum, runs the complete
+animation/controller/physics order, publishes one committed pose on success, and
+returns to paused state. A failed step publishes no animation state or events.
+
+Each animation player has a finite, bounded, tick-boundary `playbackRate` stored
+as a checked fixed-point/rational value. Positive values advance, zero holds that
+player, and negative values traverse its animation data in reverse without
+reversing simulation or physics. Rate multiplication and cursor accumulation
+preserve a per-instance remainder so equivalent tick/settings histories do not
+drift because of render cadence or repeated float rounding.
+
+The runtime instance owns these exact remainders alongside its cursors and graph
+state. Candidate cursor and remainder updates are staged and committed together;
+a failed tick cannot publish one without the other. Asset durations are intervals
+(`AnimationDeltaTime`), while cursor and event positions are absolute clip-local
+`AnimationTime` values. Serialized examples use normalized rational values rather
+than binary floating-point seconds; ANI-001.6 owns the final widths and overflow
+rules.
+
+Reverse traversal is permitted only for clips/nodes whose contract supports it.
+It samples the directed interval from the old cursor to the new cursor, emits only
+events explicitly eligible for reverse, and extracts the inverse directed root
+delta when root motion is enabled. Non-reversible procedural/external nodes return
+a typed unsupported result before instance state changes. Reverse animation never
+rewinds the physics world, undoes gameplay, or replays irreversible side effects.
+
+### 4. Large intervals and deterministic inputs
+
+Raw frame stalls never become one authoritative animation delta. Runtime's
+clamped accumulator and catch-up limit produce zero or more ordinary fixed ticks;
+animation evaluates every attempted tick separately. Whole intervals dropped by
+the host are not animation intervals and do not generate cursor jumps, root motion,
+or events. A render frame cannot reuse one authoritative evaluation across several
+catch-up ticks.
+
+A high player rate, seek-capable tool, or loop/ping-pong traversal can still cross
+multiple segments in one evaluation. Before mutation, the animation runtime
+preflights bounded limits for node visits, loop/turn crossings, event occurrences,
+root-motion segments, pose work, and output bytes. Over-budget work returns a typed
+capacity result and leaves the player, pose, event cursor, and root-motion output
+unchanged. It never partially advances and silently drops the remainder. Preview
+tools may issue an explicit silent seek after reporting the clamp; authoritative
+simulation may not.
+
+Within the declared platform/numeric contract, authoritative animation is
+reproducible from:
+
+- exact engine, animation schema, cooked asset, graph, skeleton, and retarget revisions;
+- initial graph/player state and stable random seeds;
+- ordered fixed-tick parameter/input commands and owner-admitted cinematic intents;
+- fixed quantum, simulation-rate revision history, and player-rate changes;
+- root-motion consumption policy and typed post-physics override inputs.
+
+Wall time, render cadence, interpolation count, worker completion order, GUI state,
+and pointer/container iteration order are not deterministic inputs. Cross-platform
+bit identity is not claimed unless a narrower numeric qualification says so.
+
+### 5. Fixed-tick update order
+
+The authoritative non-AI path is a validated dependency order inside the existing
+`FixedUpdate`; it does not add host phases:
+
+```text
+Apply queued owner-thread commands before FixedUpdate
+For each attempted fixed tick:
+  1. Input/gameplay/cinematic owners stage animation parameters and movement intent
+  2. Animation pre-physics evaluation stages graph state, pose, eligible IK,
+     events, and the exact directed root-motion delta
+  3. Character controller admits desired movement plus root-motion request,
+     resolves collision, and publishes the kinematic transform
+  4. Physics steps once at the fixed quantum
+  5. Physics publishes body transforms and typed pose-override results
+  6. Animation post-physics composition applies admitted overrides and finalizes
+     the candidate committed pose
+  7. Tick commit publishes animation instance state, previous/current pose
+     generations, and bounded event occurrences atomically
+After all catch-up ticks:
+  8. Presentation interpolation/overlays build an immutable render pose
+  9. Render extraction consumes that pose and its joint palette
+```
+
+Simulation-affecting IK that contributes to hit shapes or movement belongs in
+step 2 and uses only admitted fixed-tick inputs/queries. Grounding polish or other
+post-physics IK that is presentation-only may run in step 6 or presentation, but
+cannot feed same-tick root motion, controller movement, or collider state. A graph
+must declare which path a node uses; an impossible dependency cycle is rejected.
+
+Animation stages its own mutable state until tick commit. Root-motion requests and
+physics overrides carry scene, instance, tick, skeleton, and generation identity
+so duplicates, stale results, and cross-instance use fail deterministically. If a
+later participant fails after an owner has performed an irreversible in-place
+mutation, the runtime follows its fatal/rollback contract; it must not commit an
+animation cursor against an uncommitted simulation tick.
+
+### 6. Root motion and transform authority
+
+Root motion is the finite translation/rotation delta over the exact directed
+player interval evaluated in step 2. Animation publishes a typed request; it does
+not apply the delta to a scene transform, move a physics body, decide collision
+policy, or claim that the requested delta was achieved.
+
+Gameplay selects the admitted consumption mode and combines ordinary movement
+intent with the request. The character controller owns collision-aware resolution
+and the resulting kinematic transform. Ignoring or clipping root motion does not
+rewind the animation cursor. The resolution may be observed on the next tick to
+adjust locomotion state, but animation cannot resample the same interval after
+physics merely to force visual distance to match.
+
+One `(scene, animation instance, simulation tick, root-motion generation)` request
+can be committed as consumed at most once. Controller resolution records only a
+candidate consumption marker in the current tick transaction. Abort discards that
+marker and the attempt-scoped request lease; a retry of the same simulation tick
+may consume the newly staged equivalent request. Successful tick commit makes the
+marker durable, after which the same identity is a duplicate. A stale, duplicate-
+after-commit, preview, presentation, or leaked aborted-attempt request is rejected.
+Network replication owns input/state or resulting transform policy; raw
+presentation time and process-local pose handles are never replication identity.
+
+### 7. Physics override and render publication
+
+Normal animation-driven evaluation owns the candidate local/model pose. Physics
+may read an immutable pre-physics pose lease for ragdoll initialization, hit-shape
+queries, or an explicitly declared kinematic target. It cannot retain the lease
+past its tick or mutate its storage.
+
+Ragdoll/procedural physics publishes a `PhysicsPoseOverride` after the physics
+step. The override identifies the exact scene, animation instance, skeleton,
+simulation tick, joint mapping, transforms, authority mode, and finite blend
+weights. Animation validates it and composes the final committed pose. Authority
+is explicit per instance/joint set:
+
+- `AnimationDriven`: physics supplies no pose write;
+- `PhysicsDriven`: admitted physics joints are authoritative;
+- `Blended`: the animation-owned composition applies declared finite weights.
+
+Mode changes occur at a fixed-tick safe point and initialize both sides from the
+same committed pose. Two systems never write the same pose buffer. Missing,
+stale, non-finite, incompatible-skeleton, or partial-required overrides fail with
+a typed result; they are not applied by joint name guessing.
+
+After tick commit, Animation Runtime retains previous/current committed poses.
+Presentation creates a frame-owned immutable pose/palette projection with source
+scene, instance, tick pair, pose generations, and interpolation alpha. Render
+extraction consumes that projection only. Renderer work does not retain pointers
+into animation frame storage beyond the snapshot/lease contract.
+
+### 8. Concurrency, reload, and shutdown
+
+Animation instance state and publication mutate on the declared scene/runtime
+owner thread. Independent graph/pose work may execute in bounded jobs only when
+the compiled access plan proves no conflicting writes. Jobs capture immutable
+assets, owned inputs, stable identities, and generation-safe leases; they join
+before their fixed-tick stage completes. The frame thread never waits on unbounded
+background I/O or source import.
+
+Reload stages new immutable artifacts and instance migration privately. Publication
+occurs at the owner safe point after compatibility validation. Compatible state is
+mapped by stable typed IDs, never array position or display name. Failure retains
+the last good generation. Old pose generations retire after all frame/physics/
+render leases release; a late job cannot publish into a replaced scene or instance.
+
+Scene unload and shutdown stop new evaluations, cancel or join owned preparation,
+discard uncommitted candidates, drain/revoke leases in dependency order, then
+release animation storage before its assets and job/runtime dependencies disappear.
+Repeated shutdown is safe. Preview teardown cannot affect a play instance.
+
+### 9. Migration and verification
+
+The current render-frame-authoritative prose is removed rather than supported as
+a compatibility mode. Migration proceeds by responsibility:
+
+1. ANI-001.2 defines distinct typed asset, instance, pose, tick, and request IDs.
+2. ANI-001.3/.4 provide validated skeleton and mesh-binding inputs.
+3. ANI-001.5 implements bounded pose storage, generation-safe leases, and
+   previous/current publication.
+4. ANI-001.6 implements fixed-point directed clip traversal, wrap/reverse rules,
+   and bounded interval preflight.
+5. ANI-001.7/.8 preserve this clock and ownership contract through cook artifacts.
+6. ANI-001.9 qualifies malformed, skewed, reload, and lifecycle behavior.
+
+These responsibility statements do not infer scheduling from issue numbers or
+milestones; native parent/sub-issue and blocked-by relationships remain authoritative.
+Until those implementations land, the architecture is a target contract and does
+not claim a working skeletal animation runtime.
+
+Required contract coverage includes:
+
+- identical authoritative results under different render cadences and catch-up grouping;
+- pause, composed pause tokens, one-tick step, host suspension, and zero-delta resume;
+- simulation-rate changes without changing the fixed quantum or double scaling;
+- positive, zero, and reverse player rates across Once/Loop/PingPong boundaries;
+- bounded high-rate/large-interval rejection without partial cursor/event/root output;
+- root-motion ignore, collision clipping, duplicate/stale request, and failed-tick paths;
+- animation-driven, physics-driven, and blended pose authority transitions;
+- stale pose leases, preview/play isolation, reload failure, scene replacement, and repeated shutdown;
+- headless fixed-tick execution with no renderer or editor clock dependency.
+
+## Consequences
+
+Authoritative animation, movement, physics, and events now share the fixed-tick
+history, so changing render cadence cannot change their semantic order. Pause and
+single-step have one meaning, reverse playback does not pretend to reverse the
+world, and large traversals fail atomically instead of dropping hidden work. Pose
+storage has one mutable owner while physics and rendering use typed handoffs.
+
+The cost is separate simulation/presentation/preview state, previous/current pose
+retention, fixed-point cursor bookkeeping, staged tick commit, explicit physics
+override data, and bounded traversal preflight. Catch-up frames may evaluate
+animation multiple times, so animation budgets and LOD policies must be measured
+against maximum admitted fixed ticks rather than average render frames.
+
+## Rejected Alternatives
+
+### Evaluate authoritative animation once per rendered frame
+
+Rejected because zero or multiple fixed ticks may occur in one frame. Reusing one
+pose/root delta or sampling before the tick loop makes movement, events, and
+physics inputs depend on render cadence.
+
+### Let physics or the renderer own the animation clock
+
+Rejected because physics owns integration and renderer owns presentation, not
+animation player state. The host fixed scheduler supplies authoritative ticks;
+presentation only interpolates committed results.
+
+### Use raw variable delta and clamp inside each animation player
+
+Rejected because independent clamps create different time histories, silently
+drop crossings, and do not align root motion with committed physics ticks.
+
+### Apply root motion directly from animation
+
+Rejected because it bypasses gameplay policy, controller collision, transform
+authority, networking, and failed-tick handling.
+
+### Share one mutable pose buffer with physics and rendering
+
+Rejected because write ownership and lifetime become timing-dependent. Typed
+immutable leases and post-physics overrides preserve owner and generation checks.
+
+### Support negative global simulation time for reverse playback
+
+Rejected because reversing animation data does not undo physics, gameplay side
+effects, networking, or asset/runtime lifecycle. Reverse is a bounded player-local
+traversal with explicit event and root-motion policy.
+
+### Allow partial advance when an interval exceeds budget
+
+Rejected because pose, root motion, and event cursors would describe different
+fractions of the tick. Preflight and atomic failure keep them coherent.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -72,6 +72,7 @@ to the replacement.
 | [058](058-package-source-policy.md) | Package Source Policy | Proposed | 2026-09-02 |
 | [059](059-script-consumable-module-boundary.md) | Script-Consumable Module Boundary | Proposed | 2026-09-02 |
 | [060](060-release-domain-model-and-state-machine.md) | Release Domain Model and State Machine | Proposed | 2026-09-02 |
+| [061](061-animation-ownership-update-order-and-clock.md) | Animation Ownership, Update Order and Clock | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -137,6 +137,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Animation Architecture](./runtime/animation-architecture.md): skeletal
   animation, clips, animation graphs, blend trees, IK, root motion, retargeting,
   and animation events.
+- [Animation Ownership, Update Order and Clock](../adr/061-animation-ownership-update-order-and-clock.md):
+  pose ownership, fixed-tick advancement, pause/step/rate semantics, root-motion
+  timing, and physics/render handoff.
 - [VFX And Particles Architecture](./runtime/vfx-and-particles-architecture.md):
   CPU/GPU particle systems, VFX graphs, decals, and volumetric effects.
 - [Character Controller Architecture](./runtime/character-controller-architecture.md):

--- a/docs/architecture/runtime/animation-architecture.md
+++ b/docs/architecture/runtime/animation-architecture.md
@@ -11,6 +11,11 @@ The goal is to provide a deterministic, data-oriented animation runtime that can
 drive characters from simple loops to complex gameplay-responsive locomotion and
 cinematics.
 
+[ADR-061](../../adr/061-animation-ownership-update-order-and-clock.md) is the
+single normative owner of pose ownership, animation clock domains, fixed-tick
+order, root-motion timing, and physics/render handoff. This document owns the
+broader animation subsystem model and summarizes that decision.
+
 ## Scope
 
 Covered:
@@ -39,12 +44,14 @@ Not covered:
 - Animations are data assets. The runtime samples them; it does not author them.
 - Poses are the primary runtime currency: animation outputs a pose, IK modifies
   it, physics may override parts of it, and skinning consumes it.
-- The animation update runs as part of the runtime frame, before render
-  extraction. Fixed-step physics does not drive animation timing.
+- Authoritative animation advances once per attempted fixed simulation tick.
+  Presentation interpolates committed poses and editor preview uses isolated
+  state; neither advances gameplay animation.
 - Animation graphs are authored assets that compile into a runtime evaluation
   tree. They are not interpreted scripts.
-- Root motion is explicit: animation provides a delta transform; gameplay code
-  decides whether to consume it.
+- Root motion is explicit: animation stages the exact fixed-tick interval delta;
+  gameplay selects consumption policy and the character controller owns final
+  collision-aware movement.
 - Retargeting is a cook/import-time process where possible. Runtime retargeting
   is supported but more expensive.
 - GPU skinning is the default for skinned meshes. CPU skinning is a fallback for
@@ -94,12 +101,15 @@ struct Pose {
 Rules:
 
 - Local transforms are authoritative.
-- Model-space matrices are computed once per frame on first access, then cached
-  until the next pose evaluation invalidates them.
-- Poses are owned by the animation system and leased to gameplay/physics for
-  read-only inspection unless explicit write-back is declared.
-- Poses are allocated from a frame-local pool to avoid heap allocations during
-  playback.
+- Model-space matrices are computed once per pose generation on first access,
+  then cached until a new candidate pose invalidates them.
+- Mutable poses are owned only by Animation Runtime. Gameplay and physics receive
+  generation-checked read-only leases; physics returns typed post-step overrides
+  rather than writing pose arrays.
+- Working poses use bounded instance/frame storage. Previous/current committed
+  poses remain valid until presentation and render leases retire.
+- Render extraction receives a frame-owned immutable pose/palette projection
+  tagged with scene, instance, tick, and pose-generation identity.
 
 ## Animation Clip
 
@@ -109,8 +119,8 @@ A clip stores sampled animation data for one skeleton.
 struct AnimationClipDescriptor {
     ClipId id;
     SkeletonId skeleton;
-    float durationSeconds;
-    float sampleRate;
+    AnimationDeltaTime duration;
+    AnimationSampleRate sampleRate;
     WrapMode wrapMode;
     bool hasRootMotion;
     AnimationCompressionScheme compression;
@@ -138,11 +148,14 @@ Cook-time compression may reduce precision based on the active cook profile.
 ### Clip Sampling
 
 ```cpp
-Pose SampleClip(const AnimationClip& clip, float time, const Skeleton& skeleton);
+Pose SampleClip(const AnimationClip& clip, AnimationTime time,
+                const Skeleton& skeleton);
 ```
 
 Behavior:
 
+- `AnimationTime` uses the checked fixed-point/rational domain finalized by
+  ANI-001.6; authoritative cursors are not accumulated in floating-point seconds
 - time is wrapped according to `WrapMode` (`Once`, `Loop`, `PingPong`, `ClampForever`)
 - keyframe interpolation is linear or spline depending on clip metadata
 - rotations are normalized after interpolation
@@ -163,7 +176,10 @@ AnimationGraph
 ```
 
 Graph assets compile to a runtime `AnimationGraphInstance`. The graph owns its
-parameter block and pose working memory.
+parameter block, pose working memory, player cursors, and the exact fractional
+remainders produced by playback-rate multiplication and cursor accumulation.
+Candidate cursors and remainders publish together only when their fixed tick
+commits.
 
 ### Graph Parameters
 
@@ -262,8 +278,8 @@ any other pose query.
 
 ## Root Motion
 
-Root motion produces a transform delta each frame from the animation clip's root
-joint.
+Root motion produces a transform delta for one authoritative fixed-tick player
+interval from the animation clip's root joint.
 
 ```cpp
 struct RootMotionDelta {
@@ -275,11 +291,19 @@ struct RootMotionDelta {
 Rules:
 
 - root motion is optional per clip
-- gameplay chooses whether to consume the delta for character movement
+- the authoritative delta is extracted once for the exact directed fixed-tick
+  player interval; presentation and preview never produce consumable root motion
+- gameplay chooses whether to consume the delta for character movement, while
+  the controller owns collision-aware resolution and final transform authority
 - networked games must replicate root motion parameters or resulting transforms,
   not raw animation time
-- root motion deltas are accumulated and applied during the gameplay movement
-  update, not inside the animation system
+- requests carry scene/instance/tick/generation identity; consumption becomes
+  durable only at successful tick commit, an aborted attempt's lease and staged
+  marker are discarded, and a retry may consume its newly staged equivalent
+- stale, duplicate-after-commit, preview, and leaked aborted-attempt requests are
+  rejected
+- reverse playback can emit an inverse directed delta only when the clip/node and
+  owner policy admit reverse traversal; it never reverses the physics world
 
 ## Retargeting
 
@@ -312,8 +336,8 @@ Animation events are named markers attached to a clip at a specific time.
 ```cpp
 struct AnimationEvent {
     EventName name;
-    float timeSeconds;
-    std::optional<float> durationSeconds;
+    AnimationTime time;
+    std::optional<AnimationDeltaTime> duration;
     VariantMap payload;  // typed key-value map; see foundation type glossary
 };
 ```
@@ -326,9 +350,11 @@ Event types:
 - `SpawnProjectile` — fire event
 - `Custom` — gameplay-defined
 
-The animation system emits events during evaluation. Consumers subscribe by
-name. Events do not directly spawn gameplay objects; they queue commands for the
-frame update.
+The animation system stages event occurrences during fixed-tick evaluation and
+publishes them only after that tick commits. Consumers subscribe by typed event
+identity. Events do not directly spawn gameplay objects; they enter bounded owner
+queues for a later permitted boundary. Reverse and large-interval traversal follow
+ADR-061's eligibility and atomic preflight rules.
 
 ## Skinning
 
@@ -369,32 +395,31 @@ scene conversion:
 
 ### Update Order
 
-For the non-AI frame-pose path, animation produces a pose once per rendered frame.
-This is distinct from ADR-022's fixed-tick AI locomotion/rig ordering: AI cinematic
-movement enters NavIntentCommit, physics authority remains in locomotion, and rig
-update follows committed movement. The sequencer does not move that fixed-tick
-work into VariableUpdate or permit presentation samples to mutate physics.
-
-On the frame-pose path, physics may step multiple
-times per frame at a fixed interval; the animation pose is sampled before those
-steps and is not re-sampled inside a physics step.
+The authoritative non-AI path follows ADR-061 inside every attempted fixed tick.
+This remains distinct from ADR-022's AI phase graph, but both paths are fixed-tick
+contracts. Catch-up evaluates animation separately for every attempted tick; one
+render-frame pose is never reused as the authoritative input to several physics
+steps.
 
 ```text
-Frame Update
-  Gameplay sets animation parameters & behavior state
-  Cinematic owner-admitted parameters apply (no presentation interpolation)
-  Animation graph evaluates -> pose
-  IK applied -> modified pose
-  Root motion delta produced
-  Gameplay consumes root motion (character controller resolves movement)
-  Physics fixed-step(s)
-  Render extraction reads final pose and joint palette
+Attempted Fixed Tick
+  Gameplay and owner-admitted cinematic inputs stage animation parameters
+  Animation evaluates candidate pose, eligible IK, events, and root-motion delta
+  Character controller resolves desired movement plus root motion
+  Physics steps once and publishes typed body/pose overrides
+  Animation composes admitted overrides and finalizes candidate pose
+  Tick commit publishes player state, events, and previous/current poses
+
+After FixedUpdate
+  Presentation interpolates committed poses and applies presentation-only overlays
+  Render extraction reads the immutable frame pose and joint palette
 ```
 
-Interpolated cinematic presentation overlays are applied only to the render/preview
-snapshot after movement authority resolves. They do not feed this path's root-motion
-output or write animation parameters consumed by physics. Only owner-admitted
-non-interpolated inputs participate in the movement-producing pose evaluation.
+Simulation-affecting IK runs before controller/physics consumption. Post-physics
+or presentation IK cannot feed same-tick root motion, movement, or colliders.
+Interpolated cinematic overlays apply only to the render/preview snapshot after
+movement authority resolves. Only owner-admitted non-interpolated fixed-tick inputs
+participate in movement-producing evaluation.
 
 The character controller runs during the gameplay movement phase, before the
 physics world is stepped. This matches the ordering described in
@@ -407,7 +432,7 @@ The renderer receives:
 - transform
 - mesh asset
 - material
-- joint palette handle or pointer
+- frame-owned immutable joint palette snapshot/lease
 - bounds
 
 Bounds for skinned meshes must account for pose extents. Conservative bounds may
@@ -416,8 +441,11 @@ be used when exact pose bounds are too expensive.
 ### Physics
 
 Physics reads pose for ragdoll initialization or hit-detection shapes. Physics
-does not write pose unless a ragdoll or procedural physics override is active.
-Animation-to-physics handoff is explicit and event-driven.
+never writes Animation Runtime storage. Ragdoll or procedural physics publishes a
+typed post-step override for the exact scene, instance, skeleton, tick, joint map,
+and pose generation. Animation validates and composes it under explicit
+`AnimationDriven`, `PhysicsDriven`, or `Blended` authority, then publishes the
+committed pose. Animation-to-physics handoff is explicit and generation-checked.
 
 ## Asset Formats
 
@@ -445,8 +473,8 @@ Animation-to-physics handoff is explicit and event-driven.
   "schemaVersion": 1,
   "assetType": "animation_clip",
   "skeleton": "skeleton_humanoid_001",
-  "duration": 1.0,
-  "sampleRate": 30,
+  "duration": { "numerator": 1, "denominator": 1 },
+  "sampleRate": { "numerator": 30, "denominator": 1 },
   "wrapMode": "Loop",
   "hasRootMotion": true,
   "tracks": [
@@ -458,10 +486,20 @@ Animation-to-physics handoff is explicit and event-driven.
     }
   ],
   "events": [
-    { "name": "Footstep.Left", "time": 0.25 }
+    {
+      "name": "Footstep.Left",
+      "time": { "numerator": 1, "denominator": 4 }
+    }
   ]
 }
 ```
+
+The rational objects above are illustrative schema values in seconds and samples
+per second. ANI-001.6 owns their final field widths and normalization rules.
+Durations use `AnimationDeltaTime`; cursors and event positions use
+`AnimationTime`. Decoders reject zero denominators, overflow, non-canonical
+fractions, and values outside the clip's declared duration instead of converting
+through binary floating point.
 
 ### Animation Graph Asset
 
@@ -490,10 +528,14 @@ Animation-to-physics handoff is explicit and event-driven.
 
 - Unit tests for pose hierarchy updates and matrix multiplication.
 - Sampling tests for loop/ping-pong wrap modes.
+- Fixed-tick determinism tests across different render cadences and catch-up grouping.
+- Pause, single-step, simulation-rate, reverse, and large-interval budget tests.
 - Blend tree tests verifying normalized weights and rotation correctness.
 - IK solver tests for known configurations.
 - Retargeting tests comparing source and target poses.
 - Visual regression tests for skinned mesh playback.
+- Root-motion duplicate/stale request and physics-override authority tests.
+- Preview/play isolation, stale pose lease, reload, scene replacement, and shutdown tests.
 - Performance tests for joint palette upload and GPU skinning throughput.
 
 ## Related Documents

--- a/docs/architecture/runtime/character-controller-architecture.md
+++ b/docs/architecture/runtime/character-controller-architecture.md
@@ -11,6 +11,10 @@ The goal is to give gameplay systems a stable, deterministic way to move
 characters in a physics world without exposing the full complexity of rigid-body
 dynamics to every gameplay module.
 
+[ADR-061](../../adr/061-animation-ownership-update-order-and-clock.md) owns the
+fixed-tick animation/root-motion ordering and pose handoff. This document owns
+movement admission, collision resolution, and the resulting transform.
+
 ## Scope
 
 Covered:
@@ -66,20 +70,20 @@ and orientation. The controller reads and writes the transform each frame.
 ## Update Order
 
 ```text
-Frame Update
-  Gameplay reads input and animation state
-  Gameplay computes desired velocity / root motion delta
-  Animation evaluates and produces root motion delta
+Attempted Fixed Tick
+  Gameplay stages desired movement and animation parameters
+  Animation evaluates and stages the exact tick's root motion request
   Character controller resolves movement
-  Transform is updated
-  Moving platform velocity applied if attached
-  Scene runtime synchronizes transform
+  Character transform and moving-platform result are published
+  Physics steps once
+  Post-physics animation pose override/finalization runs
+  Tick commit publishes previous/current state
 ```
 
-The controller always runs after animation root motion is sampled and before
-physics fixed-step integration. This ordering ensures gameplay-driven movement
-is resolved into a final transform before the physics world is stepped, so
-physics bodies can react to the character's new position in the same frame.
+The controller runs once after animation root motion is staged and before each
+physics fixed step. Catch-up repeats the complete sequence; it does not reuse one
+render-frame root delta. This ensures gameplay-driven movement is resolved into a
+final transform before physics reacts during the same attempted tick.
 
 ## Movement Resolution
 
@@ -91,7 +95,7 @@ struct MovementRequest {
     Quat desiredOrientation;
     bool jumpRequested;
     bool crouchRequested;
-    float deltaTime;
+    FixedDeltaTime deltaTime;
 };
 ```
 
@@ -272,7 +276,7 @@ Animation root motion may provide a movement delta.
 ```cpp
 enum class RootMotionPriority {
     Suggest,     // root motion is applied only if gameplay input is zero
-    Override     // root motion replaces gameplay input for this frame
+    Override     // root motion replaces gameplay input for this fixed tick
 };
 
 struct RootMotionRequest {
@@ -287,6 +291,17 @@ struct RootMotionRequest {
 The controller treats root motion as a movement request and resolves it through
 the same collision passes. This ensures that animation-driven movement still
 respects walls, slopes, and steps.
+
+The request identifies its scene, animation instance, simulation tick, and root-
+motion generation. Controller resolution stages a consumption marker in the tick
+transaction; only successful tick commit makes that marker durable. Aborting an
+attempt discards its marker and request lease, so a retry of the same simulation
+tick can consume the newly staged equivalent request. After a successful commit,
+another request with that identity is a duplicate and is rejected. Presentation/
+editor-preview, stale, duplicate-after-commit, or leaked aborted-attempt requests
+are invalid. Reverse player traversal may submit the inverse directed delta when
+animation and gameplay policy admit it; the controller still performs ordinary
+forward collision resolution and does not reverse physics.
 
 If root motion and gameplay input conflict, gameplay input takes precedence
 unless the root motion request has `RootMotionPriority::Override`. The animation
@@ -368,7 +383,8 @@ Runtime variables:
 - Moving platform attachment and detachment tests.
 - Surface event emission tests.
 - Root motion collision tests.
-- Determinism tests for fixed-step playback.
+- Root motion duplicate/stale generation and reverse-policy tests.
+- Determinism tests for fixed-step playback under different render/catch-up grouping.
 - Performance tests for many concurrent controllers.
 
 ## Related Documents

--- a/docs/architecture/runtime/cinematic-sequencer-architecture.md
+++ b/docs/architecture/runtime/cinematic-sequencer-architecture.md
@@ -406,14 +406,14 @@ No dependent sequence action assumes a request completed in that same tick.
 
 ### Presentation And Editor Path
 
-The existing non-AI frame pose path in [Animation Architecture](./animation-architecture.md)
-remains: gameplay prepares parameters, owner-admitted non-interpolated cinematic
-parameters apply,
-animation/IK produces pose and root motion, character movement resolves under its
-owner, physics runs, and rendering extracts committed state. This path is not a
-claim of render-rate-independent simulation. Optional interpolated cinematic
-values affect only the render/preview snapshot, not authoritative property values,
-event cursors, gameplay state or physics transforms.
+The non-AI path follows
+[ADR-061](../../adr/061-animation-ownership-update-order-and-clock.md): fixed-tick
+gameplay and owner-admitted cinematic parameters feed animation/root motion,
+character movement resolves under its owner, physics steps, post-physics pose
+composition finalizes, and tick commit publishes the state later used by rendering.
+Optional interpolated cinematic values affect only the render/preview snapshot,
+not authoritative property values, event cursors, gameplay state, root motion, or
+physics transforms.
 
 ```mermaid
 flowchart TD

--- a/docs/architecture/runtime/runtime-lifecycle.md
+++ b/docs/architecture/runtime/runtime-lifecycle.md
@@ -129,6 +129,7 @@ The host tracks:
 
 - monotonic real time
 - clamped presentation delta
+- positive rational simulation rate and its revision
 - fixed simulation delta
 - accumulator
 - interpolation alpha
@@ -136,7 +137,8 @@ The host tracks:
 - frame number
 
 ```cpp
-accumulator += Clamp(realDelta, 0, maxFrameDelta);
+accumulator.AddScaled(Clamp(realDelta, RealDuration::Zero(), maxFrameDelta),
+                      simulationRate, simulationScaleRemainder);
 
 while (accumulator >= fixedDelta && steps < maxCatchUpSteps) {
     FixedUpdate(fixedDelta);
@@ -146,6 +148,17 @@ while (accumulator >= fixedDelta && steps < maxCatchUpSteps) {
 alpha = accumulator / fixedDelta;
 Render(alpha);
 ```
+
+`simulationRate` changes how much clamped elapsed time enters the accumulator;
+it does not change `fixedDelta`. Scaling uses checked rational/fixed-point math
+and the host clock owns `simulationScaleRemainder` across frames. `AddScaled`
+preflights overflow and commits the accumulator plus remainder atomically; it
+does not round through floating-point seconds or lose an unrepresented fraction.
+The baseline rate is `1/1`. A rate change commits through the owner-thread command
+boundary before fixed-step scheduling, preserves that remainder, and records a
+revision for replay evidence. Negative rates are invalid. Gameplay
+pause is separate composed state and contributes no accumulator time; it is not
+represented by a zero rate.
 
 Long stalls do not create an unbounded simulation spiral. When
 `maxCatchUpSteps` is reached, the host records dropped simulation time according
@@ -163,6 +176,11 @@ succeeds. `FrameContext::completedSimulationTick` is the count of committed
 ticks and is therefore zero before the first successful tick. Variable update
 and render extraction observe that committed count together with interpolation
 alpha.
+
+[ADR-061](../../adr/061-animation-ownership-update-order-and-clock.md) applies
+this policy to animation. Animation consumes the unchanged fixed quantum once
+per attempted tick. Host simulation rate is already represented by tick cadence;
+animation and physics do not multiply it into their delta again.
 
 The scheduler retains allocation-free cumulative counters for committed ticks,
 dropped time and steps, catch-up saturation, negative samples, and maximum-delta
@@ -207,12 +225,15 @@ Variable-rate update is not used for deterministic physics integration.
 One fixed tick executes:
 
 1. consume the input command state assigned to the tick
-2. run pre-physics gameplay systems
+2. run ordered pre-physics systems, including gameplay animation parameters,
+   animation pose/root-motion staging, and character-controller movement
 3. step physics
 4. publish physics results into scene transforms
-5. run post-physics and behavior systems
+5. run post-physics and behavior systems, including typed animation pose
+   overrides and candidate pose finalization
 6. commit deferred entity/component changes
-7. preserve previous/current state for interpolation
+7. atomically publish committed subsystem state, events, and previous/current
+   state for interpolation
 
 System ordering is declared by the scene runtime and validated before execution.
 The data bus is not used to establish per-tick system order.
@@ -222,13 +243,15 @@ The data bus is not used to establish per-tick system order.
 Variable update is used for:
 
 - editor camera and presentation behavior
+- interpolation of committed animation poses and isolated editor preview playback
 - non-simulation UI state
 - job progress and query refresh
 - audio presentation updates where supported
 - streaming and resource coordination
 
 Variable update must not introduce simulation behavior that changes with frame
-rate.
+rate. Animation presentation/preview cannot emit gameplay events, root motion,
+or physics/controller writes; its authoritative order is defined by ADR-061.
 
 ## Render Snapshot
 
@@ -276,7 +299,10 @@ document requires an explicit editor command.
 
 Pause stops simulation ticks but keeps event processing, GUI, rendering, and
 required service updates alive. Single-step advances exactly one fixed tick and
-returns to paused state.
+returns to paused state. It uses the ordinary unchanged fixed quantum and complete
+subsystem order; it does not consume accumulated wall time. Authoritative animation
+therefore holds during pause and advances once during a successful step. Isolated
+editor preview may advance only under its separate preview controls.
 
 ### Runtime Console And Development Overlays
 

--- a/docs/architecture/runtime/scene-runtime.md
+++ b/docs/architecture/runtime/scene-runtime.md
@@ -249,6 +249,13 @@ access. A stable order is produced for equal dependencies.
 Initial implementations may execute systems serially. The access contract still
 exists so future parallelism does not require redesigning system ownership.
 
+Within a fixed tick,
+[ADR-061](../../adr/061-animation-ownership-update-order-and-clock.md) requires
+gameplay parameter commit before animation pre-physics evaluation, root-motion
+request admission before character-controller movement, physics next, and typed
+post-physics pose override/finalization before tick publication. These are
+dependencies within the existing phase graph, not new `RuntimePhase` values.
+
 ## Runtime Save And Restore Integration
 
 [Runtime persistence](./save-game-and-persistence.md) is coordinated by an


### PR DESCRIPTION
## Summary

- Add ADR-061 as the single contract for animation pose ownership, clock domains, fixed-tick evaluation order, root-motion consumption, and physics/render handoff.
- Replace render-rate-authoritative animation with one transactional evaluation per attempted fixed simulation tick.
- Align Runtime Lifecycle, Animation, Character Controller, Cinematic Sequencer, and Scene Runtime around exact rational timing and immutable pose publication.

## Why

The previous architecture sampled one authoritative pose per rendered frame and then allowed zero or more physics steps to consume it. That made animation state, events, and root motion dependent on render cadence and left retry, pause, reverse playback, pose mutation, and physics handoff rules underspecified.

## Decision and boundaries

- Runtime owns a positive rational simulation rate and a persistent scaling remainder; the fixed quantum itself never changes.
- Each animation instance owns cursors, graph state, pose working memory, playback-rate remainders, and candidate publication state.
- Authoritative animation evaluates once per attempted fixed tick. Presentation interpolates committed poses only; editor preview owns isolated state.
- Large or high-rate traversals preflight all node, event, root-motion, pose, and output budgets before mutation.
- Root motion is a typed request. Controller resolution stages consumption, and only successful tick commit makes it durable; an aborted attempt can be retried without falsely rejecting the equivalent request.
- Physics publishes typed post-step pose overrides. Animation remains the only mutable pose owner and emits immutable frame pose/palette leases.
- Asset durations use `AnimationDeltaTime`; cursors/events use `AnimationTime`; serialized timing examples use exact normalized rationals.

## Review findings addressed

- Runtime accumulator scaling now names its host-owned remainder and requires checked, atomic accumulator/remainder publication.
- Root-motion duplicate protection is tied to successful tick commit instead of the resolve phase, covering failed-tick retries.
- The clip descriptor uses a duration-specific type.
- `AnimationGraphInstance` explicitly owns playback and cursor remainders.
- JSON duration, sample-rate, and event-time examples no longer imply binary floating-point time storage.

## Validation

- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`
- `npx --yes markdownlint-cli --disable MD013 MD060 -- <changed Markdown files>`
- Added local Markdown links resolve against the repository.
- `git diff origin/main --check`
- Architecture placeholder scan found no unresolved TODO/TBD/open-question markers in the changed contract.

This is an architecture-only change; the runtime implementation and executable determinism tests belong to the downstream ANI tickets.

## Risk and rollout

- This intentionally replaces the render-frame-authoritative target model. Implementations must cut over transactionally rather than preserve both clock authorities.
- Cross-platform bit identity is not claimed beyond a qualified numeric/platform contract.
- Failed tick attempts must discard candidate animation, controller-consumption, event, and pose state together.

## Issue links

- Jira: HORO-454
- GitHub: Closes #454

## Reviewer notes

Review ADR-061 sections 2–7 first, especially the candidate/commit boundary. Then verify Runtime Lifecycle owns host clock accumulation while Animation and Character Controller own only their fixed-tick transactional state.
