### PR TITLE
docs(ui): define runtime UI ownership HORO-698 #698 [RUI-001.1]

### DIFF
--- a/docs/adr/073-runtime-ui-ownership-scope-and-update-order.md
+++ b/docs/adr/073-runtime-ui-ownership-scope-and-update-order.md
@@ -1,0 +1,396 @@
+# ADR-073: Runtime UI Ownership, Scope and Update Order
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Runtime UI service ownership, game/player/scene/viewport scopes, instance identity, activation, frame update order, input, pause/suspension, render extraction, unload, failure, compatibility, and shutdown
+- **Issue**: [RUI-001.1](https://github.com/abdullahbodur/horo-engine/issues/698)
+- **Jira**: [HORO-698](https://horo-engine.atlassian.net/browse/HORO-698)
+- **Parent**: [RUI-001](https://github.com/abdullahbodur/horo-engine/issues/700)
+- **Related**: [ADR-004](004-cli-core-gui-boundary.md), [ADR-033](033-presentation-and-display-ownership.md), [ADR-054](054-extension-and-package-authority-boundary.md)
+- **Normative documents**: [Game UI and HUD](../architecture/runtime/game-ui-and-hud.md), [Runtime Lifecycle](../architecture/runtime/runtime-lifecycle.md), [Scene Runtime](../architecture/runtime/scene-runtime.md), [Input Architecture](../architecture/runtime/input-architecture.md), [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
+
+## Context
+
+Runtime game UI includes global menus, per-player HUDs, scene-owned overlays and
+world-space canvases, and viewport-local presentation. Those objects can have
+different lifetimes even when they render into the same view. Treating all UI as
+scene-owned destroys loading/menu/player UI during transitions; treating it as one
+process-global world lets scene or player data survive past its owner. Treating a
+viewport as the semantic owner of every canvas couples content to presentation.
+
+Runtime UI also crosses input, simulation, variable update, layout, render
+extraction, presentation, pause, hot reload, scene unload, editor preview, and
+shutdown. Without one phase contract it can read mutable ECS state, hit-test a
+layout the player never saw, render from editor widgets, or retire assets while an
+in-flight frame still uses them. The system needs typed Horo-owned scopes and one
+generation-safe lifecycle before document, layout, text, rendering, and authoring
+children are implemented.
+
+## Decision
+
+### 1. RuntimeUiService is the sole runtime UI authority
+
+The application/game runtime owns one `RuntimeUiService` per game-instance
+runtime. The service owns UI scope registries, runtime element instances, focus/
+interaction state, binding and layout snapshots, lifecycle transactions, viewport
+attachments, render extraction, diagnostics and retirement. It uses narrow Assets,
+Localization, Accessibility, Input and Renderer contracts; it does not own their
+registries, native objects or policy.
+
+No subsystem creates a hidden global `UiWorld`, mutates UI elements by service
+locator, or renders game UI directly. Scene, gameplay, player, viewport, editor,
+CLI and MCP code submit typed commands/queries through application capabilities.
+Runtime UI never includes or exposes ImGui, SDL, OpenGL, Metal, Vulkan, D3D12,
+native-window, editor-widget or renderer-backend types.
+
+Authoring `UiDocument`, cooked document bytes, mutable runtime instance state,
+immutable interaction/layout snapshots and `UiRenderSnapshot` are distinct
+objects with distinct owners. Editor authoring state is never a runtime instance.
+
+### 2. Every runtime instance has exactly one semantic owner scope
+
+`UiOwnerScope` is a closed typed variant:
+
+```cpp
+enum class UiOwnerScopeKind : std::uint8_t {
+    GameInstance,
+    Player,
+    Scene,
+    Viewport,
+};
+```
+
+| Scope | Owner identity and lifetime | Examples |
+|---|---|---|
+| `GameInstance` | One game-runtime generation; survives scene/player/viewport replacement and ends before that game runtime | boot/loading UI, main menu, global settings, transition cover |
+| `Player` | One generation-checked local-player/session identity; may survive scenes and attach to one or more admitted viewports | HUD, inventory, ability bar, player pause/menu state |
+| `Scene` | One exact `SceneRuntimeId` generation; activates and unloads with that scene context | scene objective panel, world-space nameplates, scene tutorial overlay |
+| `Viewport` | One exact Horo viewport/presentation attachment generation; ends on viewport destruction/replacement | per-view camera overlay, split-screen mask, viewport-local safe-area surface |
+
+An instance chooses one scope at creation and cannot silently migrate. A game-
+instance or player instance attached to a viewport remains owned by its original
+scope; attachment does not transfer ownership. A scene entity may supply a stable
+binding/anchor reference, but UI elements are not ordinary ECS entities and do not
+reuse `EntityId` as their identity.
+
+Cross-scope relationships use stable typed references and owner-approved queries.
+They do not retain pointers to another scope's tree/state. Scope destruction
+invalidates every runtime handle in that scope before its slot can be reused.
+
+### 3. Runtime identity is generation checked and authoring identity is stable
+
+Each runtime tree has a `RuntimeUiInstanceId` and every element is addressed by a
+`UiElementHandle` containing service/runtime/scope generation plus slot generation.
+Handles are transient and never serialized. Commands name the expected scope,
+instance, element and document revisions; stale or cross-scope handles fail.
+
+Both IDs use a fixed 128-bit value: one nonzero 64-bit `UiOwnershipGeneration`
+uniquely identifies the service/runtime/scope incarnation, followed by a 32-bit
+slot and a nonzero 32-bit slot generation. Zero is invalid. Slot generations use
+checked increment; releasing a slot at `UINT32_MAX` retires that slot permanently
+instead of wrapping. Ownership generations also use checked increment; exhausting
+`UINT64_MAX` closes new Runtime UI admission with `GenerationExhausted` and requires
+host-owned runtime replacement. No counter wraps, saturates into a reusable value,
+or reuses an identity still observable by a command, snapshot, render epoch, or
+lease.
+
+Authored `UiDocumentId`/`AssetId` and stable `UiElementId` values survive cook,
+reload and runtime instantiation. They are used for diagnostics, binding, saved
+semantic state and explicit reload reconciliation, not as mutable pointer/slot
+indexes. Duplicate, missing, malformed or type-incompatible IDs reject the
+candidate. Runtime focus, hover, press, capture, animation cursor, layout boxes and
+renderer resources are not authoring data.
+
+### 4. Scope and instance lifecycle are explicit transactions
+
+The service state and each scope/instance use named generations and states:
+
+```text
+Created -> Preparing -> Ready -> Activating -> Active
+Preparing | Activating -> Failed
+Active -> Deactivating -> Retiring -> Destroyed
+Ready -> Retiring -> Destroyed
+```
+
+Preparation resolves the cooked document, schemas, styles, fonts/images/materials,
+localization and binding descriptors; validates limits and capabilities; builds a
+private element tree; allocates bounded runtime state; and prepares renderer/input
+descriptors without publishing them. Activation publishes a complete instance at
+an owner-thread safe point only after its semantic owner exists and every required
+dependency is ready. Failure unwinds the candidate and preserves the prior active/
+last-good generation.
+
+Visibility, enabled state, input eligibility, pause/time policy and viewport
+attachment are orthogonal typed state; they are not lifecycle aliases. Hiding an
+instance does not destroy it, pausing gameplay does not deactivate it, and a
+temporarily unavailable viewport does not transfer it to another owner.
+
+Scope create/destroy, document replacement and cross-tree structural transactions
+commit during `ApplyQueuedOwnerThreadCommands`, or at the next
+`CommitDeferredLifecycleChanges` when requested after that frame's command cutoff.
+No scope/tree generation changes during layout, extraction or rendering.
+
+### 5. Runtime UI has one canonical frame order
+
+Runtime UI participates in the existing `RuntimePhase` sequence and adds no phase:
+
+1. `BuildInputSnapshot` commits normalized device/action/text evidence.
+2. `ApplyQueuedOwnerThreadCommands` commits admitted scope lifecycle, document/
+   resource completions and prior structural transactions.
+3. `FixedUpdate` advances gameplay/physics only. Runtime UI does not mutate trees,
+   animate presentation or dispatch UI actions from fixed simulation.
+4. During `VariableUpdate`, Runtime UI:
+   1. reads immutable committed gameplay/application binding snapshots;
+   2. routes the current input snapshot against the last successfully presented
+      `UiInteractionSnapshot` for that player/viewport;
+   3. emits typed UI actions and commits one bounded UI-local state transaction;
+   4. advances declared presentation animation/time policies;
+   5. resolves bindings, measure/arrange, focus/navigation and hit-test state;
+   6. publishes one immutable instance/layout/interaction generation.
+5. `RenderExtraction` projects active instances into immutable per-view
+   `UiRenderSnapshot` values using the published generation only.
+6. `RenderExecution` renders world-space canvases through declared world passes
+   and screen-space canvases at the frontend-owned composition point.
+7. `RenderGui` remains host/editor/development GUI composition; runtime game UI
+   does not become ImGui work merely because an editor hosts the game viewport.
+8. A successful presentation adopts the extracted interaction revision as the
+   next frame's hit-test/focus evidence. A transient skipped presentation that
+   leaves the prior image visible continues to route input only against the last
+   successfully presented snapshot; it never hit-tests the newer unpublished
+   layout. Interaction is disabled when no such snapshot exists, its owner/scope/
+   attachment generation has retired, or output invalidation means the host cannot
+   assert that the prior image remains visible. A later matching presentation
+   re-enables interaction and advances the adopted revision.
+9. `CommitDeferredLifecycleChanges` retires detached/removed generations after
+   frame ownership is closed; `EndFrame` publishes bounded metrics/observations.
+
+The last-presented interaction rule makes input target the geometry the player
+actually saw. UI actions may mutate UI-local state in the same VariableUpdate, but
+gameplay/scene/renderer mutations are typed commands for their owner's next safe
+point. A button callback never writes ECS, renderer or asset state directly.
+
+### 6. Pause, step, focus loss and suspension are distinct
+
+Gameplay pause stops fixed simulation but keeps Runtime UI lifecycle, input,
+VariableUpdate, layout, rendering and required services active. UI bindings observe
+the latest committed gameplay state. Presentation animations declare one policy:
+
+```cpp
+enum class UiTimePolicy : std::uint8_t {
+    PresentationUnscaled,
+    FollowGameplay,
+    Manual,
+};
+```
+
+`PresentationUnscaled` is the default for menus, navigation, focus and accessibility
+feedback. `FollowGameplay` freezes while gameplay is paused and advances from
+committed simulation-time evidence; it never multiplies variable delta by a guessed
+pause/rate value. `Manual` advances only through an admitted owner command.
+
+A UI action may request pause/resume through an application pause capability, but
+Runtime UI does not own pause tokens or set scheduler state. Single-step advances
+one complete fixed tick; Runtime UI then runs one ordinary VariableUpdate and
+renders the newly committed state without pretending the UI was a fixed system.
+
+Focus loss follows product input/render policy and releases pointer/text capture;
+it is not automatic gameplay pause or UI deactivation. Host suspension skips UI
+VariableUpdate/extraction/rendering with the rest of presentation. Resume resets
+the presentation-delta baseline, revalidates attachments, and never catches up
+suspended wall time.
+
+### 7. Input and focus are per player/viewport interaction context
+
+Each interactive attachment owns a generation-checked `RuntimeUiInputContextId`
+that names game runtime, optional player, viewport, active route/layer and
+interaction snapshot revision. It consumes normalized Input Architecture actions,
+pointer and text/IME snapshots; it never polls native devices or window APIs.
+
+Packaged-game routing places the top runtime UI modal/screen context before its
+associated gameplay context. Editor-play routing places native dialogs, editor
+modals and the focused editor widget/tool before the embedded runtime UI context;
+runtime UI cannot consume editor shortcuts outside its focused game viewport.
+Capture/focus tokens end on release, focus loss, route/scope/viewport destruction,
+modal replacement, device loss, suspension or shutdown.
+
+Focus is scoped, not one process-global element pointer. Split-screen players and
+multiple viewports have independent focus/navigation/capture unless an explicit
+game-instance modal policy blocks them. Structural mutation reconciles focus by
+stable element ID and declared fallback; it never leaves a dangling element handle.
+
+### 8. Viewports own attachments, not foreign semantic state
+
+A `UiViewportAttachment` owns Horo logical viewport/view identity, framebuffer and
+logical extents, DPI/safe-area snapshot, render mode/layer, input region, player
+association, visibility and presented interaction revision. Native window/surface/
+swapchain/image handles remain Platform/Renderer private.
+
+Game/player/scene instances attach through generation-checked descriptors and may
+be projected into multiple compatible views without duplicating semantic state.
+Viewport-scoped instances are destroyed with their attachment. Resize, DPI/safe-
+area, output, render-view or backend changes prepare a new attachment/layout/render
+generation and atomically replace the old one; they do not mutate a snapshot in
+flight.
+
+Screen-space overlay UI composes after world/display transform unless a declared
+render plan places it earlier. World-space UI produces backend-neutral render
+instances under the scene/view depth and visibility policy. Runtime UI never issues
+native commands, presents, selects a renderer/backend, or owns GPU retirement.
+
+### 9. Scene activation and unload have a UI barrier
+
+Scene-scoped UI preparation may run with the scene candidate, but activation waits
+until the exact `SceneRuntimeId` generation and required assets/bindings are ready.
+It publishes before the first eligible Runtime UI VariableUpdate/extraction for
+that active scene. A failed required UI candidate prevents the owning scene/product
+activation according to explicit policy; optional UI omission is declared and
+observable, never inferred from load failure.
+
+Scene UI reads immutable binding/anchor snapshots identified by scene/object/
+component generation. It retains no ECS component-pool pointers and cannot perform
+world queries during layout/rendering. Scene replacement does not destroy game-
+instance or persistent player scopes. Player removal does not destroy unrelated
+scene/global UI; viewport replacement does not destroy foreign-owned instances.
+
+Unload closes new commands/input for the scope, cancels/joins preparation and
+binding work, releases focus/capture, publishes removal for every attachment,
+waits for UI/render snapshots and resource leases to retire, destroys runtime
+state, then releases assets. Late completions and stale handles are rejected by
+generation. Repeated unload is idempotent.
+
+### 10. Editor preview is isolated from both editor UI and play state
+
+HoroEditor owns `UiDocument` tabs, dirty/save state, selection, undo/redo,
+inspectors, node/canvas presentation and preview controls. A preview creates an
+isolated game runtime and ordinary typed Runtime UI scopes/attachments. It uses the
+same cook/load/activation/input/layout/extraction/render path as a packaged game.
+
+Editor ImGui IDs, widget pointers, docking, selection, gizmos and transient style
+state never enter the document or runtime. Runtime mutations do not edit the
+authoring document. Applying an admitted preview/play change back requires an
+explicit revision-checked editor command with undo. Closing the tab/project or
+stopping preview follows the normal scope retirement barrier.
+
+### 11. Compatibility, errors and reload preserve the last good generation
+
+Documents, cooked payloads, element/property descriptors, commands, snapshots and
+capabilities are versioned Horo-owned schemas. Unknown required element/property,
+duplicate IDs, malformed trees, dependency/type mismatch, limit overflow,
+unsupported render/input/layout capability, stale owner, or migration failure
+returns a typed error with stable document/scope/element evidence. Backend/vendor
+error enums and editor display strings are translated only at adapters.
+
+Hot reload prepares a complete replacement. Stable authored element IDs may
+reconcile only explicitly compatible state such as focus, scroll or declared
+control value; runtime handles, renderer resources, captures and arbitrary widget
+memory never migrate. Publication swaps one complete generation at a safe point.
+Failure retains the old generation and diagnostic evidence.
+
+Composition is explicit: `Omitted`, `ModelOnly`, or `Rendered`. Headless tools may
+use `ModelOnly` for validation, bindings, layout and Null extraction without a
+window/GPU/input attachment. A product requiring visible/interactable UI fails
+capability preflight if only model/omitted composition is available; no hidden
+window, editor GUI or backend fallback is created.
+
+### 12. Shutdown stops producers before dependencies
+
+Shutdown closes external/editor/gameplay UI command admission and all input
+contexts first. It deactivates scene, player, viewport and game-instance scopes;
+cancels/joins document/resource/binding jobs; publishes final attachment removals;
+waits for UI extraction/render epochs and leases; destroys runtime trees and UI
+resource realizations through their owners; then releases RuntimeUiService before
+Renderer, Assets, Input, Localization or Platform dependencies disappear.
+
+Unexpected failure follows the same bounded retirement where safe. Partial startup,
+failed activation, no viewport, lost renderer and repeated stop are idempotent. A
+timeout or surviving render/resource lease reports terminal/pending failure and
+retains required owner state; it never force-frees memory visible to another frame.
+
+### 13. Migration and verification
+
+Game UI and HUD adopts this four-scope owner model and canonical phase order.
+Runtime Lifecycle records Runtime UI participation without adding phases. Scene,
+Input and Rendering documents project their scope, context and snapshot boundaries.
+RUI-001.2 and later children define exact document/tree schemas, structural
+commands, cook/reload and validation without creating another runtime UI owner.
+
+Required contract coverage includes:
+
+- game-instance/player/scene/viewport scope creation, exact owner identity,
+  persistence across unrelated owner replacement and no silent scope migration;
+- duplicate/missing/malformed stable IDs, stale/cross-scope handles, slot reuse,
+  generation wrap policy and actionable typed diagnostics;
+- partial dependency/asset/style/font/localization/binding failure, transactional
+  activation, required versus optional policy and last-good retention;
+- deterministic owner-command/VariableUpdate/layout/extraction order across zero/
+  multiple fixed ticks and 30/60/144 Hz render cadence;
+- input against last-presented layout while a transient skip preserves its image,
+  unpublished-layout rejection, invalidated-output suppression, UI-local
+  transaction visibility and cross-owner command deferral;
+- gameplay pause, nested pause tokens, single-step, UI time policies, focus loss,
+  host suspension/resume and no suspended-time catch-up;
+- split-screen/multiple viewport/player focus and capture, editor-play priority,
+  modal blocking, text/IME, device/focus loss and scope destruction;
+- screen/world-space extraction, multi-view projection, resize/DPI/safe-area/
+  output/backend replacement and no native/editor types in public snapshots;
+- scene activation/unload/replacement with pending work, player removal, viewport
+  loss, game transition cover persistence, late completion and repeated unload;
+- hot reload state reconciliation by stable authored ID with old runtime/render/
+  input leases retired before reuse;
+- Omitted/ModelOnly/Rendered composition, headless Null extraction and required-
+  capability failure without a hidden window/GUI/backend;
+- editor preview isolation, explicit apply-back command, tab/project/play stop and
+  no editor transient state in documents/runtime;
+- partial startup, renderer loss, shutdown with active scopes/jobs/captures/frames,
+  terminal lease timeout and repeated shutdown.
+
+## Consequences
+
+Global menus, persistent player HUDs, scene overlays and viewport-local surfaces
+can coexist without sharing lifetime or presentation ownership. UI actions target
+what was actually presented, fixed simulation remains deterministic, pause menus
+stay responsive, and renderer/editor/native state stays behind typed adapters.
+
+The cost is explicit scopes, lifecycle transactions, prior-presented interaction
+snapshots, phase cutoffs, generation/lease tracking and separate authoring/runtime/
+render objects. These are required to prevent stale input, dangling scene UI and
+mid-frame mutation.
+
+## Rejected Alternatives
+
+### Put every UI instance in the active scene
+
+Rejected because main/loading UI and persistent player HUDs must survive scene
+replacement, while scene-owned world UI must not outlive its scene.
+
+### Make the viewport own every canvas it displays
+
+Rejected because view attachment is presentation, not semantic ownership. Resize,
+split-screen or renderer replacement must not silently destroy game/player state.
+
+### Represent UI elements as ordinary ECS entities
+
+Rejected because document/tree identity, focus/layout mutation and UI scope lifetime
+differ from scene entity lifetime. Typed bindings connect them without aliasing IDs.
+
+### Update Runtime UI in FixedUpdate
+
+Rejected because pointer/text navigation and presentation animation would depend on
+fixed catch-up count and pause. UI reads committed simulation results in
+VariableUpdate and emits commands for owner safe points.
+
+### Hit-test the newest unpublished layout
+
+Rejected because the player may click geometry that was never presented. Input uses
+the last successfully presented interaction revision.
+
+### Render Runtime UI through ImGui in editor play
+
+Rejected because packaged games, headless tests and renderer peers need the same
+retained Horo snapshots, and editor widget state cannot be runtime identity.
+
+### Let UI callbacks mutate gameplay or renderer state directly
+
+Rejected because it bypasses owner phases, validation, undo/security and lifetime.
+UI emits typed actions/commands to the authoritative owner.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -84,6 +84,7 @@ to the replacement.
 | [070](070-capture-and-voice-io-ownership.md) | Capture and Voice I/O Ownership | Proposed | 2026-09-02 |
 | [071](071-procedural-audio-graph-ownership.md) | Procedural Audio Graph Ownership | Proposed | 2026-09-02 |
 | [072](072-audio-middleware-integration-model.md) | Audio Middleware Integration Model | Proposed | 2026-09-02 |
+| [073](073-runtime-ui-ownership-scope-and-update-order.md) | Runtime UI Ownership, Scope and Update Order | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -187,6 +187,9 @@ dependency direction in [System Design](./foundation/system-design.md).
   maps, focus, capture, modal routing, and simulation input frames.
 - [Game UI And HUD](./runtime/game-ui-and-hud.md): runtime game menus, HUDs,
   canvases, UI primitives, focus/navigation, and UI rendering.
+- [Runtime UI Ownership, Scope and Update Order](../adr/073-runtime-ui-ownership-scope-and-update-order.md):
+  game/player/scene/viewport scopes, lifecycle, frame phases, pause, input,
+  extraction, unload, compatibility, and shutdown.
 - [Networking Architecture](./runtime/networking-architecture.md): optional
   handle-based transports, session/authentication runtime, bounded I/O, and
   remote security.

--- a/docs/architecture/runtime/game-ui-and-hud.md
+++ b/docs/architecture/runtime/game-ui-and-hud.md
@@ -9,6 +9,12 @@ serialization, templates, editor authoring, and package boundaries.
 Game UI is runtime game content. It is not the same system as HoroEditor panels,
 tabs, modals, inspectors, or the editor design-system widgets.
 
+[ADR-073](../../adr/073-runtime-ui-ownership-scope-and-update-order.md) is the
+single normative owner of RuntimeUiService, game/player/scene/viewport scopes,
+instance lifecycle, frame update order, pause/suspension, input/presentation
+revisions, unload, compatibility and shutdown. This document owns the element,
+layout, authoring and product model and projects that lifecycle decision.
+
 ```text
 HoroEditor UI:
   editor tabs, panels, modals, inspector, asset browser, project browser
@@ -24,8 +30,8 @@ belongs to runtime scene/game content.
 ## Core Decisions
 
 - Game UI and HUD are runtime content, not editor UI.
-- The runtime owns a UI element tree, layout, focus, input routing, rendering,
-  serialization, and scene integration.
+- One game runtime owns `RuntimeUiService`; every UI instance has exactly one
+  game-instance, player, scene, or viewport semantic owner scope.
 - HoroEditor authoring tools invoke the same application/runtime UI creation use
   cases as CLI and MCP adapters.
 - Game UI input uses the input action system and supports keyboard, mouse, touch,
@@ -39,21 +45,77 @@ belongs to runtime scene/game content.
 ## Ownership Boundary
 
 ```text
-Scene / Game Runtime
-  +-- UiWorld
-      +-- UiCanvas
-      +-- UiScreen
-      +-- UiElementTree
-      +-- UiLayoutEngine
-      +-- UiFocusGraph
+Application / Game Runtime
+  +-- RuntimeUiService
+      +-- GameInstance scope
+      +-- Player scopes
+      +-- Scene scopes
+      +-- Viewport scopes and attachments
+      +-- UiDocument/runtime-instance registry
+      +-- UiLayout/interaction snapshots
       +-- UiInputRouter
       +-- UiRenderExtractor
       +-- UiBindingStore
 ```
 
-`UiWorld` is owned by the active game or scene runtime. HoroEditor owns only the
-authoring session, previews, inspector panels, and editor commands that modify
-serialized UI content.
+Each runtime instance chooses one scope and cannot silently migrate. Game-instance
+UI such as loading/main menus survives scene replacement. Player UI survives only
+with its generation-checked local player/session. Scene UI ends with its exact
+`SceneRuntimeId`. Viewport UI ends with that logical viewport attachment. Attaching
+game/player/scene UI to a viewport does not transfer semantic ownership.
+
+UI elements have stable authored `UiElementId` values and transient generation-
+checked runtime handles; they are not ordinary ECS entities. HoroEditor owns only
+authoring documents, previews, inspector state and revision-checked editor commands.
+It never owns or lends widget pointers to a game runtime instance.
+
+## Instance Lifecycle And Frame Order
+
+Documents, cooked data, mutable runtime trees, immutable interaction/layout
+snapshots and render snapshots are separate generations. Preparation validates and
+resolves every required dependency privately; activation publishes one complete
+tree at an owner-thread safe point. Failure retains the prior active/last-good
+generation. Scope create/destroy, document replacement and structural transactions
+commit only at ADR-073 lifecycle cutoffs, never during layout or rendering.
+
+Runtime UI uses the existing host phases:
+
+1. owner commands commit lifecycle/resource/structural work before simulation;
+2. fixed simulation publishes gameplay state but does not update the UI tree;
+3. VariableUpdate reads committed binding snapshots, routes input against the
+   last successfully presented interaction layout, applies bounded UI-local state,
+   advances declared UI time, resolves bindings/layout/focus/hit tests, and
+   publishes an immutable generation;
+4. RenderExtraction creates per-view `UiRenderSnapshot` values;
+5. RenderExecution composes world- and screen-space UI; `RenderGui` remains
+   editor/development GUI, not the game UI implementation;
+6. successful presentation adopts the next interaction revision, then deferred
+   lifecycle retirement releases old generations after frame leases close.
+
+UI actions are typed application/gameplay commands. A button handler cannot write
+ECS, renderer, asset or scheduler state directly. Failed or skipped presentation
+suppresses interaction for that viewport until a matching layout is presented, so
+the player cannot click geometry that was never visible.
+
+## Pause, Suspension And Teardown
+
+Gameplay pause stops fixed simulation, not Runtime UI lifecycle, input, layout or
+rendering. UI presentation time is explicitly `PresentationUnscaled`,
+`FollowGameplay` or `Manual`; menus/navigation default to unscaled. Pause/resume is
+requested through the application pause capability, not owned by a UI element.
+Single-step advances one fixed tick followed by one ordinary UI VariableUpdate.
+
+Host suspension skips UI variable/extraction/render work and releases interactive
+capture according to Input policy. Resume resets presentation delta and revalidates
+attachments without catching up suspended wall time. Focus loss is a separate
+product policy and does not automatically pause or destroy UI.
+
+Scene/player/viewport/game teardown closes command and input admission, cancels and
+joins preparation/binding work, releases focus/capture, publishes removal snapshots,
+waits for render/resource leases, destroys runtime state, then releases assets.
+Unrelated scopes survive. Shutdown retires all scopes before Renderer, Assets,
+Input, Localization or Platform dependencies disappear and is idempotent after
+partial activation.
 
 ## Core Runtime UI Primitives
 
@@ -90,6 +152,10 @@ A `UiCanvas` declares:
 - DPI/font scale policy
 - sorting layer and order
 - input scope
+
+The canvas does not choose semantic owner lifetime. Its containing runtime
+instance already names one ADR-073 owner scope, while each viewport attachment
+supplies logical extent, DPI, safe area, view identity and presented revision.
 
 ```cpp
 struct UiCanvasDescriptor {
@@ -189,7 +255,10 @@ Pause menu opens
 ```
 
 High-frequency pointer movement does not travel through data buses. The UI input
-router consumes input snapshots during the runtime frame.
+router consumes input snapshots during VariableUpdate through one per-player/
+viewport `RuntimeUiInputContextId`. It hit-tests the last successfully presented
+interaction revision. Split-screen focus/capture is independent unless an explicit
+game-instance modal policy blocks multiple contexts.
 
 ## Rendering Contract
 
@@ -214,7 +283,9 @@ The UI renderer supports:
 - screen-space and world-space canvas projection
 
 UI render data uses the renderer frontend. It does not call backend APIs from UI
-components.
+components. Viewport attachments and snapshots contain only Horo view/extent/DPI/
+safe-area/resource identities; native surfaces, swapchains, command buffers and
+editor GUI texture IDs remain private to Platform/Renderer adapters.
 
 ## Serialization
 
@@ -343,7 +414,9 @@ HoroEditor provides authoring tools for runtime UI:
 - play-mode preview
 
 The editor authoring UI uses HoroEditor panel/modal systems, but edited content
-remains runtime UI data.
+remains runtime UI data. Preview creates an isolated ordinary game runtime and
+ADR-073 scopes/attachments. Preview/play mutations apply back only through an
+explicit document-revision-checked editor command with undo.
 
 ## Core Vs Package Boundary
 
@@ -389,6 +462,11 @@ Metrics follow [Observability Metrics And Profiling](../observability/observabil
 
 Required tests cover:
 
+- game/player/scene/viewport scope lifetime and unrelated-scope persistence
+- lifecycle activation rollback, scene/viewport unload and repeated shutdown
+- canonical owner-command/VariableUpdate/layout/extraction/presentation order
+- last-presented hit testing across skipped/failed presentation
+- gameplay pause, single-step, UI time policy and host suspension/resume
 - layout determinism across reference resolutions
 - safe-area and scaling behavior
 - focus graph navigation with keyboard and gamepad
@@ -404,6 +482,8 @@ Required tests cover:
 
 - [UI Canvas Editor UI Reference](./ui-canvas-editor.html): widget palette, hierarchy, anchors, and design-time canvas preview panel.
 
+- [Runtime Lifecycle](./runtime-lifecycle.md): frame phases, pause, suspension and
+  shutdown order specialized by ADR-073.
 - [Input Architecture](./input-architecture.md): action maps, gamepad, focus, and
   interaction scopes.
 - [Rendering Architecture](./rendering-architecture.md): render extraction,

--- a/docs/architecture/runtime/input-architecture.md
+++ b/docs/architecture/runtime/input-architecture.md
@@ -37,6 +37,7 @@ RawInputSnapshot
 Input Router + Action Maps
        |
        +-- GUI text/navigation input
+       +-- Runtime UI player/viewport contexts
        +-- Editor commands and viewport controls
        +-- Gameplay InputFrame
 ```
@@ -135,6 +136,22 @@ available only where policy allows it.
 
 Contexts are pushed and removed through RAII tokens. A destroyed tab, modal,
 tool, or play session cannot leave an active context behind.
+
+[ADR-073](../../adr/073-runtime-ui-ownership-scope-and-update-order.md) adds
+generation-checked `RuntimeUiInputContextId` values per interactive player/
+viewport attachment. In a packaged game, the top eligible runtime UI modal/route
+precedes its associated gameplay context. In editor play, native dialogs, editor
+modals and the focused editor widget/tool precede Runtime UI; the game UI context
+is eligible only when its embedded game viewport owns focus. Runtime UI cannot
+consume editor shortcuts from an unfocused viewport.
+
+Runtime UI pointer/focus routing uses the last successfully presented
+`UiInteractionSnapshot`, not an unpublished layout. Failed/skipped presentation,
+scope or viewport destruction, route replacement, focus/device loss, suspension
+and shutdown neutralize the context and release capture. Split-screen players keep
+independent focus/capture unless an explicit game-instance modal policy blocks
+them. UI actions are typed application/gameplay commands for owner safe points,
+not direct ECS mutations from input handlers.
 
 ## Focus And Capture
 

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -1064,6 +1064,30 @@ batches stay off GPU Scene slots.
 Multiple views, including game, scene viewport, thumbnails, and previews, use
 separate `RenderView` descriptors over compatible snapshots.
 
+## Runtime UI Projection
+
+[ADR-073](../../adr/073-runtime-ui-ownership-scope-and-update-order.md) keeps
+Runtime UI semantic state in `RuntimeUiService` and gives Renderer only immutable
+per-view `UiRenderSnapshot` values. A snapshot names Horo logical UI/viewport/view/
+layout/resource generations and contains bounded draw, text, clip and projection
+data. It never contains mutable UI trees, ECS/component pointers, editor widgets,
+ImGui IDs, native surfaces, swapchains, command buffers or backend handles.
+
+World-space canvases project as ordinary view-dependent render instances under
+declared depth/visibility policy. Screen-space canvases are frontend-owned passes
+composed after world/display transform unless an explicit render plan declares an
+earlier point. Runtime UI is part of `RenderExecution`; `RenderGui` remains the
+separate host/editor/development GUI phase. A backend cannot reorder UI by native
+convenience or make editor GUI composition the packaged-game path.
+
+Viewport resize, DPI/safe-area/output change, backend replacement and resource
+reload prepare complete new attachment/layout/render generations. In-flight frames
+pin the old snapshot/resources until deferred retirement. Render completion returns
+a typed presented/skipped/failed result correlated to the UI interaction revision;
+RuntimeUiService, not Renderer, decides when that revision becomes eligible for
+next-frame input. Failed/skipped presentation cannot silently adopt unpublished
+hit-test geometry.
+
 The [VFX contract](./vfx-and-particles-architecture.md) extends the snapshot with
 bounded immutable GPU simulation work, CPU/GPU particle sources, decals and volume
 batches. VfxRenderExtractor never submits graph passes or writes mapped GPU buffers.

--- a/docs/architecture/runtime/runtime-lifecycle.md
+++ b/docs/architecture/runtime/runtime-lifecycle.md
@@ -35,6 +35,7 @@ Process Host
   +-- Audio Runtime (optional)
   +-- Network Runtime (optional)
   +-- Renderer (optional)
+  +-- Runtime UI Service (optional model-only or rendered composition)
   +-- Application Services
   +-- Runtime Console Service (optional)
   +-- MCP Service (optional)
@@ -72,10 +73,11 @@ Startup order:
 5. construct platform, jobs, data bus, and asset services
 6. initialize the requested omitted/null/device audio composition through ADR-062
 7. initialize requested renderer and window capabilities
-8. construct application services
-9. load project and initial scene through application use cases
-10. start optional runtime console, MCP, and GUI adapters
-11. enter `Ready`, then `Running`
+8. initialize the selected omitted/model-only/rendered Runtime UI composition
+9. construct application services
+10. load project and initial scene through application use cases
+11. start optional runtime console, MCP, and GUI adapters
+12. enter `Ready`, then `Running`
 
 Arguments, environment, and persisted settings are resolved through
 [Configuration System](../foundation/configuration-system.md). Startup failures return
@@ -132,6 +134,16 @@ callback queues and publishes bounded callback work; deferred lifecycle commit
 retires acknowledged scene-context barriers; `EndFrame` publishes bounded
 control snapshots. The hardware callback advances on its independent sample
 clock and never calls runtime phases.
+
+[ADR-073](../../adr/073-runtime-ui-ownership-scope-and-update-order.md) specializes
+Runtime UI without adding phases. Owner commands commit scope/document/resource
+lifecycle work. FixedUpdate publishes gameplay state but never advances UI.
+VariableUpdate routes input against the last successfully presented interaction
+snapshot, resolves committed bindings and publishes layout/focus/hit-test state.
+RenderExtraction emits immutable per-view UI snapshots and RenderExecution composes
+them. Runtime game UI is not `RenderGui`; that phase remains host/editor/development
+GUI composition. Presentation success adopts the next interaction revision and
+deferred lifecycle commit retires old scope/render generations.
 
 ## Time Model
 
@@ -254,7 +266,7 @@ Variable update is used for:
 
 - editor camera and presentation behavior
 - interpolation of committed animation poses and isolated editor preview playback
-- non-simulation UI state
+- Runtime UI input, binding, presentation animation and layout under ADR-073
 - job progress and query refresh
 - audio presentation updates where supported
 - streaming and resource coordination
@@ -314,6 +326,13 @@ subsystem order; it does not consume accumulated wall time. Authoritative animat
 therefore holds during pause and advances once during a successful step. Isolated
 editor preview may advance only under its separate preview controls.
 
+Runtime UI continues its ordinary VariableUpdate/input/layout/render path while
+gameplay is paused. Menus/navigation/accessibility feedback use declared unscaled
+presentation time by default; `FollowGameplay` UI animation freezes and `Manual`
+time advances only by owner command. A UI action requests pause through the
+application pause capability and never owns scheduler tokens directly. After
+single-step, UI observes the newly committed tick in one normal VariableUpdate.
+
 ### Runtime Console And Development Overlays
 
 The runtime console and development overlays are lifecycle participants when the
@@ -356,6 +375,10 @@ work. ADR-062 keeps the bounded audio lifecycle/control subset serviceable on
 the remaining owner-thread boundaries; the callback follows only committed audio
 suspend policy.
 
+Runtime UI performs no VariableUpdate, input dispatch, extraction or render work
+while suspended; interactive capture is released and resume revalidates viewport
+attachments with a zero-delta baseline. Suspended wall time is not UI catch-up.
+
 ## Fatal Failure
 
 A fatal runtime failure:
@@ -379,15 +402,17 @@ Canonical shutdown:
 4. cancel and join host-scoped jobs
 5. stop MCP, networking, and other transports
 6. drain owner-thread continuations
-7. release GUI and editor sessions
-8. destroy scene/project/application services after closing their renderer and
+7. close Runtime UI command/input admission, retire every scope/attachment, join
+   UI work, and release UI render/resource leases
+8. release GUI and editor sessions
+9. destroy scene/project/application services after closing their renderer and
    audio producer ports
-9. wait for renderer idle as required and destroy GPU resources
-10. quiesce/detach the audio callback, reconcile terminal outcomes,
+10. wait for renderer idle as required and destroy GPU resources
+11. quiesce/detach the audio callback, reconcile terminal outcomes,
    and release device-owned resources under ADR-062
-11. destroy remaining asset, data-bus, job, and platform services
-12. flush observability and write clean-shutdown marker
-13. transition to `Stopped`, unless a subsystem's documented fatal-retention path
+12. destroy remaining asset, data-bus, job, and platform services
+13. flush observability and write clean-shutdown marker
+14. transition to `Stopped`, unless a subsystem's documented fatal-retention path
     requires immediate process termination without normal reclamation
 
 Shutdown may be requested more than once but executes its transitions once.
@@ -398,6 +423,11 @@ Headless commands use the same initialization graph with omitted capabilities.
 A command that requires rendering explicitly requests the null or a real
 renderer. Headless execution does not create a hidden window merely to satisfy
 an accidental dependency.
+
+Runtime UI composition is independently `Omitted`, `ModelOnly`, or `Rendered`.
+Model-only headless tools may validate documents, bindings, layout and Null
+extraction without a viewport/input/GPU. A request requiring visible or interactive
+UI fails capability preflight instead of creating a hidden window or editor GUI.
 
 ## Testing
 
@@ -419,6 +449,8 @@ Required tests cover:
 - repeated shutdown requests
 - shutdown with running jobs and renderer resources
 - headless lifecycle without GUI or graphics
+- Runtime UI phase order across zero/multiple fixed ticks, gameplay pause/step,
+  suspension, failed presentation, scene/viewport teardown and shutdown
 
 ## Related Documents
 

--- a/docs/architecture/runtime/scene-runtime.md
+++ b/docs/architecture/runtime/scene-runtime.md
@@ -142,6 +142,26 @@ and authoring conveniences. Runtime modules do not parse it directly.
 `RuntimeSceneDefinition` contains validated, typed, backend-neutral data needed
 to instantiate a runtime scene.
 
+## Runtime UI Scope Boundary
+
+[ADR-073](../../adr/073-runtime-ui-ownership-scope-and-update-order.md) makes
+`RuntimeUiService` an application/game-runtime service rather than a SceneRuntime
+subsystem. A scene may declare scene-scoped UI documents and stable scene/object/
+component bindings, but the resulting UI elements are not ECS entities and the UI
+tree does not live in component pools.
+
+Scene UI preparation may accompany a scene candidate. Activation waits for the
+exact `SceneRuntimeId` generation and publishes before that scene's first eligible
+Runtime UI VariableUpdate/extraction. Bindings and world anchors are immutable
+generation-tagged snapshots; UI never retains component-pool pointers or performs
+world queries during layout/rendering.
+
+Scene unload closes its UI scope and input admission, cancels/joins pending UI
+work, publishes removal for attached views, waits for UI/render/resource leases,
+then releases scene UI state. Game-instance and persistent player UI survive scene
+replacement; viewport replacement does not transfer or destroy foreign semantic
+ownership. Late completions and stale references fail by generation.
+
 ## Runtime Identity
 
 ```cpp


### PR DESCRIPTION
## Summary

- Establishes one `RuntimeUiService` per game-instance runtime as the sole semantic owner of runtime UI.
- Defines exact GameInstance, Player, Scene, and Viewport ownership scopes; generation-safe identity; transactional lifecycle; canonical input/update/extraction/render ordering; pause/headless/editor behavior; and ordered retirement.
- Projects ADR-073 into Game UI and HUD, Runtime Lifecycle, Scene, Input, and Rendering architecture.

## Why

Runtime UI crosses scene, player, viewport, input, renderer, editor, and host lifecycle boundaries. Without a single owner and phase contract, scene UI can outlive its scene, player UI can be destroyed during scene replacement, input can target geometry that was never presented, or renderer/editor/native state can leak into the runtime model.

## Decision and boundaries

- Every UI instance has exactly one generation-checked owner scope; viewport attachment is presentation and never transfers ownership.
- Authored document/element IDs are stable and serializable; transient runtime/element handles, focus, layout, capture, animation cursors, and renderer resources are not.
- Lifecycle preparation and replacement are transactional and preserve the last-good generation on failure.
- Runtime UI updates during `VariableUpdate`, routes input against valid last-presented interaction evidence, extracts immutable per-view snapshots, and remains separate from host/editor `RenderGui`.
- Gameplay pause does not deactivate UI; each presentation animation selects an explicit unscaled, gameplay-following, or manual time policy.
- Headless composition is explicitly `Omitted`, `ModelOnly`, or `Rendered`; `ModelOnly` needs no hidden window or GPU.

## Review findings addressed

- Defined fixed 128-bit runtime/element identity using a nonzero 64-bit ownership generation, 32-bit slot, and nonzero 32-bit slot generation.
- Defined non-wrapping overflow: an exhausted slot is permanently retired; ownership-generation exhaustion closes admission with `GenerationExhausted` and requires host-owned runtime replacement.
- Clarified skipped-frame input: when the old image remains visible, input continues only against the last successfully presented snapshot; unpublished layouts are never hit-tested. Missing, retired, or invalidated presentation evidence disables interaction until a matching revision is shown.
- Confirmed required coverage already includes owner-scope survival, last-good activation rollback, pause behavior, split-screen focus/capture, and GPU/window-free ModelOnly execution.
- Reviewed the ADR index report; ADR-073 already uses the same single leading pipe as adjacent CommonMark rows, so a second pipe would create an empty column.
- Resolved the replay conflict by integrating Runtime UI retirement into the latest shutdown sequence while preserving ADR-062’s fatal-retention termination exception.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- <changed Markdown files>`
- `git diff origin/main --check`
- Added-link existence check over the Markdown diff
- Architecture placeholder scan: no matches
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. It reported the existing mbedTLS deprecation warning and skipped repository Python tests because `pytest` is unavailable.

## Risk and rollout

- ABA identity reuse is prevented by fixed-width non-wrapping generation rules and permanent slot retirement at exhaustion.
- Routing against a newly published but unpresented layout would violate “click what you see”; the contract distinguishes a harmless skipped frame that leaves prior pixels visible from invalidated presentation state.
- UI shutdown must precede Renderer, Assets, Input, Localization, and Platform destruction while retaining any state still leased by in-flight frames.
- Delivery is architecture-only. Document schemas, tree commands, cook/reload, runtime implementation, and tests follow in RUI-001 child tickets.

## Issue links

- Jira: [HORO-698](https://horo-engine.atlassian.net/browse/HORO-698)
- GitHub: Closes #698

## Reviewer notes

Review ADR-073 sections 2-5 for ownership, identity, lifecycle, and skipped-frame behavior; then sections 11-13 for compatibility, composition, shutdown, and verification. Runtime Lifecycle contains the conflict-resolved shutdown projection.


[HORO-698]: https://horo-engine.atlassian.net/browse/HORO-698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ