### PR TITLE
docs(audio): define sample layout contract HORO-527 #527 [AUD-001.3]

### DIFF
--- a/docs/adr/063-audio-sample-format-and-channel-layout.md
+++ b/docs/adr/063-audio-sample-format-and-channel-layout.md
@@ -1,0 +1,323 @@
+# ADR-063: Audio Sample Format and Channel Layout
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Backend-neutral real-time sample representation, buffer layout, speaker/Ambisonic order, silence, denormals, and clipping
+- **Issue**: [AUD-001.3](https://github.com/abdullahbodur/horo-engine/issues/527)
+- **Jira**: [HORO-527](https://horo-engine.atlassian.net/browse/HORO-527)
+- **Parent**: [AUD-001](https://github.com/abdullahbodur/horo-engine/issues/524)
+- **Related**: [ADR-062](062-audio-runtime-ownership-and-update-order.md)
+- **Normative document**: [Audio Architecture](../architecture/runtime/audio-architecture.md)
+
+## Context
+
+Audio Architecture leaves the mixer sample type, planar/interleaved boundary,
+alignment, channel ordering, silence, denormal, and clipping policy unspecified.
+If a backend's native format becomes the internal contract, DSP nodes, mixer
+graphs, middleware adapters, Null tests, and platform devices will disagree on
+buffer stride, full scale, speaker indices, and conversion ownership. An integer
+or interleaved device format must not leak upward merely because one API prefers it.
+
+The real-time core needs one representation that is efficient for per-channel DSP,
+supports explicit multichannel and Ambisonic semantics, and can be allocated from
+the callback-safe pools established by AUD-001.5. Device/source conversion remains
+necessary, but it must occur at named boundaries with deterministic validation.
+
+## Decision
+
+### 1. Canonical processing sample
+
+The canonical Horo processing sample is IEEE-754 binary32 (`float`) in native CPU
+endianness. `AudioSample` is a Horo-owned semantic type alias/wrapper; public audio
+contracts do not expose `SDL_AudioFormat`, `AVAudioFormat`, WASAPI/Core Audio/
+PipeWire structs, middleware sample enums, or device buffer pointers.
+
+Finite values are required. `-1.0F` and `+1.0F` are nominal negative/positive full
+scale, and `+0.0F` is canonical silence. Internal buses and DSP intermediates may
+exceed nominal full scale to preserve headroom; they are not clipped after every
+node. NaN and infinity are never valid audio data or silence.
+
+The internal representation is not a serialized asset format. Cooked clips,
+compressed streams, decoder output, capture devices, and native output may use
+other typed formats. Their adapters convert into/out of canonical processing
+blocks at the source/capture and final-device boundaries.
+
+### 2. Planar block contract
+
+Mixer, voice, bus, DSP, spatializer, and resampler processing uses planar
+channel-major storage:
+
+```cpp
+struct AudioPlanarBlockView {
+    AudioChannelLayoutView layout;
+    AudioSampleRate sampleRate;
+    std::span<AudioSample* const> planes;
+    AudioFrameCount validFrames;
+    AudioFrameCount capacityFrames;
+};
+```
+
+`planes.size()` equals the validated layout channel count. Each plane contains
+`capacityFrames` contiguous `AudioSample` values; the first `validFrames` are
+semantic audio. Plane starts are aligned to at least 64 bytes. Capacity may be
+rounded up for a private SIMD width, but padding is zero and is never counted as
+audio time, hashed as payload, or exposed as extra frames. Every plane in a block
+has the same capacity and valid-frame count.
+
+The exact sample and plane-pointer storage owner is a callback-safe pool, retained
+decoded block, or bounded adapter buffer. A block view and its layout view are
+borrowed for one declared processing call/epoch and cannot escape to jobs,
+scene/editor code, or a later callback. `AudioSample* const` prevents a node from
+retargeting plane entries while leaving admitted sample storage mutable. No DSP
+node changes the plane array, layout, sample rate, capacity, or ownership. In-place
+sample mutation is permitted only when the compiled graph grants exclusive write
+access; otherwise the graph assigns a separate admitted output block.
+
+Native interleaved input/output is converted only in the private backend adapter.
+Decoder/capture adapters may accept interleaved bytes outside the mixer, but must
+publish validated planar blocks before real-time graph use. Interleave/deinterleave
+uses preallocated memory and bounded work when it occurs on a callback path.
+
+### 3. Layout identity and channel roles
+
+Channel count alone is not a layout. Every block carries one validated Horo-owned
+layout value:
+
+```cpp
+enum class AudioLayoutKind : std::uint8_t {
+    Speaker,
+    Ambisonic,
+    Discrete,
+};
+
+struct AudioChannelLayout {
+    AudioLayoutKind kind;
+    std::vector<AudioChannelRole> orderedChannels;
+    std::optional<AmbisonicDescriptor> ambisonic;
+};
+
+struct AudioChannelLayoutView {
+    AudioLayoutKind kind;
+    std::span<const AudioChannelRole> orderedChannels;
+    std::optional<AmbisonicDescriptor> ambisonic;
+};
+```
+
+`AudioChannelLayout` is the owning value used in descriptors and prepared graph
+generations. Its vector may allocate only during non-callback construction or
+validation and becomes immutable before epoch publication. The retained graph
+generation owns that value for the complete callback epoch.
+`AudioChannelLayoutView` borrows its channel sequence for one processing call from
+the current retained generation; it is never stored as configuration or used to
+extend lifetime. Unknown role values, zero channels, duplicate speaker roles,
+inconsistent Ambisonic metadata, channel-count mismatch, and counts above the
+admitted profile limit are typed validation failures.
+
+Horo's baseline speaker presets use this exact plane order:
+
+| Preset | Ordered `AudioChannelRole` values |
+|---|---|
+| Mono | `FrontCenter` |
+| Stereo | `FrontLeft`, `FrontRight` |
+| 2.1 | `FrontLeft`, `FrontRight`, `LowFrequency` |
+| Quad | `FrontLeft`, `FrontRight`, `BackLeft`, `BackRight` |
+| 5.1 | `FrontLeft`, `FrontRight`, `FrontCenter`, `LowFrequency`, `SideLeft`, `SideRight` |
+| 7.1 | `FrontLeft`, `FrontRight`, `FrontCenter`, `LowFrequency`, `SideLeft`, `SideRight`, `BackLeft`, `BackRight` |
+| 7.1.4 | `FrontLeft`, `FrontRight`, `FrontCenter`, `LowFrequency`, `SideLeft`, `SideRight`, `BackLeft`, `BackRight`, `TopFrontLeft`, `TopFrontRight`, `TopBackLeft`, `TopBackRight` |
+
+These orders are Horo processing order, not a claim that every file/container or
+device uses the same indices. Adapters map semantic roles explicitly. A device
+that reports back channels where Horo expects side channels cannot reinterpret
+indices; it supplies an explicit role map or fails admission. `LowFrequency` is a
+distinct role and is never inferred from a low-pass filter or channel position.
+
+`Discrete` layouts use ordered `Discrete0` through `DiscreteN` roles and carry no
+speaker-position meaning. Generic mixing does not automatically route them to a
+speaker layout; an authored/registered conversion matrix is required.
+
+### 4. Ambisonic contract
+
+Canonical Ambisonic processing uses AmbiX semantics:
+
+- ACN (Ambisonic Channel Number) order;
+- SN3D normalization;
+- real-valued components;
+- channels ordered `ACN0, ACN1, ... ACN((order + 1)^2 - 1)`;
+- channel count exactly `(order + 1)^2` using checked arithmetic.
+
+The baseline contract admits orders 0 through 3 when the active audio profile and
+spatial provider declare the required capacity. Higher orders are optional future
+capabilities and fail typed admission today. FuMa ordering, N3D normalization,
+legacy B-format labels, and platform-native Ambisonic enums are source/provider
+formats; adapters convert them explicitly to ACN/SN3D before canonical graph use.
+
+Speaker and Ambisonic layouts cannot be reinterpreted by channel count. Encoding,
+rotation, and decoding require a typed spatial operation/provider with declared
+order, coordinate convention, speaker target, latency, and capacity. A missing
+provider is unsupported, not permission to route ACN planes as speakers.
+
+### 5. Layout conversion and mixing
+
+Every conversion names source and destination layout identities and uses a
+versioned finite matrix or specialized admitted spatial operation. Matrix rows
+are destination roles and columns are source roles. Coefficients must be finite,
+bounded, and immutable for the processed graph generation. Validation rejects
+missing required roles, duplicate routes, dimension mismatch, overflow, and a
+matrix whose declared normalization policy cannot be satisfied.
+
+No generic conversion silently invents center, LFE, height, or surround content.
+Mono/stereo fold-down/upmix behavior, LFE contribution, center/surround gains,
+headroom, and normalization are explicit profile policy. Unsupported layouts
+return a typed result rather than truncating extra channels or copying the first N
+planes. Layout conversion does not change sample rate; AUD-001.4 owns resampling.
+
+### 6. Silence, clearing, and tails
+
+Canonical silence is positive zero in every valid and padding sample. Pool acquire
+returns a block in a declared state: `Cleared` or `UninitializedForOverwrite`.
+Only a node proven to overwrite every valid output sample may request the latter.
+Partial writers must clear or mix onto a `Cleared` block. Pool release does not
+promise clearing; the next acquire owns initialization under this rule.
+
+An inactive voice produces silence but may retain finite DSP tail state according
+to its declared lifecycle. A bus/node that has a tail receives explicit silent
+input for its bounded tail interval; it does not read stale pool bytes. End-of-
+stream padding, decoder short reads, underrun fill, muted output, and missing input
+all write canonical silence for the exact missing frame range.
+
+### 7. Denormals and non-finite samples
+
+The audio backend establishes the approved floating-point environment for the
+callback thread before Horo processing and restores any host-owned environment if
+the API reuses a foreign thread. Where supported, denormal inputs/results are
+treated as zero using FTZ/DAZ or the platform-equivalent mode. DSP code cannot
+change rounding/denormal policy per node. Platforms without a reliable mode use
+bounded explicit near-zero sanitization in approved DSP primitives.
+
+Denormal handling is not a noise gate: only subnormal binary32 values normalize to
+canonical zero. It must not erase ordinary low-level audio. Reference/Null tests
+exercise both the platform mode and explicit fallback.
+
+Non-finite production is a DSP invariant violation. Development instrumentation
+records the node/bus/epoch and fails the candidate path. Shipping safety replaces
+the offending output sample with canonical silence through bounded sanitization,
+increments a fault counter, and submits a preallocated ADR-062 fault record. It
+does not continue indefinitely while hiding repeated corruption.
+
+### 8. Clipping and device conversion
+
+Internal graph operations may exceed `[-1, +1]`. Nodes that intentionally saturate,
+limit, or distort declare that behavior; ordinary mix/format conversion does not
+hard clip. The master graph owns any product limiter and headroom policy.
+
+After master processing and immediately before native-device conversion, the
+backend adapter performs one finite safety clamp to `[-1.0F, +1.0F]`. Conversion
+to integer PCM uses a versioned rounding, saturation, and optional dither policy;
+conversion to native float preserves the clamped binary32 values unless the
+device contract explicitly requires another finite range. Input capture conversion
+maps its declared native full scale into Horo nominal full scale without reusing
+output clipping policy.
+
+Clipped-sample/peak counters are allocation-free and bounded. Ordinary logging or
+per-sample diagnostics are forbidden on the callback. Clipping does not alter
+layout identity or permit non-finite values.
+
+### 9. Backend, asset, middleware, and extension boundaries
+
+Public runtime and extension DSP contracts consume `AudioPlanarBlockView`, Horo
+sample rates, and Horo layouts only. A backend or middleware adapter may use a
+private interleaved/native format internally, but must validate and convert at its
+boundary. It cannot register its native enum as an `AudioChannelRole` or make
+device negotiation mutate an already published graph layout.
+
+Asset/cook metadata records its source/cooked sample format and semantic channel
+layout independently. Runtime load/stream preparation converts decoded blocks to
+the canonical representation before callback publication. A cache key includes
+the target format/layout conversion contract; raw device-format bytes are not a
+portable mixer cache entry.
+
+DSP/spatial extensions declare supported Horo layout kinds, roles/orders, maximum
+channels/frames, alignment, in-place behavior, tail policy, and scratch needs at
+registration/prepare time. Unsupported combinations fail graph construction. A
+plugin cannot inspect native device buffers or allocate a replacement layout in
+`Process()`.
+
+### 10. Migration and verification
+
+Audio Architecture gains one summary of this ADR; it does not repeat a competing
+sample or channel policy. AUD-001.4 consumes canonical blocks for resampling,
+AUD-001.5 owns their pools/scratch, AUD-001.6 transports descriptors/commands,
+and later mixer/spatial/backend tickets consume the same layout identities.
+AUD-001.12 reconciles remaining audio documentation. These scope boundaries do not
+infer delivery order from ticket numbers or milestones.
+
+Required contract coverage includes:
+
+- binary32 full-scale/silence/non-finite behavior and bitwise positive-zero clear;
+- owning layout copy/move/immutability and rejection of layout views that outlive
+  their retained graph epoch;
+- plane count, 64-byte alignment, valid/capacity/padding, exclusive in-place, and
+  stale borrowed-view rejection;
+- exact preset orders through native/file mappings, including side/back mismatch;
+- Discrete rejection without a matrix and no silent truncation/reinterpretation;
+- Ambisonic orders 0–3, checked `(order + 1)^2`, ACN/SN3D fixtures, and rejection
+  or explicit conversion of FuMa/N3D inputs;
+- conversion-matrix dimensions, headroom/normalization, LFE policy, and layout-
+  conversion/sample-rate separation;
+- denormal platform/fallback behavior without erasing normal low-level signals;
+- internal over-range headroom, declared limiter behavior, final safety clamp,
+  integer rounding/saturation/dither fixtures, and clip/fault counters;
+- Null, native, middleware, streaming, capture, underrun, mute, tail, reset,
+  suspend, and shutdown paths with callback allocation/lock instrumentation.
+
+## Consequences
+
+All DSP and mixer code sees one backend-neutral planar binary32 representation and
+explicit semantic channel order. Backends remain free to negotiate native formats,
+but conversion ownership is visible and testable. Speaker/Ambisonic data cannot be
+silently reinterpreted, and silence, denormal, non-finite, and clipping behavior no
+longer varies by device.
+
+The cost is planar/interleaved conversion at some boundaries, explicit layout
+maps/matrices, alignment/pool discipline, Ambisonic metadata, and final format
+conversion tests. Planar storage can be less convenient for APIs that natively
+interleave, but it keeps channel DSP, SIMD, routing, and validation consistent.
+
+## Rejected Alternatives
+
+### Use the active device format internally
+
+Rejected because devices vary in sample type, interleave, channel order, and
+range. Device change would otherwise mutate graph contracts and leak native types.
+
+### Use interleaved float throughout the mixer
+
+Rejected because most DSP/routing operates per channel and would carry stride/
+shuffle complexity through every node. Interleaving is isolated to adapters.
+
+### Use integer PCM as the mixer format
+
+Rejected because repeated gain/mix/DSP operations lose headroom and require
+format-specific saturation throughout the graph.
+
+### Use float64 for every callback sample
+
+Rejected because it doubles bandwidth/storage and reduces common SIMD throughput
+without evidence that baseline real-time mixing needs it. Offline/reference tools
+may use higher precision outside the public real-time block contract.
+
+### Treat channel count as layout identity
+
+Rejected because 4/6/8-channel speaker, discrete, and Ambisonic data have different
+semantics and ordering. Every block carries a validated layout.
+
+### Adopt a platform-native or FuMa Ambisonic order
+
+Rejected because it would privilege one backend/ecosystem and make higher orders
+ambiguous. ACN/SN3D AmbiX is explicit and scales by order.
+
+### Clip after every DSP node
+
+Rejected because it destroys headroom and compounds distortion. Only declared
+effects/limiter policy and the final device safety boundary clip.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -74,6 +74,7 @@ to the replacement.
 | [060](060-release-domain-model-and-state-machine.md) | Release Domain Model and State Machine | Proposed | 2026-09-02 |
 | [061](061-animation-ownership-update-order-and-clock.md) | Animation Ownership, Update Order and Clock | Proposed | 2026-09-02 |
 | [062](062-audio-runtime-ownership-and-update-order.md) | Audio Runtime Ownership and Update Order | Proposed | 2026-09-02 |
+| [063](063-audio-sample-format-and-channel-layout.md) | Audio Sample Format and Channel Layout | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -152,6 +152,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Audio Runtime Ownership and Update Order](../adr/062-audio-runtime-ownership-and-update-order.md):
   process/control/callback authority, runtime and device states, scene-context
   barriers, suspend/recovery, fatal failure, and teardown.
+- [Audio Sample Format and Channel Layout](../adr/063-audio-sample-format-and-channel-layout.md):
+  planar binary32 processing, explicit speaker/Ambisonic order, alignment,
+  silence, denormals, layout conversion, and clipping boundaries.
 - [Input Architecture](./runtime/input-architecture.md): input snapshots, action
   maps, focus, capture, modal routing, and simulation input frames.
 - [Game UI And HUD](./runtime/game-ui-and-hud.md): runtime game menus, HUDs,

--- a/docs/architecture/runtime/audio-architecture.md
+++ b/docs/architecture/runtime/audio-architecture.md
@@ -19,6 +19,9 @@ that lifecycle decision.
   command processing.
 - The audio callback performs no heap allocation, blocking I/O, logging, or
   contended locking.
+- Canonical mixer/DSP blocks use 64-byte-aligned planar binary32 samples and an
+  explicit Horo speaker, Ambisonic, or discrete channel order under
+  [ADR-063](../../adr/063-audio-sample-format-and-channel-layout.md).
 - Game and scene code use typed handles and enqueue commands.
 - Decoding and streaming I/O occur outside the real-time thread.
 - Audio assets use the common asset identity, cooking, and cache contracts.
@@ -85,6 +88,30 @@ using AudioBusHandle = Handle<AudioBusTag>;
 
 Handles are generation checked. Asset IDs remain the persistent identity for
 clips and streams.
+
+## Internal Processing Format
+
+[ADR-063](../../adr/063-audio-sample-format-and-channel-layout.md) is the single
+normative owner of real-time sample representation and channel layout. Mixer,
+voice, bus, DSP, spatializer, resampler, and extension processing consumes
+borrowed `AudioPlanarBlockView` values: one contiguous binary32 plane per ordered
+semantic channel, at least 64-byte plane alignment, common valid/capacity frame
+counts, and positive-zero silence/padding. Persistent descriptors and prepared
+graph generations own `AudioChannelLayout`; callback blocks carry only an
+`AudioChannelLayoutView` whose span is bounded by the retained graph epoch.
+
+Speaker presets have exact Horo orders; channel count alone is never identity.
+Ambisonics uses ACN order and SN3D normalization (AmbiX), with orders 0–3 admitted
+only when profile/provider limits permit. Discrete channels carry no speaker
+meaning. Native/file/middleware layouts map explicitly at adapters and never leak
+their format enums into runtime contracts.
+
+Internal buses may exceed nominal `[-1, +1]` full scale. Declared DSP/limiter
+nodes own intentional saturation; one finite safety clamp occurs immediately
+before native output conversion. Denormals normalize under the approved callback
+floating-point environment, non-finite samples enter bounded fault policy, and
+no per-sample logging occurs. ADR-063 owns the complete conversion, silence,
+tail, denormal, clipping, and validation rules.
 
 ## Audio Assets
 
@@ -912,6 +939,10 @@ Required tests cover:
 - null backend deterministic clock
 - callback path allocation and lock checks
 - audio asset format validation
+- planar block alignment/stride/capacity/silence and borrowed-lifetime validation
+- exact speaker preset and native/file role-map fixtures without index reinterpretation
+- ACN/SN3D Ambisonic order/count and FuMa/N3D conversion/rejection fixtures
+- denormal, non-finite, internal headroom, final clamp, and integer conversion policy
 - 2D vs 3D source behavior
 - distance attenuation policy
 - listener selection and missing-listener diagnostics


### PR DESCRIPTION
## Summary

- Add ADR-063 as the backend-neutral contract for canonical audio samples, planar processing blocks, semantic channel layouts, Ambisonics, silence, denormals, and clipping.
- Select 64-byte-aligned planar IEEE binary32 processing with explicit Horo layout identity.
- Separate persistent owning channel layouts from callback-scoped borrowed layout/block views.

## Why

Without a canonical representation, device-native sample formats and channel indices can leak into DSP, mixing, Null tests, middleware, and assets. That makes processing device-dependent and allows speaker, discrete, or Ambisonic data with the same channel count to be silently reinterpreted.

## Decision and boundaries

- Mixer/DSP samples are finite IEEE binary32 values in planar channel-major blocks; positive zero is canonical silence.
- Persistent descriptors and prepared graph generations own `AudioChannelLayout` and its role sequence.
- Callback blocks carry `AudioChannelLayoutView` and `AudioSample* const` plane entries borrowed only from the retained epoch; nodes cannot retarget plane pointers or extend view lifetime.
- Speaker presets use exact Horo role orders. Discrete layouts have no speaker semantics.
- Ambisonics uses AmbiX ACN/SN3D orders 0–3 when admitted by the active profile/provider.
- Layout conversion and sample-rate conversion are separate typed operations.
- Internal buses may exceed nominal full scale; declared DSP/limiter policy owns intentional saturation and the final backend adapter applies one finite safety clamp.

## Review findings addressed

- Replaced the contradictory persistent `std::span` layout with an owning `std::vector` value constructed outside the callback.
- Added a distinct borrowed layout view tied to the retained graph epoch and explicit ownership/lifetime tests.
- Made the plane-pointer span non-retargetable while keeping admitted sample data mutable.
- The ADR index already uses the repository’s correct single-leading-pipe CommonMark convention; the suggested double pipe would create an invalid extra column and was intentionally rejected.

## Validation

- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`
- `npx --yes markdownlint-cli --disable MD013 MD060 -- <changed Markdown files>`
- Added local Markdown links resolve against the repository.
- `git diff origin/main --check`
- Architecture placeholder scan found no unresolved TODO/TBD/open-question markers in the changed contract.

This is an architecture-only change; pool, resampler, DSP, adapter, and native callback tests belong to downstream AUD tickets.

## Risk and rollout

- Planar storage requires explicit preallocated interleave/deinterleave at native boundaries and measured callback budgets.
- Owning layout vectors may allocate only during non-callback preparation and become immutable before epoch publication.
- Higher-order Ambisonics remains unsupported until an explicit capability revision.

## Issue links

- Jira: HORO-527
- GitHub: Closes #527

## Reviewer notes

Review the owning-layout versus borrowed-view distinction first, then the exact speaker/Ambisonic ordering and final clamp policy. The critical invariant is that no callback view outlives its retained graph epoch.
