### PR TITLE
docs(network): define prediction capability tiers HORO-1142 #1142 [NET-005.1]

### DIFF
--- a/docs/adr/100-prediction-capability-tiers-and-determinism-policy.md
+++ b/docs/adr/100-prediction-capability-tiers-and-determinism-policy.md
@@ -1,0 +1,303 @@
+# ADR-100: Prediction Capability Tiers and Determinism Policy
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Non-predicted baseline, local prediction and rollback/resimulation capability tiers; descriptor admission, fixed-tick input/state hooks, determinism closure, bounded histories, correction, side effects, overflow, lifecycle and qualification
+- **Issue**: [NET-005.1](https://github.com/abdullahbodur/horo-engine/issues/1142)
+- **Jira**: [HORO-1142](https://horo-engine.atlassian.net/browse/HORO-1142)
+- **Related**: [ADR-084](084-canonical-physics-solver-units-and-tolerances.md), [ADR-088](088-physics-determinism-capability-and-support-tiers.md), [ADR-092](092-character-controller-determinism-and-state-composition.md), [ADR-098](098-protocol-session-and-trust-policy.md), [ADR-099](099-replication-ownership-authority-and-compatibility.md)
+- **Normative documents**: [Multiplayer Replication Architecture](../architecture/runtime/multiplayer-replication-architecture.md), [Character Controller Architecture](../architecture/runtime/character-controller-architecture.md), [Networking Architecture](../architecture/runtime/networking-architecture.md)
+
+## Context
+
+The replication architecture historically described every client as predicted and
+showed renderer-derived prediction levels. That makes input history, state capture,
+rewind and replay appear mandatory even for games that only need authoritative
+snapshots. It also conflates responsive local speculation with full historical
+rollback, which have very different state-closure and determinism requirements.
+
+ADR-099 establishes explicit autonomous/simulated roles and owner-provided schema
+adapters. An autonomous client still has no server authority; prediction is a local
+candidate. ADR-092 provides one example of canonical fixed-tick Character state and
+aggregate restore, but it deliberately does not approve network rollback. Horo
+needs a capability policy that admits rollback only when every participating state
+owner provides a coherent checkpoint/restore/resimulation closure.
+
+The policy must remain bounded under latency, loss and delayed corrections. A
+history overrun cannot allocate indefinitely or replay unbounded ticks in one
+frame. Prediction also must not duplicate irreversible gameplay, audio, VFX,
+analytics or platform side effects during resimulation.
+
+## Decision
+
+### 1. Prediction is opt-in through three closed tiers
+
+```cpp
+enum class PredictionCapabilityTier : std::uint8_t {
+    NonPredicted,
+    LocalPrediction,
+    RollbackResimulation
+};
+```
+
+| Tier | Client simulation | Required retained history | Correction behavior |
+|---|---|---|---|
+| `NonPredicted` | No speculative canonical simulation | None; bounded presentation samples may exist separately | Apply authoritative snapshot, optionally smooth presentation |
+| `LocalPrediction` | Autonomous client's declared local candidate advances from fixed-tick inputs | Bounded pending input/sequence ledger and current candidate; no historical world checkpoints | Replace/correct current candidate, discard acknowledged inputs and continue; no rewind to an old tick |
+| `RollbackResimulation` | Declared aggregate prediction world advances from canonical fixed-tick inputs | Bounded ordered inputs, checkpoints/deltas, hashes, occurrences and authoritative receipts | Restore a compatible checkpoint, apply authoritative correction, replay ordinary fixed-tick pipeline within budget |
+
+`NonPredicted` is the default and complete production capability. It allocates no
+prediction input journal, checkpoint ring or replay workspace and schedules no
+prediction capture/restore work. Presentation interpolation is not simulation
+authority and cannot be used as a checkpoint.
+
+`LocalPrediction` improves immediate response but promises no historical rewind or
+cross-host deterministic equivalence. A correction may snap the simulation
+candidate and smooth only its visual projection. It cannot retroactively validate
+side effects or claim rollback support.
+
+`RollbackResimulation` is admitted only when the entire participating state closure
+is qualified. No profile may advertise a tier it cannot prove.
+
+### 2. A validated descriptor admits prediction
+
+```cpp
+struct PredictionDescriptor {
+    PredictionDescriptorId id;
+    PredictionDescriptorRevision revision;
+    PredictionCapabilityTier tier;
+    FixedTickRate fixedTickRate;
+    InputSchemaId inputSchema;
+    ReplicationSchemaSetId replicatedState;
+    BoundedVector<CheckpointProviderId> checkpointProviders;
+    PredictionHookSet hooks;
+    PredictionDeterminismRequirement determinism;
+    PredictionHistoryLimits history;
+    PredictionReplayLimits replay;
+    PredictionOverflowPolicy overflow;
+};
+```
+
+The gameplay owner contributes inert descriptors during host composition. The host
+selects a product profile; ADR-098 negotiation confirms the same descriptor
+revision/tier and compatible schemas before prediction activation. A server grant
+then identifies which autonomous objects/input schemas may use it.
+
+Validation rejects missing/duplicate/foreign IDs, unsupported tier, zero/overflowed
+limits, mismatched fixed rate, missing input/state schema, incomplete hook set,
+unqualified providers, incompatible determinism fingerprint, ambiguous provider
+order and policies that can exceed configured memory/work.
+
+Hooks are tier-specific:
+
+- `NonPredicted`: no prediction hooks or history are constructed;
+- `LocalPrediction`: validate/canonicalize input, advance candidate and apply
+  authoritative current-state correction;
+- `RollbackResimulation`: capture, encode/hash, restore, apply correction, simulate
+  one ordinary fixed tick, compare evidence and reconcile presentation/occurrences.
+
+Hooks are owned by the semantic state provider, not NetworkRuntime. NetworkRuntime
+orchestrates ticks, histories and correction routing without owning gameplay state.
+
+### 3. Server authority never changes
+
+Prediction does not grant client write permission. The authority server validates
+typed input/command sequences and computes the only canonical gameplay state. A
+client candidate, local hash or replay result is diagnostic/submission evidence,
+not authority.
+
+Distributed ownership transfer, peer-authoritative objects, deterministic peer
+lockstep and client-majority correction are unsupported M0/1.0 assumptions. A
+listen server still uses distinct server/client worlds. Same process, loopback,
+possession, local player or low latency cannot bypass ADR-099 grants.
+
+### 4. Prediction uses one canonical fixed-tick timeline
+
+Inputs carry session/object/authority generations, `InputSchemaId`, fixed
+`SimulationTick`, monotonic producer sequence and bounded canonical fields. The
+server accepts them only inside its configured early/late window and never rewinds
+canonical authority merely because a client predicted another result.
+
+The client maps authoritative receipts/corrections to the same fixed-tick domain.
+Presentation frames may interpolate committed/candidate samples but never create
+input ticks, advance gameplay twice or become restore identity. Time dilation,
+pause, hitch and catch-up policy cannot silently change fixed tick quantum.
+
+Inputs are immutable after admission. Duplicate, reordered, missing, conflicting or
+out-of-window sequences follow explicit reject/hold/resync rules; arrival order
+never becomes simulation order.
+
+### 5. Rollback requires a complete deterministic state closure
+
+A rollback descriptor lists every provider whose state can affect replayed output:
+Scene structure/revision, Gameplay state, Physics, Character, relevant Animation/
+root-motion state, random streams, clocks and other declared systems. Each provider
+supplies bounded canonical capture/restore and compatibility identity at the same
+post-commit tick safe point.
+
+ADR-092's Character codec/checkpoint is reused unchanged when Character participates.
+The aggregate checkpoint binds its paired Physics/world checkpoint, origin,
+structural revision, determinism fingerprint and provider manifest. Network code
+cannot invent a smaller Character state or restore native solver/component memory.
+
+All providers must satisfy the descriptor's ADR-088 determinism tier for the exact
+platform/solver/FP/job/algorithm tuple. Exact canonical hash mismatch is divergence;
+tolerances are diagnostics only. Missing provider, mismatched fingerprint/schema,
+partial capture or non-transactional restore rejects rollback activation or the
+candidate correction.
+
+Restore is aggregate and transactional. It stages/validates every provider, then
+commits at the owner safe point or leaves the current world unchanged. Replay calls
+the ordinary fixed-tick schedule and owner APIs; it does not use a shortcut update
+path.
+
+### 6. Histories and replay work are finite
+
+Every descriptor fixes:
+
+- maximum pending input count/bytes and maximum input age;
+- checkpoint interval, full/delta count, aggregate bytes and oldest restorable tick;
+- maximum authoritative receipts and occurrence ledger entries;
+- maximum correction age, replay ticks per frame and total replay work per
+  correction;
+- maximum consecutive resync/degrade events and diagnostic rate.
+
+Storage is preallocated or otherwise hard-bounded before activation. Retention
+evicts by deterministic tick order while preserving declared full/delta ancestry.
+No packet latency or loss may grow a vector/deque without limit.
+
+If a correction predates retained history, a required provider/checkpoint is
+missing, a delta chain is broken, replay exceeds work budget or input history
+overflows, rollback stops without partial restore. The client requests/awaits a
+full authoritative resync, clears incompatible candidate/history, and temporarily
+uses `NonPredicted` behavior. It never guesses missing input, expands limits or
+continues from a half-replayed world.
+
+LocalPrediction overflow similarly discards the candidate/pending ledger and
+returns to the latest authoritative state. Recovery to a higher tier requires a
+fresh server-acknowledged generation and safe-point activation.
+
+### 7. Correction publication is atomic and presentation is separate
+
+For rollback, the coordinator stages aggregate restore, authoritative correction
+and bounded replay through the target tick. Only the completed post-replay
+candidate becomes the simulation state. Gameplay/replication readers never observe
+an intermediate restored tick.
+
+Presentation may blend from the previously displayed pose to the corrected
+committed/candidate pose under a bounded visual policy. That blend is not canonical,
+is excluded from hashes/checkpoints and cannot delay authority publication.
+
+Older/duplicate corrections are ignored by tick/sequence/generation. A newer
+correction cancels an uncommitted older replay candidate by generation. A world/
+object/session/authority generation change invalidates all prediction work.
+
+### 8. Replay-safe side effects require occurrence identity
+
+Prediction-capable providers classify outputs:
+
+- canonical state mutation: captured/restored/replayed through provider hooks;
+- reversible/presentation occurrence: recorded with stable occurrence ID/tick and
+  deduplicated or reconciled after replay;
+- irreversible/external effect (achievement, purchase, save, analytics, remote
+  command): server-authoritative commit only, never emitted from speculative replay.
+
+Audio/VFX/UI feedback may be locally speculative only through an occurrence ledger
+with bounded retention and explicit confirm/cancel/update behavior. Replay does not
+double-fire events merely because a tick executes again. Generic event-bus history
+is not a checkpoint or occurrence authority.
+
+### 9. Tier lifecycle is generation-safe
+
+Prediction activates only after active ADR-098 session, replicated spawn/object
+grant, descriptor/schema agreement and required provider readiness. Tier change,
+ownership transfer, scene travel/reload, module reload, determinism-profile change,
+disconnect and reconnect increment prediction generation and clear incompatible
+history at an owner safe point.
+
+On shutdown, stop new inputs/corrections, invalidate generations, cancel replay,
+discard uncommitted candidates, remove prediction state from dispatch, drain owned
+jobs and then release histories/provider pins. Late packets/jobs cannot publish.
+NonPredicted worlds have no prediction teardown work beyond presentation samples.
+
+### 10. Qualification covers timing, loss and lifecycle
+
+Focused automated coverage proves:
+
+- descriptor validation and exact tier/hook/provider/determinism admission;
+- NonPredicted allocation/work evidence showing no input/checkpoint/replay history;
+- fixed-tick input sequence with latency, jitter, duplicate, reorder, loss and
+  early/late windows;
+- LocalPrediction correction, candidate discard, visual-only smoothing and bounded
+  input overflow;
+- rollback full/delta capture, aggregate transactional restore, exact replay/hash,
+  Character/Physics composition and first-divergence diagnostics;
+- correction older than history, broken delta/provider closure, replay-budget and
+  byte/count overflow causing full resync/NonPredicted degrade without partial
+  publication;
+- occurrence deduplication/cancel/confirm and prohibition of irreversible
+  speculative side effects;
+- spawn/despawn, ownership transfer, tier/profile change, scene travel/reload,
+  disconnect/reconnect, module unload and shutdown during capture/restore/replay;
+- same-process listen server without client authority and explicit rejection of
+  distributed authority/lockstep configuration.
+
+Deterministic golden fixtures record inputs, canonical checkpoints/hashes,
+corrections and expected post-replay state. Fuzz/property coverage targets input,
+checkpoint/delta and correction framing within hard limits.
+
+## Consequences
+
+### Positive
+
+- Games that do not need prediction pay no mandatory history or replay overhead.
+- Local responsiveness is available without claiming full rollback determinism.
+- Rollback reuses semantic state owners and canonical checkpoints instead of
+  creating network-specific state copies.
+- Latency/loss/overflow have bounded recovery rather than memory/work growth.
+- Server authority and side-effect correctness remain intact during replay.
+
+### Negative
+
+- Rollback-capable games must implement and qualify a complete provider closure.
+- Bounded history can force visible hard resync under extreme network conditions.
+- Occurrence reconciliation adds explicit gameplay/audio/VFX integration work.
+- Cross-platform rollback availability may differ by qualified determinism tuple.
+
+## Rejected Alternatives
+
+### Mandatory prediction for every client/game
+
+This imposes histories, hooks and replay cost on products that only need snapshots.
+NonPredicted is the baseline.
+
+### Treat all prediction as rollback
+
+Current-state local speculation does not prove historical restore/resimulation.
+The tiers state different guarantees explicitly.
+
+### Predict arbitrary component/ECS memory
+
+Native layout is not canonical state and bypasses ADR-099 owners. Only declared
+semantic providers with bounded hooks participate.
+
+### Unbounded history sized by observed latency
+
+Hostile or degraded networks could exhaust memory/work. Profiles set hard limits
+and overflow degrades to full resync/NonPredicted behavior.
+
+### Distributed authority or deterministic lockstep baseline
+
+These require different trust, ownership, determinism and failure models and
+conflict with the accepted server-authoritative architecture.
+
+### Replay through a special fast simulation path
+
+A shortcut can diverge from ordinary gameplay scheduling and side effects. Replay
+uses the same fixed-tick pipeline under bounded orchestration.
+
+### Emit every side effect again after rewind
+
+This duplicates irreversible/external actions and presentation effects. Stable
+occurrence identity and server-only irreversible commits are required.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -111,6 +111,7 @@ to the replacement.
 | [097](097-default-real-time-transport-backend.md) | Default Real-Time Transport Backend | Proposed | 2026-09-02 |
 | [098](098-protocol-session-and-trust-policy.md) | Protocol, Session and Trust Policy | Proposed | 2026-09-02 |
 | [099](099-replication-ownership-authority-and-compatibility.md) | Replication Ownership, Authority and Compatibility | Proposed | 2026-09-02 |
+| [100](100-prediction-capability-tiers-and-determinism-policy.md) | Prediction Capability Tiers and Determinism Policy | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -260,6 +260,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Replication Ownership, Authority and Compatibility](../adr/099-replication-ownership-authority-and-compatibility.md):
   explicit world roles, stable schema/FieldId identity, owner-safe capture/apply,
   compatibility, object generations and prohibited ambient replication.
+- [Prediction Capability Tiers and Determinism Policy](../adr/100-prediction-capability-tiers-and-determinism-policy.md):
+  non-predicted baseline, local candidates, qualified rollback provider closure,
+  bounded histories/replay, correction and side-effect reconciliation.
 - [Asset Pipeline](./runtime/asset-pipeline.md): import, cook, package, runtime
   loading, cache, and hot reload.
 - [Prefab Architecture](./runtime/prefab-architecture.md): dual-role authoring

--- a/docs/architecture/extensions/gameplay-behavior-authoring.md
+++ b/docs/architecture/extensions/gameplay-behavior-authoring.md
@@ -222,6 +222,14 @@ sessions, transport, interest or baselines, and neither may retain component vie
 or bypass behavior invariants. Publishing an ordinary gameplay event does not
 replicate it; inputs/RPCs require separate direction-scoped schemas.
 
+Prediction is separately opt-in under
+[ADR-100](../../adr/100-prediction-capability-tiers-and-determinism-policy.md).
+Gameplay owners contribute a validated descriptor and tier-required fixed-tick
+input/candidate or capture/restore/simulate/reconcile hooks. Ordinary behavior
+fields/events are never predicted automatically. Irreversible effects are
+server-authoritative; speculative presentation requires stable bounded occurrence
+identity so replay cannot duplicate it.
+
 ### Native C++ Behavior Example
 
 A native behavior is ordinary gameplay code compiled into the project gameplay

--- a/docs/architecture/runtime/character-controller-architecture.md
+++ b/docs/architecture/runtime/character-controller-architecture.md
@@ -117,6 +117,13 @@ coordinator separately owns complete ordered producer command histories and repl
 the ordinary fixed-tick pipeline. History exhaustion or missing input ends the
 rewind horizon explicitly.
 
+[ADR-100](../../adr/100-prediction-capability-tiers-and-determinism-policy.md)
+uses this contract only for an explicitly admitted `RollbackResimulation` provider
+closure. `NonPredicted` and `LocalPrediction` do not construct Character checkpoint
+history merely because a client is autonomous. Network rollback must pair Character
+with the exact Physics/world checkpoint and all other participating providers; it
+cannot restore a standalone Character blob or a network-specific field subset.
+
 ## Character Controller Component
 
 ```cpp

--- a/docs/architecture/runtime/multiplayer-replication-architecture.md
+++ b/docs/architecture/runtime/multiplayer-replication-architecture.md
@@ -245,13 +245,34 @@ event publication alone produces no network traffic.
 
 ## Prediction and Reconciliation Boundary
 
-Prediction is not implied by client role. The non-predicted path applies server
-snapshots through the same adapter without mandatory history/replay storage.
+Prediction is opt-in under
+[ADR-100](../../adr/100-prediction-capability-tiers-and-determinism-policy.md):
 
-An autonomous client may use prediction only when a later capability policy and the
-declaring gameplay owner provide canonical input/state/capture/restore hooks. Such
-state remains a local candidate; authoritative server snapshots and corrections
-win. Simulated clients never gain prediction or input-submission authority.
+| Tier | Client behavior | History/guarantee |
+|---|---|---|
+| `NonPredicted` | Applies authoritative snapshots; presentation may interpolate separately | No input journal, checkpoint ring or replay work; this is the default |
+| `LocalPrediction` | Advances an autonomous local candidate from fixed-tick input | Bounded pending inputs/current candidate; correction replaces current candidate without historical rewind |
+| `RollbackResimulation` | Restores an aggregate checkpoint, applies correction and replays the ordinary fixed-tick pipeline | Bounded input/checkpoint/occurrence history and qualified deterministic provider closure |
+
+Games select a validated `PredictionDescriptor` with input/state schemas, fixed
+tick rate, hooks, provider set, determinism requirement, history/replay limits and
+overflow policy. Missing hooks/providers or an unqualified fingerprint rejects the
+tier. Simulated clients never gain prediction or input-submission authority.
+
+Rollback reuses canonical owner contracts such as ADR-092 Character plus its paired
+Physics/world checkpoint. NetworkRuntime cannot invent a smaller state or restore
+component/native solver memory. Aggregate restore/correction/replay publishes only
+after complete transactional success.
+
+History and replay work are hard-bounded. An old correction, broken provider/delta
+closure or count/byte/replay overflow causes a full authoritative resync and
+temporary `NonPredicted` behavior; limits never expand. LocalPrediction overflow
+similarly discards its candidate and returns to authoritative state.
+
+Prediction never changes server authority. Distributed authority, peer lockstep
+and client-majority correction are unsupported. Speculative side effects require
+stable occurrence IDs and bounded confirm/cancel/deduplication; irreversible
+external effects are server-authoritative only.
 
 ## Interest Management
 
@@ -330,7 +351,7 @@ field identity, authority or compatibility.
 | -------------------- | ----------- | ----------------------- | ---------- |
 | Max players (server) | 4           | 32                      | 128        |
 | Replicated objects   | 512         | 4K                      | 16K        |
-| Client prediction    | Basic       | Full                    | Full       |
+| Client prediction    | Optional    | Optional                | Optional   |
 | Interest management  | Distance    | Spatial+Group           | Spatial+Group |
 | Dedicated server     | Yes         | Yes                     | Yes        |
 | Bandwidth budget     | 64 KB/s     | 256 KB/s                | 512 KB/s   |
@@ -355,6 +376,12 @@ Required automated coverage includes:
   overflow, cancellation and shutdown with queued work;
 - proof that arbitrary component mutations and generic event publication do not
   replicate without a registered schema and explicit capture/dirty path.
+- NonPredicted profiles allocate/schedule no prediction input/checkpoint/replay
+  history; prediction descriptors reject incomplete hooks/provider closure.
+- Latency/loss/reorder/duplicate inputs, local correction, rollback golden replay,
+  history/replay overflow, full resync/degrade and lifecycle generation changes.
+- Speculative occurrence deduplication and prohibition of irreversible client-side
+  effects during replay.
 
 Descriptor, compatibility, record framing and codec parsers receive bounded fuzz/
 property coverage. Diagnostics identify stable IDs/versions and safe reasons but
@@ -365,6 +392,7 @@ exclude field payloads by default.
 - [ADR-097: Default Real-Time Transport Backend](../../adr/097-default-real-time-transport-backend.md)
 - [ADR-098: Protocol, Session and Trust Policy](../../adr/098-protocol-session-and-trust-policy.md)
 - [ADR-099: Replication Ownership, Authority and Compatibility](../../adr/099-replication-ownership-authority-and-compatibility.md)
+- [ADR-100: Prediction Capability Tiers and Determinism Policy](../../adr/100-prediction-capability-tiers-and-determinism-policy.md)
 - [Networking Architecture](./networking-architecture.md)
 - [Scene Runtime](./scene-runtime.md)
 - [Gameplay Behavior Authoring](../extensions/gameplay-behavior-authoring.md)

--- a/docs/architecture/runtime/networking-architecture.md
+++ b/docs/architecture/runtime/networking-architecture.md
@@ -36,6 +36,7 @@ Character checkpoint.
 - **Bounded Queues and Backpressure**: Inbound and outbound message queues enforce fixed capacity bounds and deterministic drop/rejection policies for overloaded connections.
 - **Explicit Schemas & Negotiation**: Messages use typed schemas and handshake negotiation. Raw C++ memory layout, vtables, pointers, and unstructured object graphs are never serialized.
 - **Deterministic Cancellation and Shutdown**: Every connection reaches a definitive terminal state. Disconnections, timeouts, cancellations, and engine shutdown follow bounded, leak-free teardown protocols.
+- **Opt-In Prediction**: NonPredicted is the baseline and constructs no history/replay machinery. LocalPrediction and RollbackResimulation require validated ADR-100 descriptors, bounded histories and owner-provided fixed-tick hooks.
 
 ## Target Topology and Module Ownership
 
@@ -497,6 +498,8 @@ The networking subsystem requires targeted automated verification:
 - [ADR-020: Network Target Ownership and Dependency Boundary](../../adr/020-network-target-ownership-and-dependency-boundary.md)
 - [ADR-097: Default Real-Time Transport Backend](../../adr/097-default-real-time-transport-backend.md)
 - [ADR-098: Protocol, Session and Trust Policy](../../adr/098-protocol-session-and-trust-policy.md)
+- [ADR-099: Replication Ownership, Authority and Compatibility](../../adr/099-replication-ownership-authority-and-compatibility.md)
+- [ADR-100: Prediction Capability Tiers and Determinism Policy](../../adr/100-prediction-capability-tiers-and-determinism-policy.md)
 - [System Design](../foundation/system-design.md)
 - [Desired Project Trees](../desired-project-tree.md)
 - [Multiplayer Replication Architecture](./multiplayer-replication-architecture.md)


### PR DESCRIPTION
## Summary

- Define opt-in `NonPredicted`, `LocalPrediction` and `RollbackResimulation` capability tiers.
- Add ADR-100 with descriptor admission, fixed-tick inputs, deterministic provider closure, bounded history/replay, correction and lifecycle policy.
- Make non-predicted clients the complete default with no mandatory input/checkpoint/replay allocation.
- Align multiplayer, networking, Character and Gameplay documents on the same prediction seam.

## Why

- Local speculative response and historical rollback have different state, determinism and cost requirements.
- Mandatory prediction would impose history and replay overhead on every game and could duplicate irreversible side effects.

## Decision and boundaries

- LocalPrediction corrects the current candidate without historical rewind; rollback requires aggregate transactional checkpoints and replay of the ordinary fixed-tick pipeline.
- Rollback reuses canonical owner state such as ADR-092 Character paired with Physics/world state; Network cannot invent smaller checkpoint models.
- Hard count/byte/age/replay limits degrade to full authoritative resync and temporary NonPredicted behavior instead of growing memory/work.
- Server authority is unchanged; distributed authority and deterministic peer lockstep are explicitly unsupported.
- Speculative presentation uses bounded occurrence identity; irreversible effects remain server-authoritative.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Documentation lint passed
- [x] CMake configure passed
- [x] Added Markdown links resolve
- [x] Manual smoke test not applicable to an architecture-only change

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/100-prediction-capability-tiers-and-determinism-policy.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/multiplayer-replication-architecture.md docs/architecture/runtime/networking-architecture.md docs/architecture/runtime/character-controller-architecture.md docs/architecture/extensions/gameplay-behavior-authoring.md
git diff --check
git diff --cached --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- This PR defines capability contracts but does not implement prediction coordinators, histories, provider hooks or correction playback.
- Rollback availability will depend on qualified determinism tuples and complete game-specific provider closure.
- CMake reported the existing mbedTLS minimum-version deprecation warning and that pytest is unavailable, so repository Python tests were skipped.

## Issue links

- Jira: HORO-1142
- GitHub: Closes #1142

## Reviewer Notes

- Review ADR-100 first, then the multiplayer Prediction and Reconciliation section.
- Character/Gameplay/Networking edits are narrow projections of the opt-in descriptor and canonical-provider rules.