### PR TITLE
docs(network): define replication authority schema HORO-1120 #1120 [NET-003.1]

### DIFF
--- a/docs/adr/099-replication-ownership-authority-and-compatibility.md
+++ b/docs/adr/099-replication-ownership-authority-and-compatibility.md
@@ -1,0 +1,342 @@
+# ADR-099: Replication Ownership, Authority and Compatibility
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Replicated-state declaration, capture, transport and apply ownership; standalone/server/autonomous/simulated roles; stable schema and FieldId identity; compatibility, registration, lifecycle, malformed input and safe-point behavior
+- **Issue**: [NET-003.1](https://github.com/abdullahbodur/horo-engine/issues/1120)
+- **Jira**: [HORO-1120](https://horo-engine.atlassian.net/browse/HORO-1120)
+- **Related**: [ADR-092](092-character-controller-determinism-and-state-composition.md), [ADR-097](097-default-real-time-transport-backend.md), [ADR-098](098-protocol-session-and-trust-policy.md)
+- **Normative documents**: [Multiplayer Replication Architecture](../architecture/runtime/multiplayer-replication-architecture.md), [Networking Architecture](../architecture/runtime/networking-architecture.md), [Scene Runtime](../architecture/runtime/scene-runtime.md), [Gameplay Behavior Authoring](../architecture/extensions/gameplay-behavior-authoring.md)
+
+## Context
+
+The replication architecture described server authority but represented fields by
+string `PropertyPath`, implied automatic dirty-property collection and did not say
+which subsystem owns declaration, snapshot capture or application. That ambiguity
+invites scanning component memory, serializing C++ layout, treating a local client
+as authoritative, or mirroring arbitrary event-bus traffic. Each would create an
+unstable wire format and a second mutation authority beside Scene and Gameplay.
+
+Replication crosses four different concerns. A gameplay/component owner knows the
+semantic state and valid mutations. Scene owns entity/component lifetime and safe
+points. NetworkRuntime knows sessions, interest, baselines and wire scheduling. The
+transport only moves protected messages. The contract must preserve each owner
+instead of centralizing mutable gameplay state in networking.
+
+Server, autonomous client and simulated client may exist in one process (for
+example a listen-server/editor preview) and may use separate world generations.
+Process locality, player index, input device, object visibility or possession is
+not authority. Roles and grants must be explicit, world-scoped and generation-
+checked.
+
+## Decision
+
+### 1. Declaration, state, capture, transmission and apply have distinct owners
+
+| Responsibility | Owner |
+|---|---|
+| Semantic field meaning, stable schema/field IDs, codecs, validation and capture/apply adapters | Declaring gameplay/component module |
+| Canonical runtime values, entity/component lifetime and mutation safe points | Owning Scene/Gameplay system |
+| Schema registry snapshot, network object identity, dirty hints, capture orchestration, baselines, interest, serialization, transport submission and receive validation | `NetworkRuntime` |
+| Protected message delivery and connection lifecycle | Injected `INetworkTransport` |
+| Product role/trust/session composition | Host plus ADR-098 admission policy |
+
+The declaring module does not own sockets, peer/session routing or baselines.
+`NetworkRuntime` does not own canonical gameplay fields and cannot write component
+memory directly. Scene does not interpret wire packets. Transport does not know
+replication schemas or authority.
+
+A declaration is inert metadata until the host composes and validates a registry
+snapshot. Descriptor construction cannot inspect a service locator, register
+globally, capture live objects or mutate state.
+
+### 2. Execution roles are explicit capabilities, not local heuristics
+
+```cpp
+enum class ReplicationExecutionRole : std::uint8_t {
+    Standalone,
+    AuthorityServer,
+    AutonomousClient,
+    SimulatedClient
+};
+
+struct ReplicationAuthorityGrant {
+    RuntimeSceneId scene;
+    RuntimeSceneGeneration sceneGeneration;
+    ReplicationAuthorityEpoch epoch;
+    ReplicationExecutionRole role;
+    NetworkSessionGeneration sessionGeneration;
+};
+```
+
+The host creates a role for a specific runtime world; the server creates object-
+level ownership/submission grants under its authority epoch. Every capture, input
+submission, snapshot apply and RPC check validates scene, epoch, object generation,
+session generation and role. A listen server uses distinct server/client world
+roles even when both live in one process.
+
+Role capabilities are:
+
+| Role | Canonical write/capture | Network submission | Received-state apply |
+|---|---|---|---|
+| Standalone | Local gameplay systems own normal canonical mutation; no network grant exists | None | None |
+| Authority server | May capture canonical declared state at the owner safe point and publish authoritative spawn/update/despawn | Validates typed client submissions; sends authoritative state | Applies only explicit server-owned administrative/import commands, not client snapshots |
+| Autonomous client | Cannot author server state; may maintain separately declared local prediction/presentation state | May submit bounded typed input/commands permitted by its server grant | Applies authoritative corrections/snapshots through the schema adapter |
+| Simulated client | No server-state or prediction authority | No object-authoritative submission | Applies authoritative snapshots through the schema adapter for presentation/simulation |
+
+Autonomous does not mean authoritative. Prediction is an opt-in capability owned by
+a later policy; it cannot change the server's canonical state or schema rules.
+Possession, local input, local player ID, same process and successful transport
+connection never synthesize a grant.
+
+### 3. Schemas and FieldId values are durable semantic identity
+
+```cpp
+struct ReplicationSchemaVersion {
+    std::uint16_t major;
+    std::uint16_t minor;
+};
+
+struct ReplicationFieldDescriptor {
+    FieldId id;
+    ReplicationValueTypeId valueType;
+    ReplicationCodecId codec;
+    ReplicationCondition condition;
+    ReplicationFieldRequirement requirement;
+    ReplicationWritePolicy writePolicy;
+    ReplicationFieldLimits limits;
+};
+
+struct ReplicationSchemaDescriptor {
+    ReplicationSchemaId id;
+    ReplicationSchemaVersion version;
+    ModuleId owner;
+    std::span<const ReplicationFieldDescriptor> fields;
+    ReplicationCaptureBinding capture;
+    ReplicationApplyBinding apply;
+};
+```
+
+`ReplicationSchemaId` is a globally registered stable semantic ID. `FieldId` is a
+non-zero stable 32-bit numeric ID scoped by that schema. IDs are allocated once,
+persist across rename/reorder/refactor and are never reused after publication.
+Removed IDs remain tombstoned. Display names, C++ member names, editor labels,
+JSON paths, component order, reflection indices, addresses and byte offsets are
+not identity and never appear in the wire contract.
+
+Each field has one registered semantic value type, canonical bounded codec,
+condition, requiredness, write policy and limits. A type/meaning change that cannot
+preserve compatibility allocates a new `FieldId` or a new major schema with an
+explicit translator. Quantization/compression is codec policy; it does not change
+the gameplay owner's canonical field or permit lossy values to become restore/hash
+authority.
+
+RPCs and client input use separate stable schema/RPC/command IDs. A generic event
+type or event-bus subscription is not a replication declaration.
+
+### 4. Registration freezes one immutable schema-set generation
+
+Modules contribute descriptors during host composition before network world/session
+activation. Registry validation rejects:
+
+- duplicate/zero schema or field IDs, reuse of tombstoned IDs and foreign owners;
+- empty/overflowed schemas, unsorted or duplicate fields and invalid version rules;
+- missing/unregistered codecs/types, unbounded limits or unsupported conditions;
+- capture without apply support for a receive role, write-policy contradictions
+  and adapter ownership/lifecycle mismatches;
+- ambiguous compatibility edges, cycles or translators that do not produce the
+  declared target schema.
+
+Validation canonicalizes fields by numeric `FieldId` and computes a domain-
+separated schema-set fingerprint consumed by ADR-098 negotiation. A failure
+publishes nothing. Runtime sessions pin the immutable registry generation.
+
+Hot reload builds and validates a replacement generation off-thread, then swaps it
+at the owner safe point for new worlds/sessions. Existing sessions keep the old
+generation or close/re-negotiate under explicit policy. A module cannot unload
+while a registry, queued snapshot, baseline, adapter call or active session pins
+its generation. Retirement waits for bounded drain; shutdown cancels work and
+releases pins in owner order.
+
+### 5. Network object identity never aliases ECS storage
+
+The authority server allocates `NetworkObjectId` plus generation and maps it to a
+scene-qualified generation-checked `EntityRef`. IDs are unique within the server
+authority epoch and are not ECS indices, pointers, authored scene IDs, names or
+paths. Reuse increments generation; stale spawn/update/despawn messages fail.
+
+Spawn publishes object ID/generation, schema ID/version and the required initial
+field set before any delta. Despawn retires the mapping at a defined tick. Scene
+destruction/reload invalidates the authority epoch so late messages cannot target a
+replacement world or reused entity slot.
+
+### 6. Capture is explicit, immutable and owner-safe
+
+At the fixed network capture safe point, `NetworkRuntime` selects authoritative,
+relevant objects and invokes their registered capture adapters with a validated
+read-only owner-thread view, schema generation and preallocated bounded writer.
+The adapter emits canonical field values by `FieldId`.
+
+Capture cannot retain component pointers/views, mutate state, call transport,
+register fields or perform unbounded allocation/blocking I/O. NetworkRuntime may
+use explicit owner-provided revision counters or `MarkReplicationDirty(object,
+FieldId)` as scheduling hints. A dirty hint is neither authority nor a value; the
+capture adapter remains the value source.
+
+NetworkRuntime never scans ECS/component memory, reflects arbitrary members,
+serializes `sizeof(T)`, diffs padding or infers fields from editor metadata. It owns
+immutable captured snapshots and baselines after capture returns, not the source
+state.
+
+### 7. Wire records are schema-versioned and bounded
+
+Every state record carries at least:
+
+- authority epoch, network object ID/generation and authoritative simulation tick;
+- schema ID and negotiated schema version;
+- spawn/update/despawn kind plus baseline identity where applicable;
+- bounded field count and canonical ascending `FieldId` entries;
+- each entry's wire type/codec tag, bounded byte length and canonical value bytes.
+
+The receiver validates session `Active`, authority direction, epoch, object
+lifecycle, schema generation/version, record/field counts, ordering, duplicate IDs,
+types, lengths, codec bounds and total work before allocating or decoding. Native
+struct layout, endianness, padding, RTTI and pointer values never cross the wire.
+
+Malformed records fail atomically. No partial object mutation is visible and no
+unknown bytes are copied into component storage. Repeated hostile records follow
+the ADR-098 abuse/close policy.
+
+### 8. Compatibility is explicit per schema version
+
+Major versions are incompatible unless the declaring owner registers a bounded
+deterministic translator. Within a compatible major, a minor version may add an
+optional field with a canonical default. Removing a field tombstones its ID;
+changing requiredness, semantic type or meaning requires a version rule and often
+a new ID/major.
+
+Negotiation chooses one explicit compatible schema-set projection. The sender
+encodes only that projection. Unknown required schemas/fields, missing required
+fields, incompatible type/codec, unsupported translator or fingerprint mismatch
+fails admission or the affected session according to policy. Unknown optional
+length-delimited fields may be skipped only when the negotiated compatibility rule
+authorizes it.
+
+Translators operate on bounded typed field records, not raw component memory. They
+are pure with respect to world/gameplay state, cannot invent authority and are
+covered by canonical fixtures. There is no best-effort name/path match or implicit
+version downgrade.
+
+### 9. Apply validates then commits through the state owner
+
+`NetworkRuntime` decodes an entire record into a bounded typed apply command and
+validates role, session, authority, object and schema before queueing it for the
+target world. At the declared owner-thread safe point, Scene revalidates scene/
+entity generation and invokes the schema owner's apply adapter.
+
+The adapter validates semantic ranges and commits all accepted fields as one owned
+mutation or rejects the command without partial visibility. It may update
+replica/presentation or declared prediction-correction state according to role. It
+cannot write an authority-server object from a client snapshot, bypass component
+invariants, perform structural mutation outside the Scene command boundary or
+retain decoded views after return.
+
+Client input/commands are not replicated state writes. They use typed schemas,
+rate/permission checks and server-owned gameplay handlers; the server decides
+whether and how canonical state changes.
+
+### 10. Events and diagnostics are projections, not wire authority
+
+Gameplay events may mark a declared field dirty or cause gameplay to mutate owned
+state. NetworkRuntime then captures that declared state. It does not subscribe to
+the generic event bus and serialize arbitrary event payloads. Network RPC/event
+schemas are separately registered, direction-scoped and bounded.
+
+Diagnostics use schema/field/object IDs, versions, role, safe failure reason,
+counts and timing. They omit secret/session proofs and field payloads by default.
+Display paths/names may be resolved locally for tools but never affect decode,
+authority or compatibility.
+
+### 11. Qualification covers registration through retirement
+
+Focused automated coverage proves:
+
+- valid descriptor registration, canonical ordering/fingerprint and duplicate/
+  zero/tombstoned/foreign ID rejection;
+- missing codec, invalid type/limits/condition/write policy, overflowed schemas and
+  malformed compatibility graph/translator rejection;
+- standalone/server/autonomous/simulated capability matrices, including same-
+  process listen-server worlds without locality-derived authority;
+- stable field identity across rename/reorder/layout changes and rejection of
+  `PropertyPath`, offset, pointer and raw-memory fixtures;
+- exact/additive-minor/major-translated compatibility plus missing required,
+  unknown, duplicate, reordered, wrong-type and oversized field records;
+- spawn/update/despawn ordering, stale object/scene/session/authority generations,
+  disconnect, world reload and module hot-reload/unload pinning;
+- capture/apply safe-point ownership, atomic apply failure, dirty-hint behavior,
+  cancellation, queue/budget overflow and shutdown with queued snapshots/applies;
+- explicit proof that generic event publication and arbitrary ECS component
+  mutation produce no network traffic without a registered schema/dirty command.
+
+Fuzz/property coverage targets descriptor parsing, compatibility negotiation,
+record framing and field codecs under configured memory/work limits.
+
+## Consequences
+
+### Positive
+
+- Gameplay and Scene retain canonical state and mutation ownership.
+- Stable schema/`FieldId` values survive C++ refactors and editor renames.
+- Server authority is explicit per world/session/object generation, including in a
+  listen-server process.
+- Compatibility and malformed input are decided before component mutation.
+- NetworkRuntime can optimize snapshots/baselines without learning native layouts.
+- Standalone products do not pay mandatory transport, history or replication work.
+
+### Negative
+
+- Gameplay/component owners must define and maintain schemas, codecs and adapters.
+- Schema evolution requires ID discipline, tombstones, fixtures and explicit
+  translators.
+- Capture/apply indirection adds registry and safe-point integration work.
+- Automatic reflection-based replication is intentionally unavailable.
+
+## Rejected Alternatives
+
+### String `PropertyPath` as wire identity
+
+Names and paths change during refactors, localization and hierarchy edits and can
+be ambiguous. Stable numeric `FieldId` scoped by a stable schema is normative.
+
+### Serialize component/ECS memory automatically
+
+C++ layout, padding, pointers, endianness and transient fields are not semantic or
+portable. Raw scanning also bypasses codecs, bounds and state-owner invariants.
+
+### Replicate the generic event bus
+
+Local events have different lifetime, audience and payload guarantees. Mirroring
+them creates ambient network authority and an unbounded accidental protocol.
+Network commands/RPCs require explicit typed schemas.
+
+### Grant authority to the local player or local process
+
+A listen server contains server and client roles together, and compromised clients
+are still local to themselves. Only explicit world/session/object grants determine
+capability.
+
+### Let NetworkRuntime own canonical gameplay state
+
+This creates a second source of truth and lets networking bypass Scene/Gameplay
+safe points. NetworkRuntime owns captured snapshots and wire orchestration only.
+
+### Apply decoded fields directly into components
+
+Direct writes bypass generation checks, semantic validation, invariants and atomic
+commit. Apply must go through the declaring owner's adapter at the Scene safe point.
+
+### Best-effort compatibility by matching names or layouts
+
+Implicit matching hides semantic drift and produces peer-dependent results.
+Compatibility is versioned, fingerprinted and explicit.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -110,6 +110,7 @@ to the replacement.
 | [096](096-prefab-external-reference-and-binding-slot-contract.md) | Prefab External Reference and Binding Slot Contract | Proposed | 2026-09-02 |
 | [097](097-default-real-time-transport-backend.md) | Default Real-Time Transport Backend | Proposed | 2026-09-02 |
 | [098](098-protocol-session-and-trust-policy.md) | Protocol, Session and Trust Policy | Proposed | 2026-09-02 |
+| [099](099-replication-ownership-authority-and-compatibility.md) | Replication Ownership, Authority and Compatibility | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -257,6 +257,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Protocol, Session and Trust Policy](../adr/098-protocol-session-and-trust-policy.md):
   transport-to-session admission gate, compatibility, exposure-specific peer
   trust, bounded credential verification and active-session publication.
+- [Replication Ownership, Authority and Compatibility](../adr/099-replication-ownership-authority-and-compatibility.md):
+  explicit world roles, stable schema/FieldId identity, owner-safe capture/apply,
+  compatibility, object generations and prohibited ambient replication.
 - [Asset Pipeline](./runtime/asset-pipeline.md): import, cook, package, runtime
   loading, cache, and hot reload.
 - [Prefab Architecture](./runtime/prefab-architecture.md): dual-role authoring

--- a/docs/architecture/extensions/gameplay-behavior-authoring.md
+++ b/docs/architecture/extensions/gameplay-behavior-authoring.md
@@ -206,6 +206,22 @@ behaviors in an "Add Behavior" or "Add Component" flow and attach them to any
 compatible scene object. The generic inspector edits the behavior's declarative
 authoring fields. Custom inspectors still belong to the editor extension contract.
 
+### Replication Declaration Boundary
+
+[ADR-099](../../adr/099-replication-ownership-authority-and-compatibility.md)
+requires gameplay/behavior owners that opt into replication to contribute inert
+stable schema/`FieldId` descriptors plus canonical bounded codecs and capture/apply
+adapters through the generated module contribution seam. C++ member names, editor
+property paths, serialized field order, reflection offsets and raw instance memory
+never become wire identity.
+
+The behavior remains canonical state/mutation owner. Its capture adapter receives a
+read-only owner-thread view and emits declared fields; its apply adapter validates
+and commits a bounded typed command at the Scene safe point. Neither adapter owns
+sessions, transport, interest or baselines, and neither may retain component views
+or bypass behavior invariants. Publishing an ordinary gameplay event does not
+replicate it; inputs/RPCs require separate direction-scoped schemas.
+
 ### Native C++ Behavior Example
 
 A native behavior is ordinary gameplay code compiled into the project gameplay

--- a/docs/architecture/runtime/multiplayer-replication-architecture.md
+++ b/docs/architecture/runtime/multiplayer-replication-architecture.md
@@ -2,132 +2,256 @@
 
 ## Purpose
 
-This document defines the multiplayer replication subsystem for Horo Engine.
-It covers client-server architecture, object replication, RPC, authority model,
-prediction and reconciliation, interest management, dedicated server, and
-network transport.
+This document defines Horo Engine's server-authoritative replication ownership,
+schema and `FieldId` identity, runtime roles, capture/transmit/apply flow, object
+lifecycle, compatibility, RPC/input boundary, prediction seam, interest management,
+dedicated-server composition and transport integration.
 
-## Client-Server Model
+## Core Decisions
 
-Horo Engine uses an authoritative server model:
+- The authority server is the only network role that publishes canonical gameplay
+  state. Clients submit typed inputs/commands; they do not write server state.
+- Gameplay/component owners declare stable schemas, codecs and capture/apply
+  adapters. Scene/Gameplay retain canonical values and mutation safe points.
+- `NetworkRuntime` owns registry snapshots, network object identity, capture
+  orchestration, baselines, interest, wire encoding, routing and validated apply
+  commands—not gameplay state.
+- Wire fields use stable numeric `FieldId` values scoped by stable schema IDs and
+  explicit versions. Property paths, member names, offsets and native layouts are
+  presentation/implementation details only.
+- Standalone, authority-server, autonomous-client and simulated-client roles are
+  explicit world/session capabilities. Process locality, possession and input
+  devices never grant authority.
+- Only ADR-098 `Active` sessions reach replication/RPC dispatch.
+- Automatic ECS-memory and generic event-bus replication are prohibited.
 
-- The server owns game state and is authoritative for all gameplay decisions
-- Clients send input and receive replicated state
-- The server runs the full simulation; clients run a predicted simulation
-- Listen servers (one client is also the server) are supported
-- Dedicated servers (headless, no rendering) are the production target
-- Replication and RPC dispatch accept only sessions published `Active` by the
-  ADR-098 admission gate; transport connectivity is not gameplay authority
+## Ownership Boundary
+
+| Responsibility | Owner |
+|---|---|
+| Field meaning, schema/field IDs, codec, bounds and capture/apply adapters | Declaring gameplay/component module |
+| Canonical values, entity/component lifetime and mutation safe points | Scene/Gameplay owner |
+| Registry generation, network IDs, snapshots, baselines, interest, encoding, routing and receive validation | `NetworkRuntime` |
+| Protected message movement and connection lifecycle | `INetworkTransport` |
+| Role/trust/session composition | Host and ADR-098 admission policy |
+
+Declarations are inert metadata until host composition validates and publishes one
+immutable registry generation. Descriptors cannot register globally, inspect live
+objects, find a service locator or mutate state during construction.
+
+## Execution Roles and Authority
 
 ```cpp
-enum class NetworkRole {
-    ServerOnly,        // exists only on server
-    ClientOnly,        // exists only on client (e.g., local VFX)
-    ServerAuthoritative, // server owns, replicates to clients
-    ClientSubmittedMessage, // client submits non-authoritative messages validated by server
+enum class ReplicationExecutionRole : std::uint8_t {
+    Standalone,
+    AuthorityServer,
+    AutonomousClient,
+    SimulatedClient
+};
+
+struct ReplicationAuthorityGrant {
+    RuntimeSceneId scene;
+    RuntimeSceneGeneration sceneGeneration;
+    ReplicationAuthorityEpoch epoch;
+    ReplicationExecutionRole role;
+    NetworkSessionGeneration sessionGeneration;
 };
 ```
 
-## Object Replication
+The host assigns a role to a specific runtime world. The authority server issues
+object-level ownership/submission grants under its epoch. Every operation validates
+world, epoch, object generation, session generation and role.
 
-### Replicated Objects
+| Role | Canonical state | Submission | Received state |
+|---|---|---|---|
+| Standalone | Normal local Scene/Gameplay ownership; no network grant | None | None |
+| Authority server | Captures/publishes canonical declared state at safe points | Validates typed client inputs/commands | Rejects client-authored state snapshots |
+| Autonomous client | No server-state authority; may hold separately declared prediction/presentation state | Sends only commands permitted by the server grant | Applies authoritative snapshot/correction through owner adapter |
+| Simulated client | No authority or local prediction grant | No object-authoritative submission | Applies authoritative replica state through owner adapter |
 
-Objects marked for replication have their state synchronized:
+A listen-server process composes distinct server and client worlds/roles. The fact
+that both live in one process, share a player, or use loopback transport does not
+grant the client world authority. Autonomous means permitted input submission and
+possibly a separately qualified prediction capability; it never means canonical
+server write permission.
+
+## Replication Schema and Field Identity
 
 ```cpp
-struct ReplicatedObject {
-    NetworkId          networkId;
-    NetworkRole        role;
-    ReplicationOwner   owner;          // which peer has authority
-    ReplicationGroup   group;          // interest management group
-    bool               isRelevant;     // current interest state
+struct ReplicationSchemaVersion {
+    std::uint16_t major;
+    std::uint16_t minor;
+};
+
+struct ReplicationFieldDescriptor {
+    FieldId id;
+    ReplicationValueTypeId valueType;
+    ReplicationCodecId codec;
+    ReplicationCondition condition;
+    ReplicationFieldRequirement requirement;
+    ReplicationWritePolicy writePolicy;
+    ReplicationFieldLimits limits;
+};
+
+struct ReplicationSchemaDescriptor {
+    ReplicationSchemaId id;
+    ReplicationSchemaVersion version;
+    ModuleId owner;
+    std::span<const ReplicationFieldDescriptor> fields;
+    ReplicationCaptureBinding capture;
+    ReplicationApplyBinding apply;
 };
 ```
 
-### Property Replication
+`ReplicationSchemaId` is a globally registered stable semantic ID. `FieldId` is a
+non-zero stable 32-bit ID scoped by its schema. Both survive rename, reorder and
+C++ refactor. Published IDs are never reused; removed field IDs remain tombstoned.
 
-Individual properties are marked for replication:
+A field declares one semantic value type, canonical bounded codec, condition,
+requiredness, write policy and limits. Editor/display names, `PropertyPath`, C++
+member names, component order, reflection indices, pointer values and byte offsets
+never enter the wire contract.
 
-```cpp
-struct ReplicatedProperty {
-    PropertyPath       path;           // e.g., "Transform.Position"
-    ReplicationCondition condition;    // when to replicate
-    float              lerpTime;       // interpolation duration
-};
-```
+Replication conditions are descriptor policy, not authority:
 
-Replication conditions:
+- `Always`: considered for every eligible snapshot;
+- `InitialOnly`: required in the authoritative spawn record;
+- `OwnerOnly`: routed only to the granted autonomous client;
+- `SkipOwner`: omitted for that autonomous client;
+- `SimulatedOnly`: routed only to simulated-client views.
 
-- **Always**: Replicated on every change
-- **InitialOnly**: Sent once on spawn
-- **OwnerOnly**: Only to the owning client
-- **SkipOwner**: To all clients except the owner
-- **SimulatedOnly**: Only to simulated proxies (not autonomous)
+An owner may use an explicit revision counter or
+`MarkReplicationDirty(NetworkObjectId, FieldId)` as a scheduling hint. The hint
+does not contain the value and grants no write/capture authority.
 
-### Replication Update
+## Registry Composition and Lifecycle
 
-Each network tick:
+Modules contribute schema descriptors before network world/session activation.
+Validation rejects:
 
-1. Server collects dirty properties for each relevant object
-2. Properties are serialized to a per-client update buffer
-3. Buffer is sent as an unreliable or reliable datagram
-4. Client receives and deserializes updates
-5. Client interpolates between received states for smooth visual updates
+- zero, duplicate, tombstoned or foreign-owned schema/field IDs;
+- overflowed/empty schemas, duplicate/unsorted fields and invalid version graphs;
+- missing value types/codecs, unbounded limits or contradictory condition/write
+  policy;
+- missing role-required capture/apply adapter and incompatible adapter ownership;
+- ambiguous/cyclic compatibility edges or invalid translators.
 
-## Remote Procedure Calls (RPC)
+Fields are canonicalized by numeric `FieldId`. The registry computes a domain-
+separated schema-set fingerprint used by ADR-098 session negotiation. Failure
+publishes nothing; active sessions pin the complete immutable generation.
 
-RPCs allow clients and server to invoke functions on remote objects:
+Hot reload builds a candidate off-thread and publishes it at an owner safe point.
+Existing sessions retain their pinned generation or explicitly close/re-negotiate.
+Module unload waits until sessions, snapshots, baselines, queues and adapter calls
+release the old generation. Shutdown cancels work, closes dispatch and drains pins
+before module/runtime destruction.
 
-```cpp
-enum class RPCDirection {
-    Server,     // client → server (validated)
-    Client,     // server → client (reliable or unreliable)
-    Multicast,  // server → all clients
-};
+## Network Object Lifecycle
 
-struct RPCCall {
-    NetworkId          targetObject;
-    uint32_t           functionId;
-    std::vector<uint8_t> payload;     // serialized parameters
-    RPCReliability     reliability;
-};
-```
+The authority server allocates `NetworkObjectId` plus generation under a
+`ReplicationAuthorityEpoch` and maps it to one scene-qualified `EntityRef`.
+Network IDs are not ECS indices, addresses, names, hierarchy paths or authored
+scene IDs.
 
-Server RPCs are validated:
+Lifecycle records are ordered:
 
-- The calling client must own the object (or have explicit permission)
-- Parameter ranges are validated on the server
-- Rate limiting prevents RPC spam
+1. `Spawn`: object ID/generation, schema/version and required initial fields.
+2. `Update`: authoritative tick, baseline identity and changed field records.
+3. `Despawn`: terminal tick/reason; later updates for that generation fail.
 
-## Prediction And Reconciliation
+Reuse increments object generation. Scene replacement increments the authority
+epoch. Late packets can therefore never mutate a reused entity slot or replacement
+world.
 
-### Client Prediction
+## Capture and Snapshot Ownership
 
-Clients predict the result of their own input before receiving server
-confirmation:
+During the fixed network capture safe point, `NetworkRuntime` selects authoritative
+relevant objects and invokes the registered schema capture adapter with:
 
-1. Client sends input to server
-2. Client immediately applies input to its local predicted state
-3. Server processes input and sends authoritative state
-4. Client compares predicted state with authoritative state
-5. If they differ, the client reconciles (rewinds and replays)
+- a validated read-only owner-thread state view;
+- the pinned schema generation;
+- object/authority identity;
+- a preallocated bounded typed writer.
 
-```cpp
-struct PredictionState {
-    uint32_t            lastAcknowledgedInputId;
-    std::deque<InputSnapshot> pendingInputs;
-    std::deque<StateSnapshot> stateHistory;
-};
-```
+The adapter emits canonical values by `FieldId`. It cannot mutate gameplay state,
+retain component views, register fields, call the transport or allocate/block
+without bound. After return, NetworkRuntime owns the immutable captured snapshot
+and derived baselines—not the source values.
 
-### Reconciliation
+NetworkRuntime never scans ECS/component memory, reflects arbitrary fields,
+serializes `sizeof(T)`, compares padding or derives replication from editor
+metadata. Explicit capture is the only state source.
 
-When the server state arrives:
+## Wire Records and Compatibility
 
-- Discard acknowledged inputs from the pending queue
-- Apply remaining unacknowledged inputs to the server state
-- Interpolate visual state toward the corrected position
-- Log prediction errors for debugging
+Every replication state record contains:
+
+- authority epoch, object ID/generation and authoritative simulation tick;
+- schema ID and negotiated schema version;
+- spawn/update/despawn kind and baseline ID where applicable;
+- bounded field count with canonical ascending `FieldId` entries;
+- each entry's wire type/codec tag, bounded byte length and canonical bytes.
+
+The receiver validates the session is `Active`, server-to-client authority
+direction, epoch, object lifecycle, schema generation/version, counts, ordering,
+duplicate IDs, field types, lengths, codec limits and total work before decode or
+allocation. Native memory layout, padding, RTTI, vtables and pointers never cross
+the wire.
+
+Compatibility rules are explicit:
+
+- major versions are incompatible unless the declaring owner registers a bounded
+  deterministic translator;
+- a compatible minor version may add optional fields with canonical defaults;
+- removed IDs are tombstoned;
+- semantic type/meaning/requiredness changes allocate a new field ID or follow an
+  explicit major-version translation;
+- unknown/missing required fields, incompatible codec/type or unsupported
+  translator fail;
+- unknown optional length-delimited fields may be skipped only when the negotiated
+  compatibility rule permits it.
+
+ADR-098 negotiates one compatible schema-set fingerprint/projection. The sender
+encodes only that projection. There is no best-effort member/path matching, implicit
+downgrade or layout-derived compatibility.
+
+## Validated Apply Path
+
+NetworkRuntime decodes a complete record into a bounded typed apply command. It
+validates session, role, authority, object lifecycle and schema before queueing the
+command to the target world.
+
+At the owner-thread safe point, Scene revalidates scene/entity generation and calls
+the declaring owner's apply adapter. The adapter validates semantic ranges and
+commits all accepted fields as one owned mutation, or rejects without partial
+visibility. It cannot retain decoded views, bypass component invariants, perform
+structural mutation outside Scene commands or write authority-server state from a
+client snapshot.
+
+Malformed records are atomic failures. Repeated hostile records follow ADR-098's
+abuse/close policy.
+
+## Input, Commands, RPCs and Events
+
+Client input and RPCs are not replicated state writes. They use separately
+registered stable command/RPC schemas with direction, reliability, rate, permission,
+parameter and payload limits. The server validates the active principal and object
+grant, then gameplay decides whether canonical state changes.
+
+Gameplay may publish local events that cause owned state mutation or mark declared
+fields dirty. NetworkRuntime does not subscribe to the generic event bus and mirror
+arbitrary event payloads. A network event/RPC requires its own typed schema; local
+event publication alone produces no network traffic.
+
+## Prediction and Reconciliation Boundary
+
+Prediction is not implied by client role. The non-predicted path applies server
+snapshots through the same adapter without mandatory history/replay storage.
+
+An autonomous client may use prediction only when a later capability policy and the
+declaring gameplay owner provide canonical input/state/capture/restore hooks. Such
+state remains a local candidate; authoritative server snapshots and corrections
+win. Simulated clients never gain prediction or input-submission authority.
 
 ## Interest Management
 
@@ -135,105 +259,116 @@ Not all objects are relevant to all clients:
 
 ```cpp
 struct InterestSettings {
-    float    relevanceRadius;       // spatial distance
-    uint32_t maxRelevantObjects;
+    float relevanceRadius;
+    std::uint32_t maxRelevantObjects;
     ReplicationGroupMask groupMask;
 };
 
 struct ReplicationGroup {
-    ReplicationGroupId   id;
-    BoundingBox          volume;      // spatial volume
-    float                priority;
+    ReplicationGroupId id;
+    BoundingBox volume;
+    float priority;
 };
 ```
 
-Interest management is spatial (by distance) and explicit (by replication
-group). The server maintains a per-client relevant set, updated each network
-tick.
+Interest is a read-only routing input. It cannot grant authority, mutate Scene or
+change schema compatibility. The authority server maintains a per-session relevant
+set at the network tick under explicit work and bandwidth budgets.
 
 ## Dedicated Server
 
-Dedicated servers run the engine in headless mode:
-
-- No window, no rendering, no audio
-- Full physics and gameplay simulation
-- Network transport for client connections
-- Command-line configuration
-- Observability and logging for server operations
+Dedicated servers run headless with full gameplay/physics simulation, authority-
+server role, client admission, replication capture and observability. They compose
+no renderer/audio dependency merely to define network limits.
 
 ```bash
 horo-engine server --project /path/to/MyGame --map MainLevel --port 7777
 ```
 
-Server features:
-
-- Player slot management (max players, reserved slots)
-- Connection queue and authentication
-- Server travel (seamless map changes)
-- Server-side plugins for admin tools
-- Matchmaking integration hooks
+Listen and dedicated servers share the same authority, schema and admission
+contracts. A listen server's co-located client uses a separate client role/world.
 
 ## Network Transport
 
-The network layer abstracts the transport:
+Replication submits bounded messages through the backend-neutral network runtime;
+it never depends on native transport identity:
 
 ```cpp
 class IReplicationProtocol {
 public:
-    virtual Result<void> SendReplicationMessage(ClientId target, const ReplicationMessage& message) = 0;
-    virtual Result<void> BroadcastReplicationMessage(const ReplicationMessage& message) = 0;
-    virtual Result<void> PollReplicationMessages(std::span<ReplicationMessage> outMessages) = 0;
+    virtual Result<void> SendReplicationMessage(
+        ClientId target,
+        const ReplicationMessage& message) = 0;
+    virtual Result<void> BroadcastReplicationMessage(
+        const ReplicationMessage& message) = 0;
+    virtual Result<void> PollReplicationMessages(
+        std::span<ReplicationMessage> outMessages) = 0;
 };
 ```
 
-Transport policy follows
-[ADR-097](../../adr/097-default-real-time-transport-backend.md) and the
-[Networking Architecture](./networking-architecture.md):
-
-- **GameNetworkingSockets**: The production direct-IP baseline, implemented only
-  by private `NetworkTransportGNS` and projected through Horo-owned transport
-  capabilities and events.
-- **Null**: The deterministic/offline backend used for contract tests, CI and
-  products that intentionally run the network runtime without native I/O.
-- **Optional providers**: ICE/P2P, relay, WebRTC, Steam and console integrations
-  are future product-specific compositions. They are not mandatory 1.0 targets
-  and cannot be selected as silent fallback behavior.
-
-Replication does not depend on a native transport or provider identity. Session
-authentication, protocol negotiation, authority and bandwidth policy remain in
-`NetworkRuntime`; GNS packet encryption does not replace them. All transports must
-honor the same bounded queues, cancellation, malformed-input and shutdown contract.
-Before ADR-098 activation, replication messages are rejected and never buffered;
-provider identity or a claimed client role cannot grant replication authority.
+ADR-097 selects private `NetworkTransportGNS` for production direct IP and Null
+for deterministic/offline tests. Optional providers remain explicit product
+compositions. Transport encryption/provider identity does not grant replication
+authority; ADR-098 active-session admission remains mandatory.
 
 ## Bandwidth Management
 
-Replication bandwidth is managed:
+Replication scheduling observes explicit per-session/tick limits:
 
-- Per-client bandwidth budget per tick
-- Priority-based scheduling (closer/more-important objects get bandwidth first)
-- Delta compression (only changed bytes are sent)
-- Object休眠 (dormancy) for distant or irrelevant objects
-- LOD for replicated properties (fewer updates for distant objects)
+- per-client byte/message/work budgets;
+- priority scheduling of already-relevant objects;
+- baseline/delta encoding with bounded retained history;
+- replaceable unreliable snapshot policy;
+- explicit reliable-queue overflow failure.
+
+Interest, priority and budgets affect routing/scheduling only. They do not change
+field identity, authority or compatibility.
 
 ## Feature Tiers
 
 | Feature              | `es3`      | `dx11` / `dx12_vulkan` | `high_end` |
-| -------------------- | ----------- | ------------- | ------------ |
-| Max players (server) | 4           | 32            | 128          |
-| Replicated objects   | 512         | 4K            | 16K          |
-| Client prediction    | Basic       | Full          | Full         |
-| Interest management  | Distance    | Spatial+Group | Spatial+Group|
-| Dedicated server     | Yes         | Yes           | Yes          |
-| Bandwidth budget     | 64 KB/s     | 256 KB/s      | 512 KB/s     |
+| -------------------- | ----------- | ----------------------- | ---------- |
+| Max players (server) | 4           | 32                      | 128        |
+| Replicated objects   | 512         | 4K                      | 16K        |
+| Client prediction    | Basic       | Full                    | Full       |
+| Interest management  | Distance    | Spatial+Group           | Spatial+Group |
+| Dedicated server     | Yes         | Yes                     | Yes        |
+| Bandwidth budget     | 64 KB/s     | 256 KB/s                | 512 KB/s   |
+
+## Testing and Qualification
+
+Required automated coverage includes:
+
+- valid schema registration, canonical fingerprint/order and rejection of zero,
+  duplicate, tombstoned, foreign-owned and overflowed declarations;
+- missing codec/type, contradictory policy, unbounded limits and malformed/cyclic
+  compatibility translators;
+- standalone/server/autonomous/simulated capability matrices and co-located
+  listen-server worlds without locality-derived authority;
+- rename/reorder/layout changes preserving `FieldId`, with explicit rejection of
+  `PropertyPath`, offset, pointer and raw-memory fixtures;
+- exact, additive-minor and explicit-major translation plus missing/unknown/
+  duplicate/reordered/wrong-type/oversized fields;
+- spawn/update/despawn, stale object/scene/session/authority generations,
+  disconnect, scene reload and module reload/unload pinning;
+- capture/apply owner safe points, dirty hints, atomic apply rejection, queue/work
+  overflow, cancellation and shutdown with queued work;
+- proof that arbitrary component mutations and generic event publication do not
+  replicate without a registered schema and explicit capture/dirty path.
+
+Descriptor, compatibility, record framing and codec parsers receive bounded fuzz/
+property coverage. Diagnostics identify stable IDs/versions and safe reasons but
+exclude field payloads by default.
 
 ## Related Documents
 
-- [Networking Architecture](./networking-architecture.md): transport layer and connection model
-- [ADR-097: Default Real-Time Transport Backend](../../adr/097-default-real-time-transport-backend.md): production baseline and optional provider policy
-- [ADR-098: Protocol, Session and Trust Policy](../../adr/098-protocol-session-and-trust-policy.md): pre-gameplay admission, peer trust and active-session gate
-- [Scene Runtime](./scene-runtime.md): object lifecycle and network identity
-- [Physics Architecture](./physics-architecture.md): server-side physics and prediction
-- [Save Game And Persistence](./save-game-and-persistence.md): server-side save state
-- [Security Application](../security/application-security.md): server validation and anti-cheat
-- [Observability Performance](../observability/observability-performance.md): network metrics
+- [ADR-097: Default Real-Time Transport Backend](../../adr/097-default-real-time-transport-backend.md)
+- [ADR-098: Protocol, Session and Trust Policy](../../adr/098-protocol-session-and-trust-policy.md)
+- [ADR-099: Replication Ownership, Authority and Compatibility](../../adr/099-replication-ownership-authority-and-compatibility.md)
+- [Networking Architecture](./networking-architecture.md)
+- [Scene Runtime](./scene-runtime.md)
+- [Gameplay Behavior Authoring](../extensions/gameplay-behavior-authoring.md)
+- [Physics Architecture](./physics-architecture.md)
+- [Save Game And Persistence](./save-game-and-persistence.md)
+- [Application Security Architecture](../security/application-security.md)
+- [Observability Performance](../observability/observability-performance.md)

--- a/docs/architecture/runtime/networking-architecture.md
+++ b/docs/architecture/runtime/networking-architecture.md
@@ -70,7 +70,7 @@ The network subsystem is organized into four distinct CMake targets with strict 
   - Result and error types: `Result<T, NetworkErrorCode>`, `NetworkErrorCode`, `DisconnectReason`.
   - Message abstractions: `MessageView`, `ConstMessageSpan`, `IMessageSerializer`.
   - Transport interface and events: `INetworkTransport`, `ITransportEventConsumer`, `TransportEvent`, `TransportConnectionState`, `TransportCapabilities`.
-  - Replication traits and property condition flags: `ReplicationTraits<T>`, `ReplicationCondition`.
+  - Replication schema contracts: `ReplicationSchemaId`, stable `FieldId`, `ReplicationSchemaVersion`, field descriptors, canonical codec bindings and `ReplicationCondition`.
 - **Not Public**: `ITransportConnection`, `ITransportListener`, native peers, OS sockets, and backend queue types.
 
 ### 2. `HoroEngine::NetworkRuntime`
@@ -84,7 +84,7 @@ The network subsystem is organized into four distinct CMake targets with strict 
   - `NetworkSession`: Application-facing session that starts after the transport reports `Connected`.
   - `SessionAdmissionController`: Owns bounded compatibility, peer trust, credential verification and activation before gameplay dispatch.
   - `SessionStateMachine`: Manages session transitions (`Created` -> `Negotiating` -> `Authenticating` -> `Activating` -> `Active` -> `Closing` -> `Closed`).
-  - `ReplicationManager`: Manages dirty property tracking, delta compression, interest management sets, and authoritative snapshot generation.
+  - `ReplicationManager`: Pins the validated schema generation and manages explicit dirty hints, immutable captured snapshots, baselines, interest, wire routing and validated apply commands without owning gameplay state.
   - `MessageDispatcher`: Routes incoming RPCs and replication payloads to registered game handlers on the simulation thread.
 
 ### 3. `HoroEngine::NetworkTransportNull`
@@ -336,6 +336,11 @@ Messages consist of:
 - 16-bit Message Type ID.
 - 32-bit Sequence / Acknowledgement Numbers.
 - Bounded payload bytes with validated length headers.
+
+Replication payloads further carry ADR-099 authority epoch, network object ID/
+generation, authoritative tick, schema ID/version and canonical ascending stable
+`FieldId` records. Property paths, native offsets and component memory layouts are
+never protocol identity.
 
 `NetworkRuntime` performs handshake negotiation after the transport reports
 `Connected`. Until the session is `Active`, it accepts only bounded admission

--- a/docs/architecture/runtime/scene-runtime.md
+++ b/docs/architecture/runtime/scene-runtime.md
@@ -464,6 +464,25 @@ owned as logical `SceneObjectId`: it resolves to the replacement scene when the
 object remains and is cleared when the authored object was deleted. Editor state
 does not retain an old runtime's `EntityRef`.
 
+## Replication Ownership Boundary
+
+[ADR-099](../../adr/099-replication-ownership-authority-and-compatibility.md)
+keeps canonical component/gameplay values and mutation safe points in Scene and
+their declaring systems. `NetworkRuntime` may invoke a registered capture adapter
+with a validated read-only owner-thread view at the network capture safe point; it
+never scans component memory or infers wire fields from ECS layout.
+
+Received replication is a bounded typed apply command carrying scene/entity,
+authority, object and schema generations. Scene revalidates them at the owner safe
+point and invokes the declaring owner's apply adapter. The adapter commits one
+valid mutation or fails without partial visibility; NetworkRuntime cannot write a
+component pool directly. Scene reload/destruction changes generation/authority
+epoch so late records cannot target reused entity slots.
+
+Standalone, authority-server, autonomous-client and simulated-client roles are
+explicit host/world capabilities. Entity locality, possession, input device and
+same-process listen-server composition never grant Scene write authority.
+
 ## Data Bus Relationship
 
 System-to-system behavior inside one deterministic tick uses direct scheduling,


### PR DESCRIPTION
## Summary

- Define server-authoritative replication ownership and explicit standalone/server/autonomous/simulated world roles.
- Add ADR-099 with stable schema/`FieldId` wire identity, registry lifecycle, compatibility and owner-safe capture/apply paths.
- Replace `PropertyPath` and implied automatic dirty-memory replication in the normative multiplayer architecture.
- Project the boundary into Networking, Scene Runtime and Gameplay Behavior Authoring.

## Why

- String paths, native layout scanning and ambient event replication are unstable wire contracts and bypass gameplay/Scene ownership.
- Listen-server and editor processes can contain multiple roles, so process locality or possession cannot grant canonical write authority.

## Decision and boundaries

- Gameplay/component owners declare inert schemas, codecs and capture/apply adapters; Scene/Gameplay retain canonical values and mutation safe points.
- NetworkRuntime owns immutable registry generations, network object generations, snapshots, baselines, interest, serialization and validated apply commands.
- Stable non-zero 32-bit `FieldId` values are scoped by globally stable schema IDs, survive rename/reorder/refactor and remain tombstoned after removal.
- Compatibility is explicit by major/minor version, schema-set fingerprint and bounded translators; no best-effort path/layout matching.
- Client input/RPC schemas remain commands, not client-authored state writes; generic event publication alone produces no network traffic.
- Preserves the existing renderer-derived feature table for its separately ranked budget-policy ticket.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Documentation lint passed
- [x] CMake configure passed
- [x] Added Markdown links resolve
- [x] Manual smoke test not applicable to an architecture-only change

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/099-replication-ownership-authority-and-compatibility.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/multiplayer-replication-architecture.md docs/architecture/runtime/networking-architecture.md docs/architecture/runtime/scene-runtime.md docs/architecture/extensions/gameplay-behavior-authoring.md
git diff --check
git diff --cached --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- This PR defines the contract but does not implement schema registration, capture/apply adapters, wire codecs or compatibility translators.
- Gameplay modules will need explicit schema/ID discipline and lifecycle pinning during implementation.
- CMake reported the existing mbedTLS minimum-version deprecation warning and that pytest is unavailable, so repository Python tests were skipped.

## Issue links

- Jira: HORO-1120
- GitHub: Closes #1120

## Reviewer Notes

- Review ADR-099 first and then the rewritten multiplayer replication architecture.
- Networking, Scene and Gameplay changes are narrow projections of the same owner/capture/apply boundary.