### PR TITLE
docs(prefab): define nested composition and variant inheritance HORO-1046 #1046 [PFB-005.1]

### DIFF
--- a/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
+++ b/docs/adr/017-prefab-role-ownership-and-capability-tiers.md
@@ -6,6 +6,7 @@
 - **Scope**: Prefab asset definition, authoring templates, runtime spawnable templates (`CookedPrefab`), capability tiers (Tier 0, Tier 1, Tier 2), asset identity, project versioning, unknown component preservation, and lifecycle safety
 - **Issue**: [PFB-001.1](https://github.com/abdullahbodur/horo-engine/issues/1008)
 - **Jira**: [HORO-1008](https://horo-engine.atlassian.net/browse/HORO-1008)
+- **Related**: [ADR-093](093-prefab-override-property-identity-and-delta-operations.md), [ADR-094](094-prefab-nested-composition-and-variant-inheritance.md)
 - **Normative document**: [Prefab Architecture](../architecture/runtime/prefab-architecture.md)
 
 ## Context
@@ -92,6 +93,7 @@ Capability delivery is partitioned into three discrete tiers:
 - Asset Pipeline cooks `.prefab` source assets into platform-optimized, immutable binary `CookedPrefab` artifacts (`core.prefab` asset type).
 - Cooked prefabs participate in the standard `AssetRegistry` and `CookCatalog`, loaded via `IAssetProvider`.
 - Two APIs, one contract, reconciled with [ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md) (threading policy) and [ADR-010](010-job-waiting-and-operation-store-ownership.md) (`OperationStore`):
+
   ```cpp
   class SceneCommandBuffer {
   public:
@@ -105,14 +107,15 @@ Capability delivery is partitioned into three discrete tiers:
       Result<SpawnedPrefabHandle, PrefabError> SpawnPrefab(const PrefabSpawnRequest& request);
   };
   ```
+
   `SceneCommandBuffer::RequestSpawnPrefab` is the planned gameplay admission seam; successful admission returns an `OperationId`, while a full queue/store or closed scene returns a typed error without creating an operation. A host-composed spawn coordinator exclusively mutates the authoritative `OperationStore`. `SceneRuntimeAccess::SpawnPrefab` is the internal owner-thread drain, never a gameplay bypass. This Tier 1 extension adds a thread-safe admission facade without making existing SCN-001 owner-thread command-buffer methods thread-safe.
 - Spawn staging uses the existing scene allocator for fresh generation-checked `EntityId`s, copies component data, and establishes hierarchy before **commit**. `OnCreate` runs after commit, then `OnEnable` if enabled; `OnStart` runs once after first enable and before the first eligible fixed update. Created-disabled behaviors defer `OnEnable`/`OnStart` until enabled, as required by Gameplay Behavior Authoring.
 - Fail-safe: missing catalog entries, corrupted or version-mismatched cooked blobs, unregistered component types, component allocation failure, or spawn recursion return typed `PrefabError` without publishing entities or invoking behavior hooks.
 
 #### Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred)
 
-- Prefab Variants allow creating specialized prefabs that inherit from a base prefab asset and record delta overrides (property overrides, added/removed components, extra child entities).
-- Multi-tier variant inheritance chains (`Base -> VariantA -> VariantB`) evaluated as a directed acyclic graph (DAG).
+- Prefab variants specialize exactly one immediate parent and record ADR-093 property/component deltas. V1 rejects multiple parents and hierarchy add/remove/reparent deltas; [ADR-094](094-prefab-nested-composition-and-variant-inheritance.md) owns the detailed capability boundary.
+- Multi-tier variant inheritance chains (`Base -> VariantA -> VariantB`) and nested-placement edges are validated together as one bounded acyclic graph.
 - Editor workspace listens for base prefab mutation events and propagates updates in real time to open variant documents and active viewport previews.
 - Deep per-property override inspection, reverting, and pushing back to base prefab.
 

--- a/docs/adr/093-prefab-override-property-identity-and-delta-operations.md
+++ b/docs/adr/093-prefab-override-property-identity-and-delta-operations.md
@@ -7,7 +7,7 @@
 - **Issue**: [PFB-003.1](https://github.com/abdullahbodur/horo-engine/issues/1027)
 - **Jira**: [HORO-1027](https://horo-engine.atlassian.net/browse/HORO-1027)
 - **Parent**: [PFB-003](https://github.com/abdullahbodur/horo-engine/issues/1002)
-- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-017](017-prefab-role-ownership-and-capability-tiers.md), [ADR-054](054-extension-and-package-authority-boundary.md), [ADR-057](057-package-manifest-v1-typed-model.md)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-017](017-prefab-role-ownership-and-capability-tiers.md), [ADR-054](054-extension-and-package-authority-boundary.md), [ADR-057](057-package-manifest-v1-typed-model.md), [ADR-094](094-prefab-nested-composition-and-variant-inheritance.md)
 - **Normative documents**: [Prefab Architecture](../architecture/runtime/prefab-architecture.md), [Editor Document Model](../architecture/editor/editor-document-model.md), [Project Versioning and Migration](../architecture/foundation/project-versioning-and-migration.md), [Scene Runtime](../architecture/runtime/scene-runtime.md)
 
 ## Context

--- a/docs/adr/094-prefab-nested-composition-and-variant-inheritance.md
+++ b/docs/adr/094-prefab-nested-composition-and-variant-inheritance.md
@@ -1,0 +1,282 @@
+# ADR-094: Prefab Nested Composition and Variant Inheritance
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Nested prefab placement and single-parent variant edge semantics, stable placement identity, deterministic resolution and precedence, graph validation, source-revision rebase, editor provenance, cook flattening, limits and qualification
+- **Issue**: [PFB-005.1](https://github.com/abdullahbodur/horo-engine/issues/1046)
+- **Jira**: [HORO-1046](https://horo-engine.atlassian.net/browse/HORO-1046)
+- **Related**: [ADR-017](017-prefab-role-ownership-and-capability-tiers.md), [ADR-093](093-prefab-override-property-identity-and-delta-operations.md)
+- **Normative documents**: [Prefab Architecture](../architecture/runtime/prefab-architecture.md), [Editor Document Model](../architecture/editor/editor-document-model.md), [Prefab Editor Reference](../architecture/runtime/prefab-editor.html), [Project Versioning and Migration](../architecture/foundation/project-versioning-and-migration.md)
+
+## Context
+
+Prefab Architecture permits one prefab to contain repeated placements of another
+and defers variant inheritance to Tier 2. ADR-093 gives component, property and
+collection overrides stable identity, but intentionally leaves the graph that
+supplies those layers undefined. Without a graph contract, a nested reference can
+be confused with inheritance, serialized order can accidentally choose precedence,
+and multiple variants or construction callbacks can make one asset resolve to
+different effective hierarchies.
+
+Nested composition and variants serve different purposes. A nested placement adds
+one independently addressable occurrence of a referenced hierarchy beneath an
+owning hierarchy. A variant specializes one complete source asset without adding a
+second base. A scene instance then customizes the selected effective asset. These
+layers must remain separately inspectable even though cook ultimately flattens the
+result.
+
+Graph changes also cross document lifetimes. A source revision can arrive while a
+variant, containing prefab, scene and viewport are open. Resolving directly into
+live documents would allow partial publication, stale async completion and silent
+loss of ADR-093 conflicts or opaque data. The production model therefore needs a
+bounded, deterministic candidate operation before implementation begins.
+
+## Decision
+
+### 1. Composition has two closed edge kinds
+
+The authoring dependency graph admits exactly two prefab-to-prefab semantic edges:
+
+| Edge | Owner | Cardinality | Meaning |
+|---|---|---:|---|
+| `NestedPlacement` | Concrete prefab hierarchy | Zero or more, each at a unique persisted placement slot | Mount one effective referenced hierarchy beneath one owning object |
+| `VariantParent` | Variant prefab asset | Exactly one | Inherit one complete effective parent and apply one specialization delta |
+
+Ordinary mesh, material, audio and behavior dependencies remain resource edges.
+They do not compose prefab objects or participate in variant precedence. A prefab
+asset is either concrete or variant in V1. A concrete asset owns authored objects
+and nested placements. A variant owns one `VariantParent` edge and one ADR-093
+override set; it does not own a parallel hierarchy.
+
+The following are unsupported and fail validation:
+
+- multiple variant parents, mixins, traits or merge bases;
+- conditional, tag-, path- or query-selected parents;
+- a variant replacing its parent edge according to platform or runtime state;
+- construction scripts, callbacks or behavior execution during resolution;
+- V1 variant add/remove/reparent of objects or nested placement edges;
+- interpreting resource dependencies as prefab composition.
+
+These are capability limits, not hidden extension points. A future hierarchy delta
+algebra requires a new versioned decision and migration; unknown graph edge or
+operation kinds are preserved by authoring migration where possible but cannot
+resolve or cook.
+
+### 2. Every nested occurrence has stable placement identity
+
+A nested placement is authored data:
+
+```cpp
+struct NestedPrefabPlacementV1 {
+    LocalObjectId placementLocalId;
+    std::optional<LocalObjectId> parentLocalId;
+    Assets::AssetId sourcePrefab;
+    PrefabSourceRevision authoredAgainst;
+    Transform localRootTransform;
+    PrefabOverrideSetV1 overrides;
+};
+
+struct PrefabVariantInheritanceV1 {
+    Assets::AssetId immediateParent;
+    PrefabSourceRevision authoredAgainst;
+    PrefabOverrideSetV1 overrides;
+};
+```
+
+`placementLocalId` is a persisted nonzero slot in the containing concrete prefab's
+single local-ID namespace. It is not an array index, display name, path or referenced
+asset ID. Reordering siblings or moving the source asset does not change it, and a
+deleted slot is not reused while an override, conflict, orphan, history entry or
+external reference may retain it. Repeated placements of the same `sourcePrefab`
+therefore remain distinct.
+
+The referenced root is mounted at the placement slot. Descendant addresses extend
+ADR-093's `nestedInstanceScope` with `placementLocalId`; their final
+`sourceObject` remains the descendant's local ID in its owning source asset.
+`parentLocalId` selects the containing hierarchy parent, while
+`localRootTransform` is the placement transform. Neither becomes a property path or
+an implicit override record.
+
+References carry authoritative `AssetId` and exact authored-against source revision.
+Paths and labels are presentation hints only. Validation rejects zero, duplicate or
+colliding local slots and a parent that is missing or belongs to the mounted source.
+
+### 3. Resolution is one deterministic recursive function
+
+`ResolvePrefabAsset(asset, snapshot)` returns an immutable effective hierarchy and
+provenance table or a typed failure. It has no access to wall-clock time, locale,
+filesystem discovery, service locators, runtime entities or gameplay callbacks.
+
+1. Load and migrate the requested document and every reachable document into one
+   immutable registry snapshot. Pin `AssetId`, content revision, `ProjectVersion`
+   and schema-registry revision.
+2. Validate every document and the combined semantic graph before materializing an
+   effective hierarchy.
+3. For a concrete asset, materialize its authored objects. Resolve each nested
+   placement's `sourcePrefab`, apply that placement's ADR-093 override set, then
+   mount the result beneath `parentLocalId` using `placementLocalId` as the new
+   scope segment.
+4. For a variant, resolve its single `immediateParent`, then apply the variant's
+   ADR-093 override set to that complete effective parent candidate.
+5. For a scene instance, resolve its selected source asset and then apply the
+   scene-instance override set.
+6. Validate final identity, hierarchy, component, payload and expansion limits and
+   publish only the complete candidate.
+
+This algorithm defines precedence without relying on serialized record order. For
+any effective value, the oldest concrete source is lowest precedence; referenced
+asset variant layers apply oldest-to-newest; the owning nested-placement override
+applies after the referenced asset resolves; containing variant layers then apply
+when their parent candidate returns; and the outer scene-instance override is last.
+An ADR-093 duplicate or incompatible operation in one layer remains an error rather
+than last-write-wins.
+
+A variant may reference another variant because each asset still has one immediate
+parent. A nested placement may reference a concrete prefab or variant. Both cases
+use the same recursive function and provenance rules; neither creates multiple
+inheritance.
+
+### 4. The combined graph is bounded and acyclic
+
+Validation builds one graph keyed by `AssetId` and includes both semantic edge
+kinds. A deterministic depth-first traversal sorts outgoing nested placements by
+`placementLocalId` and reports the first canonical cycle path, including each edge
+kind and placement ID. A cycle across kinds, such as `A NestedPlacement B` and
+`B VariantParent A`, is still a cycle.
+
+V1 enforces these independent limits:
+
+- at most 8 `VariantParent` edges in one resolution path;
+- at most 16 `NestedPlacement` edges in one resolution path;
+- at most 256 direct nested placements in one concrete document;
+- the existing maximum expanded hierarchy depth, object count, component count and
+  payload limits after all inheritance and composition layers apply.
+
+Exact-bound inputs succeed. The next edge or expanded item fails before recursion
+or allocation exceeds its budget. Memoization may reuse an immutable effective
+asset candidate within the pinned snapshot, but mounting always produces a distinct
+placement scope. Cached output cannot erase occurrence identity or provenance.
+
+Missing assets/revisions, unsupported migrated schemas, duplicate placement IDs,
+invalid parents, unresolved ADR-093 records, cycles and exceeded limits fail the
+candidate. No partial hierarchy, dependency table or cooked artifact is published.
+
+### 5. Provenance keeps layers separately inspectable
+
+Resolution emits bounded provenance beside the effective candidate. Each effective
+object and overridden property can identify:
+
+- source asset and source revision;
+- semantic edge kind and, for nesting, the complete placement scope;
+- concrete, variant, nested-placement or scene-instance layer;
+- the ADR-093 override record, conflict or orphan responsible for the value.
+
+The provenance table is editor/build evidence, not runtime entity identity and not
+an additional source of truth. The Prefab Editor presents the single-parent chain,
+nested placement graph, effective precedence and unresolved conflicts separately.
+It never flattens those concepts into an editable anonymous property map.
+
+### 6. Source changes use detached, transactional candidates
+
+A registry change invalidates affected resolved candidates through reverse
+`AssetId` dependencies. The application pins the old and new registry snapshots,
+re-resolves descendants in deterministic topological order and runs ADR-093
+three-way rebase independently for every affected variant, nested placement and
+scene instance.
+
+Open documents and viewport projections receive one complete candidate through the
+Editor transaction/application boundary. Candidate preparation may run on workers
+using owned immutable inputs. Commit rechecks document session/revision, registry
+snapshot and cancellation on the owning thread. Failure, cancellation, stale
+completion, cycle introduction or any unresolved required record preserves the
+previous document, dirty state, history and visible projection. Conflicts and
+orphans remain explicit and lossless.
+
+Saving a concrete prefab, variant or scene never edits dependants as an incidental
+serializer side effect. Apply-to-source is the ADR-093 multi-document publication
+workflow. File watchers only report invalidation; Inspector and graph widgets issue
+typed commands.
+
+### 7. Cook consumes the resolved candidate, not the source graph at runtime
+
+Scene cook and prefab cook use the same resolver and flatten the validated effective
+hierarchy into their existing runtime definitions. The dependency-aware cache key
+includes the resolver/graph schema version, ordered semantic edge kinds and
+placement IDs, every reachable source identity/revision/artifact digest and the
+canonical override-set digests. A transitive source, edge, placement or override
+change therefore invalidates reuse.
+
+Packaged runtime receives flattened typed hierarchy data. It does not parse source
+prefabs, traverse `VariantParent`, apply authoring overrides, run construction
+scripts or choose a parent dynamically. Provenance retained for diagnostics is
+bounded and optional; it cannot authorize runtime mutation.
+
+### 8. Errors and qualification are typed
+
+The authoring/cook surface distinguishes at least `MissingPrefabSource`,
+`SourceRevisionUnavailable`, `UnsupportedPrefabSchema`, `InvalidPlacement`,
+`MultipleVariantParents`, `CyclicComposition`, `VariantDepthExceeded`,
+`CompositionDepthExceeded`, `CompositionEdgeLimitExceeded`, ADR-093
+`OverrideConflict`/`OverrideOrphan`, and the existing hierarchy/payload limit
+errors. Diagnostics include the owning asset, edge kind and stable placement scope
+without using localized text as identity.
+
+Required focused coverage includes:
+
+| Category | Scenario | Expected outcome |
+|---|---|---|
+| Valid | Concrete A nests the same variant B twice | Two distinct scopes resolve identically except for placement identity/transform |
+| Valid | Base -> VariantA -> VariantB, then scene override | Base, oldest-to-newest variants, then scene layer determine the value |
+| Valid | Outer variant overrides an object inside its parent's nested placement | Nested source and placement resolve first; outer variant targets the stable nested scope |
+| Boundary | Variant depth 8 and nested depth 16 | Exact bounds resolve and cook |
+| Boundary | Next variant/nested edge or expanded object exceeds its limit | Typed limit failure before partial allocation/publication |
+| Malformed | Duplicate/zero placement ID or missing containing parent | `InvalidPlacement`; old candidate remains active |
+| Malformed | A nests B while B inherits A | Canonical combined-edge cycle diagnostic; no artifact |
+| Malformed | Variant declares two parents or an unknown hierarchy operation | Explicit rejection; no guessed merge order |
+| Malformed | Referenced revision is missing or ADR-093 target is orphaned | Typed unresolved candidate; opaque record retained |
+| Lifecycle | Source changes while descendant re-resolution is running | Stale completion cannot replace the newer registry/document snapshot |
+| Lifecycle | Rebase is cancelled or one affected document fails | No partial multi-document/viewport publication |
+| Cook | Transitive variant, placement or override changes | Canonical cache key changes; runtime artifact contains only flattened data |
+| Capability | Construction callback would affect resolved output | Callback is never invoked; unsupported request is rejected |
+
+## Consequences
+
+- Nested composition, variant inheritance and per-instance customization have
+  distinct identities and precedence while sharing ADR-093's delta algebra.
+- Single-parent variants keep resolution linear at each asset and make provenance,
+  rebase and conflict ownership reviewable.
+- Combined-edge cycle validation and explicit limits prevent recursion and
+  unbounded authoring/cook work before publication.
+- V1 variants cannot add, remove or reparent hierarchy objects. That constraint is
+  deliberate until a closed, migratable hierarchy delta algebra is accepted.
+- Runtime stays independent of authoring graph traversal and construction-script
+  behavior at the cost of recooking when any transitive semantic input changes.
+
+## Alternatives Considered
+
+### Treat nested placement and inheritance as the same edge
+
+Rejected because repeated occurrence identity, mounting and transform semantics do
+not exist for inheritance, while inheritance precedence does not exist for an
+ordinary nested placement.
+
+### Allow multiple variant parents with serialized merge order
+
+Rejected because order becomes semantic ambient state, diamond conflicts gain no
+single immediate default, and ADR-093 three-way rebase loses an unambiguous source.
+
+### Run construction scripts while resolving
+
+Rejected because callbacks introduce code availability, side effects, ordering,
+threading and determinism into a data-validation/cook boundary.
+
+### Resolve source graphs lazily in packaged runtime
+
+Rejected because it ships authoring schemas and migration policy, increases runtime
+failure modes and allows editor/runtime results to diverge.
+
+### Publish each resolved dependant as soon as it finishes
+
+Rejected because users could observe a mixture of source revisions and a failed
+later candidate could not restore external or already-observed state atomically.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -105,6 +105,7 @@ to the replacement.
 | [091](091-footstep-and-locomotion-event-ownership.md) | Footstep and Locomotion Event Ownership | Proposed | 2026-09-02 |
 | [092](092-character-controller-determinism-and-state-composition.md) | Character Controller Determinism and State Composition | Proposed | 2026-09-02 |
 | [093](093-prefab-override-property-identity-and-delta-operations.md) | Prefab Override Property Identity and Delta Operations | Proposed | 2026-09-02 |
+| [094](094-prefab-nested-composition-and-variant-inheritance.md) | Prefab Nested Composition and Variant Inheritance | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -258,6 +258,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Prefab Override Property Identity and Delta Operations](../adr/093-prefab-override-property-identity-and-delta-operations.md):
   stable component/property/element addressing, typed delta algebra, canonical
   equality/order, transactional rebase and lossless conflict/orphan preservation.
+- [Prefab Nested Composition and Variant Inheritance](../adr/094-prefab-nested-composition-and-variant-inheritance.md):
+  stable nested-placement edges, single-parent variants, deterministic precedence,
+  combined-graph validation, transactional propagation and flattened cook output.
 - [Built-In Scene Primitives](./runtime/built-in-scene-primitives.md): core
   procedural meshes, collider shapes, and scene object primitives available
   without external packages.

--- a/docs/architecture/editor/editor-document-model.md
+++ b/docs/architecture/editor/editor-document-model.md
@@ -160,6 +160,22 @@ An external publication with uncertain/partial outcome receives an explicit
 reconciliation record; the editor cannot claim in-memory rollback undid an already
 published source file.
 
+[ADR-094](../../adr/094-prefab-nested-composition-and-variant-inheritance.md)
+extends the same transaction boundary to nested-placement and single-parent variant
+resolution. The application pins one Asset Registry snapshot, validates the
+combined `NestedPlacement`/`VariantParent` graph, resolves affected assets in
+deterministic dependency order and prepares every ADR-093 rebase before commit.
+The visible document and viewport receive one complete candidate; a cycle, missing
+revision, conflict, cancellation or stale async completion leaves the prior graph,
+projection, dirty state and history unchanged.
+
+The editor exposes concrete, variant, nested-placement and scene-instance layers
+separately through bounded provenance. A variant has exactly one immediate parent.
+Inspector and graph controls cannot add a second parent, run construction scripts,
+edit the flattened projection or mutate dependants from a file-watcher callback.
+They submit typed commands against stable `AssetId`, source revision and persisted
+placement `LocalObjectId` scope.
+
 Intermediate transaction state is not observable by tabs or panels until the
 transaction commits, unless the transaction is explicitly marked as a preview
 transaction.

--- a/docs/architecture/runtime/prefab-architecture.md
+++ b/docs/architecture/runtime/prefab-architecture.md
@@ -130,14 +130,17 @@ own those delivery decisions:
 ### Tier 2: Live Variant Inheritance & Dynamic Override Tracking (Deferred)
 
 [ADR-093](../../adr/093-prefab-override-property-identity-and-delta-operations.md)
-fixes the property/component identity and delta foundation used by this tier. It
-does not move the tier into the implemented baseline; hierarchy object operations,
-variant DAG delivery and UI remain their owning PFB-003 work.
+fixes the property/component identity and delta foundation used by this tier, and
+[ADR-094](../../adr/094-prefab-nested-composition-and-variant-inheritance.md)
+fixes nested-placement, single-parent variant and resolution semantics. Neither
+decision moves the tier into the implemented baseline; delivery and UI remain
+their owning work.
 
-- **Prefab Variants**: A variant `.prefab` references a parent base prefab `AssetId` and stores
-  only delta overrides (modified property fields, added/removed components, extra child objects).
-- **Variant Inheritance DAG**: Multi-level variant chains (`Base -> VariantA -> VariantB`) validated
-  for acyclicity.
+- **Prefab Variants**: A variant `.prefab` references exactly one immediate parent `AssetId` and
+  stores only ADR-093 property/component deltas. V1 rejects multiple parents and hierarchy
+  add/remove/reparent operations.
+- **Combined Semantic Graph**: Multi-level variant chains (`Base -> VariantA -> VariantB`) and
+  nested-placement edges are validated together for acyclicity and explicit bounds.
 - **Live Editor Propagation**: When a base prefab is modified and saved, open variant documents,
   scenes referencing the prefab, and active viewport sessions update in real time.
 - **Granular Override Management**: Deep per-property diffing, revert-to-prefab, and apply-to-prefab
@@ -182,6 +185,37 @@ Apply, revert, conflict resolution, rebase and apply-to-prefab run through typed
 document/application transactions with undo/history, revision, dirty-state and
 atomic-save semantics. Inspector/file-watcher/serializer code does not mutate the
 document or `.prefab` file directly.
+
+### Nested Composition And Variant Resolution
+
+[ADR-094](../../adr/094-prefab-nested-composition-and-variant-inheritance.md)
+defines two and only two prefab semantic edges. A concrete prefab may own bounded
+`NestedPlacement` edges, each identified by a unique persisted `LocalObjectId` slot.
+A variant owns exactly one `VariantParent` edge and an ADR-093 override set. Resource
+dependencies are not composition edges. Multiple inheritance, mixins, conditional
+parents, construction scripts and V1 hierarchy add/remove/reparent deltas are
+rejected.
+
+Resolution uses one immutable Asset Registry snapshot. A concrete asset materializes
+its authored objects, recursively resolves each nested source, applies the
+placement-local override and mounts it at the placement slot. A variant resolves
+its single immediate parent and then applies its delta. A scene instance resolves
+its selected asset and applies its instance delta last. This recursive algorithm,
+not serialized order, defines precedence and emits bounded per-object/property
+provenance for the Editor.
+
+The combined graph includes `NestedPlacement` and `VariantParent` edges and must be
+acyclic even when a cycle crosses edge kinds. Variant paths are limited to 8 edges,
+nested-placement paths to 16 edges and one concrete document to 256 direct nested
+placements; existing expanded hierarchy/object/component/payload bounds still
+apply. Validation, re-resolution and ADR-093 rebase produce detached candidates.
+Cycle, revision, conflict, bound, cancellation or stale-snapshot failure publishes
+nothing and preserves the previous document/projection.
+
+Cook consumes the complete resolved candidate. Its dependency-aware key includes
+edge kinds, placement IDs, reachable source revisions and override digests, then it
+flattens the hierarchy. Packaged runtime does not traverse authoring inheritance or
+composition graphs and never runs construction behavior to produce prefab data.
 
 ---
 
@@ -244,6 +278,9 @@ namespace Horo::Prefab {
     inline constexpr std::size_t MaximumPrefabObjectCount    = 256;
     inline constexpr std::size_t MaximumPrefabPayloadBytes   = 4 * 1024 * 1024; // 4 MiB
     inline constexpr std::size_t MaximumPrefabComponentsPerObject = 64;
+    inline constexpr std::size_t MaximumVariantInheritanceDepth = 8;
+    inline constexpr std::size_t MaximumNestedPrefabDepth = 16;
+    inline constexpr std::size_t MaximumDirectNestedPlacements = 256;
     inline constexpr std::size_t MaximumRuntimeSpawnDepth = 8; // inherited lineage, including target
 }
 ```
@@ -255,11 +292,13 @@ validate incrementally before expansion exceeds allocation limits. Limits are en
 save/import/placement, at cook (no artifact on failure), and before runtime staging.
 
 Runtime validates the artifact envelope and actual table offsets, lengths, alignment, parent
-indices, component counts, and hierarchy; header counts alone are not trusted. Require exactly
-one root, unique local IDs, valid parents, and an acyclic connected hierarchy. Invalid authored
-graphs return `InvalidHierarchy`; malformed cooked encoding returns `CorruptedPayload`;
-well-formed over-limit input returns the relevant bounds error. Static nested-inclusion cycles
-return `CyclicReferenceDetected` at authoring/cook time.
+indices, component counts, and hierarchy; header counts alone are not trusted. A concrete source
+requires exactly one root, unique local IDs, valid parents, and an acyclic connected hierarchy;
+it may own nested placements but no variant parent. A variant owns no parallel object or placement
+hierarchy and requires exactly one immediate parent. Invalid authored graphs return
+`InvalidHierarchy`; malformed cooked encoding returns `CorruptedPayload`; well-formed over-limit
+input returns the relevant bounds error. Combined nested/inheritance cycles return
+`CyclicComposition` at authoring/cook time.
 
 ### Authoring Document Structure (`PrefabDocument`)
 
@@ -281,10 +320,27 @@ struct PrefabObjectNode {
     std::vector<Gameplay::BehaviorAttachmentDefinition> behaviors;
 };
 
+struct NestedPrefabPlacementV1 {
+    LocalObjectId placementLocalId; // Persisted scope segment, never an array index
+    std::optional<LocalObjectId> parentLocalId;
+    Assets::AssetId sourcePrefab;
+    PrefabSourceRevision authoredAgainst;
+    Transform localRootTransform;
+    PrefabOverrideSetV1 overrides;
+};
+
+struct PrefabVariantInheritanceV1 {
+    Assets::AssetId immediateParent; // Exactly one parent for a variant
+    PrefabSourceRevision authoredAgainst;
+    PrefabOverrideSetV1 overrides;
+};
+
 struct PrefabDocument {
     HoroProjectVersion projectVersion; // Unified authoring version, not a prefab schema counter
     Assets::AssetId assetId;
-    std::vector<PrefabObjectNode> objects; // first node is root; local IDs are persisted, possibly sparse
+    std::vector<PrefabObjectNode> objects; // concrete only; first node is root; IDs may be sparse
+    std::vector<NestedPrefabPlacementV1> nestedPlacements; // concrete assets only
+    std::optional<PrefabVariantInheritanceV1> variant; // variant assets only
     std::vector<Assets::AssetId> referencedAssets;
 };
 ```
@@ -502,6 +558,13 @@ enum class PrefabError : std::uint32_t {
     ObjectCountExceeded,        // Template exceeds MaximumPrefabObjectCount (256)
     PayloadTooLarge,            // Template exceeds MaximumPrefabPayloadBytes (4 MiB)
     CyclicReferenceDetected,    // Nested prefab inclusion contains a cycle (authoring/cook)
+    CyclicComposition,          // Combined nested-placement/variant graph contains a cycle
+    MissingPrefabSource,        // Semantic edge references no available source revision
+    InvalidPlacement,           // Placement ID, parent, transform or scope is invalid
+    MultipleVariantParents,     // Variant does not have exactly one immediate parent
+    VariantDepthExceeded,       // More than 8 variant-parent edges in one path
+    CompositionDepthExceeded,   // More than 16 nested-placement edges in one path
+    CompositionEdgeLimitExceeded, // More than 256 direct placements in one concrete source
     SpawnRecursionDetected,     // Requested AssetId repeats in inherited spawn lineage
     SpawnDepthExceeded,         // Lineage exceeds MaximumRuntimeSpawnDepth
     AdmissionRejected,         // Queue/store capacity exhausted or admission closed
@@ -562,12 +625,22 @@ enum class PrefabError : std::uint32_t {
 | **Lifecycle** | Source and override change the same value incompatibly | Preserve explicit three-way conflict and original override bytes |
 | **Lifecycle** | Source deletes/retypes target or package schema unloads | Preserve orphan/opaque record; cook blocked until explicit resolution |
 | **Lifecycle** | Revert/rebase/apply-to-prefab fails or is cancelled | Document/source/override/history remain unchanged |
+| **Valid** | Same variant is nested twice under distinct placement IDs | Two distinct scopes with identical inherited values and independent placement overrides |
+| **Valid** | Base -> VariantA -> VariantB plus scene override | Oldest-to-newest variant precedence, then scene-instance override |
+| **Boundary** | Variant depth 8 and nested-placement depth 16 | Exact bounds resolve and cook |
+| **Malformed** | Variant depth 9, nested depth 17, or 257 direct placements | Typed graph limit; no candidate/artifact publication |
+| **Malformed** | Nested A -> B plus variant parent B -> A | `CyclicComposition` with canonical edge path; prior projection remains active |
+| **Malformed** | Variant has two parents or owns hierarchy deltas | Explicit rejection; no serialized-order merge or guessed topology |
+| **Lifecycle** | Source changes during descendant re-resolution | Stale completion cannot replace newer registry/document snapshot |
+| **Capability** | Construction callback could affect composition | Callback is never invoked; unsupported request is rejected |
 
 ---
 
 ## Related Documents
 
 - [ADR-017: Prefab Role, Ownership and Capability-Tier Decision](../../adr/017-prefab-role-ownership-and-capability-tiers.md)
+- [ADR-093: Prefab Override Property Identity and Delta Operations](../../adr/093-prefab-override-property-identity-and-delta-operations.md)
+- [ADR-094: Prefab Nested Composition and Variant Inheritance](../../adr/094-prefab-nested-composition-and-variant-inheritance.md)
 - [ADR-018: Command Registration, Permissions, Threading and Packaged-Build Policy](../../adr/018-command-registration-permissions-threading-and-packaged-build-policy.md)
 - [ADR-010: Job Waiting and Operation Store Ownership](../../adr/010-job-waiting-and-operation-store-ownership.md)
 - [Scene Runtime Architecture](./scene-runtime.md)

--- a/docs/architecture/runtime/prefab-editor.html
+++ b/docs/architecture/runtime/prefab-editor.html
@@ -1335,7 +1335,7 @@ aside.horo-drawer.drawer-closed > * { opacity:0; pointer-events:none; }
     </div>
     <div class="search"><input placeholder="Search prefabs…" /></div>
     <div class="panel-body">
-      <div class="group-note">Prefabs are authored assets. Scene documents store stable logical references; cooked scenes inline expanded objects for runtime construction.</div>
+      <div class="group-note">Prefabs are authored assets. Nested placements use stable local slots; variants have one immediate parent. Cooked scenes inline the validated effective graph.</div>
       <div class="prefab-row active"><span>◆</span><span>Door_Interactable</span><span class="meta">v7</span></div>
       <div class="prefab-row"><span>◆</span><span>Chest_Lootable</span><span class="meta">v3</span></div>
       <div class="prefab-row"><span>◆</span><span>PressurePlate</span><span class="meta">v5</span></div>
@@ -1419,11 +1419,13 @@ aside.horo-drawer.drawer-closed > * { opacity:0; pointer-events:none; }
           <div class="kv"><span>Path</span><span>assets/prefabs/interactables/Door_Interactable.prefab</span></div>
           <div class="kv"><span>Schema</span><span>prefab.v1</span></div>
           <div class="kv"><span>Objects</span><span>6 source / 6 expanded</span></div>
-          <div class="kv"><span>Dependencies</span><span>5 direct / 9 transitive</span></div>
+          <div class="kv"><span>Composition</span><span>2 nested / variant depth 1</span></div>
+          <div class="kv"><span>Dependencies</span><span>5 resource / 9 transitive</span></div>
           <div class="kv"><span>Dirty State</span><span>2 preview overrides</span></div>
           <div style="height:10px"></div>
           <div class="override-list">
             <div class="override-card active"><span class="dot blue"></span><div><div class="override-title">Source asset reference is stable</div><div class="override-sub">Path can move without breaking prefab instances.</div></div><span class="pill ok">OK</span></div>
+            <div class="override-card"><span class="dot ok"></span><div><div class="override-title">Precedence is deterministic</div><div class="override-sub">Source, variants, nested placement, then scene instance; every layer retains provenance.</div></div><span class="pill ok">OK</span></div>
             <div class="override-card"><span class="dot ok"></span><div><div class="override-title">Runtime handles are not serialized</div><div class="override-sub">Scene stores stable object and asset IDs only.</div></div><span class="pill ok">OK</span></div>
           </div>
         </div>
@@ -1476,8 +1478,8 @@ aside.horo-drawer.drawer-closed > * { opacity:0; pointer-events:none; }
           <path d="M544 110 C640 235 640 260 720 260" stroke="#e6a23c" stroke-width="2" fill="none" opacity=".55"/>
           <path d="M544 110 C640 320 640 360 720 360" stroke="#04a5fc" stroke-width="2" fill="none" opacity=".5"/>
         </svg>
-        <div class="dep-node active" style="left:26px;top:78px"><div class="graph-title">Door_Interactable.prefab</div><div class="graph-sub">authoring asset</div></div>
-        <div class="dep-node" style="left:calc(50% - 82px);top:78px"><div class="graph-title">Scene Instance</div><div class="graph-sub">LibraryDoor_A reference</div></div>
+        <div class="dep-node active" style="left:26px;top:78px"><div class="graph-title">Door_Base.prefab</div><div class="graph-sub">concrete source</div></div>
+        <div class="dep-node" style="left:calc(50% - 82px);top:78px"><div class="graph-title">Door_Interactable</div><div class="graph-sub">single VariantParent edge</div></div>
         <div class="dep-node" style="right:26px;top:48px"><div class="graph-title">mesh_door_wood_01</div><div class="graph-sub">mesh asset</div></div>
         <div class="dep-node" style="right:26px;top:132px"><div class="graph-title">mat_oak_varnished</div><div class="graph-sub">material asset</div></div>
         <div class="dep-node" style="right:26px;top:244px"><div class="graph-title">snd_door_open_01</div><div class="graph-sub">audio source</div></div>
@@ -1488,6 +1490,8 @@ aside.horo-drawer.drawer-closed > * { opacity:0; pointer-events:none; }
         <div class="card-head"><span>Asset Pipeline</span><span class="pill ok">ready</span></div>
         <div class="card-body">
           <div class="kv"><span>Import State</span><span>editor asset valid</span></div>
+          <div class="kv"><span>Graph Policy</span><span>acyclic · single parent</span></div>
+          <div class="kv"><span>Placement Scope</span><span>stable LocalObjectId chain</span></div>
           <div class="kv"><span>Sidecar</span><span>Door_Interactable.prefab.horo</span></div>
           <div class="kv"><span>Cook Targets</span><span>vulkan / opengl / null</span></div>
           <div class="kv"><span>Cache Key</span><span>asset + source + cooker + target</span></div>


### PR DESCRIPTION
## Summary

- Define distinct nested-placement and single-parent variant graph semantics.
- Fix stable placement identity, deterministic layer precedence, bounded combined-graph validation and transactional source propagation.
- Align Prefab Architecture, Editor Document Model and the Prefab Editor reference with ADR-094.

## Why

Nested composition and variant inheritance previously lacked one production graph and resolution contract. That left cycle handling, repeated-placement identity, layer precedence, revision changes and prohibited behavior ambiguous across authoring, editor projection and cook.

## Decision and boundaries

- Admit only `NestedPlacement` and `VariantParent` prefab semantic edges; variants have exactly one immediate parent.
- Resolve concrete sources, referenced variants, placement-local overrides, containing variants and the outer scene instance through one immutable-snapshot algorithm.
- Reject multiple inheritance, construction scripts and V1 hierarchy add/remove/reparent deltas.
- Validate both edge kinds as one acyclic graph with explicit variant, nesting, direct-edge and expanded-data bounds.
- Publish source-change rebase results atomically through document/application transactions; preserve conflicts and orphans.
- Flatten the validated effective candidate during cook so packaged runtime does not traverse authoring graphs.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Build configuration passed
- [x] Relevant documentation checks passed
- [x] Manual responsive smoke test passed

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/094-prefab-nested-composition-and-variant-inheritance.md docs/adr/093-prefab-override-property-identity-and-delta-operations.md docs/adr/017-prefab-role-ownership-and-capability-tiers.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/prefab-architecture.md docs/architecture/editor/editor-document-model.md
git diff --cached --check
# staged added-Markdown-link resolution check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
# agent-browser at 1440x900 and 1024x768 for prefab-editor.html
```

## Risk and rollout

- This is an architecture decision and documentation projection; implementation and executable regression coverage remain follow-up delivery work.
- CMake reported the existing mbedTLS minimum-version deprecation and unavailable-pytest warnings; repository Python tests were therefore not executed.

## Issue links

- Jira: HORO-1046
- GitHub: Closes #1046

## Reviewer Notes

- Review ADR-094 first, then the normative Prefab Architecture projection and Editor transaction rules.
- `prefab-editor.html` contains the visible single-parent, stable-placement and precedence projection used for UI alignment.
- This PR is preserved as an individual merge commit on `develop`; final review and non-squash delivery to `main` occur in PR #2508.