### PR TITLE
docs(character): define controller ownership HORO-937 #937 [CHR-001.1]

### DIFF
--- a/docs/adr/022-ai-fixed-tick-order-authority-and-simulation-budget.md
+++ b/docs/adr/022-ai-fixed-tick-order-authority-and-simulation-budget.md
@@ -24,7 +24,7 @@ Early documentation drafts introduced two architectural defects that require rat
 
 ## Decision
 
-**AI simulation is strictly decoupled from graphics backends and executes six mutation phases inside each fixed simulation tick (`PerceptionSensePoll -> BlackboardSync -> AiDecisionEvaluate -> NavIntentCommit -> CharacterControllerLocomotion -> AnimationRigUpdate`). After the tick commits, a variable-rate `RenderExtraction` presentation bridge consumes immutable snapshots. In networked topologies, dedicated servers retain exclusive authority over AI decisions, perception, and blackboards, while clients receive replicated transforms and animation targets for presentation-only interpolation. AI simulation budgets are governed exclusively by typed `GameplayAiProfile` specifications based on available CPU worker threads and memory constraints.**
+**AI simulation is strictly decoupled from graphics backends. Its four intent phases (`PerceptionSensePoll -> BlackboardSync -> AiDecisionEvaluate -> NavIntentCommit`) feed the common fixed-tick locomotion order (`AnimationPrePhysics -> CharacterControllerLocomotion -> PhysicsStep -> CharacterFinalize -> AnimationPostPhysics`). After tick commit, variable-rate `RenderExtraction` consumes immutable snapshots. In networked topologies, dedicated servers retain exclusive authority over AI decisions, perception and blackboards, while clients receive replicated transforms and animation targets for presentation-only interpolation. AI budgets are governed exclusively by typed `GameplayAiProfile` CPU/memory specifications.**
 
 ### 1. Simulation Tick Phase Order
 
@@ -43,11 +43,20 @@ Fixed-tick AI simulation executes in a strict, deterministic sequence within the
 4. NavIntentCommit
      | (pathfinding queries, steering & avoidance velocity)
      v
-5. CharacterControllerLocomotion (Physics Integration)
-     | (resolved world transforms & velocities)
+5. AnimationPrePhysics
+     | (candidate pose, simulation IK & exact tick root motion)
      v
-6. AnimationRigUpdate
-     | (skeletal pose evaluation)
+6. CharacterControllerLocomotion
+     | (platform carry, bounded query movement & staged Physics commands)
+     v
+7. PhysicsStep
+     | (rigid-body/contact/platform results)
+     v
+8. CharacterFinalize
+     | (support, attachment & authoritative collision-root transform)
+     v
+9. AnimationPostPhysics
+     | (typed pose overrides & final candidate pose)
      v
 Presentation bridge (variable-rate): RenderExtraction
      | (immutable presentation snapshot)
@@ -62,8 +71,11 @@ ownership, input/output contracts, and invariants:
 | Fixed phase 2 — `BlackboardSync` | Ingests staged stimuli, applies memory decay, updates target references, adjusts alert levels, and synchronizes external gameplay events into agent knowledge. | Staged `PerceivedStimulus` buffers, agent configuration | Updated `AIBlackboard` state | Agent blackboard mutation is isolated to this phase; prevents mid-decision race conditions. |
 | Fixed phase 3 — `AiDecisionEvaluate` | Evaluates behavior trees, state machines, or utility AI against current blackboard state under ADR-025. | `AIBlackboard`, agent behavior definitions | High-level movement intent, combat actions, state transitions | Pure decision logic. Does not directly mutate physics bodies, move collision capsules, or perform rendering calls. |
 | Fixed phase 4 — `NavIntentCommit` | Dispatches pathfinding requests, evaluates path-following waypoints, resolves local dynamic obstacle avoidance (RVO/crowd), and computes kinematic movement vectors. | Movement intent, NavMesh spatial queries, dynamic obstacles | Kinematic velocity & direction vectors for character controllers | Submits steering commands to the character locomotion layer; does not step physics simulation directly. |
-| Fixed phase 5 — `CharacterControllerLocomotion` | Executes kinematic character controller updates within the physics tick. Resolves terrain contact, collisions, stepping, and slope limits. | Kinematic velocity vectors, physics collision geometry | Committed world transforms, contact normals, linear/angular velocities | Physics collision and transform updates become authoritative for the current simulation tick. |
-| Fixed phase 6 — `AnimationRigUpdate` | Evaluates skeletal animation blend trees, locomotion state machines, and procedural IK based on committed locomotion velocity and action states. | Committed transforms, locomotion velocities, action state tags | Final bone pose transforms and animation curves | Operates on committed simulation output. Does not feed back into physics locomotion within the same tick. |
+| Common phase 5 — `AnimationPrePhysics` | Evaluates authoritative animation graphs, simulation-affecting IK and exact-tick root motion from staged AI/gameplay parameters. | Action/locomotion intent, committed animation state, fixed delta | Candidate pose, events and one root-motion request | Runs once per attempted fixed tick under ADR-061; presentation sampling never feeds locomotion. |
+| Common phase 6 — `CharacterControllerLocomotion` | Applies platform evidence and resolves Nav/Gameplay intent plus root motion with the bounded Horo query controller. | Movement/facing command, root motion, immutable Physics query/support snapshot | Candidate collision root, contacts and staged Physics commands | ADR-089 owns movement/orientation composition. It stages rather than commits transforms and never steps Physics directly. |
+| Common phase 7 — `PhysicsStep` | Applies staged platform/Character commands and advances rigid-body simulation once. | Candidate Character/kinematic commands, fixed Physics world | Body/contact/platform and pose-override results | One fixed quantum; Character does not move a second time after this step. |
+| Common phase 8 — `CharacterFinalize` | Finalizes support/platform attachment, bounded Character events and authoritative collision-root transform. | Candidate Character movement plus Physics step results | Final Character state/transform for tick commit | Updates next-tick platform evidence only; no post-Physics movement sweep. |
+| Common phase 9 — `AnimationPostPhysics` | Applies typed Physics pose overrides and finalizes the candidate skeletal pose. | Candidate pose, committed Character root, Physics overrides | Final bone pose transforms and animation curves | Does not feed back into same-tick Character/Physics movement. All common state publishes atomically at tick commit. |
 | Variable-rate bridge — `RenderExtraction` | Extracts immutable presentation snapshots of interpolated transforms and bone matrices for presentation rendering. | Previous and current committed simulation poses, interpolation $\alpha$ | Immutable `RenderSceneSnapshot` | Not a fixed-tick phase. Read-only and completely decoupled from fixed-tick mutation. |
 
 ### 2. Network Authority And Host Roles
@@ -76,14 +88,16 @@ AI execution and knowledge ownership vary strictly by host role:
   - Authoritative BlackboardSync (PRIVATE)
   - Authoritative AiDecisionEvaluate (PRIVATE)
   - Authoritative NavIntentCommit & Avoidance
+  - Authoritative AnimationPrePhysics root-motion/IK when configured
   - Authoritative CharacterControllerLocomotion
+  - Authoritative PhysicsStep, CharacterFinalize & AnimationPostPhysics
          |
          | (Replicated Transforms, Velocity, Public Action Tags)
          v [ Network Transport ]
 [ Remote Client ]
   - Presentation-only state receipt
   - Transform Interpolation (alpha)
-  - Client AnimationRigUpdate (visual blending)
+  - Client presentation Animation sampling/blending
   - RenderExtraction -> Viewport Presentation
   (NO perception queries, NO blackboard, NO decision evaluation)
 ```
@@ -91,17 +105,17 @@ AI execution and knowledge ownership vary strictly by host role:
 #### Host Roles
 
 - **Standalone Host (Single-Player / Local Preview)**:
-  - Executes all six fixed-tick phases locally, followed by the variable-rate `RenderExtraction` bridge in the same process.
+  - Executes all four AI intent phases and all five common authoritative locomotion phases locally, followed by the variable-rate `RenderExtraction` bridge in the same process.
   - The local simulation is the single authority for both gameplay decisions and presentation.
 - **Dedicated Server Host (Headless Server-Authoritative Multiplayer)**:
-  - Executes phases 1 through 5 (`PerceptionSensePoll` through `CharacterControllerLocomotion`) as the sole authoritative simulation owner.
+  - Executes phases 1 through 9 as the sole authoritative simulation owner; authoritative Animation stages remain required when root motion, simulation IK, hitboxes or pose-driven Physics participate.
   - Generates network replication snapshots containing public agent state: `NetworkId`, committed `Transform`, linear/angular velocity, active public animation state tags, and gameplay health.
-  - Headless dedicated servers omit fixed phase 6 and the presentation bridge, except that skeletal LOD may run when authoritative hitboxes require it.
+  - Headless dedicated servers omit only the presentation bridge and purely visual pose work.
   - Dedicated servers operate identically regardless of whether `NullRenderer` or a mock device is attached.
 - **Client Host (Connected Multiplayer Client)**:
   - Acts strictly as a presentation-only consumer for server-replicated AI agents.
   - Receives replicated network snapshots and applies buffer interpolation over network jitter buffers.
-  - Executes client-side `AnimationRigUpdate` and the variable-rate `RenderExtraction` bridge for visual presentation; neither grants authority over server-owned AI.
+  - Executes presentation-only Animation sampling/blending and the variable-rate `RenderExtraction` bridge; neither grants authority over server-owned AI.
   - **Forbidden on Client**: Clients NEVER execute `PerceptionSensePoll`, `BlackboardSync`, `AiDecisionEvaluate`, or `NavIntentCommit` for server-owned AI agents. Clients never invent authoritative movement or state transitions for AI.
 
 #### Privacy and Security Boundary

--- a/docs/adr/061-animation-ownership-update-order-and-clock.md
+++ b/docs/adr/061-animation-ownership-update-order-and-clock.md
@@ -7,7 +7,7 @@
 - **Issue**: [ANI-001.1](https://github.com/abdullahbodur/horo-engine/issues/454)
 - **Jira**: [HORO-454](https://horo-engine.atlassian.net/browse/HORO-454)
 - **Parent**: [ANI-001](https://github.com/abdullahbodur/horo-engine/issues/447)
-- **Related**: [ADR-014](014-sequencer-ownership-clock-authority-and-binding-boundary.md), [ADR-077](077-runtime-ui-animation-clock-and-time-domain.md)
+- **Related**: [ADR-014](014-sequencer-ownership-clock-authority-and-binding-boundary.md), [ADR-077](077-runtime-ui-animation-clock-and-time-domain.md), [ADR-089](089-character-controller-ownership-implementation-and-update-order.md)
 - **Normative documents**: [Animation Architecture](../architecture/runtime/animation-architecture.md), [Runtime Lifecycle](../architecture/runtime/runtime-lifecycle.md), [Character Controller Architecture](../architecture/runtime/character-controller-architecture.md)
 
 ## Context
@@ -51,7 +51,7 @@ pose owner.
 | Graph instance, player cursors, transition/event state, and pose working memory | Animation runtime | One scene/runtime generation; mutation only through admitted animation stages |
 | Mutable local/model pose buffers and palette preparation | Animation runtime | Never shared for external mutation; allocated from bounded instance/frame storage |
 | Gameplay parameters and movement intent | Gameplay owner | Typed per-tick snapshot committed before animation evaluation |
-| Character transform and collision result | Character controller / physics owner | Root motion is a request; animation never writes the authoritative transform |
+| Character collision-root transform and movement result | Scene-owned Horo `CharacterWorld` | Physics supplies query/platform evidence; root motion is a request and Animation never writes the authoritative root |
 | Ragdoll/body transforms | Physics runtime | Published as a typed post-physics override; physics never writes animation storage |
 | Render pose and joint palette view | Render extraction snapshot | Immutable, frame-owned projection of committed pose state |
 | Timeline preview pose | Editor preview runtime | Separate instance/storage; cannot mutate play/runtime animation state |
@@ -165,20 +165,24 @@ The authoritative non-AI path is a validated dependency order inside the existin
 ```text
 Apply queued owner-thread commands before FixedUpdate
 For each attempted fixed tick:
-  1. Input/gameplay/cinematic owners stage animation parameters and movement intent
+  1. Input/gameplay/AI/Nav/cinematic owners stage animation parameters, movement
+     intent, desired heading, stance/jump, and kinematic-platform targets
   2. Animation pre-physics evaluation stages graph state, pose, eligible IK,
      events, and the exact directed root-motion delta
-  3. Character controller admits desired movement plus root-motion request,
-     resolves collision, and publishes the kinematic transform
-  4. Physics steps once at the fixed quantum
-  5. Physics publishes body transforms and typed pose-override results
-  6. Animation post-physics composition applies admitted overrides and finalizes
+  3. Physics freezes the exact Character query/support/platform-motion evidence
+  4. Character applies platform carry, admits desired movement plus root motion,
+     resolves collision, and stages its collision-root transform/Physics commands
+  5. Physics applies staged commands and steps once at the fixed quantum
+  6. Physics publishes body/contact/platform and typed pose-override results
+  7. Character finalizes support/attachment state and its authoritative transform;
+     it does not perform a second movement pass
+  8. Animation post-physics composition applies admitted overrides and finalizes
      the candidate committed pose
-  7. Tick commit publishes animation instance state, previous/current pose
-     generations, and bounded event occurrences atomically
+  9. Tick commit publishes Physics, Character/transforms, animation instance state,
+     previous/current pose generations, and bounded events atomically
 After all catch-up ticks:
-  8. Presentation interpolation/overlays build an immutable render pose
-  9. Render extraction consumes that pose and its joint palette
+  10. Presentation interpolation/overlays build an immutable render pose
+  11. Render extraction consumes that pose and its joint palette
 ```
 
 Simulation-affecting IK that contributes to hit shapes or movement belongs in
@@ -207,6 +211,13 @@ and the resulting kinematic transform. Ignoring or clipping root motion does not
 rewind the animation cursor. The resolution may be observed on the next tick to
 adjust locomotion state, but animation cannot resample the same interval after
 physics merely to force visual distance to match.
+
+[ADR-089](089-character-controller-ownership-implementation-and-update-order.md)
+defines the exact translation modes and heading composition. There is no render-
+frame accumulator: zero attempted ticks produce no request, catch-up produces one
+distinct request per tick, and a failed tick discards the request with the staged
+animation/controller state. Root pitch/roll remains visual; only the admitted twist
+about Character's owned up basis can affect collision heading.
 
 One `(scene, animation instance, simulation tick, root-motion generation)` request
 can be consumed at most once. A stale, duplicate, preview, presentation, or

--- a/docs/adr/089-character-controller-ownership-implementation-and-update-order.md
+++ b/docs/adr/089-character-controller-ownership-implementation-and-update-order.md
@@ -1,0 +1,501 @@
+# ADR-089: Character Controller Ownership, Implementation and Update Order
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Horo-owned kinematic query-controller strategy, scene ownership, private Jolt query boundary, fixed-tick command/root-motion cadence, movement/platform/orientation composition, transform authority/publication, backend replacement, lifecycle, migration and qualification
+- **Issue**: [CHR-001.1](https://github.com/abdullahbodur/horo-engine/issues/937)
+- **Jira**: [HORO-937](https://horo-engine.atlassian.net/browse/HORO-937)
+- **Parent**: [CHR-001](https://github.com/abdullahbodur/horo-engine/issues/930)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-022](022-ai-fixed-tick-order-authority-and-simulation-budget.md), [ADR-026](026-large-world-precision-and-floating-origin-strategy.md), [ADR-061](061-animation-ownership-update-order-and-clock.md), [ADR-084](084-canonical-physics-solver-units-and-tolerances.md), [ADR-086](086-collision-layer-profile-and-query-channel-policy.md), [ADR-087](087-scene-to-physics-ownership-and-conversion.md), [ADR-088](088-physics-determinism-capability-and-support-tiers.md)
+- **Normative documents**: [Character Controller Architecture](../architecture/runtime/character-controller-architecture.md), [Animation Architecture](../architecture/runtime/animation-architecture.md), [Physics Architecture](../architecture/runtime/physics-architecture.md), [Scene Runtime](../architecture/runtime/scene-runtime.md), [Runtime Lifecycle](../architecture/runtime/runtime-lifecycle.md)
+- **Upstream references**: [Jolt v5.6.0 character controllers](https://github.com/jrouwe/JoltPhysics/blob/v5.6.0/Docs/Architecture.md#character-controllers), [Jolt v5.6.0 CharacterVirtual](https://jrouwe.github.io/JoltPhysicsDocs/5.6.0/class_character_virtual.html)
+
+## Context
+
+Character Controller Architecture describes a kinematic capsule that performs
+sweeps, slopes, steps, grounding and moving-platform behavior. ADR-061 already
+moved authoritative animation/root motion to every attempted fixed tick, but the
+remaining text still says the transform is read/written "each frame", platform
+carry occurs on the "next frame", requests carry caller-provided delta time and
+contacts allocate a `std::vector`. Ownership of the sweep algorithm and rotations
+is also incomplete.
+
+Jolt v5.6.0 offers `Character` and query-based `CharacterVirtual`. The latter uses
+narrowphase queries, supports wall sliding, stairs and moving platforms, but owns
+native state/callback/timing and is updated separately from rigid bodies. Wrapping
+it behind a public replaceable controller ABI would freeze Jolt semantics and make
+another solver reproduce native edge cases. Reimplementing every low-level collision
+query outside Physics would duplicate broadphase/filter/material/origin policy.
+
+Horo instead needs one engine-owned semantic algorithm that can be replayed,
+bounded, inspected and qualified with stable Horo queries/results. The canonical
+Jolt adapter can provide private collision casts and body evidence without becoming
+the controller contract. There is no current multi-solver Physics ABI, so a public
+`ICharacterBackend` would be premature for the same reasons rejected by ADR-084.
+
+The fixed-tick sequence must include gameplay intent, animation sampling, root
+motion, kinematic-platform targets, current dynamic-platform motion, character
+query resolution, staged impulses/kinematic presence, the Physics step, support
+finalization, transform publication and post-Physics animation. A render-frame
+accumulator cannot bridge these phases because one frame may contain zero or many
+attempted ticks.
+
+Finally, a capsule's collision up axis, gameplay desired heading, animation root-
+motion rotation, platform angular carry and rendered visual orientation are
+different authorities. Treating them all as one transform lets platform tilt rotate
+the capsule, visual lean change collision or animation overwrite collision results.
+
+## Decision
+
+### 1. Horo owns the controller semantics and sweep solver
+
+The accepted strategy is a Horo-owned kinematic query controller. Horo specifies
+the complete movement pipeline, iteration/limits, contact reduction, slope/step/
+ground/platform policy, state transitions, errors and deterministic ordering.
+
+The implementation consumes a narrow Horo `CharacterPhysicsQueryContext` borrowed
+from the exact scene `PhysicsWorld` generation. The canonical adapter maps its
+capsule casts, overlaps, body point velocity, material/filter and impulse commands
+to private Jolt narrowphase APIs. Public Character/Scene/Gameplay contracts never
+expose `JPH::Character`, `JPH::CharacterVirtual`, collectors, body/subshape IDs,
+listeners, allocators or native settings.
+
+Horo does not use `CharacterVirtual` as the semantic/state owner in CanonicalV1.
+Upstream algorithms/tests may inform implementation and qualification, but native
+update behavior is not forwarded wholesale. There is no public or extension
+`ICharacterControllerBackend`, provider registry or runtime backend selector.
+
+### 2. The initial Character domain lives behind the Physics target
+
+The first implementation lives inside `HoroEngine::Physics` as a distinct
+`Horo::Character` domain because Physics is currently one canonical target. Its
+public surface contains only Horo descriptors, commands, results, snapshots and
+generation-checked handles. Native queries remain private.
+
+If a later architecture splits Character into API/runtime targets, Character
+Runtime may depend on a backend-neutral Horo Physics query capability. Physics must
+not depend back on Character. Such a split cannot change Character semantics or
+introduce hot-path virtual dispatch without migration and qualification.
+
+Replacing Jolt or the private query adapter is therefore an implementation change,
+not a controller-backend selection. It must reproduce the Horo golden behavior and
+requalify queries, contacts, platforms, determinism and performance before shipping.
+
+### 3. Each active scene generation owns one Character world
+
+ADR-087's aggregate scene candidate owns exactly one `CharacterWorld` when the
+scene requires Character capability. It is paired with one exact `SceneRuntimeId`,
+`PhysicsWorldId`, collision-schema generation and origin generation.
+
+`CharacterWorld` owns:
+
+- controller slots/handle generations and stable authored bindings;
+- committed and candidate controller state;
+- tick-indexed command/root-motion admission;
+- per-tick fixed-capacity query/contact/impulse/event scratch;
+- support/platform attachments and previous/current publication state;
+- bounded debug/metrics snapshots.
+
+Scene components store stable authored controller identity and runtime binding
+handles, not controller objects. Gameplay borrows typed capabilities. Animation
+submits a root-motion request. Physics supplies one immutable query view and accepts
+staged commands. No subsystem caches pointers into Character storage.
+
+Character candidate preparation follows scene activation: validate descriptors and
+bindings, reserve all capacity, create controller slots against the detached Physics
+candidate, then publish both in the same no-fail aggregate commit. Failure leaves
+the prior scene/Physics/Character bundle untouched.
+
+### 4. Controller identity and state are generation checked
+
+`CharacterControllerHandle` contains scene, Character-world and slot generations.
+The binding table maps it to stable `SceneObjectId` and authored controller component
+ID. A handle is process-local/nonserializable and never aliases a replacement world
+or reused slot.
+
+The committed controller state includes finite collision-root position, velocity,
+up basis, heading, capsule/stance generation, grounded/support state, platform
+attachment, movement flags and source tick. Candidate state for an attempted tick
+is private until tick commit. Failed ticks preserve committed state and consume no
+event/publication generation.
+
+Exact field schemas, descriptor/request/result/error types are owned by CHR-001.2;
+this ADR fixes their ownership, clocks and relationships.
+
+### 5. Authoritative Character work occurs only per attempted fixed tick
+
+Gameplay submits one tick-addressed `CharacterMovementCommand` before the Character
+admission boundary. It contains desired movement/facing, jump/stance/teleport and
+root-motion consumption policy; it does not contain a caller-selected `deltaTime`.
+Character reads `FixedStepContext::fixedDelta` exactly once.
+
+Commands produced at variable/render rate are latched as input intent and assigned
+to an exact simulation tick by the gameplay/input owner. They are not integrated or
+summed by frame delta. A command may be replaced before its tick closes under a
+versioned policy; after closure, late/duplicate commands fail or target a future
+tick explicitly.
+
+Zero attempted ticks produce no Character movement. Catch-up executes a complete
+Character update for every attempted tick. Pause freezes state; single-step runs one
+ordinary update. Simulation-rate changes affect tick production, not the fixed
+quantum passed to Character.
+
+### 6. Root motion is generated and consumed once per tick
+
+ADR-061 Animation evaluates the exact directed player interval for one attempted
+tick and stages one finite `RootMotionRequest` carrying scene, animation instance,
+controller binding, tick and generation. Presentation/editor-preview sampling never
+enters Character.
+
+There is no render-frame root-motion accumulator. When one frame produces several
+ticks, Animation produces a distinct delta for each. When it produces none, no
+authoritative delta exists. A failed tick discards the staged request and does not
+advance the committed animation cursor or controller.
+
+The movement command chooses one explicit translation mode:
+
+- `GameplayOnly`: ignore root translation;
+- `RootMotionSuggest`: use root translation only when the command explicitly has no
+  gameplay translation intent;
+- `RootMotionAdditive`: sum gameplay and root translation before collision;
+- `RootMotionOverride`: root translation replaces gameplay translation.
+
+An explicit presence bit, not a velocity epsilon, distinguishes "no gameplay
+translation". Root rotation has corresponding ignore/additive/override policy in
+the heading composition below. One request is consumed at most once.
+
+### 7. The fixed-tick order is exact
+
+The authoritative non-AI/AI locomotion paths converge on this dependency order
+inside one existing `FixedUpdate` attempt:
+
+```text
+0. Apply owner-thread commands before FixedUpdate; freeze scene/world generations
+1. Input, Gameplay, AI/Nav and admitted Cinematic owners stage movement/facing,
+   animation parameters, jump/stance and kinematic-platform targets
+2. Animation pre-Physics evaluates the candidate pose, simulation IK, events and
+   one root-motion delta for this tick
+3. Physics freezes CharacterPhysicsQueryContext from committed bodies plus admitted
+   kinematic targets and support point-velocity evidence
+4. Character applies support/platform carry, composes intent/root motion, runs the
+   bounded Horo query solver and stages controller pose, impulses/presence targets
+5. Physics applies staged platform/Character commands and steps exactly once
+6. Physics publishes candidate rigid-body/contact/platform results
+7. Character finalizes grounded/support/attachment state, bounded events and the
+   authoritative collision-root transform; it does not perform a second move
+8. Animation applies admitted Physics pose overrides and finalizes candidate pose
+9. Tick commit atomically publishes Physics, Character, transforms, animation state
+   and bounded events
+10. Variable presentation interpolates committed roots/poses and applies visual-only
+    overlays before render extraction
+```
+
+Stages 1–9 are one transaction. A failure prevents the attempted tick from
+committing under Runtime Lifecycle policy. No process DataBus event establishes
+their order. Catch-up repeats all stages; presentation never runs between them.
+
+Simulation IK that affects movement/query geometry completes in stage 2. IK based
+on stage-6 contacts is post-Physics/presentation and cannot feed the same tick's
+movement. AI/Nav produces stage-1 intent; it does not run a separate controller or
+move transforms before Character.
+
+### 8. Movement displacement composes in one declared order
+
+At stage 4, Character constructs requested displacement in this order:
+
+1. derive support/platform carry from the stage-3 snapshot;
+2. establish the carried collision root and carried heading;
+3. resolve an explicit gameplay desired heading if present;
+4. rotate the tick's local-space root translation by that pre-root heading;
+5. combine gameplay translation and root translation using the selected mode;
+6. integrate Character-owned vertical velocity/gravity/jump for the fixed quantum;
+7. run the Horo capsule query pipeline over carry plus requested movement;
+8. apply the admitted root/gameplay heading result to the collision root;
+9. stage bounded impulses/presence targets for Physics.
+
+Platform carry is never added again as desired gameplay velocity. Root-motion
+translation is the animation root's local directed delta; it is not divided by
+render time or resampled after collision clipping. Movement result records requested,
+carried, achieved and rejected/clipped deltas so Gameplay/Animation can react next
+tick without rewriting this one.
+
+### 9. Up basis, heading and visual orientation have different owners
+
+The collision root is a position, one finite unit `up` basis and one normalized
+heading twist about that basis. CanonicalV1 uses project/world `+Y` by default.
+
+- `CharacterWorld` owns the capsule up basis. Gravity direction or platform normal
+  does not rotate it implicitly. A typed up-basis change commits at a safe point,
+  revalidates capsule clearance/support and may fail.
+- Gameplay owns optional absolute desired heading about the current up basis.
+  Character validates/projects it; pitch/roll are not capsule heading.
+- Animation owns local root-motion rotation for the tick. Character extracts the
+  admitted twist about up for collision heading. Residual pitch/roll remain visual
+  pose motion and never tilt the capsule.
+- Physics owns the platform transform/angular velocity sample. Full platform
+  rotation moves the attachment point; only its twist about Character up affects
+  heading when `inheritPlatformHeading` is enabled.
+- Animation/Presentation owns visual orientation/lean/aim relative to the committed
+  collision root. It cannot feed collision until a future typed fixed-tick command.
+
+Heading composition is deterministic:
+
+1. start from previous committed heading;
+2. pre-apply admitted platform twist when inheritance is enabled;
+3. replace with explicit Gameplay desired heading when present;
+4. for root `Additive`, post-apply root twist to the current base;
+5. for root `Override`, apply root twist to the carried pre-Gameplay heading and
+   ignore Gameplay desired heading for this tick;
+6. normalize/canonicalize sign and reject non-finite/degenerate results.
+
+Root translation uses the heading after steps 1–3 and before root twist. Capsule
+collision is rotationally symmetric around up; heading still owns gameplay/visual
+forward and local-root translation.
+
+### 10. Moving-platform carry uses explicit tick evidence
+
+The support attachment stores stable Physics body identity/generation, local point,
+last committed support transform/evidence and policy flags. It never retains a
+native pointer.
+
+Stage 3 supplies one immutable `PlatformMotionSample`:
+
+- for a kinematic platform, its admitted current-tick target transform/point
+  velocity;
+- for a dynamic platform, its committed pose plus point linear/angular velocity at
+  the attachment point, integrated for the fixed quantum under the Character
+  profile;
+- for static ground, zero carry.
+
+Character applies carry before its own displacement and sweeps it through collision
+like other movement. Full rotation transports the local attachment point. Optional
+heading inheritance uses only platform twist as defined above; platform tilt never
+changes capsule up in CanonicalV1.
+
+After Physics steps, Character uses the final body/contact evidence only to finalize
+support identity/local attachment and next-tick state. It does not silently move a
+second time after Physics. Dynamic-platform prediction error is observed and
+resolved by the next fixed tick's bounded support/ground/depenetration policy; it is
+not corrected from variable presentation.
+
+Detachment occurs on support loss, jump/teleport, stale body generation, rejected
+carry or explicit policy. Transfer velocity is captured as a typed tick result and
+applied exactly once under the movement profile.
+
+### 11. The Horo query solver is bounded and snapshot based
+
+The stage-3 `CharacterPhysicsQueryContext` is read-only and world/tick/generation
+affine. The baseline pipeline is:
+
+1. bounded spawn/continuing-overlap recovery;
+2. support/ground classification;
+3. platform carry sweep;
+4. requested capsule sweep with iterative slide;
+5. guarded step-up/forward/down attempt;
+6. vertical/gravity/jump sweep;
+7. bounded step-down/stick-to-ground;
+8. contact/material/support canonicalization.
+
+Exact sweep inflation, tolerances, maximum iterations, contact capacity, slope/step
+tests and failure behavior are Horo profile fields, not upstream defaults. Queries
+use stable ADR-086 channel/profile/filter identities and ADR-088 canonical result
+ordering. A query callback only records bounded evidence; gameplay/contact policy
+does not execute inside native collectors.
+
+The solver stages impulses to dynamic bodies and any optional Character presence
+target through Physics commands. It never mutates bodies while iterating query hits.
+Controller-to-controller collision is unsupported in the initial profile until a
+CharacterWorld snapshot/order policy is specified; it is not delegated implicitly
+to `CharacterVirtual`.
+
+### 12. Character owns collision-root transform publication
+
+During an attempted tick, Scene Transform is not an independent writer for a bound
+controller. Character stages the collision root at stage 4, finalizes it at stage 7
+and publishes it with the tick at stage 9. Physics owns rigid-body transforms;
+Animation owns poses; no later Gameplay/Animation system overwrites Character root.
+
+Teleport, spawn, stance/size and up-basis changes are typed Character commands with
+their own clearance/recovery/failure policy. Direct transform writes while a
+controller is active are rejected or converted by an explicit host command before
+the tick closes.
+
+Renderer interpolation consumes previous/current committed collision roots. Visual
+root/lean/aim offsets are presentation/pose state and cannot become authoritative
+through extraction. Failed ticks publish neither controller transform nor visual
+pose generation.
+
+### 13. Determinism and concurrency follow Physics tiers
+
+Character ordering/profile/command/root/platform/query/contact/state versions and
+capacities participate in ADR-088's Physics determinism fingerprint. Controllers
+iterate by stable Horo ID; commands, contacts, impulses and events use canonical
+tie-breaks. Pointer, native callback, worker completion and render order are not
+inputs.
+
+CanonicalV1 updates Character serially on the Physics owner thread using preallocated
+scratch. Future parallel controller batches require immutable shared query evidence,
+deterministic controller/body impulse reduction, per-controller FPU state and a new
+qualified tuple. Parallelism cannot change public results or let controllers observe
+partially updated peers.
+
+Character uses fixed Horo/Jolt math admitted by the effective tier. Debug/presentation
+queries and visual ground polish cannot feed simulation. Overflow produces the same
+typed failure at the canonical item; it never drops arrival-order contacts.
+
+### 14. Activation, reload, unload and origin shift are transactional
+
+Character descriptors/bindings validate and reserve all world/controller/scratch
+capacity during ADR-087 scene candidate preparation. Required Character capability
+without Physics/query/filter/material support fails activation; no null controller
+or collision-free fallback is published.
+
+Reload builds a candidate `CharacterWorld`. Typed preservation may transfer Horo
+position/velocity/heading/stance/support only when stable controller IDs, descriptor,
+Physics/filter/origin/profile and platform evidence are compatible. Native state or
+contacts are never copied. Failure preserves the active bundle.
+
+ADR-026 origin shift translates committed/candidate controller positions, contact
+points/query bounds and attachment platform evidence by the same safe-point delta;
+velocities, up, heading and local attachment do not change. No tick/query overlaps
+the shift.
+
+Unload closes commands/queries/events, cancels candidate work, drains tick/debug/
+snapshot readers, destroys controller slots/scratch and releases Physics/filter/
+material leases before Scene component storage. Shutdown is reverse dependency,
+idempotent and never calls native Character callbacks after Physics teardown.
+
+### 15. Errors, limits and observability are Horo-owned
+
+ADR-008 results cover stale/cross-world handles, missing/duplicate command or root
+motion, invalid descriptor/capsule/up/heading/transform, unsupported profile/query/
+controller collision, slope/step/stance/platform policy, overlap recovery, query/
+contact/iteration/scratch/impulse/event limit, non-finite result, generation/origin
+mismatch, tick phase, cancellation, unload and native query invariant.
+
+Velocities/displacements are validated against declared profile limits. They are not
+silently clamped. A profile may define an explicit saturating gameplay policy whose
+applied value/result flag is deterministic and observable; safety rejection remains
+distinct.
+
+Diagnostics carry bounded scene/Character/Physics/controller/tick/command/root/
+platform IDs, phase, counts and expected/actual generation. They do not log native
+pointers, raw geometry or unbounded contacts. Metrics include controller states,
+query/sweep/iteration/contact counts, step/ground/platform outcomes, clipped/rejected
+movement, scratch high water, overflow and update time. Debug draw uses immutable
+bounded snapshots outside the owner hot path.
+
+### 16. Migration from the existing frame-oriented document is explicit
+
+This decision revises affected architecture text as follows:
+
+- "reads and writes transform each frame" becomes Character-owned fixed-tick
+  candidate/final publication;
+- caller-provided `MovementRequest::deltaTime` is removed; Character consumes
+  `FixedStepContext::fixedDelta`;
+- "next frame" moving-platform carry becomes stage-3/4 evidence for the next
+  attempted fixed tick;
+- root motion is never accumulated from presentation frames and uses one request
+  per attempted tick;
+- contacts/results use bounded world-owned storage/views, not per-tick
+  `std::vector` allocation;
+- serialized layer/masks become stable collision profile/query-channel IDs;
+- native/default query-controller behavior becomes the versioned Horo solver
+  profile;
+- AI's old Character-then-Animation phase text is replaced by Gameplay/AI intent,
+  Animation pre-Physics/root motion, Character, Physics, post-Physics Animation.
+
+Existing callers that update a controller during variable/presentation update must
+submit a typed future-tick command. Direct transform writers, arbitrary delta-time
+callers and renderer-driven root motion fail migration validation rather than being
+kept as a parallel compatibility path.
+
+### 17. Qualification is part of the contract
+
+Required coverage includes:
+
+- Horo solver golden fixtures independent from native `CharacterVirtual` state;
+- zero/one/multiple catch-up ticks, pause/single-step and 30/60/144 Hz presentation
+  with identical committed Character results;
+- root translation modes, one-shot generation, failed-tick discard, local-space
+  conversion and root/gameplay/platform heading composition;
+- capsule up changes, desired heading projection, root pitch/roll visual isolation,
+  platform full-point rotation versus optional twist inheritance;
+- ground/slope/slide, step-up/down, corners, ceilings, narrow gaps, depenetration,
+  stance resize, teleport and failure budgets;
+- static/kinematic/dynamic support, platform point velocity, jump/detach/transfer,
+  stale body and dynamic prediction error across ticks;
+- stable query/contact/material/filter canonicalization, staged impulses and no body
+  mutation from collectors;
+- exact stage ordering and transform/pose visibility at every phase;
+- scene activation/rollback, reload preservation, origin shift, unload and shutdown
+  after every partial state;
+- maximum controllers, queries, contacts, iterations, scratch, impulses/events and
+  no fixed-tick heap growth;
+- same-build/platform determinism fingerprint/replay evidence and explicit downgrade
+  for unqualified features;
+- private adapter replacement parity across every Horo golden fixture;
+- fuzz/property tests for finite descriptors/commands/hit sets/order and checked
+  arithmetic.
+
+Performance evidence records controller count, scene/query complexity, fixed rate,
+platform/CPU/build, p50/p95/max stage cost, scratch/contact high water and native
+query counts. Claims do not extrapolate from empty scenes or average render frames.
+
+## Consequences
+
+Horo gains one stable, testable Character behavior independent from native controller
+classes while reusing the canonical Physics collision world. Every simulation input
+and orientation has one owner, root motion cannot depend on render cadence, and
+scene/Physics/Character publication remains transactional.
+
+The cost is owning and qualifying a sophisticated bounded sweep/step/platform
+algorithm. Upstream `CharacterVirtual` improvements are not inherited automatically;
+they must be deliberately mapped into Horo semantics. Dynamic-platform carry has an
+explicit velocity-derived pre-step model and next-tick reconciliation instead of an
+unspoken after-step correction.
+
+## Rejected Alternatives
+
+### Expose `JPH::CharacterVirtual` or wrap it as the public controller
+
+Rejected because native state, callbacks, filters, update timing and version drift
+would become public semantics and prevent backend-neutral Horo qualification.
+
+### Add a replaceable `ICharacterControllerBackend` now
+
+Rejected because Horo has one canonical Physics solver and no evidence for a useful
+multi-backend ABI. Replacement occurs below the Horo query/behavior contract.
+
+### Implement Character collision without the Physics query boundary
+
+Rejected because it would duplicate broadphase, shapes, filters, materials, origin
+and native lifetime policy outside their owner.
+
+### Update Character once per render frame
+
+Rejected because zero/multiple fixed ticks, pause, catch-up and headless execution
+would produce different collision, root motion and events.
+
+### Accumulate presentation root motion until the next Physics tick
+
+Rejected because sampling cadence and failed/dropped frames would change the
+authoritative delta. Animation evaluates one exact interval per attempted tick.
+
+### Let Animation or Gameplay write the final Character transform
+
+Rejected because collision resolution would lose authority and later writes could
+move through walls. They submit intent; Character publishes the collision root.
+
+### Rotate capsule up/heading directly with platform or visual orientation
+
+Rejected because platform tilt and animation lean/aim would alter collision
+implicitly. Full platform rotation transports the attachment point; up and heading
+follow explicit policies.
+
+### Move the Character again after Physics to match the final platform pose
+
+Rejected because other bodies already stepped against the staged pre-Physics pose
+and a second hidden query/move would not participate in the same Physics solve.
+Post-Physics finalization updates support evidence for the next tick only.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -100,6 +100,7 @@ to the replacement.
 | [086](086-collision-layer-profile-and-query-channel-policy.md) | Collision Layer, Profile and Query Channel Policy | Proposed | 2026-09-02 |
 | [087](087-scene-to-physics-ownership-and-conversion.md) | Scene-to-Physics Ownership and Conversion | Proposed | 2026-09-02 |
 | [088](088-physics-determinism-capability-and-support-tiers.md) | Physics Determinism Capability and Support Tiers | Proposed | 2026-09-02 |
+| [089](089-character-controller-ownership-implementation-and-update-order.md) | Character Controller Ownership, Implementation and Update Order | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -145,6 +145,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Character Controller Architecture](./runtime/character-controller-architecture.md):
   kinematic capsule controller, slopes, steps, moving platforms, surface
   materials, and surface events.
+- [Character Controller Ownership, Implementation and Update Order](../adr/089-character-controller-ownership-implementation-and-update-order.md):
+  Horo-owned bounded query solver, per-scene Character world, fixed-tick command/
+  root-motion cadence, platform/orientation composition and transform publication.
 - [Physics Architecture](./runtime/physics-architecture.md): fixed-step world
   ownership, transform authority, collision events, queries, and determinism.
 - [Canonical Physics Solver, Units and Tolerances](../adr/084-canonical-physics-solver-units-and-tolerances.md):

--- a/docs/architecture/runtime/animation-architecture.md
+++ b/docs/architecture/runtime/animation-architecture.md
@@ -405,12 +405,15 @@ steps.
 
 ```text
 Attempted Fixed Tick
-  Gameplay and owner-admitted cinematic inputs stage animation parameters
+  Gameplay/AI/Nav and owner-admitted cinematic inputs stage parameters, movement,
+  desired heading and kinematic-platform targets
   Animation evaluates candidate pose, eligible IK, events, and root-motion delta
-  Character controller resolves desired movement plus root motion
-  Physics steps once and publishes typed body/pose overrides
+  Physics freezes Character query/support/platform-motion evidence
+  Character applies platform carry and resolves desired movement plus root motion
+  Physics applies staged commands, steps once and publishes body/pose overrides
+  Character finalizes support and its authoritative collision-root transform
   Animation composes admitted overrides and finalizes candidate pose
-  Tick commit publishes player state, events, and previous/current poses
+  Tick commit publishes Physics, Character/transforms, player state, events, and poses
 
 After FixedUpdate
   Presentation interpolates committed poses and applies presentation-only overlays
@@ -423,9 +426,11 @@ Interpolated cinematic overlays apply only to the render/preview snapshot after
 movement authority resolves. Only owner-admitted non-interpolated fixed-tick inputs
 participate in movement-producing evaluation.
 
-The character controller runs during the gameplay movement phase, before the
-physics world is stepped. This matches the ordering described in
-[Character Controller Architecture](./character-controller-architecture.md).
+The Character controller moves before Physics and performs only support/transform
+finalization after Physics; it never performs a hidden second move. Platform carry,
+capsule up/heading, root rotation and visual orientation ownership follow
+[ADR-089](../../adr/089-character-controller-ownership-implementation-and-update-order.md)
+and [Character Controller Architecture](./character-controller-architecture.md).
 
 ### Render Extraction
 

--- a/docs/architecture/runtime/character-controller-architecture.md
+++ b/docs/architecture/runtime/character-controller-architecture.md
@@ -48,6 +48,32 @@ Not covered:
 - Surface materials drive friction, footstep audio, VFX, and gameplay events.
 - Root motion from animation may feed into the controller as a delta request,
   but the controller decides the final transform.
+- [ADR-089](../../adr/089-character-controller-ownership-implementation-and-update-order.md)
+  makes Horo's bounded query/sweep pipeline the semantic implementation. Private
+  Jolt narrowphase queries supply collision evidence; no native Character class or
+  replaceable backend ABI owns public behavior.
+- Each active scene generation owns one `CharacterWorld` paired with its exact
+  Physics world/filter/origin generations.
+- Character updates exactly once per attempted fixed tick and publishes the
+  collision-root transform only with successful tick commit.
+
+## Implementation And Ownership
+
+The first `Horo::Character` implementation lives behind `HoroEngine::Physics`.
+`CharacterWorld` owns controller slots/state, tick command admission, support
+attachments, fixed-capacity query/contact/impulse/event scratch and immutable debug
+snapshots for one scene generation. The host publishes it with the exact Physics
+world in ADR-087's aggregate scene transaction.
+
+The Horo algorithm performs bounded overlap recovery, support classification,
+platform carry, capsule sweep/slide, guarded step-up/forward/down, vertical motion,
+ground snap and contact canonicalization. It borrows one read-only world/tick-
+affine `CharacterPhysicsQueryContext`; the private adapter maps Horo queries and
+staged impulses to Jolt. It never mutates bodies from a native collector.
+
+`JPH::Character` and `JPH::CharacterVirtual` are not state or behavior authorities.
+There is no public backend selector. Replacing the private Physics query adapter
+must pass the same Horo golden, determinism and performance qualification.
 
 ## Character Controller Component
 
@@ -64,26 +90,45 @@ struct CharacterControllerDescriptor {
 };
 ```
 
-The component attaches to a scene object. The transform component owns position
-and orientation. The controller reads and writes the transform each frame.
+The component attaches to a scene object. While active, `CharacterWorld` owns the
+authoritative collision-root position, capsule up basis and heading. Scene Transform
+is the committed projection; arbitrary systems do not write it. Gameplay owns
+desired heading, Animation owns root-motion rotation/visual pose and Physics owns
+platform motion evidence under ADR-089.
 
 ## Update Order
 
 ```text
 Attempted Fixed Tick
-  Gameplay stages desired movement and animation parameters
-  Animation evaluates and stages the exact tick's root motion request
-  Character controller resolves movement
-  Character transform and moving-platform result are published
-  Physics steps once
-  Post-physics animation pose override/finalization runs
-  Tick commit publishes previous/current state
+  Gameplay/AI/Nav stage movement, facing, animation parameters and platform targets
+  Animation evaluates and stages the exact tick's root-motion request
+  Physics freezes the Character query/platform-motion snapshot
+  Character applies platform carry and resolves intent/root motion with Horo sweeps
+  Physics applies staged commands and steps once
+  Physics publishes rigid-body/contact/platform results
+  Character finalizes support and the authoritative collision-root transform
+  Post-Physics animation pose override/finalization runs
+  Tick commit publishes Physics, Character, transforms, poses and events atomically
 ```
 
-The controller runs once after animation root motion is staged and before each
-physics fixed step. Catch-up repeats the complete sequence; it does not reuse one
-render-frame root delta. This ensures gameplay-driven movement is resolved into a
-final transform before physics reacts during the same attempted tick.
+The controller moves once after animation root motion/query evidence is staged and
+before each Physics fixed step. Post-Physics Character work finalizes support and
+publication only; it never performs a hidden second move. Catch-up repeats the
+complete sequence and never reuses or accumulates a render-frame root delta.
+
+## Collision And Visual Orientation
+
+`CharacterWorld` owns a finite unit capsule up basis and collision heading twist.
+Gameplay owns optional absolute desired heading. Animation owns local root-motion
+rotation and visual pose. Physics owns platform angular evidence. Presentation owns
+visual lean/aim overlays.
+
+Character applies optional platform twist about its up basis, then an explicit
+Gameplay desired heading, then admitted root-motion twist. Root `Override` ignores
+Gameplay desired heading for that tick and applies root twist to the carried
+heading. Root translation uses the pre-root heading. Platform tilt and root/visual
+pitch or roll never rotate the capsule; changing the up basis is a typed safe-point
+command with clearance validation.
 
 ## Movement Resolution
 
@@ -91,13 +136,17 @@ final transform before physics reacts during the same attempted tick.
 
 ```cpp
 struct MovementRequest {
+    SimulationTick tick;
     Vec3 desiredVelocity;       // world-space, meters/second
     Quat desiredOrientation;
     bool jumpRequested;
     bool crouchRequested;
-    FixedDeltaTime deltaTime;
 };
 ```
+
+The controller consumes `FixedStepContext::fixedDelta`; callers cannot provide a
+different delta. Desired translation/facing use explicit presence and root-motion
+composition modes, not zero-vector/epsilon inference.
 
 ### Output
 
@@ -118,9 +167,12 @@ struct MovementResult {
     SurfaceMaterialId groundSurface;  // never invalid; falls back to defaultMaterial
     Vec3 groundNormal;
     bool hitCeiling;
-    std::vector<SurfaceContact> contacts;
+    BoundedContactView contacts;
 };
 ```
+
+The view borrows one immutable tick-result generation owned by `CharacterWorld`.
+Steady fixed ticks do not allocate a result vector.
 
 ### Collision Pass
 
@@ -205,8 +257,13 @@ Rules:
 
 - attachment is established on ground contact with a platform body
 - local offset is stored in platform space
-- next frame, the character is moved by platform delta before its own movement
-- platform angular velocity may rotate the character
+- on the next attempted fixed tick, stage-3 evidence supplies the admitted
+  kinematic target or committed dynamic point velocity
+- platform carry is swept before the character's own movement
+- full platform rotation transports the attachment point; only twist about the
+  Character-owned up basis affects heading when explicitly enabled
+- the final post-Physics platform result updates next-tick attachment evidence and
+  never causes a hidden second move in the current tick
 - detachment happens when the character leaves the platform, becomes airborne, or
   is teleported
 
@@ -275,8 +332,10 @@ Animation root motion may provide a movement delta.
 
 ```cpp
 enum class RootMotionPriority {
-    Suggest,     // root motion is applied only if gameplay input is zero
-    Override     // root motion replaces gameplay input for this fixed tick
+    GameplayOnly,
+    Suggest,     // root motion is used only when gameplay declares no translation
+    Additive,    // root and gameplay translations are summed before collision
+    Override     // root motion replaces gameplay translation for this fixed tick
 };
 
 struct RootMotionRequest {
@@ -288,9 +347,10 @@ struct RootMotionRequest {
 };
 ```
 
-The controller treats root motion as a movement request and resolves it through
-the same collision passes. This ensures that animation-driven movement still
-respects walls, slopes, and steps.
+The controller treats root motion as one tick-addressed movement request and
+resolves it through the same collision passes. Animation produces it directly from
+the authoritative fixed-tick interval; presentation frames never accumulate root
+motion. This ensures animation-driven movement respects walls, slopes, and steps.
 
 The request identifies its scene, animation instance, simulation tick, and root-
 motion generation and can be consumed at most once. Presentation/editor-preview,
@@ -299,10 +359,12 @@ may submit the inverse directed delta when animation and gameplay policy admit i
 the controller still performs ordinary forward collision resolution and does not
 reverse physics.
 
-If root motion and gameplay input conflict, gameplay input takes precedence
-unless the root motion request has `RootMotionPriority::Override`. The animation
-or gameplay system that produces the request decides the priority; the
-controller only resolves the resulting movement.
+Gameplay selects the admitted translation/rotation mode before command closure.
+`Suggest` uses an explicit gameplay-translation presence bit, not a velocity
+epsilon. Platform carry applies first. Desired gameplay heading establishes the
+pre-root basis, root translation is rotated by that basis, and admitted root twist
+then composes under ADR-089. Root pitch/roll remains visual and never tilts the
+capsule.
 
 ## Physics Material Query
 
@@ -319,17 +381,11 @@ valid material ID; the fallback from `QuerySurfaceMaterial` to the descriptor's
 
 ## Collider Filtering
 
-The controller uses collision layers and masks:
-
-- character controller layer
-- static world layer
-- dynamic body layer
-- platform layer
-- trigger/volume layer (ignored by movement sweeps; trigger enter/exit events are
-  handled by the gameplay volume system or physics callbacks, not controller
-  surface events)
-
-Layer membership is declared on the collider, not on the controller.
+The controller selects one stable project `PhysicsQueryChannelId` and explicit
+typed selectors under ADR-086. Collider profiles answer that channel with
+`Ignore`, `Overlap` or `Block`; serialized/native layer masks are not controller
+identity. Trigger inclusion is explicit. Trigger enter/exit events remain owned by
+the gameplay volume/Physics event contract, not controller surface events.
 
 ## Crouching And Size Changes
 
@@ -343,7 +399,10 @@ The controller supports runtime size changes:
   step behavior, the gameplay system must use a separate controller descriptor or
   override the movement request accordingly
 
-Size changes are gradual unless configured as immediate.
+Size changes are fixed-tick commands. A gradual transition advances once per
+committed tick under a typed profile; presentation delta never changes collision
+height. Every intermediate capsule requires clearance or the command reports its
+declared hold/reject result.
 
 ## Validation And Safety
 
@@ -352,7 +411,9 @@ Size changes are gradual unless configured as immediate.
   a budget; otherwise it reports an error.
 - Teleports bypass collision but flag the controller as needing ground
   re-evaluation. A teleport also detaches the character from any moving platform.
-- Extreme velocities are clamped before sweeping to avoid tunneling.
+- Out-of-profile velocity/displacement returns a typed safety failure. An explicit
+  profile may define deterministic saturation and reports the applied value; no
+  silent clamp is permitted.
 
 ## Diagnostics
 
@@ -381,6 +442,10 @@ Runtime variables:
 - Root motion collision tests.
 - Root motion duplicate/stale generation and reverse-policy tests.
 - Determinism tests for fixed-step playback under different render/catch-up grouping.
+- Platform carry point rotation, dynamic point-velocity prediction, optional heading
+  twist and no post-Physics second move.
+- Capsule up, Gameplay desired heading, root twist and visual pitch/roll ownership.
+- Private Physics-query adapter parity against Horo controller golden fixtures.
 - Performance tests for many concurrent controllers.
 
 ## Related Documents

--- a/docs/architecture/runtime/physics-architecture.md
+++ b/docs/architecture/runtime/physics-architecture.md
@@ -139,6 +139,25 @@ work and final generation/budget validation succeed. Replacement failure destroy
 only the candidate and leaves the prior scene/world/query state unchanged. The
 first Physics tick occurs after the complete bundle is authoritative.
 
+## Character Query Boundary
+
+[ADR-089](../../adr/089-character-controller-ownership-implementation-and-update-order.md)
+keeps the Horo Character domain behind the initial `HoroEngine::Physics` target but
+does not expose Jolt Character classes or add a replaceable backend ABI. One scene-
+owned `CharacterWorld` implements the bounded Horo overlap/support/carry/sweep/
+slide/step/ground algorithm against a read-only, tick/world-generation-affine
+`CharacterPhysicsQueryContext`.
+
+The private adapter maps Horo capsule queries, filter/material evidence and staged
+impulses/presence targets to Jolt narrowphase/body commands. Native collectors do
+not run gameplay or mutate bodies. A private adapter/solver replacement must
+reproduce Horo golden semantics and requalify determinism/performance.
+
+Character movement stages before the Physics step from committed bodies, admitted
+kinematic targets and support point-velocity evidence. Physics then applies staged
+commands and steps once. Post-Physics Character work finalizes support/attachment
+and publishes the collision root with tick commit; it never performs a second move.
+
 ## Fixed-Step Pipeline
 
 One physics tick:

--- a/docs/architecture/runtime/runtime-lifecycle.md
+++ b/docs/architecture/runtime/runtime-lifecycle.md
@@ -293,15 +293,24 @@ Variable-rate update is not used for deterministic physics integration.
 One fixed tick executes:
 
 1. consume the input command state assigned to the tick
-2. run ordered pre-physics systems, including gameplay animation parameters,
-   animation pose/root-motion staging, and character-controller movement
-3. step physics
-4. publish physics results into scene transforms
-5. run post-physics and behavior systems, including typed animation pose
-   overrides and candidate pose finalization
-6. commit deferred entity/component changes
-7. atomically publish committed subsystem state, events, and previous/current
+2. stage Gameplay/AI/Nav movement/facing, animation parameters and kinematic-platform
+   targets
+3. evaluate authoritative Animation pose/root motion and freeze Physics-owned
+   Character query/support/platform-motion evidence
+4. run Horo Character platform carry and bounded query movement, staging its root
+   and Physics commands
+5. apply staged commands and step Physics once
+6. publish Physics results, then finalize Character support/attachment and its
+   authoritative collision-root transform without a second move
+7. compose typed post-Physics Animation pose overrides and candidate pose
+8. commit deferred entity/component changes
+9. atomically publish committed subsystem state, transforms, events, and previous/current
    state for interpolation
+
+[ADR-089](../../adr/089-character-controller-ownership-implementation-and-update-order.md)
+owns this Character-specific dependency order and the separate capsule up, desired
+heading, root rotation, platform angular carry and visual orientation authorities.
+Presentation frames neither accumulate root motion nor update collision state.
 
 [ADR-084](../../adr/084-canonical-physics-solver-units-and-tolerances.md) fixes the
 initial Physics step to pinned Jolt CanonicalV1 under one owner thread and serial

--- a/docs/architecture/runtime/scene-runtime.md
+++ b/docs/architecture/runtime/scene-runtime.md
@@ -317,9 +317,11 @@ exists so future parallelism does not require redesigning system ownership.
 Within a fixed tick,
 [ADR-061](../../adr/061-animation-ownership-update-order-and-clock.md) requires
 gameplay parameter commit before animation pre-physics evaluation, root-motion
-request admission before character-controller movement, physics next, and typed
-post-physics pose override/finalization before tick publication. These are
-dependencies within the existing phase graph, not new `RuntimePhase` values.
+request admission before Character platform/query movement, Physics next,
+Character support/transform finalization without a second move, and typed
+post-Physics pose override/finalization before tick publication. ADR-089 owns the
+Character-specific details. These are dependencies within the existing phase graph,
+not new `RuntimePhase` values.
 
 ## Runtime Save And Restore Integration
 


### PR DESCRIPTION
## Summary

- Defines Horo-owned Character controller semantics, ownership, solver boundary
  and fixed-tick update order in ADR-089.
- Aligns Animation, Physics, AI, Runtime Lifecycle and scene runtime documents
  with the same staged Character/Physics contract.

## Why

The existing documents did not choose whether Horo or Jolt owned controller
semantics, who owned mutable Character state, or the exact order for root motion,
moving-platform carry, Physics stepping and transform publication. The ambiguity
allowed render cadence and native callback order to leak into authoritative
movement.

## Decision and boundaries

- Keeps the Character domain behind `HoroEngine::Physics` initially, without
  exposing Jolt Character types or introducing a replaceable public backend ABI.
- Defines one scene-owned `CharacterWorld` and a bounded Horo overlap, support,
  carry, sweep, slide, step and grounding algorithm over a private Physics query
  adapter.
- Makes movement tick-addressed: intent and Animation root motion precede
  Character movement, Physics steps once, then Character finalizes support and
  publishes at atomic tick commit without a second movement pass.
- Separates collision up, desired heading, root rotation, platform angular carry
  and visual orientation ownership.
- Defines transactional activation/rollback, generation-affine query contexts,
  bounded evidence and fail-closed limits.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Build configuration passed
- [x] Relevant documentation checks passed
- [ ] Manual smoke tested if applicable (documentation-only change)

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/089-character-controller-ownership-implementation-and-update-order.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/character-controller-architecture.md docs/adr/061-animation-ownership-update-order-and-clock.md docs/architecture/runtime/animation-architecture.md docs/architecture/runtime/runtime-lifecycle.md docs/architecture/runtime/scene-runtime.md docs/adr/022-ai-fixed-tick-order-authority-and-simulation-budget.md docs/architecture/runtime/physics-architecture.md
git diff --cached --check
# Added-link existence checker over the staged diff
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- This architecture/documentation PR does not implement the controller solver,
  private Jolt query adapter, lifecycle machinery or qualification suites.
- Existing controller code will need an explicit migration to tick-addressed
  requests and scene-owned `CharacterWorld` state.
- CMake configure reported the existing mbedTLS warning and skipped Python tests
  because pytest is unavailable.

## Issue links

- Jira: HORO-937
- GitHub: Closes #937

## Reviewer Notes

- Review ADR-089 first, then the Character architecture projection, followed by
  the cross-subsystem ordering changes.
- This PR is preserved as an individual merge commit on `develop`; final review and non-squash delivery to `main` occur in PR #2508.