### PR TITLE
docs(network): select GameNetworkingSockets baseline HORO-1106 #1106 [NET-001.9]

### DIFF
--- a/docs/adr/020-network-target-ownership-and-dependency-boundary.md
+++ b/docs/adr/020-network-target-ownership-and-dependency-boundary.md
@@ -6,6 +6,7 @@
 - **Scope**: Network target topology, compile-time dependency directions, public API encapsulation, optional linking and composition, threading model, and deterministic lifecycle/shutdown.
 - **Issue**: [NET-001.1](https://github.com/abdullahbodur/horo-engine/issues/1098)
 - **Jira**: [HORO-1098](https://horo-engine.atlassian.net/browse/HORO-1098)
+- **Companion decision**: [ADR-097](097-default-real-time-transport-backend.md) replaces the ENet-specific concrete-backend selection while preserving this boundary
 - **Normative documents**:
   - [Networking Architecture](../architecture/runtime/networking-architecture.md)
   - [System Design](../architecture/foundation/system-design.md)
@@ -22,7 +23,7 @@ In addition, networking implementations typically depend on platform-specific so
 
 ## Decision
 
-**The network subsystem is structured into four distinct target tiers with strict compile-time boundaries: `HoroEngine::NetworkApi` (public backend-neutral interfaces and value types), `HoroEngine::NetworkRuntime` (session, authentication, and replication runtime), and private concrete transports (`HoroEngine::NetworkTransportENet`, `HoroEngine::NetworkTransportNull`). `INetworkTransport` is a handle-based packet-transport abstraction; protocol negotiation and authentication belong to `NetworkRuntime`. The host injects a unique `INetworkTransport` into the runtime. Public headers strictly encapsulate all native socket descriptors, TLS contexts, event loops, and third-party transport types. Networking is fully optional; applications and tools may link without network targets or compose `NetworkTransportNull`. Transports own cross-thread queues. Runtime observes inbound events only through `PollEvents()` during `NetworkPoll`, and submits outbound payloads during `NetworkFlush`.**
+**The network subsystem is structured into four distinct target tiers with strict compile-time boundaries: `HoroEngine::NetworkApi` (public backend-neutral interfaces and value types), `HoroEngine::NetworkRuntime` (session, authentication, and replication runtime), and private concrete transports (`HoroEngine::NetworkTransportGNS`, `HoroEngine::NetworkTransportNull`). `INetworkTransport` is a handle-based packet-transport abstraction; protocol negotiation and authentication belong to `NetworkRuntime`. The host injects a unique `INetworkTransport` into the runtime. Public headers strictly encapsulate all native socket descriptors, TLS contexts, event loops, and third-party transport types. Networking is fully optional; applications and tools may link without network targets or compose `NetworkTransportNull`. Transports own cross-thread queues. Runtime observes inbound events only through `PollEvents()` during `NetworkPoll`, and submits outbound payloads during `NetworkFlush`.**
 
 ### 1. Target Topology and Allowed Dependencies
 
@@ -33,7 +34,7 @@ The network subsystem is decomposed into four discrete CMake targets:
 | `HoroEngine::NetworkApi` | Backend-neutral public types, handles, traits, interfaces | `HoroEngine::Foundation` | Value types (`NetworkId`, `NetworkAddress`, `DeliveryPolicy`), generation handles (`ConnectionHandle`, `ListenerHandle`), error codes, message views, `INetworkTransport`, `TransportEvent`, replication traits |
 | `HoroEngine::NetworkRuntime` | Session management, protocol negotiation, authentication, replication | `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Runtime` | `NetworkRuntimeCoordinator`, `NetworkSession`, `SessionStateMachine`, `ReplicationManager`. Owns the injected `unique_ptr<INetworkTransport>` |
 | `HoroEngine::NetworkTransportNull` | Deterministic in-memory/loopback/null transport | `HoroEngine::NetworkApi`, `HoroEngine::Foundation` | `NullTransportBackend` factory / descriptor for testing, headless simulation, and network-disabled fallback. No Platform, sockets, or I/O thread |
-| `HoroEngine::NetworkTransportENet` | Concrete UDP transport implementation | `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Platform` | `ENetTransportBackend` factory / descriptor. Owns I/O thread and queues. All ENet headers, sockets, and platform dependencies are `PRIVATE` |
+| `HoroEngine::NetworkTransportGNS` | Concrete production direct-IP transport | `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Platform` | `GnsTransportBackend` factory / descriptor. Owns I/O thread and queues. All GNS, crypto, protobuf, socket and platform dependencies are `PRIVATE` |
 
 ```text
                +---------------------------+
@@ -49,7 +50,7 @@ The network subsystem is decomposed into four discrete CMake targets:
 +---------------------+----+   +-----+-------------------------+
 | HoroEngine::NetworkRuntime|   | Concrete Transports (Private) |
 | (depends also on Runtime) |   | - NetworkTransportNull        |
-+---------------------------+   | - NetworkTransportENet        |
++---------------------------+   | - NetworkTransportGNS         |
                                 +-------------------------------+
 ```
 
@@ -57,7 +58,7 @@ Rules:
 
 1. `HoroEngine::NetworkApi` depends **only** on `HoroEngine::Foundation`. It contains zero runtime logic, background threads, or socket code.
 2. `HoroEngine::NetworkRuntime` depends on `NetworkApi`, `Foundation`, and `Runtime`. It never links a concrete transport backend directly. The composition root instantiates the backend and transfers `std::unique_ptr<INetworkTransport>` into the runtime.
-3. `NetworkTransportNull` depends only on `NetworkApi` and `Foundation`. It does not depend on `Platform`, open OS sockets, or create I/O threads. `NetworkTransportENet` depends on `NetworkApi`, `Foundation`, and `Platform` (plus private third-party libraries). Transports do not depend on `NetworkRuntime` or `HoroEngine::Runtime`.
+3. `NetworkTransportNull` depends only on `NetworkApi` and `Foundation`. It does not depend on `Platform`, open OS sockets, or create I/O threads. `NetworkTransportGNS` depends on `NetworkApi`, `Foundation`, and `Platform` (plus private third-party libraries). Transports do not depend on `NetworkRuntime` or `HoroEngine::Runtime`.
 4. Feature modules, gameplay modules, and editor panels consume `NetworkApi` and `NetworkRuntime` interfaces; they **never** depend on concrete transport targets.
 5. Public `NetworkApi` exposes handle-based `INetworkTransport` only. `ITransportConnection` and `ITransportListener` are not public types.
 
@@ -69,7 +70,7 @@ Public headers under `include/Horo/Network/` and `include/Horo/Runtime/` MUST NO
 - Native socket descriptors or OS handles (`SOCKET`, `int fd`, file descriptors)
 - Cryptography / TLS context types (`SSL*`, `SSL_CTX*`, OpenSSL / mbedTLS headers)
 - Event loop types (libuv `uv_loop_t`, epoll, kqueue, IOCP handles)
-- Third-party transport types (`ENetHost`, `ENetPeer`, `ENetPacket`, `SteamNetworkingSockets`, etc.)
+- Third-party transport types (GNS interfaces, handles, messages, connection information, callbacks, configuration values, etc.)
 
 All OS and third-party types remain strictly internal to the private compilation units (`src/runtime/networking/backends/...`) and are encapsulated via interface implementations or Pimpl idioms. Addresses are represented by `Horo::Network::NetworkAddress` value types; connections and listeners are referenced by generation-checked `ConnectionHandle` and `ListenerHandle` identifiers.
 
@@ -79,14 +80,14 @@ Networking is an optional engine capability.
 
 - **Offline / Non-Networked Products**: Products (such as single-player offline games, command-line utilities like `horopak`, asset compilers, or headless tools) do not link `NetworkRuntime` or concrete transports. Core engine composition, ECS, asset loading, and renderer pipelines operate normally without networking libraries present in the link graph.
 - **Single-Player / Headless Simulation**: If a game project uses replication interfaces or network components locally, the host composition root injects `HoroEngine::NetworkTransportNull`. `NetworkTransportNull` simulates loopback transport in memory without opening OS sockets or creating network I/O threads.
-- **Multiplayer Desktop & Dedicated Server**: Composition roots (`HoroEditor`, `horo-engine server`, game client) explicitly instantiate the chosen transport (`NetworkTransportENet` or platform backend) during startup and transfer unique ownership into `NetworkRuntime`. No static discovery, shared_ptr sharing, or global registry side effects are allowed.
+- **Multiplayer Desktop & Dedicated Server**: Composition roots (`HoroEditor`, `horo-engine server`, game client) explicitly instantiate the chosen transport (`NetworkTransportGNS` or an explicitly composed optional provider) during startup and transfer unique ownership into `NetworkRuntime`. No static discovery, shared_ptr sharing, or global registry side effects are allowed.
 
 ### 4. Threading Model and Frame Lifecycle
 
 Network processing is cleanly partitioned between asynchronous I/O and frame-synchronized gameplay execution:
 
 ```text
-[ Background I/O Thread ]                 // ENet; Null has none
+[ Background I/O Thread ]                 // GNS; Null has none
   Socket poll / recv / frame
          |
          v
@@ -161,7 +162,7 @@ Network shutdown is deterministic, bounded, and resource-safe:
 ## Rejected Alternatives
 
 - **Monolithic `HoroEngine::Networking` Target**: Combining API, runtime, and concrete socket libraries into one library was rejected because it would force all engine consumers to link socket/transport dependencies and prevent optional headless or null configurations.
-- **Direct Sockets in Public APIs**: Exposing `SOCKET` handles, `<sys/socket.h>`, or `ENetHost*` in public headers was rejected as it violates Horo Engine's backend-neutral architecture and leaks third-party dependencies.
+- **Direct Sockets in Public APIs**: Exposing `SOCKET` handles, `<sys/socket.h>`, or GNS interface pointers in public headers was rejected as it violates Horo Engine's backend-neutral architecture and leaks third-party dependencies.
 - **Direct Callback Invocation on I/O Threads**: Allowing network read callbacks to invoke gameplay code directly was rejected because it introduces widespread concurrency bugs, thread-safety overhead across ECS components, and non-deterministic frame execution.
 - **Global / Ambient Network Service Locator**: Using a global singleton `GetNetworkService()` was rejected; network instances must be composed explicitly by the host application.
 - **Runtime-Owned Inbound I/O Queue**: Pushing transport receive callbacks directly into a runtime-owned queue was rejected. The transport owns inbound/outbound queues; runtime drains them only through `PollEvents()`.

--- a/docs/adr/097-default-real-time-transport-backend.md
+++ b/docs/adr/097-default-real-time-transport-backend.md
@@ -1,0 +1,250 @@
+# ADR-097: Default Real-Time Transport Backend
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: The ENet-specific concrete-backend selection in [ADR-020](020-network-target-ownership-and-dependency-boundary.md); its target boundary, dependency direction and lifecycle decision remain active
+- **Scope**: First production real-time transport selection, third-party encapsulation, security and authentication ownership, direct-IP baseline, optional NAT/relay and provider composition, bounded work, shutdown, qualification and migration
+- **Issue**: [NET-001.9](https://github.com/abdullahbodur/horo-engine/issues/1106)
+- **Jira**: [HORO-1106](https://horo-engine.atlassian.net/browse/HORO-1106)
+- **Related**: [ADR-020](020-network-target-ownership-and-dependency-boundary.md)
+- **Normative documents**: [Networking Architecture](../architecture/runtime/networking-architecture.md), [Multiplayer Replication Architecture](../architecture/runtime/multiplayer-replication-architecture.md)
+
+## Context
+
+Horo needs one production transport baseline without making a third-party wire
+protocol part of `NetworkApi`. The architecture previously named ENet as the
+concrete target while the replication document separately described a Horo-owned
+reliable UDP transport as the default and listed browser, Steam and console
+providers as if they were all 1.0 implementations. That leaves implementation,
+security and support ownership ambiguous.
+
+The evaluated choices were a Horo-owned reliability layer over UDP, ENet and
+Valve's open-source GameNetworkingSockets (GNS). The comparison covered license,
+maintenance, reliable and unreliable delivery, fragmentation, congestion behavior,
+encryption, authentication, NAT/relay integration, platform portability, native
+encapsulation and lifecycle testing.
+
+The upstream snapshot evaluated for this decision is GNS v1.6.0, annotated tag
+commit `2cb93a06350bb065db53abdb0d87cf297e0bfd34`, released 2026-06-03. The ADR does
+not add or pin the dependency; the implementation change must pin an exact reviewed
+release and commit according to repository dependency policy.
+
+## Decision
+
+### 1. GameNetworkingSockets is the first production baseline
+
+The open-source GameNetworkingSockets library is the default production real-time
+transport for direct-IP Horo client/server products. The private CMake target is
+`HoroEngine::NetworkTransportGNS`. `HoroEngine::NetworkTransportNull` remains the
+deterministic, offline and contract-test backend.
+
+The baseline supports IPv4/IPv6 endpoints plus reliable and unreliable
+message-oriented delivery. GNS owns native packet encryption, fragmentation,
+reassembly, acknowledgement, retransmission and congestion behavior inside the
+concrete backend. Horo retains its application protocol, session, replication,
+queueing and scheduling contracts above that backend.
+
+The initial supported topology is direct IP. Open-source GNS does not require
+Steam for that topology. Native ICE/STUN/TURN, Steam signaling, Steam Datagram
+Relay, WebRTC and console-network provider integrations are not mandatory M0 or
+1.0 baselines.
+
+### 2. No GNS identity crosses `NetworkApi`
+
+`HoroEngine::NetworkTransportGNS` links GNS, its selected crypto provider,
+protobuf and platform socket dependencies as `PRIVATE`. GNS headers, handles,
+enums, connection-info structures, configuration keys, callback types and message
+objects never appear under `include/Horo/`.
+
+The host composition root creates the concrete backend through a private factory
+and transfers `std::unique_ptr<INetworkTransport>` into `NetworkRuntime`.
+`NetworkApi` continues to expose only Horo-owned addresses, opaque generation-
+checked handles, delivery policies, channel/lane-neutral identifiers, capability
+values, results and normalized events. Backend-specific diagnostics are copied
+into bounded Horo diagnostic records.
+
+GNS message lanes and native send flags may implement Horo delivery and priority
+policy, but their numeric values are not serialized or exposed. Unsupported policy
+combinations fail capability validation; the adapter does not silently degrade
+reliable, ordering or priority semantics.
+
+### 3. Security, authentication and traversal have separate owners
+
+GNS transport encryption and packet integrity are backend capabilities. They
+protect a concrete connection but do not establish Horo application identity,
+authorization or protocol compatibility.
+
+`NetworkRuntime` owns:
+
+- application protocol and schema negotiation;
+- credential/token exchange, peer identity and authorization policy;
+- session admission, replay policy and replication authority;
+- traversal/signaling policy, credential acquisition and host/provider choice.
+
+A concrete transport may own an ICE/STUN/TURN or provider-native traversal
+mechanism and report it through typed capabilities. The M0 GNS composition keeps
+ICE/P2P and provider-specific features disabled. Enabling traversal later requires
+an explicit product composition, credential and privacy policy, bounded lifecycle,
+platform qualification and regression evidence.
+
+Steam authentication, Steam signaling and Steam Datagram Relay belong to an
+optional Steam provider composition. Console networking, browser/WebRTC and other
+private SDKs are optional future peers behind the same Horo contract; none is a
+fallback silently selected by the GNS adapter.
+
+### 4. Configuration and work are bounded before native admission
+
+The adapter validates Horo-owned configuration before calling GNS. Products must
+set finite limits for listeners, connections, message size, channels/lanes,
+queued inbound and outbound bytes/messages, connect timeouts, close drain,
+per-poll events and per-flush submissions. Invalid, unknown or overflowed values
+fail initialization or admission with a typed Horo error.
+
+`Send()` copies accepted caller bytes into transport-owned bounded storage before
+returning. Reliable overload rejects the send; replaceable unreliable snapshots
+use the configured deterministic drop policy. Native callbacks and service work
+publish normalized events into the bounded inbound queue and never mutate runtime,
+scene, ECS or gameplay state.
+
+Malformed native messages, impossible lengths, unknown connection generations,
+unexpected callbacks and unsupported state transitions are rejected before
+publication. Native error text is diagnostic context, never a control-flow or
+serialized error identity.
+
+### 5. Cancellation and shutdown are explicit lifecycle paths
+
+Cancellation after a handle is issued stops resolution/connect work, closes any
+native attempt and publishes exactly one terminal Horo event. A late native
+callback is filtered by the connection and shutdown generation; it cannot revive a
+cancelled or reclaimed handle.
+
+Shutdown performs this order:
+
+1. stop new connect, listen and send admission;
+2. close listeners and cancel unresolved/pending connects;
+3. request connection close and perform only the configured bounded drain;
+4. stop and join the backend service thread;
+5. drain or explicitly discard native messages and normalized queued events under
+   the shutdown policy;
+6. release GNS connections, interfaces and library state; then invalidate all
+   remaining Horo handles.
+
+No callback may target the adapter or runtime after destruction. Shutdown remains
+idempotent after partial initialization and reports cleanup failures without
+skipping owned resource release.
+
+### 6. Qualification is contract-driven
+
+The implementation is not production-qualified until automated coverage proves:
+
+- successful listen/connect, reliable and unreliable transfer, close and reconnect;
+- zero/max boundary values, queue and message limits, IPv4/IPv6 and capability
+  mismatch behavior;
+- malformed, truncated, oversized, duplicate, reordered and flood inputs without
+  unbounded allocation or state mutation;
+- cancellation during resolution/connect and races with native success/failure;
+- shutdown before initialization, after partial failure and with active listeners,
+  connections, callbacks and queued messages;
+- parity of public errors, events, handles and ownership against
+  `NetworkTransportNull` contract tests;
+- dependency builds and runtime smoke tests on each claimed platform/toolchain,
+  including crypto-provider configuration and sanitizer/fuzz coverage where
+  supported.
+
+Tests may use GNS packet simulation and statistics through a private test seam.
+Those native controls do not become public API.
+
+### 7. Dependency admission and upgrades are deliberate
+
+The implementation change records the exact GNS release, resolved commit, license,
+crypto provider, protobuf/toolchain requirements and enabled/disabled features.
+The baseline build disables ICE/P2P and Steam-specific integration unless a later
+decision and product target explicitly compose them.
+
+Upgrades require upstream release-note and security review, supported-platform
+builds, wire-compatibility assessment, contract tests and lifecycle tests. A GNS
+upgrade never changes `NetworkApi` merely to mirror a native feature. Horo's
+application protocol fingerprint/version changes whenever wire or policy
+compatibility cannot be proven.
+
+### 8. Migration replaces the private baseline, not the public contract
+
+Implementation replaces the aspirational `NetworkTransportENet` target, factory
+and product mappings with `NetworkTransportGNS`. Existing backend-neutral
+`INetworkTransport`, address, handle, delivery, capability, event and runtime
+contracts remain the migration seam.
+
+There is no promise of ENet or earlier prototype wire compatibility and no saved
+project data requires migration. Any existing prototype sessions must use an
+explicit new protocol fingerprint. Tests move to the shared transport contract;
+backend-specific fixtures remain private to their adapter.
+
+If GNS later becomes unsuitable, another concrete adapter can replace it without
+changing callers. Migration cost is the adapter, dependency/build topology,
+configuration projection, platform qualification, diagnostics and wire-version
+rollout—not a public API rewrite.
+
+## Evaluation Evidence
+
+- [GameNetworkingSockets repository and feature overview](https://github.com/ValveSoftware/GameNetworkingSockets)
+- [GameNetworkingSockets v1.6.0 release](https://github.com/ValveSoftware/GameNetworkingSockets/releases/tag/v1.6.0)
+- [GameNetworkingSockets build and dependency guidance](https://github.com/ValveSoftware/GameNetworkingSockets/blob/v1.6.0/BUILDING.md)
+- [GameNetworkingSockets BSD-3-Clause license](https://github.com/ValveSoftware/GameNetworkingSockets/blob/v1.6.0/LICENSE)
+- [ENet repository and feature overview](https://github.com/lsalzman/enet)
+- [ENet MIT license](https://github.com/lsalzman/enet/blob/master/LICENSE)
+
+## Consequences
+
+### Positive
+
+- Horo starts from a maintained, permissively licensed, message-oriented transport
+  with integrated reliability, fragmentation and encrypted packet support.
+- Direct-IP client/server work has one testable baseline without requiring a
+  platform provider, relay service or browser stack.
+- Third-party replacement remains bounded by a Horo-owned public contract.
+- Security, session authentication and traversal responsibilities are explicit.
+- Production qualification includes malformed input, cancellation and shutdown,
+  rather than covering only the happy path.
+
+### Negative
+
+- GNS adds native crypto and protobuf build/dependency work plus a private adapter.
+- Horo must track upstream security, compatibility and platform changes.
+- Direct IP does not solve matchmaking, signaling, NAT traversal or relay service
+  operation by itself.
+- GNS's native model is richer than the initial Horo abstraction; unsupported
+  features remain unavailable until deliberately modeled.
+
+## Rejected Alternatives
+
+### Horo-owned reliable UDP as the production baseline
+
+Maximum control and minimal third-party dependencies do not offset ownership of a
+new wire protocol, reliability, fragmentation, congestion, crypto, abuse defense,
+cross-platform socket behavior, compatibility and fuzz/security burden. Horo may
+retain low-level experimental transports, but they are not the production default.
+
+### ENet as the production baseline
+
+ENet is small, permissively licensed and supplies reliable UDP channels,
+fragmentation and bandwidth throttling. It does not provide the selected baseline's
+integrated encrypted connection model or traversal/provider growth path. Choosing
+it would require Horo to design and qualify more security and connectivity layers
+before production use. It is not kept as a mandatory parallel backend.
+
+### Make Steam, WebRTC or console providers mandatory 1.0 transports
+
+These choices tie baseline availability to store, browser or private platform SDK
+requirements and do not cover the same product set. They remain optional future
+compositions when a product requirement and qualification matrix justify them.
+
+### Expose GNS directly through `NetworkApi`
+
+This would couple public headers, callers, serialization and tests to a replaceable
+dependency and its native lifecycle. The private adapter boundary is mandatory.
+
+### Enable ICE/P2P and relay behavior by default
+
+Traversal adds signaling, credentials, privacy, service availability, cancellation
+and platform-policy obligations. It requires a separate explicit composition and
+qualification; it is not inferred from library availability.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -108,6 +108,7 @@ to the replacement.
 | [094](094-prefab-nested-composition-and-variant-inheritance.md) | Prefab Nested Composition and Variant Inheritance | Proposed | 2026-09-02 |
 | [095](095-prefab-cook-boundary-and-artifact-model.md) | Prefab Cook Boundary and Artifact Model | Proposed | 2026-09-02 |
 | [096](096-prefab-external-reference-and-binding-slot-contract.md) | Prefab External Reference and Binding Slot Contract | Proposed | 2026-09-02 |
+| [097](097-default-real-time-transport-backend.md) | Default Real-Time Transport Backend | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -251,6 +251,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Networking Architecture](./runtime/networking-architecture.md): optional
   handle-based transports, session/authentication runtime, bounded I/O, and
   remote security.
+- [Default Real-Time Transport Backend](../adr/097-default-real-time-transport-backend.md):
+  GameNetworkingSockets direct-IP baseline, private native encapsulation,
+  security/traversal ownership, bounded lifecycle and optional provider policy.
 - [Asset Pipeline](./runtime/asset-pipeline.md): import, cook, package, runtime
   loading, cache, and hot reload.
 - [Prefab Architecture](./runtime/prefab-architecture.md): dual-role authoring

--- a/docs/architecture/delivery/build-system.md
+++ b/docs/architecture/delivery/build-system.md
@@ -178,7 +178,7 @@ network/
     HoroEngine::NetworkApi
     HoroEngine::NetworkRuntime
     HoroEngine::NetworkTransportNull
-    HoroEngine::NetworkTransportENet
+    HoroEngine::NetworkTransportGNS
 
 asset/
     HoroEngine::Assets

--- a/docs/architecture/desired-project-tree.md
+++ b/docs/architecture/desired-project-tree.md
@@ -661,7 +661,7 @@ horo-engine/
 │   │   │   │   ├── SendPayloadLifetimeTests.cpp
 │   │   │   │   ├── ReplicationManagerTests.cpp
 │   │   │   │   ├── NetworkTransportNullTests.cpp
-│   │   │   │   ├── NetworkTransportENetTests.cpp
+│   │   │   │   ├── NetworkTransportGNSTests.cpp
 │   │   │   │   └── NetworkLifecycleAndShutdownTests.cpp
 │   │   │   ├── game_ui/
 │   │   │   ├── debug/

--- a/docs/architecture/foundation/current-target-and-dependency-inventory.md
+++ b/docs/architecture/foundation/current-target-and-dependency-inventory.md
@@ -186,7 +186,7 @@ conflicts are recorded rather than treated as additional implementations.
 | `HoroEngine::NetworkApi` | Planned | Architecture exists; no production target. |
 | `HoroEngine::NetworkRuntime` | Planned | Architecture exists; no production target. |
 | `HoroEngine::NetworkTransportNull` | Planned | Null transport peer behind `NetworkApi`; Foundation-only, no `Platform`; no production target yet. |
-| `HoroEngine::NetworkTransportENet` | Planned | ENet transport peer behind `NetworkApi`; no production target yet. |
+| `HoroEngine::NetworkTransportGNS` | Planned | ADR-097 production direct-IP GNS transport peer behind `NetworkApi`; no production target yet. |
 | `HoroEngine::RenderApi` | Implemented | `HoroRenderApi` |
 | `HoroEngine::RenderFrontend` | Implemented | `HoroRenderFrontend` |
 | `HoroEngine::RenderModuleAbi` | Planned | Renderer module manifest/distribution contracts exist; no target. |

--- a/docs/architecture/foundation/system-design.md
+++ b/docs/architecture/foundation/system-design.md
@@ -301,7 +301,7 @@ HoroEngine::AudioNull
 HoroEngine::NetworkApi
 HoroEngine::NetworkRuntime
 HoroEngine::NetworkTransportNull
-HoroEngine::NetworkTransportENet
+HoroEngine::NetworkTransportGNS
 HoroEngine::NavigationApi
 HoroEngine::NavigationRuntime
 HoroEngine::NavigationRecastDetour
@@ -349,8 +349,8 @@ horopak
 ```
 
 `AudioPlatform` selects only the native implementation for the target platform;
-native audio headers remain private to that target. `NetworkTransportENet` owns the
-optional native UDP socket and ENet implementation and remains separate from typed
+native audio headers remain private to that target. `NetworkTransportGNS` owns the
+optional native socket and private GNS implementation and remains separate from typed
 session/protocol/authentication coordination in `NetworkRuntime`. `NetworkTransportNull` provides
 deterministic in-memory/null transport for headless runs, mock testing, and offline modes; it depends on `NetworkApi` and `Foundation` only, not `Platform`. The host composition root transfers unique `INetworkTransport` ownership into `NetworkRuntime`. `GameplayApi` owns the public
 registration, descriptor, behavior, and runtime-capability contracts used by

--- a/docs/architecture/runtime/multiplayer-replication-architecture.md
+++ b/docs/architecture/runtime/multiplayer-replication-architecture.md
@@ -184,13 +184,23 @@ public:
 };
 ```
 
-Transport implementations:
+Transport policy follows
+[ADR-097](../../adr/097-default-real-time-transport-backend.md) and the
+[Networking Architecture](./networking-architecture.md):
 
-- **UDP**: Default transport with reliability layer (acks, sequencing)
-- **ENet**: Optional reliable UDP library
-- **WebRTC**: Browser-based clients
-- **Steam Networking**: Steamworks integration
-- **Console**: Platform-specific networking (PSN, Xbox Live)
+- **GameNetworkingSockets**: The production direct-IP baseline, implemented only
+  by private `NetworkTransportGNS` and projected through Horo-owned transport
+  capabilities and events.
+- **Null**: The deterministic/offline backend used for contract tests, CI and
+  products that intentionally run the network runtime without native I/O.
+- **Optional providers**: ICE/P2P, relay, WebRTC, Steam and console integrations
+  are future product-specific compositions. They are not mandatory 1.0 targets
+  and cannot be selected as silent fallback behavior.
+
+Replication does not depend on a native transport or provider identity. Session
+authentication, protocol negotiation, authority and bandwidth policy remain in
+`NetworkRuntime`; GNS packet encryption does not replace them. All transports must
+honor the same bounded queues, cancellation, malformed-input and shutdown contract.
 
 ## Bandwidth Management
 
@@ -216,6 +226,7 @@ Replication bandwidth is managed:
 ## Related Documents
 
 - [Networking Architecture](./networking-architecture.md): transport layer and connection model
+- [ADR-097: Default Real-Time Transport Backend](../../adr/097-default-real-time-transport-backend.md): production baseline and optional provider policy
 - [Scene Runtime](./scene-runtime.md): object lifecycle and network identity
 - [Physics Architecture](./physics-architecture.md): server-side physics and prediction
 - [Save Game And Persistence](./save-game-and-persistence.md): server-side save state

--- a/docs/architecture/runtime/networking-architecture.md
+++ b/docs/architecture/runtime/networking-architecture.md
@@ -20,10 +20,11 @@ Character checkpoint.
 
 ## Core Decisions
 
-- **Strict Layered Architecture**: Networking is separated into target-level tiers: public contracts and types (`HoroEngine::NetworkApi`), session coordination and replication runtime (`HoroEngine::NetworkRuntime`), and private concrete transport backends (`HoroEngine::NetworkTransportNull`, `HoroEngine::NetworkTransportENet`).
+- **Strict Layered Architecture**: Networking is separated into target-level tiers: public contracts and types (`HoroEngine::NetworkApi`), session coordination and replication runtime (`HoroEngine::NetworkRuntime`), and private concrete transport backends (`HoroEngine::NetworkTransportNull`, `HoroEngine::NetworkTransportGNS`).
+- **Production Baseline**: ADR-097 selects open-source GameNetworkingSockets (GNS) for production direct-IP real-time transport. Null remains the deterministic/offline backend; ICE/P2P, relay and provider integrations require explicit optional composition.
 - **Transport vs Session Split**: `INetworkTransport` is a packet-transport abstraction. Protocol negotiation, authentication, replication, and `NetworkSession` live in `NetworkRuntime`. Transport backends do not implement application authentication.
 - **Handle-Based Public Transport API**: Public transport operations use `INetworkTransport` plus generation-checked `ConnectionHandle` / `ListenerHandle` values. `ITransportConnection` and `ITransportListener` are not public types.
-- **Complete Native Encapsulation**: Public headers expose zero OS socket descriptors (`SOCKET`, `int fd`), OS socket headers, TLS/OpenSSL contexts (`SSL*`), event loops, or third-party transport structures (`ENetHost`, `SteamNetworkingSockets`).
+- **Complete Native Encapsulation**: Public headers expose zero OS socket descriptors (`SOCKET`, `int fd`), OS socket headers, TLS/OpenSSL contexts (`SSL*`), event loops, or GNS/provider transport structures.
 - **Optional Link and Composition**: Single-player games, asset tools, and offline CLI utilities compile and run without linking transport backends. Products can compose `NetworkTransportNull` or omit the network runtime entirely.
 - **Host-Owned Injection**: The composition root instantiates a concrete transport and transfers unique ownership into `NetworkRuntime`. `NetworkRuntime` never links a concrete backend directly.
 - **Thread Isolation & Zero I/O State Mutation**: Network I/O executes on dedicated background worker threads owned by the concrete transport that needs them. I/O threads never directly mutate Scene, ECS, Entity, Component, Editor, or Gameplay state.
@@ -52,7 +53,7 @@ The network subsystem is organized into four distinct CMake targets with strict 
 +---------------------+----+   +-----+-------------------------+
 | HoroEngine::NetworkRuntime|   | Concrete Transports (Private) |
 | (depends also on Runtime) |   | - NetworkTransportNull        |
-+---------------------------+   | - NetworkTransportENet        |
++---------------------------+   | - NetworkTransportGNS         |
                                 +-------------------------------+
 ```
 
@@ -90,12 +91,13 @@ The network subsystem is organized into four distinct CMake targets with strict 
 - **Must Not Depend On**: `HoroEngine::Platform`, OS sockets, or a network I/O thread.
 - **Purpose**: Unit testing, CI verification, single-player offline simulation, and synthetic latency/loss testing harnesses. `PollEvents()` and `Send()` run on the caller thread against in-memory queues.
 
-### 4. `HoroEngine::NetworkTransportENet`
+### 4. `HoroEngine::NetworkTransportGNS`
 
-- **Role**: High-performance reliable and unreliable UDP transport implementation.
+- **Role**: Production direct-IP reliable and unreliable message transport implemented with open-source GameNetworkingSockets.
 - **Direct Dependencies**: `HoroEngine::NetworkApi`, `HoroEngine::Foundation`, `HoroEngine::Platform`.
-- **Encapsulation**: Links third-party ENet and platform socket libraries strictly as `PRIVATE`. No third-party headers or socket types leak into public includes.
-- **Owns**: I/O thread, native ENet/socket state, inbound event queue, and outbound send queue.
+- **Encapsulation**: Links GNS, its selected crypto provider, protobuf and platform socket libraries strictly as `PRIVATE`. No third-party headers, values or socket types leak into public includes.
+- **Owns**: I/O thread, native GNS/socket state and messages, inbound event queue, and outbound send queue.
+- **Baseline Features**: Direct IPv4/IPv6 only. ICE/P2P and Steam/provider-specific integration are disabled unless a product explicitly composes and qualifies them.
 
 ## Public Header Encapsulation
 
@@ -105,14 +107,14 @@ To maintain portability, compile speed, and memory safety, public headers under 
 2. **No Native Sockets / Handles**: Sockets are encapsulated as opaque integer handles or private members within backend `.cpp` files. Public APIs operate exclusively on `ConnectionHandle` and `ListenerHandle`.
 3. **No TLS / Crypto Contexts**: OpenSSL, mbedTLS, or native TLS context pointers (`SSL*`, `SSL_CTX*`) never appear in public interfaces.
 4. **No Native Event Loops**: Event loop primitives (libuv `uv_loop_t`, epoll file descriptors, kqueue, IOCP handles) remain private to backend implementations.
-5. **No Third-Party Types**: `ENetHost`, `ENetPeer`, `ENetPacket`, or Steam networking structs are strictly confined to concrete backend sources.
+5. **No Third-Party Types**: GNS interfaces, handles, messages, connection-info structures, configuration values, callbacks and Steam networking structures are strictly confined to concrete backend sources.
 
 ## Host Composition and Transport Ownership
 
-The host composition root selects and instantiates the backend. `NetworkRuntime` never links `NetworkTransportNull` or `NetworkTransportENet`.
+The host composition root selects and instantiates the backend. `NetworkRuntime` never links `NetworkTransportNull` or `NetworkTransportGNS`.
 
 ```cpp
-auto transport = CreateENetTransport(config); // or CreateNullTransport(config)
+auto transport = CreateGnsTransport(config); // or CreateNullTransport(config)
 NetworkRuntime runtime({
     .transport = std::move(transport),
 });
@@ -235,21 +237,21 @@ NetworkSession
 
 - **Transport `Created`**: Handle allocated; request validated. `Connect()` has already returned.
 - **Transport `Resolving`**: Asynchronous DNS for a hostname endpoint.
-- **Transport `Connecting`**: Native connect and transport-level handshake (for example ENet peer connect). No application token is exchanged here.
+- **Transport `Connecting`**: Native connect and transport-level handshake. No application token is exchanged here.
 - **Transport `Connected`**: Packets can flow. `NetworkRuntime` now creates a `NetworkSession`.
 - **Session `Negotiating`**: Schema/protocol version, compression, and MTU agreement.
 - **Session `Authenticating`**: `NetworkRuntime` validates application credentials. Tokens are runtime/session data, not `ConnectRequest` fields on the transport.
 - **Session `Active`**: Gameplay messages, RPCs, and replication are admitted.
 - **Closing / Closed / Failed**: Each layer tears down independently. Session close requests transport `Close()`. Transport `Failed` fails the associated session.
 
-Future transports (SteamNetworkingSockets, WebRTC, and similar) replace only the transport machine. They must not absorb session authentication.
+Future provider transports replace only the transport machine. They must not absorb session authentication.
 
 ## Queue Ownership
 
 Model A is normative:
 
 ```text
-Transport I/O thread (ENet) or caller thread (Null)
+Transport I/O thread (GNS) or caller thread (Null)
     -> transport-owned inbound event queue
     -> NetworkRuntime calls transport.PollEvents(consumer)
 
@@ -274,7 +276,7 @@ The transport owns:
 To prevent race conditions and frame stalls, network operations are strictly partitioned:
 
 ```text
-[ Background I/O Worker Thread ]          // ENet only; Null has none
+[ Background I/O Worker Thread ]          // GNS only; Null has none
   OS Socket Poll -> Recv Packets -> Framing
          |
          v
@@ -338,6 +340,17 @@ Messages consist of:
 
 Mismatched protocol versions or invalid authentication tokens fail the **session** with `NetworkErrorCode::IncompatibleProtocol` or `NetworkErrorCode::AuthenticationFailed`. The transport connection is then closed. Transport backends must not interpret authentication tokens.
 
+GNS connection encryption and packet integrity are private transport capabilities;
+they do not authenticate a Horo user, authorize a session or replace application
+protocol negotiation. `NetworkRuntime` owns credential/token exchange, peer trust,
+session admission and replication authority.
+
+NAT traversal is an optional capability boundary. A concrete adapter may own an
+ICE/STUN/TURN or provider-native mechanism, while `NetworkRuntime` and the host own
+signaling policy, credential acquisition and provider selection. The baseline GNS
+composition does not enable traversal, Steam signaling/authentication, Steam
+Datagram Relay, WebRTC or console-provider SDKs.
+
 ## Delivery Semantics and Backpressure
 
 [ADR-070](../../adr/070-capture-and-voice-io-ownership.md) keeps voice packet policy
@@ -364,14 +377,15 @@ All transport queues have bounded capacities:
 
 ## Deterministic Cancellation and Shutdown
 
-- **Cancellation**: Connect and resolve requests accept `CancellationToken`. Triggering cancellation immediately halts DNS lookups and connection attempts. The transport connection moves to `Failed` with `NetworkErrorCode::OperationCancelled`, reported through `PollEvents()`.
+- **Cancellation**: Connect and resolve requests accept `CancellationToken`. Triggering cancellation halts DNS lookups and connection attempts, closes any native attempt and reports exactly one terminal `NetworkErrorCode::OperationCancelled` event through `PollEvents()`. Generation checks discard late native callbacks.
 - **Graceful Teardown**: Session close asks the transport to `Close()`. The transport transmits a disconnect frame and starts a bounded drain timer. Upon expiry or peer ACK, native resources are reclaimed.
 - **Process Shutdown Sequence**:
   1. The host calls `NetworkRuntime::Shutdown()`.
   2. Runtime fails/closes all sessions and stops admitting gameplay messages.
-  3. Runtime calls `INetworkTransport::Shutdown()`: listeners stop accepting, connections send disconnect notices, I/O threads stop and join with a bounded timeout.
-  4. Runtime destroys the unique transport.
-  5. Session pools and dispatcher tables are freed.
+  3. Runtime calls `INetworkTransport::Shutdown()`: listeners stop accepting, pending connects are cancelled, connections send disconnect notices and perform only the bounded close drain.
+  4. The backend stops and joins its I/O thread, drains or explicitly discards native and normalized messages under the shutdown policy, then releases native library state.
+  5. Runtime destroys the unique transport. No callback may target it after destruction.
+  6. Session pools and dispatcher tables are freed.
 
 ## Optional Composition and Product Configurations
 
@@ -379,8 +393,8 @@ Horo Engine products compose networking according to their needs:
 
 | Configuration | Composed Targets | Behavior |
 |---|---|---|
-| **Editor / IDE** (`HoroEditor`) | `NetworkApi`, `NetworkRuntime`, `NetworkTransportENet` | Full multiplayer preview, network debugger panel, local test servers. |
-| **Dedicated Server** (`horo-engine server`) | `NetworkApi`, `NetworkRuntime`, `NetworkTransportENet` | Headless execution, high-tick simulation, no rendering or audio dependencies. |
+| **Editor / IDE** (`HoroEditor`) | `NetworkApi`, `NetworkRuntime`, `NetworkTransportGNS` | Direct-IP multiplayer preview, network debugger panel and local test servers. |
+| **Dedicated Server** (`horo-engine server`) | `NetworkApi`, `NetworkRuntime`, `NetworkTransportGNS` | Direct-IP headless execution and high-tick simulation without rendering or audio dependencies. |
 | **Offline Game Client** | `NetworkApi`, `NetworkRuntime`, `NetworkTransportNull` | Uses replication/session API locally; zero socket operations, Platform sockets, or I/O threads. |
 | **Tooling / Packager** (`horopak`) | *None* | Links zero network targets; compiles cleanly with minimal footprint. |
 
@@ -413,10 +427,18 @@ The networking subsystem requires targeted automated verification:
    - Cancellation during DNS and connect; `Connect()` already returned a handle.
    - Unique-ptr injection: runtime shutdown destroys the transport exactly once.
    - Process shutdown with active connections and pending queued messages without hangs or memory leaks.
+4. **GNS Adapter Contract Tests (`NetworkTransportGNSTests`)**:
+   - Successful direct-IP IPv4/IPv6 listen, connect, reliable/unreliable transfer, close and reconnect.
+   - Zero/max message, connection, listener, channel/lane and queue boundaries; unsupported capability combinations fail explicitly.
+   - Malformed, truncated, oversized, duplicate, reordered and flood input is rejected without unbounded allocation or runtime mutation.
+   - Cancellation racing native success/failure publishes one terminal event and cannot revive a stale handle.
+   - Shutdown before initialization, after partial failure and with active native callbacks/messages is bounded, idempotent and callback-free after destruction.
+   - Dependency builds and smoke tests cover every claimed platform/toolchain and crypto-provider configuration; sanitizer/fuzz evidence is retained where supported.
 
 ## Related Documents
 
 - [ADR-020: Network Target Ownership and Dependency Boundary](../../adr/020-network-target-ownership-and-dependency-boundary.md)
+- [ADR-097: Default Real-Time Transport Backend](../../adr/097-default-real-time-transport-backend.md)
 - [System Design](../foundation/system-design.md)
 - [Desired Project Trees](../desired-project-tree.md)
 - [Multiplayer Replication Architecture](./multiplayer-replication-architecture.md)


### PR DESCRIPTION
## Summary

- Select open-source GameNetworkingSockets as Horo's first production direct-IP real-time transport baseline.
- Add ADR-097 and project the decision into networking, replication, target topology, build and test architecture documents.
- Keep GNS and its crypto/protobuf/native state private behind Horo-owned `NetworkApi` contracts.

## Why

- The architecture named ENet in one place, a Horo-owned reliable UDP layer in another, and listed provider transports as if all were mandatory 1.0 baselines.
- Production work needs one explicit backend plus clear ownership for encryption, authentication, NAT/relay, bounded work and shutdown.

## Decision and boundaries

- Baseline direct IP uses `NetworkTransportGNS`; `NetworkTransportNull` remains the deterministic/offline contract backend.
- Session authentication and protocol negotiation stay in `NetworkRuntime`; native packet encryption is only a transport capability.
- ICE/P2P, relay, Steam, WebRTC and console providers remain explicit optional future compositions.
- Records GNS v1.6.0 / tag commit `2cb93a06350bb065db53abdb0d87cf297e0bfd34` as the evaluation snapshot; dependency admission and exact pinning are deferred to implementation.
- Defines success, boundary, malformed-input, cancellation and shutdown qualification coverage.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Documentation lint passed
- [x] CMake configure passed
- [x] Added Markdown links resolve
- [x] Manual smoke test not applicable to an architecture-only change

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/020-network-target-ownership-and-dependency-boundary.md docs/adr/097-default-real-time-transport-backend.md docs/adr/README.md docs/architecture/README.md docs/architecture/delivery/build-system.md docs/architecture/desired-project-tree.md docs/architecture/foundation/current-target-and-dependency-inventory.md docs/architecture/foundation/system-design.md docs/architecture/runtime/multiplayer-replication-architecture.md docs/architecture/runtime/networking-architecture.md
git diff --check
git diff --cached --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- This PR does not add GNS or qualify a production binary; implementation must still pin and build the dependency, select a crypto provider, and run the specified platform/lifecycle coverage.
- Existing aspirational ENet target names are deliberately replaced across normative projections; downstream implementation branches must follow the new target name.
- CMake reported the existing mbedTLS minimum-version deprecation warning and that pytest is unavailable, so repository Python tests were skipped.

## Issue links

- Jira: HORO-1106
- GitHub: Closes #1106

## Reviewer Notes

- Review ADR-097 first, then the networking and multiplayer replication projections.
- The remaining architecture edits are target-name and topology projections of the same decision.