### PR TITLE
docs(save): define archive compatibility policy HORO-1410 #1410 [SAV-002.1]

### DIFF
--- a/docs/adr/112-save-archive-container-and-compatibility-policy.md
+++ b/docs/adr/112-save-archive-container-and-compatibility-policy.md
@@ -1,0 +1,236 @@
+# ADR-112: Save Archive Container and Compatibility Policy
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Portable `.horosave` framing, canonical logical-state serialization, archive and schema version axes, state/content/publication identities, release compatibility declarations, migration support and forward rejection
+- **Issue**: [SAV-002.1](https://github.com/abdullahbodur/horo-engine/issues/1410)
+- **Jira**: [HORO-1410](https://horo-engine.atlassian.net/browse/HORO-1410)
+- **Related**: [ADR-003](003-artifact-identity.md), [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-057](057-package-manifest-v1-typed-model.md), [ADR-060](060-release-domain-model-and-state-machine.md)
+- **Normative documents**: [Save Game And Persistence](../architecture/runtime/save-game-and-persistence.md), [Release Architecture](../architecture/release/release.md), [Distribution And Update](../architecture/release/distribution-and-update.md)
+
+## Context
+
+Runtime save authority and transactional capture/restore are defined, and the save
+architecture proposes a single-file envelope. It still uses archive revision and
+content identity ambiguously, treats one module version axis as both whole-save and
+participant schema, and lets release metadata collapse compatibility to one
+`saveFormatVersion`. Those ambiguities cannot become shipped user data.
+
+The same logical state can be encoded with different compression or presentation
+metadata. Identical archive bytes can be replicated without being a new logical slot
+publication. A new durable write of unchanged state must still be distinguishable
+from the publication it replaced. One digest or timestamp cannot safely answer all
+three questions.
+
+Portable persistence also cannot inherit C++ object layout, host endianness, locale,
+unordered-container iteration or compiler floating-point behavior. Readers need an
+explicit answer for direct readability, migration and newer unsupported input before
+allocating or interpreting participant payloads.
+
+## Decision
+
+### 1. `.horosave` is an explicitly encoded single-file container
+
+HoroSave v1 uses the 32-byte preamble, bounded deterministic entry table, stored
+entry payload and integrity trailer defined by the normative save architecture. All
+multibyte envelope and entry-table integers are explicitly encoded little-endian.
+Implementations read and write fields individually; native structs, bitfields,
+`sizeof(T)`, padding, pointer values, native enum width and in-memory container layout
+are forbidden format inputs.
+
+The payload contains deterministic metadata plus independently coded data entries.
+Entry identity, order, lengths, codec and required/optional status are explicit.
+Unknown flags, duplicate entries, gaps, overlaps, trailing bytes, invalid lengths and
+unsupported required codecs fail before decoding. Filesystem paths never occur in the
+entry table.
+
+JSON metadata is a deterministic bounded interchange surface, not the canonical
+logical-state representation. It uses UTF-8, sorted keys, duplicate-key rejection,
+locale-independent numbers and schema-defined required fields. Data entries use
+participant codecs registered by stable typed identity.
+
+### 2. Canonical logical state has a storage-independent byte form
+
+Every required save participant produces a canonical logical byte stream before any
+compression, encryption, entry packing, signature or publication metadata is added.
+The whole-save canonical stream is composed in ascending `StableTypeId` byte order
+and includes stable project/world/base-scene and base-dataset identities, the
+`SaveSchemaVersion`, each participant ID and `ParticipantSchemaVersion`, and each
+participant's canonical state.
+
+Canonical codecs obey these rules:
+
+- fields have stable numeric IDs and schema-defined presence/default rules;
+- integers have explicit width and signed representation; booleans are exactly 0 or
+  1; enums serialize their declared stable value;
+- floating values use declared IEEE 754 binary32/binary64 encoding, normalize
+  negative zero to positive zero and reject non-finite values unless a participant
+  schema defines one exact canonical non-finite representation;
+- strings are length-delimited validated UTF-8 scalar sequences with no locale,
+  platform or implicit normalization; semantic normalization must occur before the
+  codec under a versioned participant rule;
+- maps/sets sort by canonical encoded key bytes and reject duplicate canonical keys;
+  sequences retain schema-defined semantic order; and
+- padding, addresses, runtime handles, unordered iteration, timestamps, display
+  names, compression choices and publication identities never enter the stream.
+
+Changing a canonical rule is a save or participant schema change. A reader never
+reconstructs canonical state by reserializing untrusted JSON with its local library.
+
+### 3. State, content and publication use three typed identities
+
+```cpp
+struct CanonicalStateHash { Sha256 value; };
+struct ArchiveContentHash { Sha256 value; };
+struct SlotGenerationId { Opaque128 value; };
+```
+
+`CanonicalStateHash` is the domain-separated SHA-256 of the canonical whole-save
+stream. It answers whether two snapshots represent the same logical state under the
+same semantic dependencies and schemas. It excludes slot ID/generation, capture and
+wall-clock times, display name, play duration, entry layout, codec/compression,
+signature and other publication metadata. It is useful for equivalence and
+determinism evidence, not archive integrity or slot concurrency.
+
+`ArchiveContentHash` is the domain-separated SHA-256 of the final v1 preamble and
+payload bytes, excluding the integrity trailer that carries it. It is computed only
+after metadata, entry layout, codecs and `SlotGenerationId` are frozen. It answers
+which immutable archive content was verified or transferred. Any covered byte change
+requires a new value and signature. It does not mean logical-state equality.
+
+`SlotGenerationId` is a nonzero opaque 128-bit identity allocated by the storage
+authority for one intended durable publication to one logical slot. Publication
+records the expected parent generation for compare-and-swap/conflict checks. An ID
+is never derived from time, path, counter display, either hash or content. Failed
+pre-publication attempts may consume an ID but never publish it; successful overwrite,
+migration or explicit import gets a new ID even when logical state is unchanged.
+Replication, download and recovery copies of the same logical publication retain its
+generation. Copying into a new logical slot requires a new finalized archive.
+
+The archive manifest stores `CanonicalStateHash`; the header stores the logical slot
+and `SlotGenerationId`; the trailer stores `ArchiveContentHash`. Catalog, operation,
+cloud and restore APIs carry the typed values without calling any of them a generic
+archive revision. Timestamps are presentation/provenance metadata only.
+
+### 4. Four version axes remain independent
+
+| Version | Authority |
+|---|---|
+| `ArchiveFormatVersion` | Horo-owned envelope, entry table and trailer codec |
+| `SaveSchemaVersion` | Whole-save canonical root, required roles and cross-participant composition |
+| `ParticipantSchemaVersion` | One `StableTypeId` participant's canonical payload and migration chain |
+| `ProductSaveCompatibilityVersion` | Product release's declared compatibility matrix and policy epoch |
+
+Base asset/dataset revisions remain dependency identities rather than schema
+versions. Engine version, project build ID and product semantic version are bounded
+diagnostics/provenance; none selects a codec or implies compatibility.
+
+Archive metadata declares its archive/save/participant data versions and the
+producing product compatibility version. A release declares its product compatibility
+version plus exact write versions, inclusive direct-readable and migratable ranges,
+required participant ranges, migration policy and forward policy. The product version
+is incremented whenever that matrix or required participant set changes incompatibly;
+it does not replace any codec version or enter `CanonicalStateHash`.
+
+### 5. Compatibility preflight is explicit and fail-closed
+
+Readers preflight in this order: framing/limits, `ArchiveFormatVersion`, outer
+integrity and trusted signature policy, metadata/save schema, required participant
+set and versions, dependency identities, then decoded participant hashes. A version
+is directly readable only when every required axis is in the release's declared
+direct range. A version is migratable only when every required axis is in a declared
+migration-source range and the sealed registry contains one complete deterministic
+bounded path to a directly readable version.
+
+Any newer archive, save schema, required participant schema or product compatibility
+version outside the declared ranges is rejected with a typed unsupported-newer error.
+Readers do not best-effort parse forward data. Unknown optional participants may be
+skipped only when the manifest marks them optional and no required participant
+declares a dependency on them. Missing/unknown required participants always reject.
+
+Migration verifies the source first, operates on detached staging, preserves the
+source unless an explicit replacement policy was captured, and emits current writer
+versions with a new `SlotGenerationId`, `ArchiveContentHash` and signature. It may
+preserve `CanonicalStateHash` only when the canonical logical state and semantic
+dependency identities are unchanged.
+
+### 6. Release manifests publish a complete save policy
+
+The release manifest contains a versioned `saveCompatibility` object with:
+
+- `productSaveCompatibilityVersion` and the exact archive/save versions written;
+- inclusive direct-readable and migration-source archive/save ranges;
+- required participant IDs with direct and migration-source schema ranges;
+- the migration policy (`AutomaticReversible`, `AutomaticOneWay`,
+  `UserConfirmed` or `Unsupported`) and a migration-catalog identity;
+- `minimumSupportedProductSaveCompatibilityVersion`; and
+- `forwardReadPolicy`, which is `Reject` for v1.
+
+Preflight validates that current writer versions are directly readable, all declared
+migration ranges have complete registered paths, and required participant declarations
+match the sealed product composition. The old flat `saveFormatVersion` and
+`minimumReadableSaveFormatVersion` fields are legacy input only and cannot be emitted
+by new manifests because they cannot represent the four independent axes.
+
+### 7. Stable releases have a minimum migration and deprecation horizon
+
+Before product 1.0, every shipped preview declares its exact support window and keeps
+fixtures for every version it claims; no compatibility is inferred across previews.
+From product 1.0 onward, each stable release must migrate saves from at least the
+previous two stable minor release lines and for at least 12 months after each source
+line's last release, whichever is longer. Product policy may extend this window.
+
+Patch releases may not narrow direct-read or migration ranges, remove a required
+migration path or increment the product compatibility version. Dropping support in a
+later minor/major release requires deprecation in two preceding stable minor release
+lines, release notes and a final supported bridge release capable of writing the next
+current form. A major release may reject older input only after that horizon; rollback
+must retain the untouched source archive. Security policy may block a vulnerable
+decoder sooner, but the release must declare the exception and present a typed
+security rejection rather than silently treating the save as corrupt.
+
+Fixtures cover the oldest supported, every migration boundary, current writer and
+one-newer rejected forms for each version axis. Golden canonical-state vectors run on
+all supported platforms/compilers; archive fixtures also cover byte-exact framing,
+endianness, hashes, signatures and generation conflict behavior.
+
+## Consequences
+
+### Positive
+
+- Compiler ABI, host endianness and unordered iteration cannot define save format.
+- Logical equivalence, immutable archive integrity and slot concurrency are no longer
+  conflated.
+- Releases can truthfully preflight direct read, migration and forward rejection.
+- Compatibility removal has a measurable horizon and fixture obligation.
+
+### Costs
+
+- Canonical codecs and migration registries need golden cross-platform fixtures.
+- Release composition must validate participant ranges and migration coverage.
+- Every durable publication must finalize metadata before hashing/signing and cannot
+  patch timestamps or catalog fields afterward.
+
+## Rejected Alternatives
+
+### Serialize C++ structs directly and version the build
+
+Rejected because padding, endianness, enum width and compiler ABI are not portable
+or stable format contracts.
+
+### Use one save format version for container and all participants
+
+Rejected because independent participant evolution would force unrelated migrations
+and still would not describe product compatibility.
+
+### Use one digest or timestamp as revision, content and state identity
+
+Rejected because equivalent state may have different archive bytes, while repeated
+publication of equivalent state still needs a distinct conflict generation. Clocks
+also do not establish causality.
+
+### Parse newer versions best-effort
+
+Rejected because unknown required semantics can produce plausible but invalid state;
+forward incompatibility must fail before live-runtime mutation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -123,6 +123,7 @@ to the replacement.
 | [109](109-avoidance-crowd-and-renderer-independent-budget.md) | Avoidance, Crowd and Renderer-Independent Budget | Proposed | 2026-09-02 |
 | [110](110-navigation-editor-surface-and-command-ownership.md) | Navigation Editor Surface and Command Ownership | Proposed | 2026-09-02 |
 | [111](111-gameplay-ai-document-panel-and-runtime-debug-ownership.md) | Gameplay AI Document, Panel and Runtime-Debug Ownership | Proposed | 2026-09-02 |
+| [112](112-save-archive-container-and-compatibility-policy.md) | Save Archive Container and Compatibility Policy | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -308,6 +308,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Save Game And Persistence](./runtime/save-game-and-persistence.md): runtime
   save state, slot format, migration, cloud save, integrity, and secure archive
   loading.
+- [Save Archive Container and Compatibility Policy](../adr/112-save-archive-container-and-compatibility-policy.md):
+  portable framing, canonical logical state, independent version axes, typed
+  state/content/publication identities, release declarations and support horizon.
 - [Navigation And AI Architecture](./runtime/navigation-and-ai-architecture.md):
   NavMesh, pathfinding, dynamic obstacle overlays, perception, crowd, blackboard,
   and editor bake tooling.

--- a/docs/architecture/release/distribution-and-update.md
+++ b/docs/architecture/release/distribution-and-update.md
@@ -253,6 +253,14 @@ Product updates may require migration of user-level state:
 - plugin resolution cache
 - update state records
 
+Runtime save archives are governed separately by the release manifest's
+`saveCompatibility` contract and
+[ADR-112](../../adr/112-save-archive-container-and-compatibility-policy.md). Update
+activation does not rewrite save slots. Save migration verifies the source archive,
+uses detached staging, preserves the original unless captured product/user policy
+authorizes replacement, and publishes a new slot generation only through the runtime
+save transaction.
+
 User projects are not migrated during product update activation. User-state
 migration runs only after the new product version starts and validates the
 state schema.
@@ -338,8 +346,9 @@ Required tests cover:
 
 - [Release Architecture](./release.md)
 - [Release Security](./release-security.md)
+- [ADR-112](../../adr/112-save-archive-container-and-compatibility-policy.md): save
+  compatibility, migration and slot-publication identity.
 - [Horo Package System](../packages/package-system.md): package updates and dependency resolution
 - [Application Security](../security/application-security.md)
 - [Platform Abstraction](../foundation/platform-abstraction.md)
 - [Configuration System](../foundation/configuration-system.md)
-

--- a/docs/architecture/release/release.md
+++ b/docs/architecture/release/release.md
@@ -300,13 +300,30 @@ format compatibility.
 
 The release manifest may include:
 
-- `saveFormatVersion`
-- `minimumReadableSaveFormatVersion`
+- a versioned `saveCompatibility` object
 - `networkProtocolVersion`
 - `modApiVersion`
 - `assetArchiveFormatVersion`
 - `requiredEngineRuntimeVersion`
 - `requiredPluginApiVersion`
+
+When a product supports runtime saves, `saveCompatibility` is required and contains:
+
+- `productSaveCompatibilityVersion`;
+- exact `writeArchiveFormatVersion` and `writeSaveSchemaVersion`;
+- inclusive direct-readable and migration-source ranges for archive/save schemas;
+- every required save participant ID with its direct-readable and migration-source
+  `ParticipantSchemaVersion` ranges;
+- `minimumSupportedProductSaveCompatibilityVersion`;
+- migration policy and the sealed migration-catalog identity; and
+- `forwardReadPolicy`, which is `Reject` for HoroSave v1.
+
+Preflight rejects a release when its current writer versions are not directly
+readable, a declared migration range lacks a complete bounded path, or required
+participant declarations differ from sealed product composition. Engine/build and
+product semantic versions are provenance, not save-codec selectors. The legacy flat
+`saveFormatVersion` and `minimumReadableSaveFormatVersion` fields are read-only
+migration input and are not emitted by new manifests.
 
 A game update must not silently make existing user saves unreadable. If a save
 migration is required, the game release profile declares whether migration is:
@@ -315,6 +332,15 @@ migration is required, the game release profile declares whether migration is:
 - automatic but one-way
 - explicit user-confirmed
 - unsupported
+
+Before product 1.0, each shipped preview declares exact supported ranges and retains
+fixtures for those claims. From product 1.0 onward, a stable release supports
+migration from at least the previous two stable minor lines and for at least 12
+months after each source line's last release, whichever is longer. Patch releases
+cannot narrow this window. Removing support requires deprecation in two preceding
+stable minor lines, release notes and a final bridge release. Security policy may
+block a vulnerable decoder earlier only through an explicit manifest exception and
+typed security diagnostic.
 
 Network protocol incompatibility must be represented explicitly so multiplayer
 clients, dedicated servers, and tools can reject incompatible connections with a
@@ -485,6 +511,9 @@ artifact integrity follow [Release Security](./release-security.md).
 - [Release Security](./release-security.md): signing and credential boundaries.
 - [Distribution And Update](./distribution-and-update.md): installation
   packages, update manifests, activation, and rollback.
+- [ADR-112](../../adr/112-save-archive-container-and-compatibility-policy.md):
+  runtime-save container, version axes, release compatibility fields and support
+  horizon.
 - [Horo Package System](../packages/package-system.md): package lockfile freeze and
   content package to release chunk mapping.
 - [Observability Architecture](../observability/observability.md): structured records, job

--- a/docs/architecture/runtime/save-game-and-persistence.md
+++ b/docs/architecture/runtime/save-game-and-persistence.md
@@ -6,6 +6,8 @@ This document defines runtime save authority, coherent snapshot capture, durable
 archives, transactional restore, migration, host isolation and security for
 HORO-1391 #1391 [SAV-001.1]. These are normative implementation requirements; the
 complete save service/archive protocol is not claimed as implemented by this change.
+ADR-112 freezes the portable archive, canonical state, identity and compatibility
+policy for HORO-1410 #1410 [SAV-002.1].
 
 - RuntimeSaveService coordinates one runtime save/restore authority under the
   application/session lifetime. It never retains an unleased reference to a scene
@@ -13,8 +15,9 @@ complete save service/archive protocol is not claimed as implemented by this cha
 - Runtime state is never serialized through SceneDocument or the authoring AST.
 - Capture produces owned immutable data at a Scene lifecycle safe point; workers
   serialize, hash, sign and perform all durable file operations.
-- A save is one final immutable file. Its digest excludes the integrity trailer;
-  signing finishes before the one durable publication, never afterward.
+- A save is one final immutable file. Its `ArchiveContentHash` excludes the
+  integrity trailer; signing finishes before the one durable publication, never
+  afterward.
 - Restore prepares every required participant before a no-fail owner-boundary
   publication. A failed preparation leaves the active runtime unchanged.
 - Signature acceptance is trusted host policy, never a flag chosen by the archive.
@@ -90,6 +93,9 @@ Schematic interface shapes (not new installed headers):
 struct SaveGameSlotId { Uuid value; }; // nonzero opaque identity, never a path
 struct SaveOperationHandle { OperationId value; };
 struct RestoreOperationHandle { OperationId value; };
+struct CanonicalStateHash { Sha256 value; };
+struct ArchiveContentHash { Sha256 value; };
+struct SlotGenerationId { Opaque128 value; }; // nonzero, never time/hash-derived
 
 enum class SaveOperationPhase : uint8_t {
     Queued, CapturingSnapshot, Serializing, FinalizingArchive, WritingTemporary,
@@ -106,7 +112,9 @@ struct SaveOperationSnapshot {
     SaveCommitOutcome commitOutcome;
     float progress;
     OptionalError terminalError;
-    OptionalArchiveRevision archiveRevision;
+    OptionalSlotGenerationId slotGeneration;
+    OptionalCanonicalStateHash canonicalState;
+    OptionalArchiveContentHash archiveContent;
 };
 struct SaveRequest {
     BoundedUtf8 displayName;       // metadata only, never a filename
@@ -219,6 +227,40 @@ Optional thumbnails are omitted on timeout, stale scene or headless execution.
 An explicitly required thumbnail may fail the save after its configured finite
 deadline, without blocking the owner. Late readbacks only retire their own resources.
 
+## Canonical Logical State
+
+Every required participant produces a canonical logical byte stream before entry
+packing, compression, signing or publication metadata. The whole-save canonical
+stream contains the stable project/world/base-scene and base-dataset identities,
+`SaveSchemaVersion`, then participant ID, `ParticipantSchemaVersion` and canonical
+payload tuples sorted by `StableTypeId` bytes. Optional participant presence is part
+of the logical stream when its state participates in restore.
+
+Canonical participant codecs use stable numeric field IDs and schema-defined
+presence/default rules. Integers have explicit widths and signed representation;
+booleans are 0 or 1; enums use declared stable values. Declared IEEE 754 floats are
+encoded explicitly, normalize negative zero to positive zero and reject non-finite
+values unless that schema defines one exact canonical representation. Strings are
+length-delimited validated UTF-8 scalar sequences with no locale or implicit
+normalization. Maps and sets sort by canonical encoded key bytes and reject duplicate
+canonical keys; sequences retain schema-defined semantic order.
+
+Compiler padding, pointer/native-handle values, native enum widths, unordered
+iteration, wall/capture timestamps, play duration, display name, slot/generation,
+entry layout, codec/compression and signature metadata never enter canonical state.
+Changing a canonical rule requires a `SaveSchemaVersion` or owning
+`ParticipantSchemaVersion` change and migration. The identity is:
+
+```text
+CanonicalStateHash = SHA256(
+    ASCII("HoroSave.CanonicalState.v1") || 0x00 || canonicalSaveState)
+```
+
+`CanonicalStateHash` establishes logical equivalence under the same schemas and
+semantic dependencies. It is not a file-integrity value, conflict generation or
+authentication proof. Readers validate it from decoded canonical participant state;
+they do not reconstruct it by reserializing metadata JSON with a local library.
+
 ## Single-File Archive And Integrity Envelope
 
 A durable .horosave is **one regular file**, never a live directory bundle. Payload
@@ -255,8 +297,8 @@ JSON reserialized by the reader.
 
 | Logical payload entry | Content |
 |---|---|
-| header.json | Slot/archive revision, project/world/account scope, baseSceneAsset, timestamps, display name and slot kind |
-| manifest.json | Stable module/chunk IDs, each module schema version, required flags, lengths, codecs and per-chunk SHA-256 |
+| header.json | Logical slot ID, `SlotGenerationId`, optional parent generation, producing `ProductSaveCompatibilityVersion`, project/world/account scope, baseSceneAsset, timestamps, display name and slot kind |
+| manifest.json | `SaveSchemaVersion`, `CanonicalStateHash`, StableTypeId-sorted participant/chunk IDs, each `ParticipantSchemaVersion`, required flags, lengths, codecs and per-chunk SHA-256 |
 | runtime_ecs.bin | Stable authored/spawn identities, dynamic components, tombstones and reference remap records |
 | gameplay module entries | Each registered module's versioned state |
 | slot_player_state.bin | Slot-scoped player state only; no global settings/achievements |
@@ -266,14 +308,14 @@ JSON reserialized by the reader.
 These names describe entry roles, not directories to extract on disk. Header metadata
 has no checksum field; manifest has no archiveSignature field. Manifest per-chunk
 hashes cover raw decoded **data** entries only, not header/manifest themselves.
-The outer digest authenticates all stored metadata and compressed bytes. After
+`ArchiveContentHash` authenticates all stored metadata and compressed bytes. After
 outer verification, bounded decode checks each data entry's raw digest and length.
 Every required entry has exactly one manifest record; unknown required data fails.
 
 The trailer is encoded in this exact order:
 
 ```text
-payloadSha256       32 bytes
+archiveContentHash  32 bytes
 signatureAlgorithm   2 bytes (uint16: 0 None, 1 Ed25519)
 signerKeyId         16 bytes (opaque key ID; all zero only for None)
 signatureByteLength  2 bytes (uint16: 0 or 64)
@@ -290,22 +332,25 @@ Hash/signature inputs are normative (`||` concatenates bytes; each ASCII tag
 includes exactly one terminating zero byte):
 
 ```text
-payloadSha256 = SHA256(
-    ASCII("HoroSave.Payload.v1") || 0x00 || preamble || payload)
+ArchiveContentHash = SHA256(
+    ASCII("HoroSave.ArchiveContent.v1") || 0x00 || preamble || payload)
 
 signatureMessage =
     ASCII("HoroSave.Signature.v1") || 0x00 ||
     uint16LE(signatureAlgorithm) || signerKeyId ||
-    uint16LE(signatureByteLength) || payloadSha256
+    uint16LE(signatureByteLength) || ArchiveContentHash
 
 signature = Ed25519.Sign(trustedHostPrivateKey, signatureMessage)
 ```
 
-This is Ed25519 over the framed message, not Ed25519ph. Neither digest nor signature
-is part of its own input. Choose the signature scheme/length before constructing
-the preamble, hash the final preamble/payload once, then append the complete trailer.
-No header/manifest/archive bytes are patched after durable publication. Changing
-metadata, chunks or compression requires a new digest/signature and a new transaction.
+This is Ed25519 over the framed message, not Ed25519ph. `ArchiveContentHash` is the
+typed identity of the final immutable preamble/payload bytes; the self-referential
+integrity trailer that carries it is excluded. Neither that hash nor the signature
+is part of its own input. Choose the signature scheme/length before constructing the
+preamble, hash the final preamble/payload once, then append the complete trailer. No
+header/manifest/archive bytes are patched after durable publication. Changing slot
+generation, timestamps, metadata, chunks or compression requires a new hash/signature
+and a new transaction, even when `CanonicalStateHash` is unchanged.
 
 ### Trusted Signature Policy
 
@@ -323,16 +368,17 @@ Optional and Required modes. The file cannot choose or weaken it.
 
 The host binds trusted key IDs to project, account/server/world scope and permitted
 algorithm. Public keys/trust roots are not supplied by the archive. Signed headers
-bind these identities and ArchiveRevision; load compares them to the requested
-namespace. Required signing failure or unavailable signer fails the save before
-publication; ordinary clients hold no server private key and cannot invent a local
-unsigned substitute. A trusted asynchronous signer may be injected with bounded
-timeout, but no signing network call blocks the simulation thread.
+bind these identities, the logical slot and `SlotGenerationId`; load compares them
+to the requested namespace. Required signing failure or unavailable signer fails the
+save before publication; ordinary clients hold no server private key and cannot
+invent a local unsigned substitute. A trusted asynchronous signer may be injected
+with bounded timeout, but no signing network call blocks the simulation thread.
 
 No mode stores credentials/private keys in saves. Digests are not authentication;
 a valid signature also does not prevent replay of an old valid save. Titles needing
-anti-rollback require separately trusted revision/anti-replay state, not a timestamp
-inside the attacker-controlled file. The archive is not encrypted by this protocol.
+anti-rollback require separately trusted generation/anti-replay state, not a
+timestamp inside the attacker-controlled file. The archive is not encrypted by this
+protocol.
 
 ## Save Pipeline, Publication And Cancellation
 
@@ -340,11 +386,12 @@ inside the attacker-controlled file. The archive is not encrypted by this protoc
 Admit operation and namespace/slot mutation lease
     -> capture coherent immutable snapshot at owner lifecycle safe point
     -> worker serialize/compress, per-chunk hashes and final payload
-    -> compute outer digest, required/optional signing, append final trailer
+    -> allocate SlotGenerationId and finalize publication metadata
+    -> compute ArchiveContentHash, required/optional signing, append final trailer
     -> write unique sibling temporary file and flush final bytes
     -> enter non-cancellable commit gate
     -> worker AtomicReplace plus required directory/container durability
-    -> publish owner catalog/result and cloud-sync intent for exact archive revision
+    -> publish owner catalog/result and cloud-sync intent for exact slot generation
     -> Completed (local durable success)
 ```
 
@@ -384,9 +431,10 @@ already exposes richer outcomes.
   TooLate; cloud upload failure cannot undo the local save.
 - OutcomeUnknown yields Failed with commitOutcome Unknown, quarantines further slot
   mutation/sync, and retains a recovery diagnostic/transaction record. Reopen/validate
-  the destination under the lease, compare its archive revision/digest with old/new
-  expectations and retry durability where supported. Do not delete a possibly
-  published archive or blindly retry over it. Report old/new/unresolved truthfully.
+  the destination under the lease, compare its `SlotGenerationId` and
+  `ArchiveContentHash` with old/new expectations and retry durability where supported.
+  Do not delete a possibly published archive or blindly retry over it. Report
+  old/new/unresolved truthfully.
   Reconciliation has a separate operation/catalog revision; it does not rewrite the
   original immutable Failed/Unknown result into a retroactive success.
 
@@ -398,9 +446,10 @@ Temporary or migration files are never catalogued as save slots. Cleanup is not 
 from a synchronous EnumerateSaveSlots call. No portable crash guarantee is assumed
 for an unqualified filesystem/platform container.
 
-Cloud registration occurs only for the final validated local archive revision after
-PublishedDurable. It pins that version or revalidates its digest before transfer so
-a concurrent later save cannot be uploaded under an older revision ID. A bounded
+Cloud registration occurs only for the final validated local slot generation after
+PublishedDurable. It pins that generation or revalidates its `ArchiveContentHash`
+before transfer so a concurrent later save cannot be uploaded under an older
+generation. A bounded
 pending-sync record is reconstructed from the catalog on restart if the process dies
 between durable save and registration. Completed means local durability; cloud state
 (Pending/Synced/Failed) is separate and cannot turn local success into false rollback.
@@ -410,10 +459,10 @@ between durable save and registration. Completed means local durability; cloud s
 ### Prepare Without Mutating The Active Runtime
 
 1. Pin a read lease/version of the source archive. Bound/check the framing and outer
-   digest, enforce trusted signature policy, then decode metadata/chunks with all
-   length/hash/schema/identity checks. Verify project/account/world scope and base
-   AssetId/dataset/package dependencies. Browsing unverified headers shows untrusted
-   metadata, not an authenticated playable slot.
+   `ArchiveContentHash`, enforce trusted signature policy, then decode metadata/chunks
+   with all length/hash/schema/identity checks. Verify project/account/world scope and
+   base AssetId/dataset/package dependencies. Browsing unverified headers shows
+   untrusted metadata, not an authenticated playable slot.
 2. Migrate only detached staging data if needed. Workers deserialize ECS records,
    provider state, SlotPlayerState and persistent world deltas into a private
    PreparedRuntimeBundle. Pin provider registry and AssetRegistry revisions/leases.
@@ -526,23 +575,32 @@ peer quiescence/relevance and resynchronization policy are explicit prerequisite
 a server restore; old replication messages are fenced by the new runtime/session
 incarnation. Local cosmetic/client state must not overwrite server gameplay state.
 
-## Archive And Module Versioning
+## Archive, Schema And Product Compatibility
 
-Version axes are independent:
+The four version axes are independent:
 
 | Version | Authority / use |
 |---|---|
-| archiveFormatVersion | Envelope/container codec; preflight framing and archive migration |
-| moduleSchemaVersion | StableTypeId-keyed module payload codec, including ECS and slot player state |
-| base asset/dataset revision | Dependency/delta compatibility; not a module version |
-| engineVersion / projectBuildId | Bounded diagnostic metadata; not schema authority |
+| `ArchiveFormatVersion` | Horo-owned envelope, entry table and trailer codec; framing preflight and archive migration |
+| `SaveSchemaVersion` | Whole-save canonical root, required roles and cross-participant composition |
+| `ParticipantSchemaVersion` | StableTypeId-keyed participant payload codec and independent migration chain, including ECS and slot player state |
+| `ProductSaveCompatibilityVersion` | Product release's declared compatibility matrix/policy epoch; never a codec selector |
 
-SaveGameManifest contains a StableTypeId-sorted list of module entries with explicit
-schemaVersion, required flag and chunk IDs. It is not a string-keyed map of engine
-version aliases. Header metadata contains stable project/baseSceneAsset/slot/archive
-IDs; display names never select codecs or resolve base assets.
+Base asset/dataset revisions are semantic dependency identities, not schemas.
+`engineVersion`, `projectBuildId` and product semantic version are bounded diagnostic
+provenance; none determines readability. A newer engine build is not rejected solely
+by its build string.
 
-The inert SaveMigrationRegistry has two distinct step kinds:
+SaveGameManifest contains `SaveSchemaVersion`, `CanonicalStateHash` and a
+StableTypeId-sorted list of participant entries with explicit
+`ParticipantSchemaVersion`, required flag and chunk IDs. It is not a string-keyed map
+of engine-version aliases. Header metadata contains stable project, base-scene,
+logical-slot and `SlotGenerationId` values. Display names and timestamps never select
+codecs, resolve assets, establish causality or participate in logical-state identity.
+The header also records the producing `ProductSaveCompatibilityVersion` as policy
+provenance, never as a participant codec selector.
+
+The inert SaveMigrationRegistry has three distinct step kinds:
 
 ```cpp
 struct ArchiveMigrationStep {
@@ -550,46 +608,77 @@ struct ArchiveMigrationStep {
     ArchiveFormatVersion to;
     ArchiveMigrationFn migrate;
 };
-struct ModuleMigrationStep {
-    StableTypeId module;
-    ModuleSchemaVersion from;
-    ModuleSchemaVersion to;
-    ModuleMigrationFn migrate;
+struct SaveSchemaMigrationStep {
+    SaveSchemaVersion from;
+    SaveSchemaVersion to;
+    SaveSchemaMigrationFn migrate;
+};
+struct ParticipantMigrationStep {
+    StableTypeId participant;
+    ParticipantSchemaVersion from;
+    ParticipantSchemaVersion to;
+    ParticipantMigrationFn migrate;
 };
 ```
 
-Composition validates unique edges, supported deterministic paths, bounded resource
-costs and declared cross-module dependencies. Registry functions operate only on
-staging readers/writers, never on live ECS, account profiles or source files. Archive
-migration changes container structure; module migration advances only that module's
-schema (e.g. quests 7 -> 8 independently of inventory 2 -> 5). A newer engine build
-is not rejected solely by its build string: unsupported archive/required-module
-versions or missing migration paths determine compatibility. No implicit backward
-schema downgrade is permitted.
+Composition validates unique edges, complete deterministic paths, bounded resource
+costs and declared cross-participant dependencies, then seals a migration-catalog
+identity. Registry functions operate only on staging readers/writers, never on live
+ECS, account profiles or source files. Archive migration changes container structure;
+save-schema migration changes root composition; participant migration advances only
+that participant (for example quests 7 -> 8 independently of inventory 2 -> 5). No
+implicit backward schema downgrade is permitted.
+
+Compatibility preflight proceeds through framing/limits, archive version, outer
+integrity/signature, save schema, required participant set/schema, then semantic
+dependency identities and decoded hashes. Direct load is allowed only when every
+required axis is in the release manifest's inclusive direct-readable range. Migration
+is allowed only when every required axis is in a declared migration-source range and
+the sealed registry has one complete path to current directly readable writer
+versions. Unknown optional participants may be skipped only when no required
+participant depends on them. Missing/unknown required participants reject.
+
+Any newer archive format, save schema, required participant schema or product
+compatibility version outside the declared range fails with a typed unsupported-newer
+result before live mutation. Readers do not best-effort interpret forward input.
 
 Verify the original archive under its trusted signature policy **before** migration.
 Migrate into operation-owned staging and validate the output. For restore, an in-memory
-candidate may use a trusted deterministic migration of an authenticated source;
-that does not make newly serialized bytes carry the old signature. A durable upgraded
-archive always gets new hashes/signature and traverses the same finalize/flush/commit
-pipeline. Required signing without an authorized signer forbids durable replacement;
-it may still permit host-approved in-memory restore migration. Never copy the old
-signature onto changed payload or weaken Required to produce an upgrade.
+candidate may use a trusted deterministic migration of an authenticated source; that
+does not make newly serialized bytes carry the old signature. A durable upgraded
+archive always gets a new `SlotGenerationId`, `ArchiveContentHash`, signature and the
+current writer versions, then traverses the same finalize/flush/commit pipeline.
+`CanonicalStateHash` remains unchanged only if logical state and semantic dependency
+identities remain equivalent. Required signing without an authorized signer forbids
+durable replacement; it may still permit host-approved in-memory restore migration.
+Never copy the old signature onto changed payload or weaken Required for an upgrade.
 
 Original slots remain unchanged unless explicit user confirmation or captured host
-auto-upgrade policy authorizes replacement. Consent binds source archive revision,
-migration plan and destination namespace; revalidate under the slot lease before
-commit so a new save/cloud update is not overwritten by stale consent. Migration
-failure/cancellation only retires its staging. Unique sibling migration temporaries
-are not save slots and follow the same lease-aware cleanup/crash reconciliation.
+auto-upgrade policy authorizes replacement. Consent binds the source
+`SlotGenerationId`, `ArchiveContentHash`, migration plan and destination namespace;
+revalidate them under the slot lease before commit so a new save/cloud update is not
+overwritten by stale consent. Migration failure/cancellation only retires its staging.
+Unique sibling migration temporaries are not save slots and follow the same
+lease-aware cleanup/crash reconciliation.
 
-Legacy proposed checksumSha256/archiveSignature and player_profile.bin layouts have
-no mechanically valid implicit v1 interpretation. A supported older implementation
-needs an explicit versioned reader/migration with bounded verification and policy;
-otherwise reject UnsupportedArchiveVersion. Never guess whether self-referential
+Before product 1.0, each shipped preview declares exact supported ranges and retains
+fixtures for every claimed version; compatibility is not inferred across previews.
+From product 1.0, every stable release migrates saves from at least the previous two
+stable minor release lines and for at least 12 months after each source line's last
+release, whichever is longer. Patch releases cannot narrow ranges or remove migration
+paths. Later removal requires deprecation in two preceding stable minor release lines,
+release notes and a final bridge release. A security-blocked vulnerable decoder may
+shorten this only through an explicit release-manifest exception and typed security
+diagnostic, never a false corrupt-save result.
+
+Legacy proposed `checksumSha256`/`archiveSignature`, generic archive-revision,
+single-`saveFormatVersion` and `player_profile.bin` layouts have no mechanically valid
+implicit v1 interpretation. A supported older implementation needs an explicit
+versioned reader/migration with bounded verification and declared release policy;
+otherwise reject `UnsupportedArchiveVersion`. Never guess whether self-referential
 hashing or signature stripping was intended. Account-global data in an old slot is
-not restored into the account store; any explicit import is a separate user-authorized
-account migration with conflict/merge policy.
+not restored into the account store; any explicit import is a separate
+user-authorized account migration with conflict/merge policy.
 
 ## Storage Namespace And Path Safety
 
@@ -643,9 +732,11 @@ achievement/cloud-account APIs. Account policy may merge monotonic progression, 
 that is never an automatic rewind from slot_player_state.bin.
 
 Cloud adapters receive only final signed/unsigned archives allowed by the namespace
-policy. Conflict detection uses archive revision/content identity; timestamps are
-presentation metadata, not authority to overwrite local data. Conflict UI or headless
-host policy consumes typed local/remote revisions, times and play duration. Optional
+policy. Conflict detection compares `SlotGenerationId` lineage and
+`ArchiveContentHash`; `CanonicalStateHash` may show logical equivalence but cannot win
+a compare-and-swap. Timestamps are presentation metadata, not causality or authority
+to overwrite local data. Conflict UI or headless host policy consumes typed
+local/remote generations, content/state hashes, times and play duration. Optional
 game-specific summaries come from a bounded host presenter; engine code does not
 assume character levels or a Main Menu.
 
@@ -676,7 +767,7 @@ operation outcomes.
 | Capture budget/coherence failure | Defer under bounded policy or Failed; no live ECS freeze |
 | Write/full/signing failure before commit | Failed/NotCommitted; previous archive intact; owned temp eventually retired |
 | AtomicReplace or durability outcome uncertain | Failed/Unknown; reconcile/quarantine slot, no cloud publication or blind retry |
-| Corrupt digest/chunk / missing or invalid required signature | Failed before restore staging/publication |
+| Corrupt archive-content hash/chunk / missing or invalid required signature | Failed before restore staging/publication |
 | Missing asset / incompatible schema / required provider failure | Retire candidate; active runtime preserved |
 | Stale scene/registry/archive before commit | Reject candidate; never publish into a replacement incarnation |
 | Cancellation before commit gate | Cancelled/NotCommitted after owned work reaches safe terminal cleanup |
@@ -704,6 +795,10 @@ documentation change:
 - Byte fixtures for the 32-byte preamble, unsigned/signed trailer lengths, exact hash
   ranges and signature message. Tamper header, lengths, compressed bytes, raw chunks,
   trailer, algorithm/key ID and trailing data; verify no self-reference or post-commit edit.
+- Cross-platform/compiler golden canonical-state vectors, map ordering, negative zero,
+  non-finite policy and proof that timestamps/display/compression/generation do not
+  change `CanonicalStateHash` while covered archive-byte changes do change
+  `ArchiveContentHash`.
 - Required signature stripping, wrong project/account/world, untrusted key, signer
   timeout, malformed inputs, decompression bombs and unsupported schema versions.
 - Snapshot admission versus eventual worker failure, per-operation sticky outcomes,
@@ -715,8 +810,11 @@ documentation change:
   commit and asynchronous retirement under native fence delay.
 - Save/restore unloaded/resident/evicting cells, dropped-item/tombstone/cross-cell cases,
   bounded spill chunks, stale generations and changed base dataset revisions.
-- Independent archive/module migration paths, stale consent and signed migration
-  without signing authority; unchanged source on pre-publication failure.
+- Independent archive/save/participant migration paths, minimum support horizon,
+  current/oldest/one-newer fixtures, stale consent and signed migration without
+  signing authority; unchanged source on pre-publication failure.
+- Repeated equivalent-state publications with distinct `SlotGenerationId` values,
+  replica preservation, parent-generation compare-and-swap and timestamp skew.
 - Slot ID/path attack cases, symlink/reparse races, active-temp cleanup exclusion,
   other-process mutation, named-slot import and signed conflict-copy identity mapping.
 - Busy autosave coalescing, bounded retry exhaustion, rotation only after success,
@@ -745,4 +843,5 @@ and regression coverage.
 - [ADR-010](../../adr/010-job-waiting-and-operation-store-ownership.md): OperationStore and non-blocking work.
 - [ADR-012](../../adr/012-world-streaming-partition-authority-and-subsystem-boundaries.md): Cell authority and barriers.
 - [ADR-008](../../adr/008-error-model-exception-boundary-and-registry.md): Typed error propagation.
+- [ADR-112](../../adr/112-save-archive-container-and-compatibility-policy.md): Portable container, canonical state, version axes, identities and compatibility horizon.
 - [Application Security](../security/application-security.md): Trust and untrusted-input boundaries.


### PR DESCRIPTION
## Summary

- Freezes the portable HoroSave v1 container and canonical logical-state rules.
- Separates `ArchiveFormatVersion`, `SaveSchemaVersion`, `ParticipantSchemaVersion`, and `ProductSaveCompatibilityVersion`.
- Defines distinct `CanonicalStateHash`, `ArchiveContentHash`, and `SlotGenerationId` semantics.
- Expands release manifests to represent direct-read, migration-source, and forward-reject policy with an explicit support horizon.

## Why

The existing save design conflated logical state, archive-byte integrity, and durable slot publication under generic revision/digest language. It also reduced release compatibility to one save-format number, which could not safely represent independent container and participant evolution.

## Decision and boundaries

- Adds ADR-112 and updates the normative save, release, distribution, and architecture indexes.
- HoroSave fields are explicitly encoded and endian-defined; C++ layout, padding, native enums, pointers, unordered iteration, locale, and volatile publication metadata cannot define logical state.
- Newer unsupported archive/save/required-participant versions fail closed before live mutation.
- Stable products must retain migration support for at least two prior minor lines and 12 months, with explicit deprecation/bridge requirements.
- Mutable catalog labels/categories remain outside the archive transaction.

This PR defines the format and compatibility contract; codec, migration registry, release-schema, and fixture implementation remain follow-up work.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Markdown lint passed
- [x] Added Markdown links resolve
- [x] Staged diff checks passed
- [x] CMake configure passed
- [ ] Full build/test suite not run; this is a documentation-only decision

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- <changed-markdown-files>
git diff --check
git diff --cached --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- The two-minor/12-month compatibility floor is a product policy commitment and deserves explicit reviewer agreement.
- Cross-platform canonical fixtures and migration coverage are required before runtime saves can ship.
- CMake reported the existing mbedTLS deprecation warning and skipped repository Python tests because pytest is unavailable.

## Issue links

- Jira: HORO-1410
- GitHub: Closes #1410

## Reviewer Notes

Review ADR-112 first, then the save architecture’s canonical-state/container sections, and finally the release-manifest projection. Focus on the three identity boundaries and the four independent version axes.