### PR TITLE
docs(ai): define editor debug ownership HORO-1370 #1370 [GAI-006.1]

### DIFF
--- a/docs/adr/111-gameplay-ai-document-panel-and-runtime-debug-ownership.md
+++ b/docs/adr/111-gameplay-ai-document-panel-and-runtime-debug-ownership.md
@@ -1,0 +1,205 @@
+# ADR-111: Gameplay AI Document, Panel and Runtime-Debug Ownership
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Blackboard, decision-graph and environment-query asset document routes; graph commands, history, save/conflict, compilation diagnostics, live runtime inspection, debug commands, provider extensions, presentation lifetime and lifecycle
+- **Issue**: [GAI-006.1](https://github.com/abdullahbodur/horo-engine/issues/1370)
+- **Jira**: [HORO-1370](https://horo-engine.atlassian.net/browse/HORO-1370)
+- **Related**: [ADR-013](013-environment-query-ownership-item-and-scoring-model.md), [ADR-021](021-gameplay-ai-ownership-scheduling-and-behavior-boundary.md), [ADR-022](022-ai-fixed-tick-order-authority-and-simulation-budget.md), [ADR-025](025-ai-decision-assets-and-gameplay-behavior-boundary.md), [ADR-056](056-external-editor-ui-boundary.md), [ADR-110](110-navigation-editor-surface-and-command-ownership.md)
+- **Normative documents**: [Navigation and AI Architecture](../architecture/runtime/navigation-and-ai-architecture.md), [Editor Document Model](../architecture/editor/editor-document-model.md), [Editor Panel Host](../architecture/editor/editor-panel-host.md), [Gameplay Behavior Authoring](../architecture/extensions/gameplay-behavior-authoring.md)
+
+## Context
+
+Gameplay AI has durable blackboard schemas, behavior-tree/state-machine/utility
+graphs and environment-query templates, plus compiled plans and scene-owned live
+instances. The editor has shared multi-document and graph-surface contracts, but no
+decision maps every AI asset to a route or separates authoring state from live task,
+node, blackboard and query state.
+
+A graph widget must not become semantic graph storage. A runtime panel must not own
+the task it displays, cancel simulation when closed or copy a live blackboard into
+authoring state. Provider extensions must not receive ImGui, mutable ECS/runtime
+objects or permission to bypass compile and safe-point commands.
+
+## Decision
+
+### 1. Every AI asset opens an explicit document route
+
+| Asset | Route | Semantic editor | Cooked output |
+|---|---|---|---|
+| `BlackboardSchemaAsset` | `BlackboardSchemaDocumentRoute` | Typed key/type/default/category table | Immutable schema descriptor |
+| `BehaviorTreeAsset` | `DecisionGraphDocumentRoute{BehaviorTree}` | Shared graph surface plus behavior-tree validator | `CookedBehaviorTreePlan` |
+| `StateMachineAsset` | `DecisionGraphDocumentRoute{StateMachine}` | Shared graph surface plus transition validator | `CookedStateMachinePlan` |
+| `UtilityAiAsset` | `DecisionGraphDocumentRoute{Utility}` | Shared graph surface plus scorer validator | `CookedUtilityPlan` |
+| `EnvironmentQueryTemplate` | `EnvironmentQueryDocumentRoute` | Shared staged graph/list surface plus EQS validator | `EnvironmentQueryPlan` |
+
+The editor document host owns one session/revision/history/dirty/save/recovery/
+external-conflict lifecycle per open asset. Asset Registry `AssetId` is durable
+identity; tab index, path, graph-widget ID and runtime plan pointer are not.
+`SceneDocument` separately owns agent-component references to these assets.
+
+Opening the same asset focuses its existing session. Cross-asset edits use the
+EDT-003 multi-document transaction contract: pin every session/revision, validate a
+complete candidate, commit correlated semantic history entries or change none.
+Saving one document never silently saves dependencies.
+
+### 2. Shared graph widgets are presentation adapters
+
+Decision and EQS graph documents reuse `INodeGraphSurface`, `GraphViewSnapshot`,
+stable Horo graph/node/pin/link IDs and drained `GraphEditCommand` intent. The
+widget owns selection, pan/zoom, drag and context-menu state only. Subsystem document
+controllers validate node types, pins, cycles, references, blackboard bindings,
+paradigm rules and bounded payloads before an editor command commits.
+
+Node placement, routing bends, comments and view state follow the shared metadata
+policy; semantic topology remains in the source asset. Widget/native library types
+never enter assets, commands, cook output or runtime. Undo/redo stores semantic
+deltas, not widget memory snapshots.
+
+Blackboard tables use shared editor field/table components and the same command
+contract. Renaming/removing a key is a schema edit; updating dependent documents is
+a deliberate multi-document migration, never a string search or runtime mutation.
+
+### 3. Compilation is derived and revision-correlated
+
+Document edits invalidate compilation currentness but do not modify an active play
+instance. Compilation captures immutable source and dependency revisions, runs
+through the application/cook capability and publishes diagnostics/cooked plans only
+if the capture remains current. Worker completion cannot commit a document command.
+
+Compile success does not clear dirty state; save success does not imply compile
+success. A failed/stale compile keeps the last valid cooked plan identifiable but
+cannot claim current. Applying a compatible plan to PIE uses the runtime's staged
+safe-point replacement policy; incompatibility restarts/rejects according to
+ADR-025, never through a graph-tab callback.
+
+### 4. The Gameplay AI panel is read-only by default
+
+A dockable `GameplayAiTab`, closed by default, projects selected world/agent,
+blackboard values, active plan/node stacks, task status, perception summary, EQS
+requests/results, budgets and typed failures. It receives document-open commands,
+bounded diagnostic queries and an `IGameplayAiInspectionQuery`; no mutable runtime,
+ECS, blackboard, task or provider pointer crosses the boundary.
+
+Inspection results name Scene/runtime incarnation, fixed tick, agent generation,
+plan/schema asset and runtime-plan revisions. Pages/snapshots are immutable, bounded
+and carry truncation/staleness evidence. Replacement or slot reuse clears selection
+rather than retargeting a native index.
+
+Hidden panels perform no polling, graph-layout, paging or debug extraction. Closing
+releases subscriptions and snapshot leases only. It cannot cancel a task, EQS query,
+simulation, PIE session or runtime provider. Reopening queries current authority;
+the panel is never a runtime-state cache of record.
+
+### 5. Debug commands cross an explicit safe-point seam
+
+Read-only inspection requires no mutation permission. Pause/step selected AI,
+request reevaluation, set a development blackboard override, abort a task or run an
+EQS probe are distinct typed developer commands, individually capability/build/
+session/authority gated. They capture expected world/agent/plan/schema generations,
+enter the runtime command queue and commit only at the owning fixed-tick safe point.
+
+UI callbacks, EditorDataBus subscribers and workers cannot apply a command directly.
+Results are typed and correlated; stale, forbidden, unsupported, capacity and
+shutdown outcomes remain distinct. Shipping/server-private policy may omit all
+mutation and redact inspection. A debug override is transient runtime state and is
+never written into a source asset unless the user invokes a separate validated
+editor command after explicit review.
+
+### 6. Providers and extensions contribute data, not authority
+
+AI node, sense, planner or EQS providers publish inert typed descriptors: stable
+type IDs, pins/properties, localization keys, icons, validation/capability metadata
+and optional host-rendered bounded diagnostic fields. Creating/validating a
+descriptor performs no registration, runtime lookup or lifecycle callback.
+
+External UI follows ADR-056 host-rendered schema/action contracts. It receives no
+`IWorkspacePanel`, ImGui context, mutable document, live blackboard/task, provider
+object or service locator. Extensions cannot replace core command validation,
+publish cooked plans, issue hidden debug commands or retain callbacks after module
+detachment. Missing providers preserve opaque source data and report typed
+unavailable nodes; they do not reinterpret or delete it.
+
+### 7. Presentation uses shared editor systems
+
+AI document/panel/modal surfaces use the editor design system, stable `UiText`
+localization keys, semantic tokens, shared graph adapter and standard focus/input
+rules. Asset/node/type IDs and runtime diagnostics remain technical data. New copy
+updates aligned `en-US`/`tr-TR` catalogs and covers long/localized text, narrow
+docks, zoom, selection, disabled/loading/stale/error and keyboard states.
+
+Creation, migration/conflict and destructive confirmation are transient modals.
+Routine authoring is a document; live inspection is a panel. Modal/tab/panel closure
+never controls simulation lifetime.
+
+### 8. Notifications follow committed authority
+
+Document owners publish bounded source-revision invalidation after commit. Cook
+owners publish plan/diagnostic revisions. Runtime exposes inspection-generation
+invalidation. Surfaces query the authority for full state; EditorDataBus is not a
+command channel and subscriber order is irrelevant.
+
+PIE owns all live brains, blackboards, tasks, perception memories and EQS requests.
+Editor shutdown detaches surfaces/subscriptions and leases before destroying their
+query services; runtime shutdown independently closes command admission, cancels
+runtime work and destroys scene-owned state. No UI destructor performs runtime
+cleanup.
+
+### 9. Qualification covers ownership and lifecycle
+
+Required evidence includes:
+
+- each asset route, duplicate-open focus, independent dirty/save/recovery/conflict
+  and missing-provider opaque-data retention;
+- graph/table command apply/revert, semantic validation, cross-asset transaction
+  all-or-nothing behavior and no widget-type persistence;
+- current/stale compile and plan replacement with document/runtime revisions;
+- live inspection paging/redaction/truncation, agent/world reuse and stale leases;
+- hidden/closed panel doing no work and never cancelling task/query/simulation;
+- every debug command permission, safe-point, stale/capacity/shutdown result and no
+  direct widget/worker mutation;
+- extension attach/detach, denied action, unavailable provider and no ImGui/native/
+  runtime object leakage; and
+- shared graph/design/localization behavior across long text, focus and error states.
+
+## Consequences
+
+### Positive
+
+- Every AI source asset, cooked plan and live instance has one owner.
+- Decision/EQS editors reuse the shared graph and multi-document contracts.
+- Runtime debugging is useful without transferring task/node lifetime to UI.
+- Provider extensions remain typed, bounded and safe for headless products.
+
+### Costs
+
+- Each asset kind needs a semantic document controller and validator adapter.
+- Runtime inspection/debug requires generation-safe snapshots and commands.
+- Cross-schema migrations require real multi-document transaction support.
+
+## Rejected Alternatives
+
+### One monolithic AI editor tab owns every asset and runtime instance
+
+Rejected because document/history/conflict and scene-runtime lifetimes differ.
+
+### Let graph widgets validate or serialize gameplay semantics
+
+Rejected because the shared widget is presentation-only and cannot own subsystem
+schemas, cook compatibility or runtime rules.
+
+### Bind live task/node pointers to tree widgets
+
+Rejected because PIE replacement, parallel tasks and panel closure would create
+dangling identity and accidental cancellation.
+
+### Apply blackboard edits directly while inspecting
+
+Rejected because runtime mutation requires permissions, generations and a fixed-
+tick safe point; authoring changes require document commands.
+
+### Allow arbitrary provider ImGui panels
+
+Rejected because they bypass host design/localization, permissions, lifecycle and
+backend-neutral boundaries.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -122,6 +122,7 @@ to the replacement.
 | [108](108-dynamic-overlay-carving-and-tile-rebuild-policy.md) | Dynamic Overlay, Carving and Tile-Rebuild Policy | Proposed | 2026-09-02 |
 | [109](109-avoidance-crowd-and-renderer-independent-budget.md) | Avoidance, Crowd and Renderer-Independent Budget | Proposed | 2026-09-02 |
 | [110](110-navigation-editor-surface-and-command-ownership.md) | Navigation Editor Surface and Command Ownership | Proposed | 2026-09-02 |
+| [111](111-gameplay-ai-document-panel-and-runtime-debug-ownership.md) | Gameplay AI Document, Panel and Runtime-Debug Ownership | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -332,6 +332,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Navigation Editor Surface and Command Ownership](../adr/110-navigation-editor-surface-and-command-ownership.md):
   definition/Scene documents, bake operation projection, dockable inspection,
   transient modals, viewport overlays and provider UI limits.
+- [Gameplay AI Document, Panel and Runtime-Debug Ownership](../adr/111-gameplay-ai-document-panel-and-runtime-debug-ownership.md):
+  blackboard/decision/EQS document routes, shared graph commands, derived compile
+  state, immutable live inspection and safe-point debug actions.
 
 - [Cinematic Sequencer Architecture](./runtime/cinematic-sequencer-architecture.md):
   timeline, tracks, clock authority, typed property bindings, evaluation phase,

--- a/docs/architecture/editor/editor-document-model.md
+++ b/docs/architecture/editor/editor-document-model.md
@@ -368,6 +368,19 @@ ADR-106 publication neither advances history nor clears dirty state, and undo do
 not delete cooked artifacts. A deliberate cross-document edit requires a staged
 multi-document transaction; UI surfaces cannot write either document directly.
 
+## Gameplay AI Asset Documents
+
+[ADR-111](../../adr/111-gameplay-ai-document-panel-and-runtime-debug-ownership.md)
+defines separate document routes for blackboard schemas, behavior-tree/state-
+machine/utility graphs and EQS templates. Each keeps its own asset-rooted session,
+revision, semantic history, dirty/save/recovery/conflict state and subsystem
+validator. Shared graph widgets emit commands but own no semantic storage.
+
+Cross-schema/reference edits use the staged multi-document transaction contract.
+Compilation is revision-correlated derived work and does not clear dirty state.
+Live PIE blackboards, nodes, tasks and query results never enter document history;
+importing reviewed runtime data requires a separate typed editor command.
+
 ## Runtime Conversion
 
 The document converts to `RuntimeSceneDefinition` through an editor service.

--- a/docs/architecture/editor/editor-panel-host.md
+++ b/docs/architecture/editor/editor-panel-host.md
@@ -69,6 +69,7 @@ EditorLayer
     |                       +-- PerformanceTab
     |                       +-- RenderInspectorTab (registered, closed by default)
     |                       +-- NavigationTab (registered, closed by default)
+    |                       +-- GameplayAiTab (registered, closed by default)
     |
     +-- EditorModalHost          exclusive modal workflows above the workspace
 ```
@@ -843,6 +844,18 @@ Visible as the Workspace panel with the following tabs:
     lifetime or accesses provider/native state.
   - Provider/extension detail uses validated host-rendered schema under ADR-110
     and ADR-056, not arbitrary plugin ImGui.
+
+- **Gameplay AI tab**: selected-agent blackboard, active plan/node/task, perception,
+  EQS and budget inspection.
+  - Owner: `GameplayAiTab`, registered closed by default.
+  - Queries: bounded immutable `IGameplayAiInspectionQuery` pages carrying world,
+    agent, plan/schema and tick generations.
+  - Executes: document-open actions and separately authorized typed runtime-debug
+    commands through safe-point capabilities.
+  - Owns only presentation selection, filters and paging. Hide/close stops polling
+    and releases leases; it never cancels a task, query, simulation or PIE session.
+  - Provider detail uses ADR-111/ADR-056 host-rendered schema, never runtime/native
+    pointers or arbitrary plugin ImGui.
 
 - **MCP tab**: MCP command history and activity.
   - Owner: `McpTab`

--- a/docs/architecture/extensions/gameplay-behavior-authoring.md
+++ b/docs/architecture/extensions/gameplay-behavior-authoring.md
@@ -526,6 +526,14 @@ are not linked into packaged runtime modules.
 
 ## Editor Separation
 
+[ADR-111](../../adr/111-gameplay-ai-document-panel-and-runtime-debug-ownership.md)
+requires gameplay-AI blackboard, decision and EQS authoring to reuse the shared
+multi-document/graph command contracts. Live debug panels consume immutable
+Scene-generation snapshots and do not own behavior/task/node lifetime. Any runtime
+debug mutation is a permissioned typed safe-point command; provider extensions
+contribute inert metadata or host-rendered schema, not ImGui or mutable runtime
+objects.
+
 Game code may expose metadata used by generic editor property and scene tools.
 Editor-specific presentation extensions belong to the editor extension
 contract and are not linked into game runtime modules.

--- a/docs/architecture/runtime/navigation-and-ai-architecture.md
+++ b/docs/architecture/runtime/navigation-and-ai-architecture.md
@@ -1243,6 +1243,13 @@ AI decision making is authored as dedicated graph assets that compile into flat,
 
 ### Graph Asset Model And UI Independence
 
+[ADR-111](../../adr/111-gameplay-ai-document-panel-and-runtime-debug-ownership.md)
+maps blackboard schemas, the three decision graph kinds and EQS templates to
+explicit asset-document routes. Decision/EQS graph tabs reuse the shared Horo
+`GraphViewSnapshot`/`GraphEditCommand` surface, while subsystem document
+controllers own semantic validation, history, save/conflict and compilation.
+Cooked plans and live Scene-owned instances never become editor document state.
+
 1. **Pure Semantic Graph Assets**:
    - Persisted graph identity is established by typed assets: `BehaviorTreeAsset` (`.horo_bt`), `StateMachineAsset` (`.horo_sm`), and `UtilityAiAsset` (`.horo_utility`).
    - Assets contain only semantic topology: stable `GraphId`, `NodeId`, `PinId`, `PropertyId`, schema versions, node type identifiers, property bindings, and blackboard key bindings.
@@ -1516,6 +1523,12 @@ surfaces use the shared design system and localization catalogs.
 - Perception visualization (sight cones, hearing radii, known stimuli)
 - AI debug panel (blackboard inspector, behavior tree state, active path)
 - NavMesh generation diagnostics (build time, coverage percentage)
+
+The closed-by-default `GameplayAiTab` reads bounded immutable, generation-scoped
+runtime snapshots. Hiding/closing it stops polling and releases leases only; it
+cannot cancel tasks, EQS work, simulation or PIE. Authorized developer mutations
+are typed, permissioned runtime commands committed at fixed-tick safe points, never
+direct widget writes. Provider UI remains inert metadata/host-rendered schema.
 
 ## Simulation Lifecycle And Fixed-Tick Phase Ordering
 


### PR DESCRIPTION
## Summary

- Defines explicit editor document routes for blackboard, behavior-tree, state-machine, utility-AI, and environment-query assets.
- Separates semantic authoring, compilation, live runtime inspection, and debug-command ownership.
- Makes shared graph widgets presentation-only and keeps runtime AI lifetime independent from panels and modals.

## Why

Gameplay AI had no single decision mapping durable AI assets to editor routes or separating authoring state from live tasks, blackboards, and queries. Without that boundary, graph widgets and inspection panels could accidentally become semantic storage or runtime mutation authorities.

## Decision and boundaries

- Adds ADR-111 and projects the decision into the editor document model, panel host, gameplay behavior authoring, and navigation/AI architecture.
- Runtime inspection is read-only by default; mutating debug actions use capability-gated, generation-checked commands at the fixed-tick safe point.
- Provider extensions contribute inert typed descriptors and bounded diagnostics, not ImGui or mutable runtime objects.
- Compilation remains derived and revision-correlated; save success, compile success, and runtime plan activation remain distinct states.

This PR defines architecture contracts only; editor/runtime implementation is intentionally deferred to the focused delivery tickets.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Markdown lint passed
- [x] Added Markdown links resolve
- [x] Staged diff checks passed
- [x] CMake configure passed
- [ ] Full build/test suite not run; this is a documentation-only decision

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- <changed-markdown-files>
git diff --check
git diff --cached --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- The contracts require future generation-safe inspection snapshots and command queues that are not implemented here.
- Provider extension and localization behavior still need implementation-level regression coverage.
- CMake reported the existing mbedTLS deprecation warning and skipped repository Python tests because pytest is unavailable.

## Issue links

- Jira: HORO-1370
- GitHub: Closes #1370

## Reviewer Notes

Review ADR-111 first, then the Navigation and AI projection, followed by the editor document/panel contracts. The key invariant is that UI presentation never owns AI asset semantics or live runtime lifetime.