### PR TITLE
docs(network): define project configuration ownership HORO-1185 #1185 [NET-009.1]

### DIFF
--- a/docs/adr/102-runtime-network-modes-and-authority-exposure.md
+++ b/docs/adr/102-runtime-network-modes-and-authority-exposure.md
@@ -24,7 +24,8 @@ package may contain both client and server support while one invocation selects
 only one mode. Conversely, a client-only package must not manufacture server
 authority because a launch argument or project value asks it to listen. The build
 profile and project-configuration ownership that produce the support declaration
-belong to NET-009.1; this decision defines the runtime seam they must satisfy.
+belong to [ADR-103](103-network-project-configuration-and-build-profile-ownership.md);
+this decision defines the runtime seam they must satisfy.
 
 Listen servers make process-global answers especially unsafe. Their authority
 server world and local client world share a process but not canonical state,
@@ -75,7 +76,8 @@ Mode selection cannot add a missing target/backend, load an undeclared module,
 weaken a trust policy or reinterpret headless/render/audio support. A package may
 support both `Client` and `DedicatedServer`; one process invocation still activates
 exactly one plan. The source, precedence and cook rules for the product declaration,
-profile and request remain NET-009.1.
+profile and request are defined by
+[ADR-103](103-network-project-configuration-and-build-profile-ownership.md).
 
 ### 2. The host validates one finite composition plan
 

--- a/docs/adr/103-network-project-configuration-and-build-profile-ownership.md
+++ b/docs/adr/103-network-project-configuration-and-build-profile-ownership.md
@@ -1,0 +1,407 @@
+# ADR-103: Network Project Configuration and Build-Profile Ownership
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Network project defaults, user preview preferences, release/build-role policy, runtime host overrides, credential references, product capability manifests, provider isolation, migration and cross-surface resolution
+- **Issue**: [NET-009.1](https://github.com/abdullahbodur/horo-engine/issues/1185)
+- **Jira**: [HORO-1185](https://horo-engine.atlassian.net/browse/HORO-1185)
+- **Related**: [ADR-002](002-credential-handling.md), [ADR-009](009-configuration-schema-precedence-and-secret-boundary.md), [ADR-097](097-default-real-time-transport-backend.md), [ADR-098](098-protocol-session-and-trust-policy.md), [ADR-101](101-interest-priority-and-network-budget-model.md), [ADR-102](102-runtime-network-modes-and-authority-exposure.md)
+- **Normative documents**: [Configuration System](../architecture/foundation/configuration-system.md), [Networking Architecture](../architecture/runtime/networking-architecture.md), [Build System](../architecture/delivery/build-system.md), [Release Architecture](../architecture/release/release.md), [Release Security](../architecture/release/release-security.md), [Application Security](../architecture/security/application-security.md)
+
+## Context
+
+ADR-102 separates the network modes supported by a product artifact from the one
+mode selected by a runtime host. ADR-101 defines renderer-independent scheduling
+profiles, and ADR-098 requires immutable exposure/trust policy before a listener or
+connection is created. Horo still needs one ownership contract for the inputs that
+select those policies and for the artifact that proves what a package can realize.
+
+Without that contract, the editor preview, CLI, MCP, CI workflow and packaged host
+may each merge project JSON, user state, command-line flags and environment values
+differently. A release profile could be mistaken for a developer CMake build
+profile; a renderer quality tier could become a network budget; or a runtime flag
+could ask a client-only package to instantiate a server backend. Provider-specific
+options could also escape as untyped strings.
+
+Credentials cross an even stricter boundary. Project policy may declare that a
+remote server identity or provider credential is required, but portable project
+files and product manifests cannot contain passwords, tokens or private keys.
+Machine-specific credential bindings do not belong in committed project data and
+resolved secret values must not enter configuration snapshots, cache keys,
+diagnostics or build artifacts.
+
+ADR-009 already defines Horo's one general configuration precedence and credential
+reference boundary. This decision specializes that model for networking rather
+than creating a second settings resolver. It defines source legality, domain
+projection, build-role artifacts, runtime validation and lifecycle. It does not
+choose concrete default values, implement account login, define provider-native
+configuration or replace release/signing policy.
+
+## Decision
+
+### 1. Foundation resolves settings; Network owns their domain meaning
+
+Ownership is split without duplicating authority:
+
+| Responsibility | Owner |
+|---|---|
+| Typed setting/source/provenance contracts, canonical ADR-009 precedence, immutable snapshots and atomic publication | Foundation Configuration |
+| Stable `network.*` descriptors, legal sources, validation, cross-field invariants and projection into network policy | Network module |
+| Collection of selected descriptors and construction of one resolver/use case | Application composition root |
+| Portable project defaults | Project model through typed Network descriptors |
+| Local preview preferences | User-configuration owner; never project or release authority |
+| Product kind, supported network modes, included targets/providers and security/capability floors | Release profile plus Release/Pipeline services |
+| Runtime selection within packaged support | Host adapter request validated by the application use case |
+| Credential values and private-key operations | Injected credential/signing provider |
+| Native/provider option translation | Selected private transport/provider adapter |
+
+The Network module contributes inert descriptors under its registered namespace.
+It cannot call `getenv()`, read project/user files, register globally or resolve a
+credential. The application invokes one typed `ResolveNetworkConfiguration` use
+case for editor, CLI, MCP, CI and packaged hosts. Surface adapters parse protocol
+input and present typed results; they do not merge sources or reinterpret policy.
+
+### 2. Inputs remain distinct typed layers
+
+The network projector consumes these immutable inputs:
+
+```cpp
+struct NetworkConfigurationInputs {
+    ConfigurationSnapshot resolvedSettings;
+    NetworkProjectPolicySnapshot projectPolicy;
+    std::optional<NetworkPreviewPreferences> previewPreferences;
+    std::optional<NetworkReleaseProfile> releaseProfile;
+    std::optional<NetworkProductCapabilityManifest> packagedCapabilities;
+    NetworkHostRequest hostRequest;
+};
+```
+
+`resolvedSettings` contains descriptor-backed scalar/ID selections and their
+ADR-009 provenance. `projectPolicy` contains the versioned typed profile catalog
+and capability requests referenced by those IDs; it is not a second precedence
+map. Release/product constraints and the host request are likewise validation
+inputs, not additional last-write-wins setting stores.
+
+These values have different ownership and legal destinations:
+
+| Layer | Examples | Legal persistence/use |
+|---|---|---|
+| Schema defaults | safe baseline mode request, Null/test policy, bounded limits | Module descriptor packaged with the owning code |
+| Project policy | protocol/schema family, allowed product use, default trust/profile IDs, qualified network project profiles, provider capability requests | Versioned portable project configuration |
+| User preview preferences | last local preview mode, loopback endpoint, simulated latency/loss preset, preview player count | Local user configuration only; editor/test preview only |
+| Release profile | game-runtime versus dedicated-server product kind, supported ADR-102 modes, required targets/providers, security floors, public capability evidence | Versioned release input and job snapshot |
+| Session/host request | requested supported mode, endpoint/bind/port, map/session intent, safe diagnostic toggles | Memory-only typed request; descriptor/source-policy gated |
+| Environment/invocation map | explicitly bound safe host overrides | Captured once by the host and passed to ADR-009; never read by Network directly |
+| Credential binding | requirement ID to provider-owned opaque reference | Private user/CI/host input; resolved only by the consuming operation |
+
+Project policy cannot carry user preview state. Preview preferences cannot affect
+cook, release, CI qualification or packaged defaults. Release policy cannot be
+weakened by a project, user or session value. A packaged host does not reopen
+authoring project/user documents; it validates a host request against its embedded
+product capability manifest.
+
+### 3. ADR-009 precedence applies only where a source is legal
+
+Network settings use the canonical ADR-009 order: invocation, explicitly bound
+environment, session, project, user, packaged profile and schema default. Every
+descriptor declares its legal sources and reload policy. Illegal candidates produce
+typed diagnostics even when a higher-precedence legal value exists; they are not
+silently ignored.
+
+Precedence chooses among candidates for one setting. It does not override
+constraints. Product capability, security floors, trust requirements, supported
+modes and provider availability form a validated constraint envelope. The
+effective request is the intersection of that envelope and the resolved operator/
+project intent. A higher-precedence value cannot:
+
+- enable an ADR-102 mode or native target absent from the product manifest;
+- lower remote authentication, transport protection or bind/exposure policy;
+- select an unqualified provider or capability;
+- expand ADR-101 budgets beyond the packaged/qualified project profile;
+- import a renderer/device/backend tier as network policy; or
+- turn a preview-only preference into packaged behavior.
+
+Failure returns a typed source-aware result such as `ModeNotPackaged`,
+`ProviderUnavailable`, `TrustFloorViolation`, `CredentialCapabilityUnavailable`
+or `NetworkProfileUnavailable`. There is no silent provider, transport, role,
+security or profile fallback.
+
+### 4. One pure projection produces the effective configuration
+
+The application use case invokes a pure Network-owned projector after ADR-009
+resolution:
+
+```cpp
+struct EffectiveNetworkConfiguration {
+    EffectiveNetworkConfigurationId id;
+    ConfigurationRevision configurationRevision;
+    NetworkPolicySchemaVersion schemaVersion;
+    NetworkProjectPolicyRevision projectRevision;
+    std::optional<NetworkReleaseProfileId> releaseProfile;
+    std::optional<ProductBuildId> productBuild;
+    RuntimeNetworkModeRequest modeRequest;
+    NetworkProjectProfileId schedulingProfile;
+    NetworkTrustPolicyId trustPolicy;
+    NetworkTransportProviderId transportProvider;
+    NetworkEndpointPolicy endpoints;
+    CredentialRequirementSet credentialRequirements;
+    SafeConfigurationProvenance provenance;
+};
+```
+
+Projection validates all fields and cross-field invariants before publishing one
+complete snapshot. It performs no socket/provider initialization, credential
+resolution, file write or artifact publication. The ADR-102 host planner consumes
+this snapshot plus probed packaged capabilities and either creates a complete mode
+plan or fails before world/listener/session publication.
+
+`SafeConfigurationProvenance` contains stable setting/source/profile/provider IDs,
+schema/revision/digest and redacted source locations. It contains no raw secret,
+credential reference, tokenized endpoint, unrestricted path or environment dump.
+Configuration and role changes branch on typed fields, never on provenance text.
+
+### 5. Release profiles own build-role selection
+
+Developer CMake profiles (`editor`, `cli`, `runtime-only`, `tests`) choose a local
+build target set and are not product network roles. Renderer/device feature tiers
+describe graphics capability and are also orthogonal.
+
+A typed `NetworkReleaseProfile` attached to a product release profile selects:
+
+- product kind and exact supported ADR-102 runtime modes;
+- required `NetworkApi`, `NetworkRuntime` and private transport/provider artifacts;
+- protocol/schema compatibility and minimum security/trust policy revisions;
+- allowed `NetworkProjectProfileId` values and qualification evidence;
+- platform/architecture/provider variants and redistribution/license evidence;
+- whether runtime endpoint/mode overrides are permitted and within which bounds;
+  and
+- public credential requirements, such as `server_identity`, without binding a
+  provider entry or carrying a private value.
+
+Release validation resolves project policy plus this release profile into an
+immutable `NetworkArtifactPlan` pinned to the release job's input revision. The
+plan is used by configure, build, cook, package and final verification. A later
+editor/user/configuration change cannot mutate the running job.
+
+Client/listen/dedicated targets are included only when named by the plan. An
+artifact supporting multiple modes includes their union deliberately and records
+that support. An artifact cannot infer server support from `Release`, headless,
+`runtime-only`, renderer absence or executable naming.
+
+### 6. Product artifacts carry capabilities, never authority or secrets
+
+Packaging emits a versioned immutable `NetworkProductCapabilityManifest` that
+contains only safe product facts:
+
+- product build ID, manifest schema/revision/digest and target platform;
+- supported ADR-102 modes and their required network target/provider IDs;
+- protocol/schema compatibility ranges and fingerprints;
+- allowed trust/profile IDs, security floors and safe public trust-anchor IDs;
+- provider adapter/API versions, capability bits, license/notice identity and
+  qualification evidence IDs; and
+- allowed runtime override fields and bounds.
+
+The manifest is descriptive capability evidence. It does not select the active
+mode, create a session or grant server authority. It contains no password, token,
+private key, reusable authorization header, credential reference/binding, provider
+account secret, unrestricted environment value or machine-local credential-store
+path. Public certificates/trust anchors may be packaged when required; the
+corresponding private key remains provider-owned.
+
+Final verification proves that every declared provider/target artifact is present,
+hash-matched and permitted, and that no undeclared server/provider artifact leaked
+into the package. Missing required capability fails packaging; optional capabilities
+are absent only when the release profile explicitly planned their omission.
+
+### 7. Credential requirements and values never share a model
+
+Project/release policy names a stable `CredentialRequirementId` and required
+capability, such as server identity signing or a relay-provider token. A private
+host/CI binding maps that requirement to a typed opaque `CredentialReference`.
+The reference is not portable project policy and is omitted from the product
+manifest, persistent job history, cache keys and ordinary diagnostics.
+
+The consuming operation resolves the reference through an explicitly injected
+provider immediately before use. The resulting owning secure value/operation
+handle is bounded, short-lived and never enters `ConfigurationSnapshot`,
+`EffectiveNetworkConfiguration`, child-process arguments, logs, events, support
+bundles or artifacts. Hardware/remote signing providers may expose only an
+operation handle, never key bytes.
+
+Environment-carried raw secrets are a compatibility-only private operation input
+under ADR-002/ADR-009. The host removes them from the ordinary configuration map
+and environment summary, passes them through the credential channel and excludes
+them from subprocess inheritance unless that exact operation requires an approved
+protected channel. Redaction is a backstop, not storage permission.
+
+Missing provider capability, unresolved/expired reference, denied access or wrong
+credential kind fails the consuming validation/activation stage. It cannot select
+a weaker trust mode, embed the value or fall back to an anonymous provider.
+
+### 8. Provider configuration is backend-neutral and isolated
+
+Portable policy selects a stable `NetworkTransportProviderId` and Horo-owned typed
+capabilities/limits. Provider-specific contributions use validated registered
+descriptor namespaces owned by their adapter package. Public/project/release
+contracts contain no GNS/Steam/WebRTC/console SDK structure, native enum, handle,
+callback, raw option map or provider environment-variable convention.
+
+The private adapter translates the frozen Horo configuration into native values at
+activation and reports effective capabilities. Unknown provider fields, an absent
+adapter, version/capability mismatch or prohibited platform/redistribution class
+fails explicitly. A provider cannot read project files, environment or credential
+stores directly, choose the runtime mode, widen bind exposure or register settings
+through native initialization side effects.
+
+### 9. Preview, automation and packaged hosts use one use case
+
+All entry points submit the same typed resolution request:
+
+- Editor may add user preview preferences and a memory-only session override.
+- CLI and MCP translate their protocol inputs to the same host request and return
+  the same ordered diagnostics/provenance.
+- CI supplies a release profile, explicit safe inputs and private credential
+  bindings through the automation credential provider.
+- Packaged hosts load the embedded capability manifest and accept only its declared
+  runtime overrides.
+
+The editor Settings/Build & Release surfaces are adapters. They do not persist a
+second network model or run provider probes while editing a draft. Preview first
+resolves/validates a candidate; cancel discards it, and apply publishes through the
+Foundation configuration transaction at the declared synchronization point.
+
+Automation output is deterministic for equal public inputs. Safe job manifests and
+cache identities include configuration/profile/schema/provider revisions and
+artifact-plan digest, never credential values or machine-specific references.
+
+### 10. Migration is versioned, bounded and source-aware
+
+Network project policy and product capability manifests carry independent schema
+versions. A pure migration stage runs before ADR-009/domain validation and emits an
+ordered report. Migrations may rename/split typed keys, convert units and map a
+known legacy role/profile identifier. They cannot read secrets/providers, probe
+hardware, infer a mode from renderer tiers or silently invent a trust/profile
+value.
+
+Unknown future required fields, lossy/ambiguous legacy role mappings and malformed
+credential-shaped values fail without changing the source. Editor migration writes
+only through the project transaction with backup/rollback. CLI/MCP/CI dry-run and
+apply use the same migration service and report. Packaged runtime does not rewrite
+an old capability manifest; it rejects an unsupported schema and requires rebuild
+or an explicitly shipped read-only compatibility decoder.
+
+Legacy network values derived from renderer/device tiers are reported and removed
+from authority. Migration requires an explicit network project profile selection
+or the schema default only when the profile descriptor documents that safe default.
+
+### 11. Reload, operation and shutdown lifetimes are explicit
+
+Each preview, build, cook, release and runtime activation pins its effective
+configuration and public input revisions. Setting reload policy is domain-specific:
+
+- preview preferences apply to the next preview unless a descriptor safely permits
+  a preview restart;
+- release/build role, provider set, trust floors and supported modes are frozen for
+  the release job/product artifact;
+- runtime mode, transport provider, exposure and credential requirements require
+  host restart/recomposition;
+- ADR-101 profile replacement follows its network-tick generation contract; and
+- existing ADR-098 sessions pin their negotiated policy/generations.
+
+Replacement validates a complete candidate before publication. Failure retains
+the last-good snapshot/artifact and returns typed diagnostics. Shutdown closes new
+resolution/credential admission, cancels operations, revokes secure values,
+retires pinned snapshots after consumers drain and then destroys providers. Late
+completion cannot publish configuration or artifacts into a retired generation.
+
+### 12. Tests cover source, artifact and credential boundaries
+
+Focused automated coverage must include:
+
+- identical effective results/ordered diagnostics across editor, CLI, MCP, CI and
+  packaged-host adapters for equivalent typed inputs;
+- every legal/illegal source and ADR-009 precedence pair, including security floors
+  that cannot be weakened by higher-precedence values;
+- project/user/preview/release/session separation and proof that preview settings do
+  not enter builds, packages or automation;
+- standalone/client/listen/dedicated artifact plans, multi-mode union, missing
+  targets/providers, unsupported runtime mode and no silent fallback;
+- proof that renderer backend/device/quality tiers and developer CMake profiles do
+  not alter network mode, provider or scheduling profile;
+- product manifest canonicalization, hashes, platform/provider variants, final
+  artifact inventory and rejection of undeclared/missing content;
+- secret/private-key/reference pattern scans over project files, product manifests,
+  job history, cache keys, logs, diagnostics, environment summaries and artifacts;
+- credential-provider success, missing/expired/wrong-kind/denied bindings, remote or
+  hardware operation handles, cancellation and guaranteed secure-value retirement;
+- provider namespace/type/version/capability validation with no native type or raw
+  option/environment leakage;
+- versioned project/manifest migration, dry-run/apply parity, unknown future fields,
+  interrupted write rollback and renderer-tier legacy migration; and
+- snapshot pinning, concurrent configuration changes, cancelled build/release,
+  host restart requirements and shutdown with in-flight provider/credential work.
+
+## Consequences
+
+### Positive
+
+- Every surface resolves the same typed network policy and can explain safe
+  provenance without owning another precedence implementation.
+- Product artifacts prove exactly which network modes/providers they support while
+  runtime selection remains a separate validated decision.
+- Project portability, local preview convenience and release security no longer
+  compete as one loosely typed settings map.
+- Secrets/private keys stay provider-owned and cannot leak through configuration,
+  manifests, caches or ordinary environment reporting.
+- Renderer/device tiers and developer build profiles cannot silently control
+  network capability or budgets.
+
+### Costs
+
+- Network descriptors need explicit legal-source, reload and cross-field policy.
+- Release/package validation must produce and verify a canonical capability
+  manifest and artifact inventory.
+- Adapters and migrations must translate legacy inputs into the shared use case
+  instead of maintaining convenient host-local parsers.
+- Credential requirements need provider binding and lifecycle plumbing even when a
+  local prototype previously accepted a raw string.
+
+## Rejected Alternatives
+
+### Let each editor/CLI/MCP/CI host merge network settings
+
+Rejected because precedence, source legality, diagnostics and security floors would
+drift between authoring, automation and packaged execution.
+
+### Store all network settings in the project
+
+Rejected because user preview state, host endpoints, credential bindings and
+release-role/security policy have different portability and trust owners.
+
+### Put raw secrets or private keys in an encrypted project/build manifest
+
+Rejected because portable artifacts still become long-lived secret containers,
+expand decryption/key-distribution scope and leak through caches/history. Providers
+own secret values and operations.
+
+### Derive server/client builds from CMake configuration or renderer tier
+
+Rejected because developer build mechanics and graphics capability do not describe
+the supported runtime mode, trust policy, transport provider or network workload.
+
+### Allow runtime overrides to add missing capabilities
+
+Rejected because configuration cannot create unlinked targets, absent provider
+artifacts, redistribution rights, qualification evidence or trust material.
+
+### Expose provider-native option maps in project configuration
+
+Rejected because native types/strings would leak backend identity, bypass Horo
+validation and make migration/provider replacement unbounded.
+
+### Resolve credentials while building the configuration snapshot
+
+Rejected because snapshots are shared, persistent and observable. Secret resolution
+belongs to the shortest consuming operation and returns no reusable configuration
+value.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -114,6 +114,7 @@ to the replacement.
 | [100](100-prediction-capability-tiers-and-determinism-policy.md) | Prediction Capability Tiers and Determinism Policy | Proposed | 2026-09-02 |
 | [101](101-interest-priority-and-network-budget-model.md) | Interest, Priority and Network Budget Model | Proposed | 2026-09-02 |
 | [102](102-runtime-network-modes-and-authority-exposure.md) | Runtime Network Modes and Authority Exposure | Proposed | 2026-09-02 |
+| [103](103-network-project-configuration-and-build-profile-ownership.md) | Network Project Configuration and Build-Profile Ownership | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -269,6 +269,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Runtime Network Modes and Authority Exposure](../adr/102-runtime-network-modes-and-authority-exposure.md):
   package support versus runtime selection, standalone/client/listen/dedicated
   host plans, scoped role capabilities and generation-safe lifecycle.
+- [Network Project Configuration and Build-Profile Ownership](../adr/103-network-project-configuration-and-build-profile-ownership.md):
+  shared typed resolution, project/preview/release source boundaries, role-aware
+  product manifests, credential-provider isolation and migration.
 - [Asset Pipeline](./runtime/asset-pipeline.md): import, cook, package, runtime
   loading, cache, and hot reload.
 - [Prefab Architecture](./runtime/prefab-architecture.md): dual-role authoring

--- a/docs/architecture/delivery/build-system.md
+++ b/docs/architecture/delivery/build-system.md
@@ -108,6 +108,16 @@ Local development defaults to the `editor` profile because most contributors wor
 on the editor and runtime together. Headless CI jobs default to the `cli`
 profile to minimize build time for tooling-only changes.
 
+Developer build profiles are not product roles. In particular, `runtime-only`,
+`cli`, a Release configuration, headless execution or renderer omission does not
+mean client, listen-server or dedicated-server. Under
+[ADR-103](../../adr/103-network-project-configuration-and-build-profile-ownership.md),
+the product release profile produces a typed `NetworkArtifactPlan` naming exact
+ADR-102 modes, targets, private providers, platform variants and qualification
+evidence. Configure/build/package consume that pinned plan and fail if required
+content is unavailable; they never infer network capability from a renderer/device
+tier or silently include a server/provider target.
+
 ### Adding A New Preset
 
 New presets must be reviewed if they change compiler flags, generator, or

--- a/docs/architecture/foundation/configuration-system.md
+++ b/docs/architecture/foundation/configuration-system.md
@@ -22,6 +22,9 @@ bus, secret vault, or replacement for authoritative runtime models.
   snapshot becomes active.
 - Unknown keys and invalid values produce diagnostics; they do not silently
   change behavior.
+- Domain projectors such as ADR-103 Network consume the one resolved snapshot and
+  apply typed cross-field/capability constraints; they do not implement another
+  source-precedence resolver.
 
 ## Configuration Domains
 
@@ -48,6 +51,28 @@ resolution, trust decisions, and development overrides follow
 [Horo Package System](../packages/package-system.md) and the dedicated
 [Package Source Policy](../../adr/058-package-source-policy.md). Generic settings
 precedence does not choose package authorities or resolve source conflicts.
+
+### Network configuration specialization
+
+[ADR-103](../../adr/103-network-project-configuration-and-build-profile-ownership.md)
+uses this resolver for every editor, CLI, MCP, CI and packaged-host entry point.
+The Network module owns inert `network.*` descriptors, legal sources, validation
+and projection into one `EffectiveNetworkConfiguration`; Foundation remains the
+only source/precedence/provenance authority.
+
+Portable project policy, local user preview preferences, product release profiles,
+memory-only host requests and private credential bindings remain distinct typed
+inputs. Precedence applies only to sources permitted by each descriptor. Product
+capability and security floors constrain the winning values: a higher-precedence
+override cannot add an unpackaged network mode/provider, weaken trust policy,
+expand a qualified network budget or import renderer/device tiers.
+
+Project files and packaged product manifests contain no credential value, private
+key or machine-specific credential binding. They may declare stable credential
+requirements; private user/CI/host input binds those requirements to opaque
+provider references, and only the consuming operation resolves a short-lived
+secure value. Safe provenance and ordinary environment summaries omit both raw
+values and machine-specific references.
 
 ## Schema
 

--- a/docs/architecture/release/release-security.md
+++ b/docs/architecture/release/release-security.md
@@ -44,6 +44,13 @@ Secrets are accessed through credential handles resolved at execution time.
 Persistent release requests, project files, manifests, logs, and job history do
 not contain raw secret values.
 
+ADR-103 network policy further separates public `CredentialRequirementId` values
+from private host/CI bindings. Project files and product capability manifests carry
+neither credential bindings nor machine-specific references. The consuming network
+or release operation resolves its private binding through an injected provider;
+hardware/remote providers may expose only an operation handle. Ordinary environment
+summaries, cache keys and provenance omit raw values and private references.
+
 Credential providers may include:
 
 - operating-system credential stores for local hosts

--- a/docs/architecture/release/release.md
+++ b/docs/architecture/release/release.md
@@ -65,6 +65,22 @@ Each profile declares:
 - update and patch eligibility
 - store/publication destination eligibility
 
+For a network-capable game profile,
+[ADR-103](../../adr/103-network-project-configuration-and-build-profile-ownership.md)
+also requires a typed network release profile naming supported ADR-102 modes,
+exact NetworkRuntime/private provider artifacts, protocol/schema compatibility,
+security/trust floors, allowed renderer-independent network project profiles,
+platform/provider variants, redistribution evidence and permitted runtime override
+bounds. The release job freezes those inputs into one `NetworkArtifactPlan` used
+by configure, build, cook, package and final verification.
+
+Packaging emits a safe `NetworkProductCapabilityManifest` describing supported
+modes/providers and public compatibility/security evidence. It grants no runtime
+authority and contains no credential value/reference, private key, authorization
+header, machine-local credential path or unrestricted environment value. Public
+credential requirements are stable IDs; the release operation resolves their
+private bindings through an injected provider only at the stage that needs them.
+
 For an Audio middleware profile, ADR-072 additionally requires the exact adapter
 package, SDK/runtime/native libraries, cooked banks and bindings, target variants,
 license/notice files, redistribution class, hashes and qualification evidence.

--- a/docs/architecture/runtime/networking-architecture.md
+++ b/docs/architecture/runtime/networking-architecture.md
@@ -39,6 +39,7 @@ Character checkpoint.
 - **Opt-In Prediction**: NonPredicted is the baseline and constructs no history/replay machinery. LocalPrediction and RollbackResimulation require validated ADR-100 descriptors, bounded histories and owner-provided fixed-tick hooks.
 - **Network-Owned Scheduling**: One NetworkRuntime scheduler applies immutable renderer-independent project profiles, per-connection bandwidth/work/queue ledgers, bounded interest and weighted-deficit fairness.
 - **Typed Runtime Mode Plan**: ADR-102 separates package-supported modes from the one standalone, client, listen-server or dedicated-server plan selected before world publication. Gameplay receives world/session-generation-scoped roles and capabilities; process globals, locality and headless state never grant authority.
+- **Shared Typed Configuration**: ADR-103 applies ADR-009 once across editor, CLI, MCP, CI and packaged hosts. Project defaults, preview preferences, release role, host requests and credential bindings retain distinct owners; product capability/security floors constrain runtime selection.
 
 ## Target Topology and Module Ownership
 
@@ -470,6 +471,37 @@ unpublishes the client session view and cannot promote a client to standalone.
 Shutdown unpublishes views and invalidates grants before worlds, sessions,
 listeners or transports are destroyed.
 
+## Project Configuration and Product Capability
+
+[ADR-103](../../adr/103-network-project-configuration-and-build-profile-ownership.md)
+specializes the Foundation configuration resolver without creating a Network-local
+precedence implementation. The Network module contributes inert `network.*`
+descriptors and projects the resolved snapshot into one validated
+`EffectiveNetworkConfiguration`. Editor, CLI, MCP, CI and packaged hosts call the
+same application use case and receive the same typed diagnostics/provenance.
+
+Portable project policy owns protocol/profile/trust/provider intent; local user
+configuration owns preview-only preferences; the product release profile owns
+supported ADR-102 modes, exact targets/providers, security floors and qualification
+evidence; a host request selects only within that envelope. Renderer backend,
+device/quality tier, developer CMake profile and headless state cannot select a
+network mode, transport or ADR-101 scheduling profile.
+
+Packaging emits a safe versioned `NetworkProductCapabilityManifest`. It describes
+supported modes/providers, public compatibility/security evidence and permitted
+override bounds, but grants no authority. Project files and manifests contain no
+raw credential/private-key values or private credential bindings. They declare
+stable credential requirements; private host/CI input binds an opaque provider
+reference, and the consuming operation resolves a short-lived value/operation
+handle. Missing mode/provider/credential/trust capability fails explicitly without
+fallback.
+
+Every preview, release job and runtime activation pins the effective configuration
+revision. Migration is versioned and cannot infer network values from renderer
+tiers. Runtime mode/provider/exposure changes require ADR-102 host recomposition;
+existing sessions keep their negotiated generations until bounded replacement or
+shutdown.
+
 ## Optional Composition and Product Configurations
 
 Horo Engine products declare only the modes and network targets they can realize:
@@ -495,6 +527,8 @@ Networking integrates with Horo's diagnostic and metric infrastructure:
 The networking subsystem requires targeted automated verification:
 
 1. **Unit Tests (`tests/unit/runtime/networking/`)**:
+   - `NetworkConfigurationTests`: legal source/precedence matrix, security-floor constraints, cross-surface parity, renderer/build-profile isolation and unavailable capability errors.
+   - `NetworkArtifactPlanTests`: mode/provider target inventory, canonical manifest, migration and proof that credentials/private bindings never enter public outputs.
    - `NetworkAddressTests`: IPv4, IPv6, hostname, loopback, port parsing, serialization.
    - `TransportConnectionStateTests`: `Connect()` returns immediately; `Created` / `Resolving` / `Connecting` / `Connected`; invalid transitions; timeout.
    - `SessionStateMachineTests`: `Negotiating` / `Authenticating` / `Activating` / `Active`; only Active reaches gameplay dispatch.
@@ -537,6 +571,7 @@ The networking subsystem requires targeted automated verification:
 - [ADR-100: Prediction Capability Tiers and Determinism Policy](../../adr/100-prediction-capability-tiers-and-determinism-policy.md)
 - [ADR-101: Interest, Priority and Network Budget Model](../../adr/101-interest-priority-and-network-budget-model.md)
 - [ADR-102: Runtime Network Modes and Authority Exposure](../../adr/102-runtime-network-modes-and-authority-exposure.md)
+- [ADR-103: Network Project Configuration and Build-Profile Ownership](../../adr/103-network-project-configuration-and-build-profile-ownership.md)
 - [System Design](../foundation/system-design.md)
 - [Desired Project Trees](../desired-project-tree.md)
 - [Multiplayer Replication Architecture](./multiplayer-replication-architecture.md)

--- a/docs/architecture/security/application-security.md
+++ b/docs/architecture/security/application-security.md
@@ -198,6 +198,15 @@ Horo principal; credential expiry or revocation closes the M0 session. Credentia
 proofs, trust secrets and transcript secret material never enter logs, metrics,
 errors, project data or diagnostic bundles.
 
+[ADR-103](../../adr/103-network-project-configuration-and-build-profile-ownership.md)
+requires portable network policy to name only a stable credential requirement.
+Private user/CI/host input binds that requirement to a credential-provider
+reference, which is resolved only inside the bounded consuming operation. Product
+capability manifests, project files, caches, ordinary environment summaries and
+safe provenance contain neither raw secret/private-key values nor machine-specific
+bindings. Missing provider capability fails explicitly and cannot select a weaker
+trust policy.
+
 Admission enforces finite pre-active connections, bytes, messages, fields, attempts,
 verification work, per-source rate and timeouts before expensive verification.
 Malformed, incompatible, replayed, downgraded, expired or hostile input fails
@@ -267,3 +276,4 @@ Required tests cover:
 - [Error And Diagnostics](../foundation/error-and-diagnostics.md)
 - [Networking Architecture](../runtime/networking-architecture.md)
 - [ADR-098: Protocol, Session and Trust Policy](../../adr/098-protocol-session-and-trust-policy.md)
+- [ADR-103: Network Project Configuration and Build-Profile Ownership](../../adr/103-network-project-configuration-and-build-profile-ownership.md)


### PR DESCRIPTION
## Summary

- Define one typed network configuration path shared by editor, CLI, MCP, CI and packaged hosts.
- Separate portable project policy, user preview preferences, product release roles, host requests and private credential bindings.
- Freeze role-aware artifact planning and a safe product capability manifest for standalone/client/listen/dedicated products.
- Project the decision into Foundation configuration, build, release, security and networking architecture.

## Why

- Host-local setting merges would drift in precedence, diagnostics and security behavior.
- Developer CMake profiles and renderer/device tiers do not describe product network roles, transport capability or replication budgets.
- Secret values, private keys and machine-specific credential bindings must not enter portable project files, manifests, cache keys or ordinary environment summaries.

## Decision and boundaries

- ADR-103 keeps ADR-009 Foundation resolution as the sole source-precedence authority; Network owns typed descriptors, cross-field constraints and effective-policy projection.
- Release profiles freeze exact ADR-102 modes, targets/providers, security floors and qualification evidence into a `NetworkArtifactPlan`.
- Packaging records safe capability evidence without granting runtime authority or carrying credential bindings.
- Credential requirements are public stable IDs; only the bounded consuming operation resolves a private provider reference/value.
- Migration, unavailable capability, cross-surface parity, packaging, automation and secret-pattern scanning requirements are explicit.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Documentation lint passed
- [x] CMake configure passed
- [x] Added Markdown links resolve
- [x] Manual smoke test not applicable

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/103-network-project-configuration-and-build-profile-ownership.md docs/adr/102-runtime-network-modes-and-authority-exposure.md docs/adr/README.md docs/architecture/README.md docs/architecture/foundation/configuration-system.md docs/architecture/delivery/build-system.md docs/architecture/release/release.md docs/architecture/release/release-security.md docs/architecture/security/application-security.md docs/architecture/runtime/networking-architecture.md
git diff --check
git diff --cached --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- This PR defines architecture but does not implement Network descriptors, the domain projector, artifact-plan generation or migration tooling.
- Concrete project/release profile values still require qualified product policy; the ADR intentionally does not derive them from graphics tiers.
- CMake reported the existing mbedTLS deprecation warning and unavailable pytest.

## Issue links

- Jira: HORO-1185
- GitHub: Closes #1185

## Reviewer Notes

- Review ADR-103 first, then the Foundation configuration specialization and build/release/security projections.