### PR TITLE
docs(network): define session trust policy HORO-1110 #1110 [NET-002.1]

### DIFF
--- a/docs/adr/098-protocol-session-and-trust-policy.md
+++ b/docs/adr/098-protocol-session-and-trust-policy.md
@@ -1,0 +1,350 @@
+# ADR-098: Protocol, Session and Trust Policy
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Transport-to-session admission boundary, wire compatibility, listener trust profiles, peer and application identity, credential binding, active-session gating, bounded hostile parsing, timeout, revocation, diagnostics and shutdown
+- **Issue**: [NET-002.1](https://github.com/abdullahbodur/horo-engine/issues/1110)
+- **Jira**: [HORO-1110](https://horo-engine.atlassian.net/browse/HORO-1110)
+- **Related**: [ADR-020](020-network-target-ownership-and-dependency-boundary.md), [ADR-097](097-default-real-time-transport-backend.md)
+- **Normative documents**: [Networking Architecture](../architecture/runtime/networking-architecture.md), [Application Security Architecture](../architecture/security/application-security.md), [Multiplayer Replication Architecture](../architecture/runtime/multiplayer-replication-architecture.md)
+
+## Context
+
+A native transport can report `Connected` after it has established packet flow and
+possibly an encrypted channel. That fact does not prove that the peer is the
+intended product/server, that its application protocol is compatible, that a user
+or service is authorized, or that gameplay messages are safe to parse. Treating
+transport connectivity as a gameplay session would let malformed or hostile peers
+reach replication and RPC dispatch before Horo establishes trust.
+
+ADR-097 makes the distinction concrete. GameNetworkingSockets encrypts ordinary
+connections, but its API explicitly reports whether a peer identity was
+authenticated and leaves application policy to the caller. An IP address is not
+an authenticated identity. Horo must therefore own the protocol and trust
+decision above every transport, including Null and future provider backends.
+
+The policy must also distinguish loopback development, LAN and remote exposure.
+Loopback tests cannot require an external identity service. LAN does not make a
+peer trustworthy merely because its address is private. Remote listeners require
+stronger admission and cannot silently inherit a developer setting. All profiles
+still need bounded parsing, deterministic compatibility, terminal timeouts and a
+clean shutdown path.
+
+## Decision
+
+### 1. Transport connection and application session are separate authorities
+
+`INetworkTransport` owns connectivity, packet confidentiality/integrity capability,
+native peer evidence and transport close. It emits normalized transport events but
+never creates an application principal or authorizes gameplay.
+
+`NetworkRuntime` owns one `SessionAdmissionController` per listener/runtime
+composition. Only that controller may create and activate a `NetworkSession`. The
+state machine is:
+
+```text
+Created
+  -> Negotiating
+  -> Authenticating
+  -> Activating
+  -> Active
+  -> Closing
+  -> Closed
+
+Any non-terminal state -> Failed
+```
+
+`TransportConnectionState::Connected` creates a `NetworkSession` in `Created`; it
+does not enter `Active`. Before `Active`, only bounded admission control messages
+are accepted on the reserved control channel. Gameplay, RPC, replication, voice,
+console and extension messages received early are rejected, counted and may close
+the connection under abuse policy. They are never buffered for later dispatch.
+
+`MessageDispatcher`, `ReplicationManager` and gameplay callbacks receive messages
+only when the owner-thread session table contains the matching generation in
+`Active`. Transport callbacks, queue ordering and a forged session ID cannot
+bypass that lookup.
+
+### 2. The host supplies an immutable trust-policy snapshot
+
+The composition root resolves credentials, trust anchors and product policy before
+opening a listener or beginning a connection. It supplies a Horo-owned immutable
+`NetworkTrustPolicySnapshot` containing:
+
+```cpp
+enum class NetworkExposure : std::uint8_t {
+    LoopbackDevelopment,
+    LocalNetwork,
+    Remote
+};
+
+struct NetworkTrustPolicySnapshot {
+    NetworkTrustPolicyId id;
+    NetworkTrustPolicyRevision revision;
+    NetworkExposure exposure;
+    ProtocolCompatibilityPolicy protocol;
+    TransportProtectionPolicy transportProtection;
+    PeerTrustPolicy peerTrust;
+    SessionCredentialPolicy credentials;
+    SessionLimitPolicy limits;
+};
+```
+
+Project data, a remote peer and a transport backend cannot choose or weaken this
+snapshot, install a trust root, disable verification or widen bind scope. Secret
+material remains in the host credential provider; the snapshot contains opaque
+credential/trust handles and public policy only.
+
+The listener validates exposure against the effective bind addresses. A loopback
+profile may bind only OS loopback addresses. A LAN profile may not bind a public
+interface unless host policy explicitly resolves it as `Remote`. DNS names and
+private-address appearance are not trust evidence. A configuration mismatch fails
+before listener publication.
+
+Policy updates create a new listener/runtime generation. Existing sessions retain
+their admission snapshot except that explicit trust, credential or principal
+revocation may close them. A reload cannot retroactively weaken an active session.
+
+### 3. Protection and identity requirements are exposure-specific
+
+| Exposure | Transport confidentiality/integrity | Server/host identity | Client application admission |
+|---|---|---|---|
+| Loopback development | Required for native socket transport when supported; Null is in-memory | May use explicit local-only identity because both endpoints and bind are proven loopback | Explicit local development principal or configured credential; never inferred from `Connected` |
+| Local network | Required | Required through a product trust anchor, exact public-key/certificate pin, or explicit out-of-band pairing result | Host policy requires a credential or explicitly grants a bounded LAN guest principal |
+| Remote | Required | Required through a product trust anchor or exact pin/provider verifier | Required short-lived application admission proof; anonymous transport peers cannot become active |
+
+An IP-address identity, private subnet, successful key exchange, encrypted-but-
+unauthenticated channel, process ownership claim or user-visible server name is not
+authenticated peer identity.
+
+LAN pairing is an explicit user/host transaction that verifies a short-lived
+out-of-band value and stores a scoped pin. Trust-on-first-use without confirmation
+is not the default. LAN guest mode is an explicit product policy with a minimal
+principal/capability set, finite lifetime and diagnostic visibility; it is not an
+implicit anonymous fallback.
+
+Remote clients present a short-lived admission proof issued or accepted by the
+host's configured identity/matchmaking service. It is bound to the intended
+product, server identity, protocol negotiation, client/server nonces and expiry so
+captured proof cannot be replayed into another listener/session. The runtime asks
+an injected credential verifier for a typed result; it does not parse provider-
+specific tokens or store raw secrets in session state.
+
+Transport client certificates or provider identity may supply peer evidence to
+that verifier. They do not automatically define Horo gameplay roles. Conversely,
+an application token sent over an unauthenticated remote channel is insufficient
+because the client cannot prove which server received it.
+
+### 4. Negotiation is canonical, bounded and downgrade-resistant
+
+The admission protocol uses a fixed binary envelope and closed registered message
+types. Every envelope is validated for minimum header, declared length, total
+length, message count, field count and profile limits before allocation or nested
+decode. Unknown required fields/messages fail; unknown explicitly optional fields
+may be skipped only within their bounded length.
+
+The hello exchange carries Horo-owned values:
+
+- product/application ID and protocol family ID;
+- minimum/maximum supported wire protocol version;
+- gameplay schema-set fingerprint and compatibility epoch;
+- required and optional feature/capability IDs;
+- selected trust profile ID/revision and transport protection evidence;
+- fresh client/server nonces and a canonical transcript version.
+
+The server selects the highest mutually supported version that is not below either
+side's configured security/compatibility floor. Required capability sets and
+schema fingerprints must satisfy the version's explicit compatibility table.
+There is no lexicographic version comparison, best-effort schema guessing, native
+struct layout negotiation or silent feature downgrade.
+
+Both sides compute the same canonical transcript digest. Peer verification,
+credential proof and activation acknowledgements bind to that digest. A retry or
+new transport connection uses fresh nonces and a new admission generation.
+
+### 5. Authentication produces a bounded principal, not ambient authority
+
+Successful verification produces a Horo-owned immutable `SessionPrincipal`:
+
+```cpp
+struct SessionPrincipal {
+    NetworkPrincipalId principalId;
+    NetworkSessionId sessionId;
+    NetworkTrustLevel trustLevel;
+    BoundedVector<NetworkRoleId> roles;
+    BoundedVector<NetworkCapabilityId> capabilities;
+    CredentialProvenanceId provenance;
+    MonotonicDeadline expiresAt;
+};
+```
+
+`NetworkSessionId` is a fresh cryptographically random 128-bit value scoped to one
+admission generation. It is correlation identity, not an authentication secret.
+Principal, roles and capabilities come only from the injected verifier/host policy;
+client claims are input to verification, never authority.
+
+The principal is copied into the owner-thread session table only during the atomic
+`Authenticating -> Activating` transition. Activation completes after both peers
+exchange and validate transcript-bound activation acknowledgements. Only then is
+the session published as `Active` and admitted to dispatch.
+
+Credential expiry, absolute session lifetime, inactivity policy, concurrent-session
+limits and revocation behavior are explicit product policy. The M0 baseline closes
+the session on expiry/revocation; it does not silently extend or refresh authority
+inside gameplay dispatch. A future reauthentication flow must return to a closed
+admission gate and cannot preserve queued gameplay across failed verification.
+
+### 6. Admission work and hostile behavior are bounded
+
+Every listener policy defines finite limits for pre-active connections, admission
+bytes/messages, message size, authentication attempts, credential-verifier work,
+per-source rate, total concurrent verification, negotiation deadline and
+activation deadline. Limits have units and deterministic reject/close behavior.
+
+Admission parsing occurs before gameplay deserialization and validates before
+allocation. Expensive credential verification is scheduled only after cheap
+envelope, product, version, capability, nonce and protection checks. A per-listener
+budget drains completed verification on the owner thread. Cancellation and timeout
+invalidate the admission generation; late verifier or transport completion is
+discarded.
+
+Malformed, incompatible and hostile peers receive only bounded safe failure codes
+where disclosure policy permits. Internal verifier detail, token contents, trust
+anchors, account existence, schema inventory and native error strings are not sent
+to the peer. Repeated early gameplay, oversized input, nonce replay, rate-limit
+evasion or invalid proof follows the configured abuse close policy.
+
+### 7. Failure, cancellation and shutdown are terminal
+
+An incompatible protocol, failed peer proof, invalid/expired credential, malformed
+admission message, timeout, cancellation or revocation transitions the session once
+to `Failed`/`Closing`. It never falls back to a weaker exposure or guest profile.
+The transport is closed after a bounded safe failure response when permitted.
+
+Shutdown order is:
+
+1. stop accepting new transport connections and admission messages;
+2. invalidate admission generations and cancel verifier work;
+3. remove every session from gameplay dispatch before closing transports;
+4. close active and pre-active sessions under the bounded drain policy;
+5. drain/discard late completions by generation, release principal snapshots and
+   wipe short-lived proof material;
+6. destroy verifier/runtime state only after no callback can publish into it.
+
+Partial initialization and repeated shutdown are safe. No session becomes active
+during or after shutdown.
+
+### 8. Diagnostics preserve evidence without secrets
+
+Diagnostics record policy ID/revision, exposure, protocol outcome, safe failure
+class, selected version/fingerprint ID, trust level, session generation, timing,
+rate-limit action and close reason. They do not record credentials, admission
+proofs, raw tokens, private keys, transcript secret material or unnecessary remote
+payloads.
+
+Metrics distinguish transport-connected, negotiating, authenticating, active,
+rejected, timed-out and revoked sessions. A transport connection count is never
+reported as an authenticated player count.
+
+### 9. Qualification covers the complete gate
+
+Focused automated coverage proves:
+
+- valid loopback, LAN and remote flows through activation and gameplay dispatch;
+- connected transport with early gameplay never reaches a gameplay/replication
+  callback;
+- version/fingerprint/capability boundaries, downgrade attempts and policy/bind
+  mismatches;
+- malformed/truncated/oversized/duplicate/reordered admission messages, unknown
+  required fields, nonce replay, proof replay, rate/flood limits and verifier
+  exhaustion;
+- wrong server pin/trust root, unauthenticated encrypted peer, invalid/expired/
+  revoked credential and LAN guest capability bounds;
+- negotiation, verification and activation timeouts plus cancellation races and
+  late completions;
+- shutdown at every state, partial verifier initialization, active revocation and
+  zero dispatch/callback after teardown;
+- secret redaction in errors, logs, metrics and diagnostic bundles.
+
+Contract tests run against Null and the production GNS adapter. Host/provider
+credential verifiers use deterministic fakes for failure/race coverage and bounded
+integration tests for real provider composition.
+
+## Security References
+
+- [GameNetworkingSockets identity and authentication API](https://github.com/ValveSoftware/GameNetworkingSockets/blob/master/include/steam/isteamnetworkingsockets.h)
+- [GameNetworkingSockets identity types and unauthenticated status](https://github.com/ValveSoftware/GameNetworkingSockets/blob/master/include/steam/steamnetworkingtypes.h)
+- [OWASP ASVS 5.0 Session Management](https://github.com/OWASP/ASVS/blob/master/5.0/en/0x16-V7-Session-Management.md)
+- [NIST SP 800-63B-4: Authentication and Authenticator Management](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63b-4.pdf)
+
+These references inform the threat model and session controls; this ADR does not
+claim blanket ASVS or NIST conformance for every game product.
+
+## Consequences
+
+### Positive
+
+- Transport connectivity can never bypass protocol, identity or authorization.
+- Loopback, LAN and remote exposure have explicit non-ambient trust rules.
+- Protocol downgrade, replay and pre-auth gameplay paths have one bounded owner.
+- Provider credentials and native transport identities remain behind Horo-owned
+  typed verification contracts.
+- Metrics and diagnostics distinguish connectivity from authenticated sessions.
+
+### Negative
+
+- Products must provision trust roots/pins, credential verifiers and session policy
+  before exposing LAN or remote listeners.
+- LAN pairing and remote admission add user/service lifecycle work beyond encrypted
+  packet transport.
+- Strict compatibility fingerprints require deliberate rollout/version policy.
+- Closing on expiry/revocation is less seamless than transparent refresh, which is
+  intentionally deferred until a safe reauthentication contract exists.
+
+## Rejected Alternatives
+
+### Treat transport `Connected` as an active gameplay session
+
+Encryption and packet flow do not prove product compatibility, application
+identity or authorization. This would expose gameplay parsers and authority before
+admission completes.
+
+### Trust IP address, private subnet or LAN membership
+
+Network location is attacker-influenced and does not authenticate a host or user.
+LAN requires encryption plus explicit host trust and application admission policy.
+
+### Accept encrypted but unauthenticated remote connections
+
+Encryption without authenticated server identity remains vulnerable to an active
+intermediary and cannot safely carry application credentials. Remote activation
+requires both server trust and application admission proof.
+
+### Let each transport/provider define session identity and roles
+
+This would make gameplay authority backend-dependent and expose provider semantics
+through runtime code. Provider evidence is input to the Horo verifier, not the
+principal model.
+
+### Default trust-on-first-use for LAN
+
+Silent first contact can pin an attacker's identity. Explicit pairing or a
+preconfigured product trust anchor/pin is required.
+
+### Buffer gameplay until authentication completes
+
+Pre-auth buffering creates memory pressure, replay ambiguity and an alternate
+dispatch path. Early gameplay is rejected and never replayed after activation.
+
+### Use flexible unbounded JSON negotiation
+
+An extensible text object does not justify attacker-controlled allocation,
+recursion or ambiguous canonicalization. The admission envelope is closed,
+versioned, binary and bounded.
+
+### Fall back to a weaker profile after failure
+
+Automatic guest, plaintext or local-profile fallback converts attack/failure into
+authority. Admission failure is terminal; a different profile requires a new
+explicit host composition.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -109,6 +109,7 @@ to the replacement.
 | [095](095-prefab-cook-boundary-and-artifact-model.md) | Prefab Cook Boundary and Artifact Model | Proposed | 2026-09-02 |
 | [096](096-prefab-external-reference-and-binding-slot-contract.md) | Prefab External Reference and Binding Slot Contract | Proposed | 2026-09-02 |
 | [097](097-default-real-time-transport-backend.md) | Default Real-Time Transport Backend | Proposed | 2026-09-02 |
+| [098](098-protocol-session-and-trust-policy.md) | Protocol, Session and Trust Policy | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -254,6 +254,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Default Real-Time Transport Backend](../adr/097-default-real-time-transport-backend.md):
   GameNetworkingSockets direct-IP baseline, private native encapsulation,
   security/traversal ownership, bounded lifecycle and optional provider policy.
+- [Protocol, Session and Trust Policy](../adr/098-protocol-session-and-trust-policy.md):
+  transport-to-session admission gate, compatibility, exposure-specific peer
+  trust, bounded credential verification and active-session publication.
 - [Asset Pipeline](./runtime/asset-pipeline.md): import, cook, package, runtime
   loading, cache, and hot reload.
 - [Prefab Architecture](./runtime/prefab-architecture.md): dual-role authoring

--- a/docs/architecture/runtime/multiplayer-replication-architecture.md
+++ b/docs/architecture/runtime/multiplayer-replication-architecture.md
@@ -16,6 +16,8 @@ Horo Engine uses an authoritative server model:
 - The server runs the full simulation; clients run a predicted simulation
 - Listen servers (one client is also the server) are supported
 - Dedicated servers (headless, no rendering) are the production target
+- Replication and RPC dispatch accept only sessions published `Active` by the
+  ADR-098 admission gate; transport connectivity is not gameplay authority
 
 ```cpp
 enum class NetworkRole {
@@ -201,6 +203,8 @@ Replication does not depend on a native transport or provider identity. Session
 authentication, protocol negotiation, authority and bandwidth policy remain in
 `NetworkRuntime`; GNS packet encryption does not replace them. All transports must
 honor the same bounded queues, cancellation, malformed-input and shutdown contract.
+Before ADR-098 activation, replication messages are rejected and never buffered;
+provider identity or a claimed client role cannot grant replication authority.
 
 ## Bandwidth Management
 
@@ -227,6 +231,7 @@ Replication bandwidth is managed:
 
 - [Networking Architecture](./networking-architecture.md): transport layer and connection model
 - [ADR-097: Default Real-Time Transport Backend](../../adr/097-default-real-time-transport-backend.md): production baseline and optional provider policy
+- [ADR-098: Protocol, Session and Trust Policy](../../adr/098-protocol-session-and-trust-policy.md): pre-gameplay admission, peer trust and active-session gate
 - [Scene Runtime](./scene-runtime.md): object lifecycle and network identity
 - [Physics Architecture](./physics-architecture.md): server-side physics and prediction
 - [Save Game And Persistence](./save-game-and-persistence.md): server-side save state

--- a/docs/architecture/runtime/networking-architecture.md
+++ b/docs/architecture/runtime/networking-architecture.md
@@ -23,6 +23,8 @@ Character checkpoint.
 - **Strict Layered Architecture**: Networking is separated into target-level tiers: public contracts and types (`HoroEngine::NetworkApi`), session coordination and replication runtime (`HoroEngine::NetworkRuntime`), and private concrete transport backends (`HoroEngine::NetworkTransportNull`, `HoroEngine::NetworkTransportGNS`).
 - **Production Baseline**: ADR-097 selects open-source GameNetworkingSockets (GNS) for production direct-IP real-time transport. Null remains the deterministic/offline backend; ICE/P2P, relay and provider integrations require explicit optional composition.
 - **Transport vs Session Split**: `INetworkTransport` is a packet-transport abstraction. Protocol negotiation, authentication, replication, and `NetworkSession` live in `NetworkRuntime`. Transport backends do not implement application authentication.
+- **Admission Before Gameplay**: Transport `Connected` creates a pre-active session only. The runtime's bounded admission controller is the sole authority that may negotiate, authenticate, activate and publish a session to gameplay.
+- **Host-Owned Trust**: The composition root supplies an immutable loopback-development, LAN or remote trust-policy snapshot. Project data, peers and transports cannot choose trust roots, weaken authentication or widen bind scope.
 - **Handle-Based Public Transport API**: Public transport operations use `INetworkTransport` plus generation-checked `ConnectionHandle` / `ListenerHandle` values. `ITransportConnection` and `ITransportListener` are not public types.
 - **Complete Native Encapsulation**: Public headers expose zero OS socket descriptors (`SOCKET`, `int fd`), OS socket headers, TLS/OpenSSL contexts (`SSL*`), event loops, or GNS/provider transport structures.
 - **Optional Link and Composition**: Single-player games, asset tools, and offline CLI utilities compile and run without linking transport backends. Products can compose `NetworkTransportNull` or omit the network runtime entirely.
@@ -80,7 +82,8 @@ The network subsystem is organized into four distinct CMake targets with strict 
 - **Key Components**:
   - `NetworkRuntimeCoordinator`: Owns the injected transport and active sessions, and ticks during `NetworkPoll` / `NetworkFlush`.
   - `NetworkSession`: Application-facing session that starts after the transport reports `Connected`.
-  - `SessionStateMachine`: Manages session transitions (`Created` -> `Negotiating` -> `Authenticating` -> `Active` -> `Closing` -> `Closed`).
+  - `SessionAdmissionController`: Owns bounded compatibility, peer trust, credential verification and activation before gameplay dispatch.
+  - `SessionStateMachine`: Manages session transitions (`Created` -> `Negotiating` -> `Authenticating` -> `Activating` -> `Active` -> `Closing` -> `Closed`).
   - `ReplicationManager`: Manages dirty property tracking, delta compression, interest management sets, and authoritative snapshot generation.
   - `MessageDispatcher`: Routes incoming RPCs and replication payloads to registered game handlers on the simulation thread.
 
@@ -228,6 +231,7 @@ NetworkSession
   Created                 // allocated when transport reaches Connected
     -> Negotiating        // protocol version, channels, capabilities
     -> Authenticating     // runtime/session token validation
+    -> Activating         // transcript-bound mutual activation acknowledgement
     -> Active
     -> Closing
     -> Closed
@@ -240,7 +244,8 @@ NetworkSession
 - **Transport `Connecting`**: Native connect and transport-level handshake. No application token is exchanged here.
 - **Transport `Connected`**: Packets can flow. `NetworkRuntime` now creates a `NetworkSession`.
 - **Session `Negotiating`**: Schema/protocol version, compression, and MTU agreement.
-- **Session `Authenticating`**: `NetworkRuntime` validates application credentials. Tokens are runtime/session data, not `ConnectRequest` fields on the transport.
+- **Session `Authenticating`**: `NetworkRuntime` validates host/peer trust and application credentials against the immutable listener policy. Tokens are runtime/session data, not `ConnectRequest` fields on the transport.
+- **Session `Activating`**: Both peers validate transcript-bound activation acknowledgements; no gameplay dispatch is permitted yet.
 - **Session `Active`**: Gameplay messages, RPCs, and replication are admitted.
 - **Closing / Closed / Failed**: Each layer tears down independently. Session close requests transport `Close()`. Transport `Failed` fails the associated session.
 
@@ -290,7 +295,7 @@ To prevent race conditions and frame stalls, network operations are strictly par
   Frame Phase: NetworkPoll
     - transport.PollEvents(consumer)
     - advance TransportConnection states
-    - create/advance NetworkSession (negotiate, authenticate)
+    - create/advance NetworkSession (negotiate, authenticate, activate)
     - dispatch Active-session messages to ReplicationManager / gameplay
   Frame Phase: Simulation & Gameplay Update
   Frame Phase: NetworkFlush
@@ -323,7 +328,7 @@ To prevent race conditions and frame stalls, network operations are strictly par
 
 Allowed adjacent orders are `NetworkPoll -> Simulation -> NetworkFlush -> RenderExtraction -> Render`. `NetworkFlush` after `RenderExtraction` is forbidden as the default because it adds render-extract latency to the network path without a transport requirement.
 
-## Message Schema and Protocol Negotiation
+## Message Schema, Protocol Negotiation and Session Trust
 
 Messages consist of:
 
@@ -332,13 +337,27 @@ Messages consist of:
 - 32-bit Sequence / Acknowledgement Numbers.
 - Bounded payload bytes with validated length headers.
 
-`NetworkRuntime` performs handshake negotiation after the transport reports `Connected`:
+`NetworkRuntime` performs handshake negotiation after the transport reports
+`Connected`. Until the session is `Active`, it accepts only bounded admission
+messages on the reserved control channel. Early gameplay, RPC, replication, voice,
+console and extension messages are rejected and never buffered for later dispatch.
 
-- Minimum and maximum supported protocol versions.
-- Supported compression algorithms and MTU payload limits.
-- Authentication credentials and capability flags.
+The canonical hello exchange includes:
 
-Mismatched protocol versions or invalid authentication tokens fail the **session** with `NetworkErrorCode::IncompatibleProtocol` or `NetworkErrorCode::AuthenticationFailed`. The transport connection is then closed. Transport backends must not interpret authentication tokens.
+- Product/protocol family identity and minimum/maximum wire versions.
+- Gameplay schema-set fingerprint and compatibility epoch.
+- Required/optional capability IDs, compression and MTU limits.
+- Trust-policy ID/revision, transport protection evidence and fresh nonces.
+
+The server selects the highest mutually supported version above both configured
+compatibility/security floors. Required capabilities and schema fingerprints use
+an explicit compatibility table; no string comparison, native-layout inference or
+silent downgrade is permitted. Both peers bind verification and activation to a
+canonical transcript digest.
+
+Mismatched protocol versions, trust failures or invalid credentials fail the
+**session** with a typed safe error and then close the transport. Transport
+backends must not interpret application credentials.
 
 GNS connection encryption and packet integrity are private transport capabilities;
 they do not authenticate a Horo user, authorize a session or replace application
@@ -350,6 +369,34 @@ ICE/STUN/TURN or provider-native mechanism, while `NetworkRuntime` and the host 
 signaling policy, credential acquisition and provider selection. The baseline GNS
 composition does not enable traversal, Steam signaling/authentication, Steam
 Datagram Relay, WebRTC or console-provider SDKs.
+
+### Exposure and Admission Policy
+
+The host supplies an immutable `NetworkTrustPolicySnapshot` before listener/connect
+creation. Effective bind scope must agree with its exposure:
+
+| Exposure | Required channel/peer policy | Application admission |
+|---|---|---|
+| Loopback development | Proven loopback bind/peer; native encryption when supported; Null may remain in-memory | Explicit local principal or configured credential |
+| Local network | Encryption/integrity plus product trust anchor, exact pin or explicit out-of-band pairing | Credential or explicitly configured bounded LAN guest principal |
+| Remote | Encryption/integrity plus authenticated server identity | Required short-lived transcript/nonces/server-bound admission proof |
+
+IP/private-subnet identity, successful key exchange and encrypted-but-
+unauthenticated transport are not peer authentication. A remote connection cannot
+become active without both server trust and application admission. Provider/native
+identity is verifier evidence, not gameplay authority.
+
+Successful verification creates an immutable Horo `SessionPrincipal` containing a
+fresh random session ID, principal ID, trust level, bounded roles/capabilities,
+credential provenance and expiry. Client claims never grant authority directly.
+Expiry or revocation closes the M0 session; transparent reauthentication is not
+part of this baseline.
+
+Admission has finite byte/message/field, pre-active connection, verifier-work,
+attempt, per-source rate, negotiation and activation limits. Cheap canonical
+parsing and compatibility checks precede expensive verification. Timeout,
+cancellation or shutdown invalidates the admission generation, so late transport
+or verifier completion cannot activate a session.
 
 ## Delivery Semantics and Backpressure
 
@@ -381,7 +428,7 @@ All transport queues have bounded capacities:
 - **Graceful Teardown**: Session close asks the transport to `Close()`. The transport transmits a disconnect frame and starts a bounded drain timer. Upon expiry or peer ACK, native resources are reclaimed.
 - **Process Shutdown Sequence**:
   1. The host calls `NetworkRuntime::Shutdown()`.
-  2. Runtime fails/closes all sessions and stops admitting gameplay messages.
+  2. Runtime stops admission, invalidates verification generations, removes every session from gameplay dispatch and cancels verifier work.
   3. Runtime calls `INetworkTransport::Shutdown()`: listeners stop accepting, pending connects are cancelled, connections send disconnect notices and perform only the bounded close drain.
   4. The backend stops and joins its I/O thread, drains or explicitly discards native and normalized messages under the shutdown policy, then releases native library state.
   5. Runtime destroys the unique transport. No callback may target it after destruction.
@@ -413,7 +460,8 @@ The networking subsystem requires targeted automated verification:
 1. **Unit Tests (`tests/unit/runtime/networking/`)**:
    - `NetworkAddressTests`: IPv4, IPv6, hostname, loopback, port parsing, serialization.
    - `TransportConnectionStateTests`: `Connect()` returns immediately; `Created` / `Resolving` / `Connecting` / `Connected`; invalid transitions; timeout.
-   - `SessionStateMachineTests`: `Negotiating` / `Authenticating` / `Active`; auth failure does not require transport-level auth.
+   - `SessionStateMachineTests`: `Negotiating` / `Authenticating` / `Activating` / `Active`; only Active reaches gameplay dispatch.
+   - `SessionAdmissionTests`: protocol/schema compatibility, transcript binding, exposure/bind policy, principal creation, expiry and revocation.
    - `NetworkHandleTests`: stale handle -> `InvalidHandle`; send-after-close -> `ConnectionClosed`; duplicate `Close` is idempotent.
    - `SendPayloadLifetimeTests`: caller buffer may be overwritten after `Send()` returns.
    - `ReplicationManagerTests`: Dirty property extraction, delta compression, interest management queries.
@@ -424,7 +472,11 @@ The networking subsystem requires targeted automated verification:
    - Graceful disconnect and timeout handling.
 3. **Integration & Lifecycle Tests**:
    - Full client-server connect, session authenticate, transfer, and disconnect sequences.
+   - Connected peers sending early gameplay never reach gameplay/replication callbacks.
+   - Loopback, LAN and remote valid flows; wrong pins/roots, unauthenticated encryption, invalid/expired/revoked credentials and downgrade/replay attempts.
+   - Bounded malformed/truncated/oversized admission input, rate/flood limits and verifier exhaustion.
    - Cancellation during DNS and connect; `Connect()` already returned a handle.
+   - Negotiation, verification and activation timeout/cancellation races discard late completions.
    - Unique-ptr injection: runtime shutdown destroys the transport exactly once.
    - Process shutdown with active connections and pending queued messages without hangs or memory leaks.
 4. **GNS Adapter Contract Tests (`NetworkTransportGNSTests`)**:
@@ -439,9 +491,11 @@ The networking subsystem requires targeted automated verification:
 
 - [ADR-020: Network Target Ownership and Dependency Boundary](../../adr/020-network-target-ownership-and-dependency-boundary.md)
 - [ADR-097: Default Real-Time Transport Backend](../../adr/097-default-real-time-transport-backend.md)
+- [ADR-098: Protocol, Session and Trust Policy](../../adr/098-protocol-session-and-trust-policy.md)
 - [System Design](../foundation/system-design.md)
 - [Desired Project Trees](../desired-project-tree.md)
 - [Multiplayer Replication Architecture](./multiplayer-replication-architecture.md)
 - [Runtime Lifecycle](./runtime-lifecycle.md)
 - [Concurrency And Job System](../foundation/concurrency-and-jobs.md)
 - [Network Debugger UI Reference](./network-debugger.html)
+- [Application Security Architecture](../security/application-security.md)

--- a/docs/architecture/security/application-security.md
+++ b/docs/architecture/security/application-security.md
@@ -25,6 +25,9 @@ editor and CLI hosts.
   access for remote exposure.
 - Runtime console and remote-console access are profile-gated, permission-scoped,
   and denied remotely by default.
+- Real-time transport connectivity is never application trust. `NetworkRuntime`
+  owns bounded protocol/session admission under an immutable host-selected
+  loopback, LAN or remote trust policy before gameplay dispatch.
 - Secrets remain in credential providers and short-lived secure memory.
 - Package source credentials and credential handles never enter package/project
   manifests, lockfiles, cache provenance exported to projects, logs, diagnostics
@@ -166,6 +169,40 @@ capability.
 Redirects, proxy behavior, certificate validation, and download integrity are
 explicit for update and package operations.
 
+## Real-Time Session Trust
+
+[ADR-098](../../adr/098-protocol-session-and-trust-policy.md) defines the
+real-time admission boundary. A transport `Connected` event, encrypted packet
+channel, IP address, private subnet or provider identity claim does not authorize a
+gameplay session. Before `Active`, only bounded control-channel admission messages
+may reach `SessionAdmissionController`; all gameplay/RPC/replication input is
+rejected and never queued for later dispatch.
+
+The host resolves an immutable trust-policy snapshot before listener/connect
+creation. Projects, peers and transports cannot install trust anchors, weaken
+verification or widen bind scope. Exposure requirements are:
+
+- loopback development proves both bind and peer are loopback and grants only an
+  explicit local principal or configured credential; the profile cannot bind LAN
+  or public interfaces;
+- LAN requires encryption/integrity, authenticated server identity through a
+  product trust anchor, exact pin or explicit pairing, and either a credential or
+  an explicitly bounded guest policy;
+- remote requires encryption/integrity, authenticated server identity and a
+  short-lived replay-resistant application admission proof bound to the server,
+  protocol transcript, nonces and expiry.
+
+Provider/native identity and client claims are inputs to an injected credential
+verifier, not gameplay roles. Successful verification produces a bounded immutable
+Horo principal; credential expiry or revocation closes the M0 session. Credentials,
+proofs, trust secrets and transcript secret material never enter logs, metrics,
+errors, project data or diagnostic bundles.
+
+Admission enforces finite pre-active connections, bytes, messages, fields, attempts,
+verification work, per-source rate and timeouts before expensive verification.
+Malformed, incompatible, replayed, downgraded, expired or hostile input fails
+terminally and never falls back to a weaker/guest profile.
+
 ## Diagnostic And Privacy Policy
 
 [ADR-070](../../adr/070-capture-and-voice-io-ownership.md) treats microphone,
@@ -213,6 +250,9 @@ Required tests cover:
 - plugin permission and trust checks
 - MCP authentication, authorization, and rate limiting
 - credential redaction across every signal
+- loopback/LAN/remote bind and trust-policy enforcement
+- protocol downgrade, schema/capability mismatch, wrong peer pin/root and replayed admission proof
+- pre-active gameplay denial, bounded malformed admission input, timeout, revocation and shutdown races
 - parser resource limits and malformed input
 - update signature rejection
 
@@ -225,3 +265,5 @@ Required tests cover:
 - [Runtime Debug Console And Development Overlays](../runtime/debug-console-and-overlays.md)
 - [Horo Package System](../packages/package-system.md): package trust levels and code contribution policy
 - [Error And Diagnostics](../foundation/error-and-diagnostics.md)
+- [Networking Architecture](../runtime/networking-architecture.md)
+- [ADR-098: Protocol, Session and Trust Policy](../../adr/098-protocol-session-and-trust-policy.md)


### PR DESCRIPTION
## Summary

- Define a strict transport-to-session admission gate: `Connected` never grants gameplay dispatch.
- Add ADR-098 with canonical compatibility negotiation, exposure-specific trust, bounded credential verification and terminal lifecycle rules.
- Align networking, application security and multiplayer replication documents on the same active-session authority.

## Why

- Encrypted packet connectivity does not prove application compatibility, intended server identity, user/service authorization or safe gameplay input.
- Loopback development, LAN and remote exposure need explicit host-owned policies without allowing project data or peers to weaken trust.

## Decision and boundaries

- Adds `Activating` after negotiation/authentication; only the owner-thread `Active` table can reach gameplay/RPC/replication dispatch.
- Loopback relaxation is valid only for proven loopback bind/peer; LAN requires encrypted authenticated host trust or explicit pairing; remote additionally requires short-lived replay-bound application admission proof.
- Provider/native identities feed a Horo verifier but never directly grant roles or authority.
- Defines canonical transcript binding, downgrade resistance, finite parsing/verifier/rate/time budgets, expiry/revocation and generation-safe cancellation/shutdown.
- Adds valid, incompatible, malformed, hostile, timeout, revocation, redaction and teardown coverage requirements.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Documentation lint passed
- [x] CMake configure passed
- [x] Added Markdown links resolve
- [x] Manual smoke test not applicable to an architecture-only change

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/098-protocol-session-and-trust-policy.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/networking-architecture.md docs/architecture/runtime/multiplayer-replication-architecture.md docs/architecture/security/application-security.md
git diff --check
git diff --cached --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- This PR freezes contracts but does not implement the admission controller, credential provider integrations or security qualification suite.
- Product compositions must still provision trust roots/pins, verifier policy and listener exposure intentionally.
- CMake reported the existing mbedTLS minimum-version deprecation warning and that pytest is unavailable, so repository Python tests were skipped.

## Issue links

- Jira: HORO-1110
- GitHub: Closes #1110

## Reviewer Notes

- Review ADR-098 first, then networking architecture's state machine and exposure table, followed by the application-security projection.
- The replication edit only enforces the same pre-active dispatch gate at the consumer boundary.