### PR TITLE
docs(ui): define presentation route architecture HORO-768 #768 [RUI-008.1]

### DIFF
--- a/docs/adr/073-runtime-ui-ownership-scope-and-update-order.md
+++ b/docs/adr/073-runtime-ui-ownership-scope-and-update-order.md
@@ -116,6 +116,10 @@ attachment are orthogonal typed state; they are not lifecycle aliases. Hiding an
 instance does not destroy it, pausing gameplay does not deactivate it, and a
 temporarily unavailable viewport does not transfer it to another owner.
 
+[ADR-080](080-runtime-ui-presentation-scope-layer-and-route.md) projects these
+owner scopes into typed presentation bands and transactional route stacks without
+changing ownership or lifetime authority.
+
 Scope create/destroy, document replacement and cross-tree structural transactions
 commit during `ApplyQueuedOwnerThreadCommands`, or at the next
 `CommitDeferredLifecycleChanges` when requested after that frame's command cutoff.

--- a/docs/adr/080-runtime-ui-presentation-scope-layer-and-route.md
+++ b/docs/adr/080-runtime-ui-presentation-scope-layer-and-route.md
@@ -1,0 +1,404 @@
+# ADR-080: Runtime UI Presentation Scope, Layer and Route
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Runtime UI presentation dimensions, persistent/player/scene/viewport ownership projection, world/HUD/screen/overlay/modal/loading/debug bands, route/stack identity and transactions, visibility/coverage/input/transition semantics, loading/debug policy, rendering, errors, compatibility, and shutdown
+- **Issue**: [RUI-008.1](https://github.com/abdullahbodur/horo-engine/issues/768)
+- **Jira**: [HORO-768](https://horo-engine.atlassian.net/browse/HORO-768)
+- **Parent**: [RUI-008](https://github.com/abdullahbodur/horo-engine/issues/767)
+- **Related**: [ADR-033](033-presentation-and-display-ownership.md), [ADR-073](073-runtime-ui-ownership-scope-and-update-order.md), [ADR-077](077-runtime-ui-animation-clock-and-time-domain.md), [ADR-078](078-runtime-ui-input-context-and-player-routing.md)
+- **Normative documents**: [Game UI and HUD](../architecture/runtime/game-ui-and-hud.md), [Runtime Lifecycle](../architecture/runtime/runtime-lifecycle.md), [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
+
+## Context
+
+Runtime UI includes persistent menus and transition covers, per-player HUDs,
+scene-owned world/screen overlays, viewport-local masks, modal dialogs, loading
+presentation and development diagnostics. These concepts overlap but are not one
+hierarchy. A persistent player HUD can render in the HUD band, a scene-owned route
+can present as a modal, and a game-instance loading cover can hide all player stacks
+without owning or destroying them.
+
+If one `layer` field controls lifetime, z-order, input and route navigation, moving
+content visually can accidentally transfer ownership or destroy state. Arbitrary
+integer z values and backend draw order would make modal/loading priority
+non-portable. A process-global route stack would let split-screen players replace
+each other's screens, while a separate uncoordinated stack per viewport could fail
+to enforce a game-instance modal or loading cover.
+
+ADR-073 owns GameInstance/Player/Scene/Viewport semantic lifetime. ADR-078 owns
+input audiences/modal exclusivity. ADR-077 owns screen-transition clocks. This
+decision composes those axes into one presentation/route contract without changing
+their authorities. RUI-008.2 through RUI-008.10 implement stack operations,
+modal/focus, async loading/recovery, HUD association, persistence, loading,
+cinematic suppression, split screen and qualification within it.
+
+## Decision
+
+### 1. Ownership, audience, route, band and visibility are separate dimensions
+
+Every presented route/instance records five independent typed facts:
+
+1. ADR-073 `UiOwnerScope`: who owns semantic state/lifetime;
+2. ADR-078 `UiInputAudience`: which player(s)/game instance may interact;
+3. `UiRouteInstanceId`/stack: navigation identity and transactional history;
+4. `UiPresentationBand`: ordered composition/input role;
+5. `UiRouteVisibilityState`: current presentation eligibility without ownership
+   transfer.
+
+`Persistent` is not a magic visual layer. GameInstance-owned UI persists across
+scene/player/viewport replacement; Player-owned UI persists across scenes only with
+that player; Scene/Viewport UI ends with its exact owner. A route cannot extend a
+scope's lifetime by setting a persistent flag, and attaching it to another viewport
+does not transfer ownership.
+
+Changing band, audience, owner scope or stack is a typed replacement transaction,
+not mutation of one ambiguous integer. Renderer, Input and editor widgets consume
+the resolved plan; none infer semantic ownership from draw order or visibility.
+
+### 2. Route and stack identities are stable and generation checked
+
+The model uses:
+
+- `UiRouteId`: stable authored route definition identity;
+- `UiRouteInstanceId`: generation-checked activation of one route/document/owner;
+- `UiRouteStackId`: one stack owned by an exact game/player/audience scope;
+- `UiRouteOperationId`: one idempotent transactional navigation request;
+- `UiPresentationLayerId`: one band-local route/layer generation;
+- `UiPresentationPlanId`: immutable per-view resolved composition generation.
+
+Serialized route definitions reference stable route/document/style/binding/transition
+IDs and typed policies. They never store stack indexes, live route instances,
+viewport slots, editor tabs, ImGui IDs, native window/surface handles, backend z
+values or transition cursors.
+
+Stack positions/handles are process-local and generation checked. A pop/replace/
+completion names expected stack/top/route generations; stale or duplicate operations
+fail/idempotently return their prior result and cannot target a reused slot.
+
+### 3. Core presentation bands have fixed order and roles
+
+Core bands, low to high, are:
+
+```cpp
+enum class UiPresentationBand : std::uint8_t {
+    World,
+    Hud,
+    Screen,
+    Overlay,
+    Modal,
+    Loading,
+    Debug,
+};
+```
+
+| Band | Role | Default owner/audience/input |
+|---|---|---|
+| `World` | World-space canvases and scene/view annotations | Usually Scene/Player; view/depth policy; no screen-stack takeover |
+| `Hud` | Persistent player/game status presentation | Player or GameInstance; non-exclusive unless declared control handles input |
+| `Screen` | Full-page routes such as menu, inventory, map, pause | GameInstance/Player/Scene; stack navigation and route focus |
+| `Overlay` | Toasts, prompts, subtitles, temporary panels | Any compatible owner; non-exclusive by default |
+| `Modal` | Confirmation/blocking route above associated stacks | Any compatible owner plus ADR-078 Viewport/Player/GameInstance exclusivity |
+| `Loading` | Boot/scene transition/fatal recovery cover | GameInstance owner; host/application controlled; global cover policy |
+| `Debug` | Development/diagnostic overlays | GameInstance/Viewport in admitted non-shipping/diagnostic profiles; non-interactive by default |
+
+Native/host-critical dialogs remain outside Runtime UI and above its input stack.
+The fixed band order is product semantics, not renderer/backend convenience. A
+package may register a finite sublayer within an allowed band through a versioned
+namespace/permission, but cannot insert above Loading/Debug, redefine core order or
+gain modal/global input authority merely by choosing a band.
+
+Within one band/view, stable order is game-instance policy group, audience/player
+order, route stack depth, declared bounded band-local order, element paint order and
+stable IDs. Pointer address, hash/load completion, native window order and backend
+batch order never break ties.
+
+### 4. Route stacks are scoped, with explicit cross-stack arbitration
+
+One game runtime may own:
+
+- a game-instance route stack for global/persistent screens;
+- one or more per-player route stacks;
+- scene-local stacks tied to exact `SceneRuntimeId` generations;
+- viewport-local stacks tied to exact attachments;
+- a host-controlled Loading stack and profile-gated Debug layers.
+
+A stack cannot directly pop/replace a route in another stack. Cross-stack effects
+are explicit arbitration records:
+
+- a game-instance modal may cover/block selected or all player/viewport stacks;
+- Loading may cover every production stack while leaving them alive;
+- a player modal covers only that player's admitted stacks unless authorized as
+  game-instance scope;
+- scene unload retires its stacks/routes but does not pop game/player routes;
+- viewport replacement retires only viewport-owned stacks and reattaches foreign-
+  owned routes through explicit attachment reconciliation.
+
+Covered stacks retain semantic state/declared update policy but lose input and
+presentation eligibility according to the covering route. They are not removed or
+reparented. Arbitration is part of one immutable presentation plan generation.
+
+### 5. Route operations prepare then commit atomically
+
+Version 1 operations are `Push`, `Pop`, `ReplaceTop`, `Reset`, `ShowOverlay`,
+`Dismiss` and typed cover/suppression requests. RUI-008.2 may implement them but
+must preserve this transaction:
+
+```text
+Requested -> Preparing -> Ready -> Committing -> Entering -> Active
+                 \-> Failed/RolledBack
+Active -> Exiting -> Retiring -> Destroyed
+```
+
+Preparation resolves the route definition, owner/audience/stack/band policy,
+document/style/font/image/binding/input/transition dependencies and capacity in a
+private candidate. It does not remove or hide the current route. Commit validates
+expected stack/top/owner generations and atomically publishes the new stack plus
+presentation/input/transition plan at an ADR-073 safe point.
+
+Failure/cancellation before commit preserves the previous stack/focus/input/
+presentation generation. After commit, entry failure follows the route's explicit
+rollback, fallback-route or fail-closed policy; no half-visible stack mutation is
+published. Operations arriving after the cutoff commit in a later generation.
+
+### 6. Visibility and lifecycle states are not aliases
+
+`UiRouteVisibilityState` distinguishes:
+
+- `Entering`: committed route preparing first eligible presentation;
+- `Visible`: active in a presentation plan;
+- `Covered`: retained beneath a covering route/band and ineligible for ordinary
+  input;
+- `Suppressed`: explicitly hidden by product/cinematic/accessibility policy while
+  owner/route state remains;
+- `Suspended`: host/background/attachment policy holds update and presentation;
+- `Exiting`: committed exit transition/lifecycle;
+- `Retiring`: no new update/input/presentation; waiting for leases.
+
+Visibility does not create/destroy semantic state, imply modal input, transfer
+ownership or reset route history. Update policies while Covered/Suppressed are
+explicit: `HoldPresentationOnly`, `UpdateBindings`, or `UpdateAllNonInteractive`.
+No covered route receives input or emits ordinary actions. Simulation-bound UI may
+observe later committed data when uncovered; it cannot replay hidden input.
+
+HUD/cinematic suppression is reference-counted/owner-token policy rather than a
+global boolean. Removal/expiry restores only the affected band/route generation and
+does not override a newer suppression owner.
+
+### 7. Input activation follows the resolved route plan and presentation
+
+Each interactive route creates an ADR-078 context naming exact route/stack/band/
+audience/viewport/interaction generations. `Hud`, `Screen` and `Overlay` default to
+non-exclusive handled-only input; `Modal` declares Viewport/Player/GameInstance
+exclusivity; Loading admits only its host-approved cancel/retry/accessibility
+actions; Debug is non-interactive unless a development capability explicitly
+creates a separate editor/diagnostic context.
+
+Entering routes do not become input eligible until their first matching
+`UiInteractionSnapshot` is successfully presented. This prevents navigation/
+submission against invisible geometry. Covered/Suppressed/Suspended/Exiting/
+Retiring routes are ineligible, release affected capture/text composition, and
+preserve/restore focus through ADR-078 route-generation tokens.
+
+A visual band or high draw order never grants exclusivity. Conversely an ADR-078
+exclusive modal blocks associated lower contexts even if its visible element does
+not handle an action. Route plan and input context publication are one transaction.
+
+### 8. Transitions are bound to exact route generations
+
+Entry/exit/cover/uncover/suppression transitions use ADR-077 `ScreenTransition`
+timelines owned by one exact route/stack/layer generation. Transition descriptors
+do not own navigation or visibility; route lifecycle selects their gate and consumes
+their typed completion/cancellation evidence.
+
+A required finite entry transition may delay `Visible`/input eligibility and a
+required finite exit transition may delay `Retiring` only within declared deadlines.
+Optional/infinite decorative motion never blocks stack progress. Reduced-motion
+policy may resolve a transition to zero duration while completing the same route
+transaction in that VariableUpdate.
+
+Replace/pop/owner destruction, route operation rollback, dependency failure,
+suspension policy and shutdown cancel old timelines exactly once. A late completion
+cannot activate or retire a route generation that has been replaced.
+
+### 9. Loading is a game-instance transition cover, not scene state
+
+Loading routes that must span scene replacement are GameInstance-owned and live in
+the host-controlled Loading stack. They may bind immutable progress/status/error/
+retry snapshots through explicit providers but cannot poll jobs, block streaming
+threads, own scene lifetime or invoke renderer/native presentation directly.
+
+Loading commit can cover current scene/player/viewport stacks before destructive
+transition work begins. Removing the cover requires the target route/scene/UI
+generation to be active and successfully presented according to policy; otherwise
+the last-good loading/recovery route remains. Scene unload cannot destroy it.
+
+Boot/fatal recovery may use a minimal declared dependency profile. Missing required
+loading UI in a product profile fails startup/transition according to host policy;
+it does not silently reveal partially initialized gameplay. RUI-008.7 owns detailed
+startup/progress/retry behavior within this boundary.
+
+### 10. Debug presentation is isolated and non-authoritative
+
+Debug routes/layers are admitted only in development/diagnostics profiles or an
+explicit authenticated developer capability. They consume bounded redacted
+observability/snapshot data and cannot mutate gameplay/UI/renderer state without a
+separate typed authorized command.
+
+Debug draws above Runtime UI production bands for inspection but is non-interactive
+and click-through by default. If interactive, it receives a distinct high-priority
+editor/diagnostic context and cannot masquerade as a production modal/loading route.
+It does not participate in packaged product route history, accessibility claims or
+save/restore state unless a product explicitly promotes a feature to a production
+band.
+
+Omitted Debug support is a valid shipping composition. It does not create a hidden
+ImGui/console overlay, native surface or renderer backend dependency.
+
+### 11. Rendering consumes one immutable per-view presentation plan
+
+Runtime UI resolves owner/audience/stack/band/visibility/attachment state into one
+immutable `UiPresentationPlan` per view. The plan contains ordered Horo route/layer/
+layout/style/resource snapshot identities, world/screen composition roles, clip and
+interaction revisions. It contains no mutable stack, editor widgets, ImGui draw
+lists, native surfaces/swapchains, command buffers or backend z handles.
+
+Render extraction uses the plan once; backend batching may combine equal paint
+state but cannot reorder across semantic bands/layers, uncover routes, choose a
+loading/debug fallback or advance transitions. Successful presentation correlates
+the exact plan/interaction revisions before newly entering routes become input
+eligible. Failed/skipped presentation leaves prior last-presented interaction
+evidence and route input suppressed.
+
+World band participates in declared view/depth passes; screen-space bands compose
+at frontend-owned points. Renderer/device/output replacement builds a new plan/
+resource generation while old frames retain leases; route semantic state survives
+unless its actual owner ends.
+
+### 12. Persistence, save/restore and compatibility are explicit
+
+Route definition/stack policy/cooked descriptors are versioned semantic data.
+Runtime stack/route instances, focus/capture, transition cursors, visibility covers,
+loading progress and debug layers are transient unless a later save contract
+explicitly serializes stable route state.
+
+Restoration resolves stable `UiRouteId`, owner/audience role and declared semantic
+state into fresh generation-checked instances; it never restores stack slots,
+pointers or old viewport/native identity. Missing/incompatible routes apply explicit
+required/optional/fallback migration policy.
+
+Unknown required band, owner/audience, operation, visibility/update, input,
+transition or cover policy rejects and requests recook/migration. Package sublayers
+must name a compatible registered namespace/permission and cannot alter core band
+order.
+
+### 13. Errors, limits and shutdown are typed
+
+Errors follow ADR-008 with stable reason codes for unknown/duplicate/stale route/
+stack/operation/layer/plan, owner/audience/viewport mismatch, forbidden band/scope,
+invalid order/cover/modal/visibility/transition, missing dependency/fallback,
+capacity/deadline, cancellation, presentation failure, version mismatch and
+shutdown. Context includes bounded route/stack/owner/audience/band/generation
+evidence without user text or native/editor/backend state.
+
+Limits cover stacks/routes/layers per owner/view, operation queue, preparation work,
+band-local order, simultaneous covers/modals/loading/debug layers, transition
+blockers, retained plans/generations and diagnostics. Exhaustion rejects/backpressures
+before commit or retains the last-good route/cover; it never partially mutates a
+stack or drops a required loading/modal barrier.
+
+Shutdown closes route operations/input, cancels preparation/transitions, commits
+all stacks/routes to Exiting/Retiring without admitting callbacks, publishes final
+empty plans, waits input/render/resource/provider leases, then destroys route state
+before Runtime UI dependencies disappear. Repeated/partial shutdown is idempotent.
+
+### 14. Verification is part of the contract
+
+Required coverage includes:
+
+- GameInstance/Player/Scene/Viewport ownership crossed with every compatible band,
+  no persistence flag lifetime extension and no attachment ownership transfer;
+- stable route/stack/operation/layer/plan IDs, stale/duplicate operations and slot
+  reuse;
+- exact core band/order and deterministic game/audience/stack/local/paint tie order;
+- independent game/player/scene/viewport stacks and game modal/loading cross-stack
+  cover without destroying covered routes;
+- Push/Pop/Replace/Reset/overlay/dismiss prepare/commit/rollback/fallback and
+  dependency/capacity/cancellation failure;
+- Entering/Visible/Covered/Suppressed/Suspended/Exiting/Retiring update/input/focus/
+  capture semantics and reference-counted suppression restoration;
+- first-successful-presentation input gate, exclusive modal blocking and
+  failed/skipped presentation;
+- required/optional/zero-duration/reduced-motion entry/exit transitions, deadlines,
+  replacement and stale completion;
+- game-instance loading across scene unload/replacement, last-good recovery and no
+  blocking job/native/renderer ownership;
+- Debug omitted/non-interactive/authorized-interactive profiles and no production
+  authority or hidden ImGui path;
+- multi-player/split-screen/multi-view route plans, viewport replacement, world/
+  screen composition and backend/device/output replacement leases;
+- malformed/version-skewed policies, package sublayer permissions, limits,
+  redacted diagnostics, save/restore migration and repeated shutdown.
+
+Property tests generate route stacks/operations/covers and verify owner lifetime,
+plan ordering and rollback. Screenshot/video tests may qualify presentation later,
+but cannot replace semantic stack/plan/input/lifecycle tests.
+
+## Consequences
+
+Persistent menus, per-player HUDs, scene/viewport overlays, modals, loading covers
+and debug presentation coexist without conflating lifetime, z-order, input and
+navigation. Split-screen stacks remain independent while global modal/loading
+policy can cover them transactionally, and Renderer receives one portable plan.
+
+The cost is multiple explicit dimensions, generation-scoped route/stack/operation/
+plan identity, prepare/commit/rollback, fixed bands, cover/suppression policy and
+lease-based retirement. Content cannot rely on arbitrary z integers or one global
+stack.
+
+## Rejected Alternatives
+
+### Put persistence, player/scene/viewport scope and visual layer in one enum
+
+Rejected because lifetime, audience and composition are orthogonal. Combining them
+prevents valid pairs and lets visual moves change ownership.
+
+### Use arbitrary integer z-order across all Runtime UI
+
+Rejected because modal/loading/debug priority and package permissions become
+content/backend order rather than typed product policy.
+
+### Keep one process-global route stack
+
+Rejected because split-screen players, scenes, viewports and multiple game runtimes
+need independent navigation/lifetime with explicit global arbitration.
+
+### Let each viewport own every route it displays
+
+Rejected because persistent game/player UI may attach to multiple/replacement
+viewports without transferring semantic state.
+
+### Mutate the active stack before dependencies are ready
+
+Rejected because failure leaves partial visibility/input/focus state. Operations
+prepare privately and commit atomically with rollback/fallback.
+
+### Make visibility equivalent to route lifetime
+
+Rejected because covered/suppressed HUD/screens must retain owner state and restore
+without recreation, while destroyed owners must retire even if still visible.
+
+### Activate route input before first presentation
+
+Rejected because invisible geometry/focus could consume navigation or submit. Input
+starts only after a matching interaction revision is presented.
+
+### Make Loading scene-owned
+
+Rejected because it must survive scene unload/replacement and cover failure/recovery.
+Transition loading is GameInstance-owned host-controlled presentation.
+
+### Implement Debug as an always-present ImGui overlay
+
+Rejected because packaged/headless/runtime renderer compositions cannot depend on
+editor GUI state and debug must not gain hidden input or mutation authority.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -91,6 +91,7 @@ to the replacement.
 | [077](077-runtime-ui-animation-clock-and-time-domain.md) | Runtime UI Animation Clock and Time Domain | Proposed | 2026-09-02 |
 | [078](078-runtime-ui-input-context-and-player-routing.md) | Runtime UI Input Context and Player Routing | Proposed | 2026-09-02 |
 | [079](079-runtime-ui-binding-provider-schema-identity-and-lifetime.md) | Runtime UI Binding Provider Schema, Identity and Lifetime | Proposed | 2026-09-02 |
+| [080](080-runtime-ui-presentation-scope-layer-and-route.md) | Runtime UI Presentation Scope, Layer and Route | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -208,6 +208,10 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Runtime UI Binding Provider Schema, Identity and Lifetime](../adr/079-runtime-ui-binding-provider-schema-identity-and-lifetime.md):
   typed provider/property schemas, scoped instances, immutable read snapshots,
   owner-validated writes, registration/revocation, module unload, and compatibility.
+- [Runtime UI Presentation Scope, Layer and Route](../adr/080-runtime-ui-presentation-scope-layer-and-route.md):
+  orthogonal owner/audience/route/band/visibility dimensions, fixed presentation
+  bands, transactional scoped stacks, loading/debug policy, input, transitions,
+  and immutable rendering plans.
 - [Networking Architecture](./runtime/networking-architecture.md): optional
   handle-based transports, session/authentication runtime, bounded I/O, and
   remote security.

--- a/docs/architecture/runtime/game-ui-and-hud.md
+++ b/docs/architecture/runtime/game-ui-and-hud.md
@@ -125,6 +125,30 @@ Unrelated scopes survive. Shutdown retires all scopes before Renderer, Assets,
 Input, Localization or Platform dependencies disappear and is idempotent after
 partial activation.
 
+## Presentation Scope, Bands And Routes
+
+[ADR-080](../../adr/080-runtime-ui-presentation-scope-layer-and-route.md) keeps
+semantic owner scope, input audience, route-stack membership, presentation band
+and visibility as independent typed dimensions. Persistence derives only from the
+ADR-073 GameInstance/Player/Scene/Viewport owner; moving content between visual
+bands or covering it never transfers ownership or extends lifetime.
+
+Core presentation order is fixed from World, HUD, Screen and Overlay through Modal,
+Loading and Debug. Backends may batch within the published plan but cannot reorder
+these semantic bands. Game, player, scene and viewport route stacks remain
+independent, with explicit cross-stack cover/arbitration for modal and loading
+presentation instead of implicit process-global z values.
+
+Push, pop, replace and cross-stack operations prepare privately, then commit or
+roll back atomically at ADR-073 lifecycle cutoffs. Routes move through Entering,
+Visible, Covered, Suppressed, Suspended, Exiting and Retiring visibility states
+without making visibility a lifetime alias. A route becomes input-eligible only
+after its matching interaction revision is successfully presented.
+
+Transition loading is GameInstance-owned so it survives scene replacement and can
+cover recovery. Debug presentation is profile-gated, non-authoritative and cannot
+gain hidden input or gameplay mutation authority.
+
 ## Core Runtime UI Primitives
 
 The engine core provides these UI primitives without packages:

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -1096,6 +1096,12 @@ identities. Renderer may convert linear colors, resolve resources and batch equa
 paint state, but cannot read editor/ImGui styles, select state overrides, inherit a
 property, replace a token or mutate a computed-style generation.
 
+[ADR-080](../../adr/080-runtime-ui-presentation-scope-layer-and-route.md) gives
+Renderer one immutable `UiPresentationPlan` per view. Its semantic World, HUD,
+Screen, Overlay, Modal, Loading and Debug band order is fixed; a backend may batch
+compatible draws within the plan but cannot reorder bands. Runtime UI and the host
+own loading/debug availability, coverage and authority policy, never a backend.
+
 World-space canvases project as ordinary view-dependent render instances under
 declared depth/visibility policy. Screen-space canvases are frontend-owned passes
 composed after world/display transform unless an explicit render plan declares an

--- a/docs/architecture/runtime/runtime-lifecycle.md
+++ b/docs/architecture/runtime/runtime-lifecycle.md
@@ -168,6 +168,12 @@ revision writes as commands for provider-owner safe points. Provider revocation
 closes admission and drains snapshot/command/UI leases through deferred lifecycle
 retirement before player/scene/game/module storage or code disappears.
 
+[ADR-080](../../adr/080-runtime-ui-presentation-scope-layer-and-route.md) prepares
+route operations privately and commits complete stack generations at the same
+ADR-073 lifecycle cutoff. VariableUpdate evaluates route-generation transitions,
+then extraction publishes immutable per-view presentation plans. Removed routes
+retire only after interaction, snapshot, render and transition leases close.
+
 ## Time Model
 
 The host tracks:


### PR DESCRIPTION
## Summary

- Adds ADR-080 as the normative Runtime UI presentation-scope, semantic-band, and
  route-stack architecture.
- Defines transactional route operations, cross-stack arbitration, input gates,
  transitions, loading/debug policy, and immutable per-view presentation plans.
- Projects the decision into Runtime UI, lifecycle, and renderer architecture.

## Why

Persistent menus, player HUDs, scene/viewport presentation, modals, loading covers,
and diagnostics cannot safely collapse ownership lifetime, visual order, input
authority, and navigation into one global layer or route stack.

## Decision and boundaries

- Owner scope, input audience, stack membership, semantic presentation band, and
  visibility are independent typed dimensions.
- Persistence follows ADR-073 ownership and is never inferred from visual placement.
- Core ordering is `World → HUD → Screen → Overlay → Modal → Loading → Debug`, with
  deterministic tie-breaking independent of pointer/load order.
- Game, player, scene, and viewport stacks remain independent; typed cross-stack
  cover/suppression policy arbitrates presentation and input without destroying
  covered routes.
- Push/pop/replace and cross-stack operations prepare and commit transactionally,
  preserving the prior stack and focus on candidate failure.
- Input admission requires successful presentation of the matching interaction
  revision; Renderer receives immutable plans and owns no route policy.

## Review findings addressed

- Codacy reported no blocking inline finding on this PR.
- Its suggested ownership, atomicity, modal arbitration, input-gate, loading,
  ordering, and suppression scenarios are captured as normative coverage in
  ADR-080; executable coverage will be implemented by the dependent runtime work.
- Cross-PR findings are intentionally consolidated in the final `develop → main`
  integration PR, as requested.

## Validation

- Existing branch Codacy analysis: success
- Architecture/documentation validation recorded by the original PR
- Final combined Markdown, link, configure, and Codacy validation will run on the
  `develop → main` integration PR.

## Risk and rollout

This is architecture-only and does not implement route stacks, modal focus, loading
recovery, HUD association, or presentation-plan extraction. It is merged to
`develop` as one preserved merge commit; it reaches `main` only after combined
review fixes and final validation succeed.

## Issue links

- Jira: HORO-768
- GitHub: Closes #768

## Reviewer notes

Review ADR-080 Sections 1–11, then the Game UI, Runtime Lifecycle, and Rendering
projections. This PR targets the temporary `develop` integration branch; its commit
identity is preserved for the final non-squash merge into `main`.
