### PR TITLE
docs(network): define runtime network modes HORO-1161 #1161 [NET-007.1]

### DIFF
--- a/docs/adr/102-runtime-network-modes-and-authority-exposure.md
+++ b/docs/adr/102-runtime-network-modes-and-authority-exposure.md
@@ -1,0 +1,346 @@
+# ADR-102: Runtime Network Modes and Authority Exposure
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Standalone, client, listen-server and dedicated-server host composition; package support versus runtime selection; world-scoped role and authority exposure; startup, travel, disconnect and shutdown lifecycle
+- **Issue**: [NET-007.1](https://github.com/abdullahbodur/horo-engine/issues/1161)
+- **Jira**: [HORO-1161](https://horo-engine.atlassian.net/browse/HORO-1161)
+- **Related**: [ADR-097](097-default-real-time-transport-backend.md), [ADR-098](098-protocol-session-and-trust-policy.md), [ADR-099](099-replication-ownership-authority-and-compatibility.md), [ADR-100](100-prediction-capability-tiers-and-determinism-policy.md), [ADR-101](101-interest-priority-and-network-budget-model.md)
+- **Normative documents**: [Networking Architecture](../architecture/runtime/networking-architecture.md), [Multiplayer Replication Architecture](../architecture/runtime/multiplayer-replication-architecture.md), [Runtime Lifecycle](../architecture/runtime/runtime-lifecycle.md), [System Design](../architecture/foundation/system-design.md)
+
+## Context
+
+Horo defines transport, admission, replication, prediction and scheduling contracts,
+but does not yet freeze how a product becomes a standalone runtime, client, listen
+server or dedicated server. Without a composition decision, code may infer server
+authority from a process flag, headless state, a local player, a listener, a loopback
+connection or the fact that a server and client share one process. Those heuristics
+conflict with ADR-099's world-scoped roles and can expose mutually incompatible
+capabilities to one gameplay world.
+
+Compile/package capability and runtime behavior are also different concerns. A
+package may contain both client and server support while one invocation selects
+only one mode. Conversely, a client-only package must not manufacture server
+authority because a launch argument or project value asks it to listen. The build
+profile and project-configuration ownership that produce the support declaration
+belong to NET-009.1; this decision defines the runtime seam they must satisfy.
+
+Listen servers make process-global answers especially unsafe. Their authority
+server world and local client world share a process but not canonical state,
+session role, authority epoch or mutation rights. Dedicated servers share the same
+server contract without local-player or presentation capabilities. Standalone
+worlds have normal local gameplay ownership but no network authority grant.
+
+This ADR defines the finite mode plan, legal capability matrix, scoped exposure
+contract and lifecycle. It does not define project settings storage, build-profile
+schema, matchmaking, server orchestration, distributed authority or lockstep.
+
+## Decision
+
+### 1. Package support and runtime mode are separate typed facts
+
+Every runnable artifact exposes an immutable product capability declaration before
+application services are constructed:
+
+```cpp
+enum class RuntimeNetworkMode : std::uint8_t {
+    Standalone,
+    Client,
+    ListenServer,
+    DedicatedServer
+};
+
+struct NetworkProductModeSupport {
+    ProductBuildId productBuild;
+    NetworkProductModeSupportRevision revision;
+    EnumSet<RuntimeNetworkMode> supportedModes;
+};
+
+struct RuntimeNetworkModeRequest {
+    RuntimeNetworkMode requestedMode;
+    NetworkModeProfileId profile;
+    NetworkTrustPolicyId trustPolicy;
+};
+```
+
+The package declaration says only which modes the artifact can realize. It does
+not select the current mode or grant authority. The host resolves command-line,
+application and trusted configuration intent into one request, checks it against
+the declaration and produces one immutable `RuntimeNetworkPlan` for the host
+generation. An unsupported mode fails startup with a typed error before a world,
+listener, outbound connection or local player is published.
+
+Mode selection cannot add a missing target/backend, load an undeclared module,
+weaken a trust policy or reinterpret headless/render/audio support. A package may
+support both `Client` and `DedicatedServer`; one process invocation still activates
+exactly one plan. The source, precedence and cook rules for the product declaration,
+profile and request remain NET-009.1.
+
+### 2. The host validates one finite composition plan
+
+The resolved plan describes roles and owned services rather than scattered
+booleans:
+
+```cpp
+enum class NetworkWorldKind : std::uint8_t {
+    Standalone,
+    AuthorityServer,
+    Client
+};
+
+struct NetworkWorldPlan {
+    NetworkWorldSlotId slot;
+    NetworkWorldKind kind;
+    ReplicationExecutionRole replicationRole;
+    LocalPlayerPolicy localPlayer;
+};
+
+struct RuntimeNetworkPlan {
+    RuntimeNetworkPlanId id;
+    HostGeneration hostGeneration;
+    RuntimeNetworkMode mode;
+    NetworkRuntimePolicy networkRuntime;
+    ListenerPolicy listener;
+    OutboundSessionPolicy outboundSession;
+    std::span<const NetworkWorldPlan> worlds;
+};
+```
+
+Composition validation rejects duplicate world slots, a missing required world,
+more than one authority world, an authority role in client/standalone mode, a
+listener without an authority world, an outbound gameplay session in dedicated
+mode, a local player in dedicated mode and any world role/capability combination
+outside the matrix below. The plan is frozen before Scene/Application activation;
+descriptor validation has no side effects.
+
+| Mode | Worlds | Local player owner | Listener/admission owner | Outbound gameplay session | Canonical authority |
+|---|---|---|---|---|---|
+| `Standalone` | One standalone world | Application owns an optional local-player service scoped to that world | None | None | Normal local Scene/Gameplay ownership; no network authority epoch/grant |
+| `Client` | One client world | Application owns local-player service scoped to the client world | None | `NetworkRuntime` owns one or more bounded client session attempts | Remote server; local world receives autonomous/simulated grants only after admission |
+| `ListenServer` | One authority-server world and one distinct local client world | Application owns local player only in the client world | Server-side `NetworkRuntime` owns listener, admission and active server sessions | Local client uses an explicit admitted loopback session | Server world only |
+| `DedicatedServer` | One authority-server world | None | `NetworkRuntime` owns listener, admission and active server sessions | None | Server world only |
+
+An editor preview or test harness must instantiate one of these same plans. It may
+use Null/in-memory transport and synthetic principals, but cannot introduce an
+`Editor`, `Preview`, `Host` or `Local` authority role.
+
+### 3. World role and service ownership are distinct
+
+The process host owns the immutable plan and lifecycle. `NetworkRuntime` owns
+transport injection, listeners, admission, sessions, authority epochs,
+replication/scheduling generations and their teardown. Scene/Gameplay own
+canonical world values and safe points. Application/Input own local-player and
+device assignment. A local player is not a session, and neither is authority.
+
+In listen-server mode the server and client worlds have distinct runtime scene
+IDs/generations, replication roles, session views, command queues and mutation
+safe points. The loopback path crosses the same bounded ADR-098 admission and
+typed submission/apply boundaries as a remote client. An implementation may
+optimize protected message movement after validation, but it cannot share mutable
+world storage, bypass schemas or apply the client world directly to the server.
+
+Dedicated and listen servers use the same server role, admission, replication,
+interest and budget contracts. Headless operation only omits window, renderer,
+audio, input and local-player capabilities. It does not create a different
+authority model or renderer-derived network profile.
+
+Standalone composition omits `NetworkRuntime` and concrete transports by default.
+A product that deliberately includes an offline Null facade may expose only the
+standalone role; it creates no listener, session principal, authority epoch,
+replication capture or transport worker.
+
+### 4. Gameplay receives a scoped, generation-checked role view
+
+Gameplay code receives a read-only view from its current world execution context:
+
+```cpp
+struct GameplayNetworkRoleView {
+    RuntimeNetworkPlanId plan;
+    HostGeneration hostGeneration;
+    RuntimeSceneId scene;
+    RuntimeSceneGeneration sceneGeneration;
+    ReplicationExecutionRole role;
+    std::optional<NetworkSessionGeneration> sessionGeneration;
+    std::optional<ReplicationAuthorityEpoch> authorityEpoch;
+    EnumSet<GameplayNetworkCapability> capabilities;
+};
+```
+
+The capability set is derived only from the validated mode/world plan plus active
+ADR-098 session and ADR-099 object grants. It is not configurable independently.
+The finite capabilities distinguish local canonical mutation, authoritative
+capture/publication, bounded client input submission, autonomous prediction and
+authoritative snapshot application. Validation rejects incompatible pairs such as
+authoritative publication with client snapshot apply, or server authority with
+autonomous-client submission in one world view.
+
+`authorityEpoch` exists only for an authority-server world. A client view gains a
+session generation only after the session is `Active`; object submission still
+requires the server-issued object grant. Standalone exposes local gameplay
+ownership without inventing an epoch or session generation.
+
+The view may be borrowed only during the owner execution scope or copied as an
+immutable value. Every privileged command revalidates plan, host, scene, session,
+authority and object generations at the owning safe point. A stale or foreign view
+returns a typed rejection and performs no mutation.
+
+### 5. Ambient and process-derived authority are prohibited
+
+Gameplay and feature modules must not discover authority from:
+
+- a process-global `IsServer`, `IsClient`, `NetMode` or mutable singleton;
+- launch arguments, executable name, build configuration or package target;
+- headless state, absent renderer/audio/input, thread identity or frame phase;
+- listener/connection presence, transport backend, IP range or loopback locality;
+- local-player count, device assignment, possession, ownership display labels or
+  editor play state; or
+- service-locator availability, same-process pointers or direct world storage.
+
+A scoped convenience query may derive an answer from
+`GameplayNetworkRoleView`, but the boolean is presentation/control-flow evidence,
+not a transferable authority token. Mutations require the typed operation/grant
+accepted by the actual owner. Debug, console, admin and cheat permission remain
+separate capability checks; dedicated/listen-server mode does not grant them.
+
+### 6. Startup publishes no partial role
+
+Startup order for a network-capable runtime is:
+
+1. load and verify product mode support;
+2. resolve the trusted runtime mode request and referenced policy IDs;
+3. validate the complete plan and target/backend availability without side effects;
+4. construct the selected NetworkRuntime/transport and local-player services;
+5. create unpublished world candidates with their exact world roles;
+6. start required listener or outbound attempt under the immutable trust policy;
+7. publish worlds and scoped role views only after their local construction succeeds;
+8. publish a client session view to gameplay only after ADR-098 activation.
+
+A listener becoming bound does not publish authority into a client world. A
+transport becoming connected does not publish a gameplay session. Failure unwinds
+only constructed owners in reverse order and invalidates the host/plan generation,
+so a late bind, connect or verifier completion cannot resurrect the runtime.
+
+### 7. Travel, reconnect and disconnect preserve mode boundaries
+
+Runtime network mode is immutable for one host generation. Changing among
+standalone, client, listen-server and dedicated-server requires bounded host
+recomposition/restart; a live world cannot silently acquire or lose server
+authority.
+
+Scene travel preserves the plan but prepares new world generations. Server travel
+allocates a new authority epoch and republishes admitted sessions/object grants
+only after the new authority world commits. Client travel applies only a
+server-admitted transition and replaces its client world generation. Listen-server
+travel commits compatible server and client candidates as an aggregate lifecycle
+operation; neither world observes a half-replaced pair.
+
+Reconnect allocates a new session generation and repeats negotiation,
+authentication and activation. Old principals, object grants, prediction history,
+replication baselines and role views remain stale. Client disconnect removes the
+active session view before further gameplay dispatch and enters the explicit
+application disconnect route; it never promotes the client world to standalone.
+A listen server's local-client disconnect does not stop or transfer authority from
+the server world. Loss of the server listener stops new admission but does not
+silently change the existing authority role; host policy chooses bounded recovery
+or shutdown.
+
+### 8. Shutdown revokes exposure before destroying owners
+
+Shutdown closes external admission and gameplay submission first. The host then:
+
+1. marks the plan stopping and rejects new listener/connect/travel requests;
+2. unpublishes gameplay role/session views and invalidates session/object grants,
+   authority epochs, prediction histories and replication work generations;
+3. stops local-player/input producers and drains accepted owner commands;
+4. unloads client and authority worlds through their Scene safe points;
+5. closes sessions/listeners, cancels admission and bounded network work, then
+   shuts down and destroys the transport under ADR-098/ADR-097; and
+6. retires the plan and host generation after all leases close.
+
+Repeated shutdown is idempotent. Late transport, verifier, travel, capture or
+apply completions can observe only stale generations and cannot republish a role,
+session or world. A partial-startup unwind uses the same owner order for the
+resources that were actually constructed.
+
+### 9. Tests qualify the full mode and lifecycle matrix
+
+Focused automated coverage must include:
+
+- each valid mode plan and every invalid world/listener/outbound/local-player role
+  combination, including unsupported package modes;
+- proof that launch flags, headless state, local players, listener presence,
+  loopback transport and same-process pointers cannot synthesize authority;
+- standalone startup with NetworkRuntime omitted and with an explicitly composed
+  inert Null facade;
+- client admission success/failure, pre-Active invisibility, reconnect generation
+  replacement, disconnect without standalone promotion and stale grant rejection;
+- listen-server isolation, admitted loopback flow, separate world storage/queues,
+  local-client disconnect and aggregate travel without authority transfer;
+- dedicated startup without window/renderer/audio/input/local-player services,
+  while preserving server admission, simulation and replication;
+- travel/reload allocating new scene/authority generations and rejecting late
+  packets, verifier work, prediction history and apply/capture commands;
+- shutdown and partial-startup failure at every construction stage, repeated stop,
+  active/pending sessions and no callback or role publication after destruction;
+  and
+- compile/link checks that client-only/standalone artifacts cannot activate
+  undeclared server targets or concrete backends.
+
+## Consequences
+
+### Positive
+
+- Runtime topology, service ownership and gameplay authority are explicit and
+  testable across standalone, client, listen and dedicated products.
+- One artifact may safely support multiple runtime selections without treating a
+  package capability as current authority.
+- Listen servers preserve the same client/server trust, schema and mutation
+  boundaries as remote compositions.
+- Generation-scoped views make travel, reconnect, disconnect and teardown reject
+  stale work instead of leaking ambient role state.
+- Dedicated servers stay headless without making renderer/audio absence a gameplay
+  authority signal.
+
+### Costs
+
+- Hosts must validate and retain a mode/world plan and pass scoped role views into
+  gameplay execution.
+- Listen-server tests require two world lifecycles and explicit loopback admission
+  rather than a shared-world shortcut.
+- Mode changes require host recomposition instead of convenient live global-flag
+  mutation.
+
+## Rejected Alternatives
+
+### A process-global network mode or `IsServer()` singleton
+
+Rejected because a listen server contains both server and client worlds, and a
+process-global answer cannot carry scene/session/authority generations.
+
+### Infer authority from listener, transport or locality
+
+Rejected because connectivity and locality are transport facts. They do not prove
+session activation, principal admission, world role or object authority.
+
+### Treat standalone as a one-peer authority server
+
+Rejected because standalone has normal local gameplay ownership and should not pay
+for or accidentally expose sessions, replication, authority epochs or transport
+work.
+
+### Share one mutable world in listen-server mode
+
+Rejected because direct client access would bypass admission, schemas, prediction
+correction, ownership safe points and the server's canonical authority boundary.
+
+### Let runtime flags enable modes absent from the package
+
+Rejected because runtime configuration cannot safely create missing targets,
+backends, trust material or qualification evidence.
+
+### Change network mode during scene travel
+
+Rejected because travel changes world generations, not host composition. Combining
+them would expose half-transitioned services and make authority revocation
+ambiguous.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -113,6 +113,7 @@ to the replacement.
 | [099](099-replication-ownership-authority-and-compatibility.md) | Replication Ownership, Authority and Compatibility | Proposed | 2026-09-02 |
 | [100](100-prediction-capability-tiers-and-determinism-policy.md) | Prediction Capability Tiers and Determinism Policy | Proposed | 2026-09-02 |
 | [101](101-interest-priority-and-network-budget-model.md) | Interest, Priority and Network Budget Model | Proposed | 2026-09-02 |
+| [102](102-runtime-network-modes-and-authority-exposure.md) | Runtime Network Modes and Authority Exposure | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -266,6 +266,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Interest, Priority and Network Budget Model](../adr/101-interest-priority-and-network-budget-model.md):
   renderer-independent network profiles, immutable relevancy facts,
   per-connection ledgers, weighted fairness and bounded overload behavior.
+- [Runtime Network Modes and Authority Exposure](../adr/102-runtime-network-modes-and-authority-exposure.md):
+  package support versus runtime selection, standalone/client/listen/dedicated
+  host plans, scoped role capabilities and generation-safe lifecycle.
 - [Asset Pipeline](./runtime/asset-pipeline.md): import, cook, package, runtime
   loading, cache, and hot reload.
 - [Prefab Architecture](./runtime/prefab-architecture.md): dual-role authoring

--- a/docs/architecture/foundation/system-design.md
+++ b/docs/architecture/foundation/system-design.md
@@ -10,6 +10,14 @@ Horo Engine has two supported hosts:
 Both hosts expose MCP. MCP is a standard engine capability, not a separate
 product mode.
 
+Standalone, client, listen-server and dedicated-server are typed runtime network
+plans selected by a host, not additional executables or ambient process modes.
+The product artifact declares which plans it can support; one invocation validates
+and activates exactly one plan before world/application publication. Gameplay
+observes only its world-scoped, generation-checked role view under
+[ADR-102](../../adr/102-runtime-network-modes-and-authority-exposure.md), never an
+executable-name, headless-state or process-global authority flag.
+
 `horopak` is a purpose-built packaging executable, not a third engine host. It
 composes pipeline and platform capabilities for deterministic package creation
 and does not expose the full application surface, an interactive runtime, or an

--- a/docs/architecture/runtime/multiplayer-replication-architecture.md
+++ b/docs/architecture/runtime/multiplayer-replication-architecture.md
@@ -24,6 +24,9 @@ dedicated-server composition and transport integration.
   devices never grant authority.
 - Only ADR-098 `Active` sessions reach replication/RPC dispatch.
 - Automatic ECS-memory and generic event-bus replication are prohibited.
+- ADR-102 host plans map standalone/client/listen/dedicated modes to finite world
+  roles before publication. Gameplay receives only a generation-scoped role view;
+  process globals and same-process locality never expose authority.
 
 ## Ownership Boundary
 
@@ -74,6 +77,13 @@ that both live in one process, share a player, or use loopback transport does no
 grant the client world authority. Autonomous means permitted input submission and
 possibly a separately qualified prediction capability; it never means canonical
 server write permission.
+
+`ReplicationExecutionRole` describes one world, not the process. ADR-102 resolves
+the complete host mode plan and supplies the current plan, host, scene, session and
+authority generations in a read-only gameplay role view. Every capture, apply,
+input/RPC submission and prediction request revalidates that view plus its
+object-level grant. A process-global `IsServer`, executable/build kind, listener,
+headless state, local player, possession or loopback connection cannot substitute.
 
 ## Replication Schema and Field Identity
 
@@ -311,7 +321,19 @@ Interest is a read-only routing input. It cannot grant authority, mutate Scene,
 mark values dirty or change schema compatibility. Despawn and permission revocation
 use the reserved lifecycle class rather than ordinary relevance deferral.
 
-## Dedicated Server
+## Runtime Mode Projection
+
+[ADR-102](../../adr/102-runtime-network-modes-and-authority-exposure.md) maps host
+modes onto the roles above:
+
+- standalone publishes one `Standalone` world and creates no network authority
+  epoch, session or replication work;
+- client publishes one client world whose autonomous/simulated capabilities exist
+  only through the current Active session and server-issued object grants;
+- listen server publishes distinct authority-server and local-client worlds and
+  crosses the same admitted schema/command boundaries as a remote composition; and
+- dedicated server publishes one authority-server world with no local-player or
+  presentation capabilities.
 
 Dedicated servers run headless with full gameplay/physics simulation, authority-
 server role, client admission, replication capture and observability. They compose
@@ -323,6 +345,10 @@ horo-engine server --project /path/to/MyGame --map MainLevel --port 7777
 
 Listen and dedicated servers share the same authority, schema and admission
 contracts. A listen server's co-located client uses a separate client role/world.
+Travel replaces world/authority generations without changing the host mode.
+Reconnect replaces the client session generation; disconnect cannot promote a
+client world to standalone or transfer listen-server authority. Shutdown removes
+all gameplay role views and invalidates grants before retiring worlds and sessions.
 
 ## Network Transport
 
@@ -391,6 +417,9 @@ Required automated coverage includes:
   compatibility translators;
 - standalone/server/autonomous/simulated capability matrices and co-located
   listen-server worlds without locality-derived authority;
+- valid/invalid standalone/client/listen/dedicated host plans; unsupported package
+  modes, process/headless/listener/local-player inference and mutually incompatible
+  role capabilities are rejected before world publication;
 - rename/reorder/layout changes preserving `FieldId`, with explicit rejection of
   `PropertyPath`, offset, pointer and raw-memory fixtures;
 - exact, additive-minor and explicit-major translation plus missing/unknown/
@@ -427,6 +456,7 @@ exclude field payloads by default.
 - [ADR-099: Replication Ownership, Authority and Compatibility](../../adr/099-replication-ownership-authority-and-compatibility.md)
 - [ADR-100: Prediction Capability Tiers and Determinism Policy](../../adr/100-prediction-capability-tiers-and-determinism-policy.md)
 - [ADR-101: Interest, Priority and Network Budget Model](../../adr/101-interest-priority-and-network-budget-model.md)
+- [ADR-102: Runtime Network Modes and Authority Exposure](../../adr/102-runtime-network-modes-and-authority-exposure.md)
 - [Networking Architecture](./networking-architecture.md)
 - [Scene Runtime](./scene-runtime.md)
 - [Gameplay Behavior Authoring](../extensions/gameplay-behavior-authoring.md)

--- a/docs/architecture/runtime/networking-architecture.md
+++ b/docs/architecture/runtime/networking-architecture.md
@@ -38,6 +38,7 @@ Character checkpoint.
 - **Deterministic Cancellation and Shutdown**: Every connection reaches a definitive terminal state. Disconnections, timeouts, cancellations, and engine shutdown follow bounded, leak-free teardown protocols.
 - **Opt-In Prediction**: NonPredicted is the baseline and constructs no history/replay machinery. LocalPrediction and RollbackResimulation require validated ADR-100 descriptors, bounded histories and owner-provided fixed-tick hooks.
 - **Network-Owned Scheduling**: One NetworkRuntime scheduler applies immutable renderer-independent project profiles, per-connection bandwidth/work/queue ledgers, bounded interest and weighted-deficit fairness.
+- **Typed Runtime Mode Plan**: ADR-102 separates package-supported modes from the one standalone, client, listen-server or dedicated-server plan selected before world publication. Gameplay receives world/session-generation-scoped roles and capabilities; process globals, locality and headless state never grant authority.
 
 ## Target Topology and Module Ownership
 
@@ -441,15 +442,44 @@ All transport queues have bounded capacities:
   5. Runtime destroys the unique transport. No callback may target it after destruction.
   6. Session pools and dispatcher tables are freed.
 
+## Runtime Network Modes and Authority Exposure
+
+[ADR-102](../../adr/102-runtime-network-modes-and-authority-exposure.md)
+separates the immutable modes supported by a product artifact from the one mode
+selected for a host generation. Runtime flags and project configuration can select
+only a declared mode; they cannot add a missing target/backend or synthesize
+server authority.
+
+| Runtime mode | World composition | Network service ownership | Gameplay authority exposure |
+|---|---|---|---|
+| `Standalone` | One standalone world | Omitted by default; an explicit Null facade remains inert | Normal local Scene/Gameplay ownership without a network session, grant or authority epoch |
+| `Client` | One client world | Outbound attempts and Active sessions owned by `NetworkRuntime`; no listener | Autonomous/simulated capabilities only through the current admitted session and object grants |
+| `ListenServer` | Separate authority-server and local-client worlds | Server listener/admission plus an explicitly admitted loopback client session | Server authority appears only in the server world; locality never grants the client world authority |
+| `DedicatedServer` | One authority-server world | Server listener, admission and sessions; no outbound gameplay client | Server-world authority with no local player, renderer, audio, input or window requirement |
+
+The host validates the whole world/listener/outbound/local-player matrix before
+publishing a world. Gameplay receives an immutable `GameplayNetworkRoleView`
+scoped by plan, host, scene and optional session/authority generations. Privileged
+operations revalidate those generations at the owner safe point. A process-global
+`IsServer`, listener presence, local player, loopback address, executable name,
+headless state or service-locator result is never authority.
+
+Mode is fixed for one host generation. Travel replaces world/authority generations
+without changing mode; reconnect creates a new session generation. Disconnect
+unpublishes the client session view and cannot promote a client to standalone.
+Shutdown unpublishes views and invalidates grants before worlds, sessions,
+listeners or transports are destroyed.
+
 ## Optional Composition and Product Configurations
 
-Horo Engine products compose networking according to their needs:
+Horo Engine products declare only the modes and network targets they can realize:
 
 | Configuration | Composed Targets | Behavior |
 |---|---|---|
-| **Editor / IDE** (`HoroEditor`) | `NetworkApi`, `NetworkRuntime`, `NetworkTransportGNS` | Direct-IP multiplayer preview, network debugger panel and local test servers. |
-| **Dedicated Server** (`horo-engine server`) | `NetworkApi`, `NetworkRuntime`, `NetworkTransportGNS` | Direct-IP headless execution and high-tick simulation without rendering or audio dependencies. |
-| **Offline Game Client** | `NetworkApi`, `NetworkRuntime`, `NetworkTransportNull` | Uses replication/session API locally; zero socket operations, Platform sockets, or I/O threads. |
+| **Editor / IDE** (`HoroEditor`) | `NetworkApi`, `NetworkRuntime`, `NetworkTransportGNS`, optional Null test backend | Validates an explicit standalone/client/listen/dedicated preview plan; no editor-only authority role. |
+| **Network-capable game artifact** | `NetworkApi`, `NetworkRuntime`, selected qualified transport(s) | May support client/listen/dedicated modes according to its cooked product capability declaration. |
+| **Standalone artifact** | Network targets omitted by default; optional `NetworkApi`, `NetworkRuntime`, `NetworkTransportNull` test facade | Standalone role only; the optional facade creates no listener, session, replication or authority epoch. |
+| **Dedicated-server artifact** | `NetworkApi`, `NetworkRuntime`, `NetworkTransportGNS` | Headless dedicated plan without renderer, audio, input, window or local-player dependencies. |
 | **Tooling / Packager** (`horopak`) | *None* | Links zero network targets; compiles cleanly with minimal footprint. |
 
 ## Observability and Diagnostics
@@ -478,6 +508,10 @@ The networking subsystem requires targeted automated verification:
    - `PollEvents()` drains the transport-owned in-memory queue on the caller thread.
    - Graceful disconnect and timeout handling.
 3. **Integration & Lifecycle Tests**:
+   - Complete standalone/client/listen/dedicated plan matrix, including unsupported package modes and incompatible world/listener/outbound/local-player capabilities.
+   - World-scoped role exposure rejects authority inferred from flags, headless state, listeners, local players, loopback or same-process pointers.
+   - Listen-server worlds remain isolated through admitted loopback, travel and local-client disconnect; client disconnect never promotes to standalone.
+   - Travel/reconnect replace scene, authority and session generations; stale grants, role views and late work cannot mutate or republish state.
    - Full client-server connect, session authenticate, transfer, and disconnect sequences.
    - Connected peers sending early gameplay never reach gameplay/replication callbacks.
    - Loopback, LAN and remote valid flows; wrong pins/roots, unauthenticated encryption, invalid/expired/revoked credentials and downgrade/replay attempts.
@@ -502,6 +536,7 @@ The networking subsystem requires targeted automated verification:
 - [ADR-099: Replication Ownership, Authority and Compatibility](../../adr/099-replication-ownership-authority-and-compatibility.md)
 - [ADR-100: Prediction Capability Tiers and Determinism Policy](../../adr/100-prediction-capability-tiers-and-determinism-policy.md)
 - [ADR-101: Interest, Priority and Network Budget Model](../../adr/101-interest-priority-and-network-budget-model.md)
+- [ADR-102: Runtime Network Modes and Authority Exposure](../../adr/102-runtime-network-modes-and-authority-exposure.md)
 - [System Design](../foundation/system-design.md)
 - [Desired Project Trees](../desired-project-tree.md)
 - [Multiplayer Replication Architecture](./multiplayer-replication-architecture.md)

--- a/docs/architecture/runtime/runtime-lifecycle.md
+++ b/docs/architecture/runtime/runtime-lifecycle.md
@@ -19,6 +19,9 @@ for editor and game runtimes.
 - Shutdown is ordered, idempotent, and stops producers before dependencies.
 - Headless execution follows the same lifecycle without window, input, GUI, or
   graphics capabilities unless requested.
+- Network-capable hosts validate one ADR-102 standalone/client/listen/dedicated
+  mode plan before world publication. Runtime mode stays fixed for the host
+  generation and gameplay authority remains world/session-generation scoped.
 
 ## Runtime Owners
 
@@ -70,18 +73,41 @@ Startup order:
 2. initialize emergency diagnostics and platform directories
 3. start observability and emit build/system identity
 4. resolve configuration
-5. construct platform, jobs, data bus, and asset services
-6. initialize the requested omitted/null/device audio composition through ADR-062
-7. initialize requested renderer and window capabilities
-8. initialize the selected omitted/model-only/rendered Runtime UI composition
-9. construct application services
-10. load project and initial scene through application use cases
-11. start optional runtime console, MCP, and GUI adapters
-12. enter `Ready`, then `Running`
+5. validate product capabilities and resolve one ADR-102 runtime network plan
+6. construct platform, jobs, data bus, and asset services
+7. initialize the requested network runtime/transport and local-player composition
+8. initialize the requested omitted/null/device audio composition through ADR-062
+9. initialize requested renderer and window capabilities
+10. initialize the selected omitted/model-only/rendered Runtime UI composition
+11. construct application services and unpublished world candidates with exact roles
+12. load and atomically publish the initial scene/world composition
+13. start optional runtime console, MCP, and GUI adapters
+14. enter `Ready`, then `Running`
 
 Arguments, environment, and persisted settings are resolved through
 [Configuration System](../foundation/configuration-system.md). Startup failures return
 typed errors and retain enough diagnostics for CLI or GUI presentation.
+
+### Runtime network mode lifecycle
+
+[ADR-102](../../adr/102-runtime-network-modes-and-authority-exposure.md) separates
+the modes supported by an artifact from the one plan selected for a host
+generation. Unsupported requests and incompatible listener/outbound/local-player/
+world-role combinations fail before any world or authority view is published.
+Standalone omits networking by default; client, listen-server and dedicated-server
+plans compose only their declared services.
+
+Transport `Connected` is not a gameplay lifecycle transition. A client role view
+gains a session generation only after ADR-098 activation. Listen-server authority
+and local-client worlds publish as distinct roles even in one process. Dedicated
+mode omits presentation/local-player services without changing server authority.
+
+Travel preserves mode while replacing scene and authority generations; listen-
+server travel commits compatible server/client candidates together. Reconnect
+repeats admission under a new session generation. Disconnect unpublishes the
+client session view and cannot silently turn the world into standalone. Changing
+runtime network mode requires bounded host recomposition rather than a scene
+transition or global-flag mutation.
 
 ## Frame Phases
 
@@ -486,20 +512,22 @@ Canonical shutdown:
 
 1. transition host to `Stopping`
 2. stop external request acceptance and close modal workflows
-3. stop play simulation and unload active scenes
-4. cancel and join host-scoped jobs
-5. stop MCP, networking, and other transports
-6. drain owner-thread continuations
-7. close Runtime UI command/input admission, retire every scope/attachment, join
+3. unpublish ADR-102 gameplay network role/session views, invalidate grants and
+   stop local-player/input producers
+4. stop play simulation and unload active scenes
+5. cancel and join host-scoped jobs
+6. stop MCP, networking, and other transports
+7. drain owner-thread continuations
+8. close Runtime UI command/input admission, retire every scope/attachment, join
    UI work, and release UI render/resource leases
-8. release GUI and editor sessions
-9. wait for renderer idle as required and destroy GPU resources
-10. stop audio producers, quiesce/detach the callback, reconcile terminal outcomes,
+9. release GUI and editor sessions
+10. wait for renderer idle as required and destroy GPU resources
+11. stop audio producers, quiesce/detach the callback, reconcile terminal outcomes,
    and release device-owned resources under ADR-062
-11. destroy application and engine services
-12. stop job and platform services
-13. flush observability and write clean-shutdown marker
-14. transition to `Stopped`
+12. destroy application and engine services
+13. stop job and platform services
+14. flush observability and write clean-shutdown marker
+15. transition to `Stopped`
 
 Shutdown may be requested more than once but executes its transitions once.
 
@@ -537,6 +565,10 @@ Required tests cover:
 - headless lifecycle without GUI or graphics
 - Runtime UI phase order across zero/multiple fixed ticks, gameplay pause/step,
   suspension, failed presentation, scene/viewport teardown and shutdown
+- standalone/client/listen/dedicated network plan startup, admission, aggregate
+  listen-server travel, disconnect/reconnect generation replacement and shutdown
+- rejection of incompatible role capabilities and of authority inferred from
+  process flags, locality, local players, listeners, headless state or build kind
 
 ## Related Documents
 
@@ -546,6 +578,7 @@ Required tests cover:
 - [Physics Architecture](./physics-architecture.md)
 - [Audio Architecture](./audio-architecture.md)
 - [Networking Architecture](./networking-architecture.md)
+- [ADR-102: Runtime Network Modes and Authority Exposure](../../adr/102-runtime-network-modes-and-authority-exposure.md)
 - [Asset Pipeline](./asset-pipeline.md)
 - [Runtime Debug Console And Development Overlays](./debug-console-and-overlays.md)
 - [Concurrency And Job System](../foundation/concurrency-and-jobs.md)


### PR DESCRIPTION
## Summary

- Define one typed standalone, client, listen-server or dedicated-server plan per host generation.
- Separate package-supported modes from runtime selection and reject unsupported or incompatible compositions before world publication.
- Expose gameplay authority only through world/session-generation-scoped roles and capabilities.
- Project the decision into networking, replication, runtime lifecycle and system design.

## Why

- Process-global mode flags cannot describe both server and client worlds in a listen-server process.
- Listener presence, locality, headless state, local players and build kind are connectivity/composition facts, not gameplay authority.
- Travel, reconnect, disconnect and shutdown need explicit generation invalidation so stale work cannot retain or manufacture authority.

## Decision and boundaries

- ADR-102 defines the product-support/runtime-selection seam while leaving project/build-profile storage and precedence to NET-009.1.
- The validated mode matrix gives standalone no network authority, client only admitted autonomous/simulated capabilities, listen server isolated server/client worlds and dedicated server no local-player/presentation dependency.
- Gameplay receives an immutable role view scoped by plan, host, scene, session and authority generations; privileged commands revalidate owner grants at safe points.
- Mode changes require host recomposition. Travel preserves mode, reconnect replaces the session generation and disconnect never promotes client to standalone.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Documentation lint passed
- [x] CMake configure passed
- [x] Added Markdown links resolve
- [x] Manual smoke test not applicable

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/102-runtime-network-modes-and-authority-exposure.md docs/adr/README.md docs/architecture/README.md docs/architecture/foundation/system-design.md docs/architecture/runtime/networking-architecture.md docs/architecture/runtime/multiplayer-replication-architecture.md docs/architecture/runtime/runtime-lifecycle.md
git diff --check
git diff --cached --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- This PR freezes architecture but does not implement the mode-plan validator, role-view API or lifecycle tests.
- NET-009.1 still owns project configuration, build-profile declaration and precedence details.
- CMake reported the existing mbedTLS deprecation warning and unavailable pytest.

## Issue links

- Jira: HORO-1161
- GitHub: Closes #1161

## Reviewer Notes

- Review ADR-102 first, then the networking/replication projections and runtime lifecycle ordering.