### PR TITLE
docs(save): define local storage ownership HORO-1425 #1425 [SAV-003.1]

### DIFF
--- a/docs/adr/112-save-archive-container-and-compatibility-policy.md
+++ b/docs/adr/112-save-archive-container-and-compatibility-policy.md
@@ -209,8 +209,8 @@ endianness, hashes, signatures and generation conflict behavior.
 
 - Canonical codecs and migration registries need golden cross-platform fixtures.
 - Release composition must validate participant ranges and migration coverage.
-- Every durable publication must finalize metadata before hashing/signing and cannot
-  patch timestamps or catalog fields afterward.
+- Every durable publication must finalize archive metadata before hashing/signing;
+  mutable catalog labels/categories remain outside the archive transaction.
 
 ## Rejected Alternatives
 

--- a/docs/adr/113-local-storage-user-profile-and-slot-ownership.md
+++ b/docs/adr/113-local-storage-user-profile-and-slot-ownership.md
@@ -1,0 +1,287 @@
+# ADR-113: Local Storage, User Profile and Slot Ownership
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Product and environment storage identity, platform-user partitions, game-profile ownership, save categories, logical slot addressing, physical storage mapping, multi-user fallback, profile switching and cloud/UI boundaries
+- **Issue**: [SAV-003.1](https://github.com/abdullahbodur/horo-engine/issues/1425)
+- **Jira**: [HORO-1425](https://horo-engine.atlassian.net/browse/HORO-1425)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-010](010-job-waiting-and-operation-store-ownership.md), [ADR-112](112-save-archive-container-and-compatibility-policy.md)
+- **Normative documents**: [Save Game And Persistence](../architecture/runtime/save-game-and-persistence.md), [Platform Services](../architecture/runtime/platform-services-architecture.md), [Platform Abstraction](../architecture/foundation/platform-abstraction.md)
+
+## Context
+
+The runtime save service owns capture/restore, ADR-112 separates logical state,
+archive content and publication generation, and the storage adapter owns safe durable
+file operations. The remaining namespace language still combines project, account,
+user and environment informally. The platform-services cloud example also represents
+a slot as a free-form string.
+
+Display product names, executable paths, platform gamertags and save labels are not
+stable or safe storage keys. Platform backends vary from no user concept, through one
+current user, to several concurrently signed-in users. PIE, development and packaged
+production builds must not discover each other's save files by accident. UI and cloud
+sync need stable addressing, but neither should receive a host path.
+
+A game profile is also not the platform account itself. One platform user may own
+multiple game profiles, an offline installation may have no platform identity, and
+account linking/import must not silently retarget existing slots. The ownership and
+switching transaction must be fixed before slot lifecycle and cloud synchronization
+build on it.
+
+## Decision
+
+### 1. Save addressing is a typed hierarchy
+
+The domain uses distinct nonzero opaque identities:
+
+```cpp
+struct ProductStorageId { Uuid value; };
+struct EnvironmentStorageId { Uuid value; };
+struct LocalUserStorageId { Uuid value; };
+struct GameProfileId { Uuid value; };
+struct ServerStorageOwnerId { Uuid value; };
+struct SaveGameSlotId { Uuid value; };
+
+using SaveOwnerId = Variant<UserProfileOwner, ServerWorldOwner>;
+
+struct SaveNamespaceId {
+    ProductStorageId product;
+    EnvironmentStorageId environment;
+    SaveOwnerId owner;
+};
+
+struct SaveAddress {
+    SaveNamespaceHandle namespaceHandle;
+    SaveGameSlotId slot;
+};
+```
+
+`UserProfileOwner` contains one `LocalUserStorageId` and one `GameProfileId`.
+`ServerWorldOwner` contains one `ServerStorageOwnerId` and stable world/tenant scope.
+The variant prevents a dedicated-server world from masquerading as a client profile.
+
+`SaveNamespaceHandle` is a generation-checked runtime capability obtained from the
+active profile/session binding. Callers do not construct it from IDs. `SaveAddress`
+is sufficient for Runtime Save, catalog UI and cloud-sync coordination; it contains
+no path, filename, display label, platform SDK handle or personally identifiable
+value.
+
+IDs are scoped by their parent tuple. Implementations may allocate UUIDs globally,
+but correctness does not assume a profile or slot ID is unique outside its product,
+environment and owner namespace.
+
+### 2. Product and environment identities are configuration authority
+
+`ProductStorageId` is assigned once in product/project configuration and copied into
+release manifests. Product display name, publisher text, bundle/executable name,
+install directory, semantic version, branch and update channel do not derive or
+change it. A deliberate product fork allocates a new ID and uses explicit import if
+old saves are supported; copying a project directory does not silently create a new
+storage identity.
+
+`EnvironmentStorageId` partitions storage policy. Packaged production releases that
+are intended to share saves across updates use the same production environment ID.
+Developer standalone, automated tests, editor preview and PIE use explicitly distinct
+IDs. Each PIE session receives an ephemeral unique environment ID. A staging/channel
+build shares production storage only through an explicit product policy reviewed as a
+compatibility/security choice, never because executable names match.
+
+The application composition root validates both identities before constructing save
+or profile services. Missing, zero or duplicated product/environment configuration
+fails save capability admission; no fallback uses the current directory or product
+name.
+
+### 3. Platform users map to private local storage partitions
+
+Platform Services owns the live `PlatformUserHandle` and authentication session. A
+game identity/profile service maps that handle, within the selected platform backend,
+to a persistent opaque `LocalUserStorageId`. It stores no gamertag, email, display
+name or raw provider token in directory names. A handle from one backend/provider
+namespace is never compared directly with another backend's handle.
+
+A backend claiming multi-device/cloud persistence provides a stable opaque
+authenticated-user scope so the same provider account maps consistently on each
+device. If it cannot, cloud save is unavailable and local fallback uses an
+installation-local identity. Hashing a mutable gamertag or email is never a fallback.
+
+The platform adapter reports one of these capabilities:
+
+| Capability | Required behavior |
+|---|---|
+| `SingleLocalUser` | No stable platform-user selection exists. Bind one installation-local user partition; platform-user switching returns `NotSupported`. |
+| `CurrentPlatformUser` | Exactly the authenticated/current platform user may be bound. Sign-out closes that binding; another user cannot inherit it. |
+| `MultiplePlatformUsers` | The host may select among explicit signed-in handles; every selected handle maps to a distinct local partition. |
+
+Lack of multi-user capability never means all platform users share a guessed global
+directory. An offline/guest partition is a distinct installation-local identity. A
+later sign-in does not merge, rename or re-own guest data automatically; the product
+may offer an explicit verified import/copy transaction.
+
+If a platform cannot provide a stable user mapping across launches, it advertises
+`SingleLocalUser` or an unavailable persistence capability. It must not hash a mutable
+display name and claim durable multi-user isolation.
+
+### 4. The profile service owns game profiles, not save files
+
+Within one local-user partition, the game profile service owns the profile catalog,
+`GameProfileId`, display metadata, account association and which profile is active.
+It may support one default profile or multiple profiles according to product policy.
+Platform Services does not create/select a game profile, and Runtime Save does not
+own account linking or profile metadata.
+
+Profile/account data such as settings, accessibility, achievements and account-wide
+statistics is stored through the profile authority in a separate schema and
+transaction domain. Runtime slot state may reference its owning profile namespace but
+loading an old slot cannot roll back the profile store. Deleting a slot does not
+delete a profile; deleting a profile is a higher-level confirmed operation that first
+closes its namespace and applies retention/cloud policy.
+
+Moving/copying a profile across local users or products is explicit migration/import.
+It validates destination ownership, archive scope and compatibility, allocates new
+destination slot publications where required, and preserves source data until the
+transaction succeeds. Rebinding the same IDs or renaming directories is forbidden.
+
+### 5. Save category and display metadata do not identify a slot
+
+`SaveGameSlotId` is the logical slot identity. It is unrelated to
+`SlotGenerationId`: the former survives overwrites, while ADR-112 allocates the latter
+for each durable publication. A slot catalog record contains its typed ID, category,
+bounded display metadata, latest generation/content/state identities and lifecycle
+state.
+
+`SaveCategoryId` is typed policy metadata such as Manual, Quick, Auto, Checkpoint or a
+registered product category. It controls capacity, rotation, overwrite and UI
+presentation. A quicksave alias or autosave ring maps to slot IDs in the catalog;
+neither is a filename. Reclassification changes catalog metadata transactionally and
+does not change slot identity or require a new archive publication.
+
+Display names are bounded UTF-8 user metadata and may be duplicated, localized or
+changed. UI selection always retains `SaveAddress`; it never loads/deletes by row
+index, label or timestamp.
+
+### 6. Only the storage adapter maps namespaces to physical storage
+
+The platform abstraction resolves an application state root for the validated
+`ProductStorageId`. `SaveStorageAdapter` exclusively maps
+`SaveNamespaceId + SaveGameSlotId` to storage. On ordinary filesystems the conceptual
+shape is:
+
+```text
+<product-state-root>/
+  <environment-id>/
+    <owner-id>/
+      catalog
+      slots/<save-slot-id>.horosave
+      staging/<owned-operation-id>.temporary
+```
+
+Every component uses a fixed lossless filesystem-safe encoding of its opaque ID.
+Free-form product/user/profile/category/slot labels are never path components. The
+adapter validates containment and no-follow semantics and owns catalog publication,
+per-slot leases, temporary naming, atomic replacement, durability reconciliation and
+cleanup. Secure consoles may map the same typed keys to container records without
+exposing any path.
+
+The profile/account store, cloud retry journal, editor recovery, authored project and
+PIE sandbox are separate sibling/virtual namespaces with separate owners and schemas.
+They cannot share a live catalog or mutation lease merely because they use the same
+platform root.
+
+### 7. User/profile switching is an owner transaction
+
+The application/session owner performs a switch in this order:
+
+1. close new save, load, delete, import and cloud-apply admission for the old binding;
+2. request cooperative cancellation for pre-commit work and boundedly settle or
+   retain ownership for work already beyond its commit gate;
+3. stop cloud scheduling for the old namespace, release catalog/slot leases and
+   invalidate its `SaveNamespaceHandle` generation;
+4. bind the selected platform user and game profile, validate product/environment,
+   open its catalog and publish a new immutable catalog snapshot; then
+5. reopen admission and cloud scheduling for the new binding.
+
+No operation changes namespace in flight. Completions capture the old namespace
+generation and may finalize/report only against that authority; they cannot update the
+new user's UI/catalog. Sign-out follows the same close path. A post-commit local save
+may finish in the old namespace but cannot be uploaded under the new platform user.
+
+Failure opening the new profile leaves save capability in an explicit NoActiveProfile
+state. The host may rebind the old profile through a new transaction; it does not keep
+half of each binding active. UI surface closure never switches or destroys a profile.
+
+### 8. UI and cloud consume typed projections, not filesystem knowledge
+
+Catalog UI receives immutable bounded records keyed by `SaveAddress` and submits
+typed commands with expected namespace/catalog revisions. It receives presentation
+metadata and typed status, never local paths, raw platform handles or mutable catalog
+objects.
+
+The save/cloud coordinator derives a bounded `CloudSaveObjectKey` from the typed
+product/environment/profile/slot address and authenticated provider-user context;
+installation-local user IDs and host paths are not serialized into it. Platform
+Services treats that key and finalized archive as opaque. Gameplay/UI cannot submit
+arbitrary strings as cloud object keys, and the backend cannot resolve or edit a local
+path. Replicas retain the archive's logical slot/generation identity; importing into
+a different typed namespace is a Runtime Save operation, not a provider rename.
+
+This decision freezes addressing and ownership only. The cloud authority, provider
+revision/write preconditions, offline state and divergent-generation resolution are
+owned by SAV-006. Provider timestamps remain presentation/provenance and are not an
+automatic selection rule.
+
+### 9. Qualification proves isolation and switching
+
+Required evidence includes:
+
+- two products with identical display/executable names, two environment IDs and two
+  local users with identical display names never collide;
+- `SingleLocalUser`, current-user and multi-user capabilities, sign-out/restart,
+  unavailable stable identity and guest-to-signed-in import behavior;
+- multiple profiles per user, duplicate/renamed display labels, category changes,
+  quicksave/autosave aliases and slot overwrites without identity confusion;
+- switch races before and after the commit gate, stale async completions, catalog
+  open failure, cloud retry suspension and no cross-user UI publication;
+- traversal, symlink/reparse, case, non-ASCII metadata and malformed/duplicate catalog
+  attacks without using labels as paths;
+- production/development/PIE/test/server isolation and explicit approved sharing; and
+- UI/cloud operations using typed addresses on filesystem and secure-container test
+  adapters with no path exposure.
+
+## Consequences
+
+### Positive
+
+- Product, user, profile and environment boundaries prevent accidental storage
+  collision.
+- Platforms without multi-user support have explicit safe behavior.
+- Slot/category/display/publication concepts are no longer conflated.
+- UI and cloud sync remain portable across filesystem and secure-container backends.
+
+### Costs
+
+- Product configuration needs stable storage IDs and fork/import tooling.
+- Identity/profile services need persistent platform-user mapping and switch fencing.
+- Catalog and cloud adapters must translate typed addresses without leaking paths.
+
+## Rejected Alternatives
+
+### Build paths from product, user or save display names
+
+Rejected because names are mutable, non-unique, locale-sensitive and unsafe as
+cross-platform path identity.
+
+### Treat the current platform user as the game profile
+
+Rejected because offline platforms, multiple game profiles, account linking and
+dedicated servers have different ownership and lifetime.
+
+### Use quicksave/manual/autosave names as slot IDs
+
+Rejected because category and presentation change independently while a logical slot
+must survive overwrites and retain generation lineage.
+
+### Give UI or cloud backends local save paths
+
+Rejected because it bypasses namespace validation, leases, secure containers and the
+single storage authority.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -124,6 +124,7 @@ to the replacement.
 | [110](110-navigation-editor-surface-and-command-ownership.md) | Navigation Editor Surface and Command Ownership | Proposed | 2026-09-02 |
 | [111](111-gameplay-ai-document-panel-and-runtime-debug-ownership.md) | Gameplay AI Document, Panel and Runtime-Debug Ownership | Proposed | 2026-09-02 |
 | [112](112-save-archive-container-and-compatibility-policy.md) | Save Archive Container and Compatibility Policy | Proposed | 2026-09-02 |
+| [113](113-local-storage-user-profile-and-slot-ownership.md) | Local Storage, User Profile and Slot Ownership | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -311,6 +311,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Save Archive Container and Compatibility Policy](../adr/112-save-archive-container-and-compatibility-policy.md):
   portable framing, canonical logical state, independent version axes, typed
   state/content/publication identities, release declarations and support horizon.
+- [Local Storage, User Profile and Slot Ownership](../adr/113-local-storage-user-profile-and-slot-ownership.md):
+  product/environment/user/profile namespaces, slot/category identity, path
+  authority, multi-user fallback and profile-switch fencing.
 - [Navigation And AI Architecture](./runtime/navigation-and-ai-architecture.md):
   NavMesh, pathfinding, dynamic obstacle overlays, perception, crowd, blackboard,
   and editor bake tooling.

--- a/docs/architecture/foundation/platform-abstraction.md
+++ b/docs/architecture/foundation/platform-abstraction.md
@@ -105,6 +105,14 @@ Callers never build these paths from `$HOME`, `%APPDATA%`, or platform-specific
 string literals. Locations follow platform conventions and the storage policies
 in the owning architecture documents.
 
+Application state roots are opened for a validated `ProductStorageId`; product
+display name, executable path and current working directory are not storage identity.
+Platform Abstraction returns a root/container capability only. Under
+[ADR-113](../../adr/113-local-storage-user-profile-and-slot-ownership.md), the save
+storage adapter alone maps environment, local-user/game-profile or server owner and
+logical slot IDs beneath that capability. UI, gameplay and cloud backends never
+receive the resulting host path.
+
 ## Window And Event Pump
 
 Window creation is optional. A window owns:
@@ -305,6 +313,8 @@ Required tests cover:
 - [Concurrency And Job System](./concurrency-and-jobs.md)
 - [Input Architecture](../runtime/input-architecture.md)
 - [Android Platform Host](./android-platform-host.md)
+- [ADR-113](../../adr/113-local-storage-user-profile-and-slot-ownership.md): product
+  state roots and save namespace/path ownership.
 - [XR Architecture](../runtime/vr-ar-architecture.md)
 - [Release Security](../release/release-security.md)
 - [Extension System](../extensions/plugin-system.md)

--- a/docs/architecture/runtime/platform-services-architecture.md
+++ b/docs/architecture/runtime/platform-services-architecture.md
@@ -108,10 +108,10 @@ public:
     GetLeaderboardEntries(LeaderboardId id, const LeaderboardQuery& query);
 
     PlatformServiceRequest<CloudSaveMetadata>
-    ReadCloudSave(SaveSlotId slot);
+    ReadCloudSave(CloudSaveObjectKey key);
 
     PlatformServiceRequest<void>
-    WriteCloudSave(SaveSlotId slot, std::span<const std::byte> data);
+    WriteCloudSave(CloudSaveObjectKey key, std::span<const std::byte> data);
 
     PlatformServiceRequest<void>
     SetPresence(const PresenceState& state);
@@ -311,41 +311,43 @@ replacement for the local save system; it is an upload/download layer on top of
 local save files.
 
 ```cpp
-struct SaveSlotId { StableString value; };
+struct CloudSaveObjectKey { BoundedOpaqueBytes value; };
+struct ProviderObjectRevision { BoundedOpaqueBytes value; };
 
 struct CloudSaveMetadata {
-    SaveSlotId slot;
-    Timestamp modifiedTime;
+    CloudSaveObjectKey key;
+    ProviderObjectRevision revision;
+    Timestamp modifiedTime; // presentation/provenance only, never causality
     uint64_t sizeBytes;
 };
 
 class ICloudSaveService {
 public:
-    virtual PlatformServiceRequest<CloudSaveMetadata>
+    virtual PlatformServiceRequest<std::vector<CloudSaveMetadata>>
     List() = 0;
 
     virtual PlatformServiceRequest<std::vector<std::byte>>
-    Read(SaveSlotId slot) = 0;
+    Read(CloudSaveObjectKey key) = 0;
 
     virtual PlatformServiceRequest<void>
-    Write(SaveSlotId slot, std::span<const std::byte> data) = 0;
+    Write(CloudSaveObjectKey key, std::span<const std::byte> data) = 0;
 
     virtual PlatformServiceRequest<void>
-    Delete(SaveSlotId slot) = 0;
+    Delete(CloudSaveObjectKey key) = 0;
 };
 ```
 
-Conflict resolution is configured per project:
+Under ADR-113, gameplay and UI never create `CloudSaveObjectKey` from a string. The
+save/cloud coordinator derives it from the typed product/environment/profile/slot
+address and authenticated provider-user context. Installation-local user IDs are not
+serialized into it. It is not a local path, display name or `SaveGameSlotId` with
+erased scope. The backend treats both key and finalized archive bytes as opaque and
+never edits the local format or catalog.
 
-```text
-prefer_local   -- local save wins, upload overwrites cloud
-prefer_cloud   -- cloud save wins, download overwrites local
-most_recent    -- compare timestamps, newer wins
-manual         -- prompt the player (UI owns the choice)
-```
-
-The engine calls `Read` at game start and `Write` after the local save system
-commits a new save. Cloud save never directly edits the local save format.
+Provider revisions and timestamps are returned as transport metadata. They do not
+select a winning local/cloud generation automatically. SAV-006 owns write
+preconditions, offline authority and divergent-generation resolution; UI may present
+a choice but never becomes sync authority.
 
 ### Presence
 
@@ -534,6 +536,13 @@ The null backend is always available. It:
 Platform services do not own the game user account. They expose a platform user
 handle that the game identity layer can map to its own player profile.
 
+ADR-113 requires that mapping to produce a private provider-scoped
+`LocalUserStorageId` and then select a product-owned `GameProfileId`. Raw platform
+handles, gamertags, emails and display names are not save-directory or cloud-slot
+identity. Backends explicitly report single-local-user, current-user-only or
+multi-user capability; unsupported switching returns `not_supported` rather than
+sharing a guessed user namespace.
+
 ```cpp
 struct PlatformSessionState {
     bool signedIn;
@@ -696,7 +705,8 @@ Configuration authority lives in Project Settings:
 
 - active platform backend selection
 - achievement, leaderboard, stat, and presence stable ID tables
-- cloud save conflict resolution policy
+- cloud save capability, timeout and retry policy; conflict resolution authority is
+  owned by the save/cloud coordinator
 - per-service timeout and retry policy
 - offline queue persistence settings
 
@@ -722,7 +732,8 @@ Required tests cover:
 - offline queue persists and replays in order
 - request cancellation does not leak state
 - stable ID registries reject unregistered names
-- cloud save conflict resolution strategies
+- typed cloud-object addressing, provider revision propagation and no timestamp-based
+  automatic winner selection
 - session sign-in/out triggers queue replay and state callbacks
 - unavailable services return `not_supported`
 - presence updates coalesce to the most recent state
@@ -768,5 +779,7 @@ Platform-specific backend tests live in the private platform repositories.
 - [Audio Architecture](./audio-architecture.md)
 - [Input Architecture](./input-architecture.md)
 - [Platform Abstraction Architecture](../foundation/platform-abstraction.md)
+- [ADR-113](../../adr/113-local-storage-user-profile-and-slot-ownership.md): product,
+  user/profile and logical-slot addressing across local and cloud boundaries.
 - [Extension System](../extensions/plugin-system.md)
 - [Release Security](../release/release-security.md)

--- a/docs/architecture/runtime/save-game-and-persistence.md
+++ b/docs/architecture/runtime/save-game-and-persistence.md
@@ -8,6 +8,8 @@ HORO-1391 #1391 [SAV-001.1]. These are normative implementation requirements; th
 complete save service/archive protocol is not claimed as implemented by this change.
 ADR-112 freezes the portable archive, canonical state, identity and compatibility
 policy for HORO-1410 #1410 [SAV-002.1].
+ADR-113 freezes product/environment/user/profile namespaces, logical slot addressing
+and storage mapping for HORO-1425 #1425 [SAV-003.1].
 
 - RuntimeSaveService coordinates one runtime save/restore authority under the
   application/session lifetime. It never retains an unleased reference to a scene
@@ -90,7 +92,16 @@ cannot unload codecs under a worker or register through ambient service discover
 Schematic interface shapes (not new installed headers):
 
 ```cpp
+struct ProductStorageId { Uuid value; };
+struct EnvironmentStorageId { Uuid value; };
+struct LocalUserStorageId { Uuid value; };
+struct GameProfileId { Uuid value; };
 struct SaveGameSlotId { Uuid value; }; // nonzero opaque identity, never a path
+struct SaveNamespaceHandle { GenerationCheckedHandle value; };
+struct SaveAddress {
+    SaveNamespaceHandle namespaceHandle;
+    SaveGameSlotId slot;
+};
 struct SaveOperationHandle { OperationId value; };
 struct RestoreOperationHandle { OperationId value; };
 struct CanonicalStateHash { Sha256 value; };
@@ -107,7 +118,7 @@ enum class SaveCommitOutcome : uint8_t {
 };
 struct SaveOperationSnapshot {
     OperationId operation;
-    SaveGameSlotId slot;
+    SaveAddress address;
     SaveOperationPhase phase;
     SaveCommitOutcome commitOutcome;
     float progress;
@@ -117,7 +128,7 @@ struct SaveOperationSnapshot {
     OptionalArchiveContentHash archiveContent;
 };
 struct SaveRequest {
-    BoundedUtf8 displayName;       // metadata only, never a filename
+    BoundedUtf8 displayName;       // catalog metadata only, never archive/path identity
     SaveRequestKind kind;         // manual, quicksave, autosave
     ThumbnailPolicy thumbnail;   // optional/omitted or explicitly required
 };
@@ -125,14 +136,14 @@ struct SaveRequest {
 class RuntimeSaveService final {
 public:
     RuntimeSaveService(IRuntimeSessionHost&, SaveProviderRegistry&,
-                       SaveStorageAdapter&, PlatformServices&, JobSystem&,
-                       OperationStore&);
+                       SaveStorageAdapter&, SaveNamespaceBinding&,
+                       PlatformServices&, JobSystem&, OperationStore&);
     Result<SaveOperationHandle> SaveSlotAsync(
-        SaveGameSlotId, SaveRequest, CancellationToken);
+        SaveAddress, SaveRequest, CancellationToken);
     Result<RestoreOperationHandle> LoadSlotAsync(
-        SaveGameSlotId, RestoreRequest, CancellationToken);
+        SaveAddress, RestoreRequest, CancellationToken);
     Result<OperationId> RefreshCatalogAsync(CancellationToken);
-    Result<OperationId> DeleteSlotAsync(SaveGameSlotId, CancellationToken);
+    Result<OperationId> DeleteSlotAsync(SaveAddress, CancellationToken);
     SaveCatalogSnapshot GetCatalogSnapshot() const; // cached immutable data; no I/O
     Result<SaveOperationSnapshot> GetOperationSnapshot(OperationId) const;
     void PumpOwnerThread();              // bounded record drain; never filesystem I/O
@@ -297,7 +308,7 @@ JSON reserialized by the reader.
 
 | Logical payload entry | Content |
 |---|---|
-| header.json | Logical slot ID, `SlotGenerationId`, optional parent generation, producing `ProductSaveCompatibilityVersion`, project/world/account scope, baseSceneAsset, timestamps, display name and slot kind |
+| header.json | Logical slot ID, `SlotGenerationId`, optional parent generation, producing `ProductSaveCompatibilityVersion`, project/world/account scope, baseSceneAsset and bounded provenance timestamps |
 | manifest.json | `SaveSchemaVersion`, `CanonicalStateHash`, StableTypeId-sorted participant/chunk IDs, each `ParticipantSchemaVersion`, required flags, lengths, codecs and per-chunk SHA-256 |
 | runtime_ecs.bin | Stable authored/spawn identities, dynamic components, tombstones and reference remap records |
 | gameplay module entries | Each registered module's versioned state |
@@ -680,42 +691,127 @@ hashing or signature stripping was intended. Account-global data in an old slot 
 not restored into the account store; any explicit import is a separate
 user-authorized account migration with conflict/merge policy.
 
-## Storage Namespace And Path Safety
+## Product, User, Profile And Slot Storage
 
-SaveGameSlotId is an opaque nonzero UUID. Quicksave/autosave/manual names are catalog
-labels mapping to IDs, not filename strings accepted from gameplay. SaveStorageAdapter
-alone formats the canonical UUID filename in a trusted project/account/environment
-namespace. Runtime APIs accept no raw path; displayName is bounded validated UTF-8
-metadata and never concatenated into a path. Existing named slots require an explicit
-catalog import/mapping, not silently treating a name as a path.
+### Typed namespace hierarchy
 
-The adapter resolves the trusted save root and enforces containment using safe
-handle-relative/no-follow platform operations, not a string prefix test. Reject
-symlink/reparse redirection, traversal, alternate-stream/device/path separators and
-unexpected file types at the storage boundary. Temporary names include operation
-identity and are created exclusively in the same storage namespace/filesystem.
-Never follow entry names or embedded paths from the archive into the filesystem.
-Authorized imports copy untrusted input through bounded verification into that namespace.
+`ProductStorageId` is stable product configuration copied into release metadata; it
+is never derived from display name, executable/install path, semantic version, branch
+or update channel. `EnvironmentStorageId` explicitly separates production,
+development, tests and each unique PIE session. A product fork allocates a new product
+ID and imports old saves deliberately. Missing/zero identities disable save admission
+rather than falling back to a current directory or name.
 
-Mutations acquire a namespace/slot lease that covers final source/destination checks
-and publication; other processes/cloud adapters use the same locking/version protocol.
-Credentials, scope authority and lock paths come from trusted host composition, not
-archive metadata. Cleanup only targets owned temporary records under a valid lease;
-a wildcard sweep must not unlink another process's active work. Catalog/delete/import
-operations apply the same typed-ID, containment and generation checks.
+The namespace owner is a typed variant. A client `UserProfileOwner` combines one
+opaque `LocalUserStorageId` with one product-owned `GameProfileId`. A dedicated/headless
+`ServerWorldOwner` combines a `ServerStorageOwnerId` with stable world/tenant scope.
+The resulting `SaveNamespaceId { product, environment, owner }` is opened by the
+application/profile owner and exposed to Runtime Save as a generation-checked
+`SaveNamespaceHandle`. Callers cannot construct a handle from raw IDs.
 
-Foundation's existing path-based DurableFileSystem primitives are building blocks,
-not proof that all no-follow/containment/outcome guarantees already exist. SaveStorageAdapter
-must implement and qualify these platform guarantees before a production save path
-is enabled. Secure console/cloud containers may map IDs to platform records rather
-than expose host filesystem paths, while preserving the same transaction outcomes.
+Platform Services owns live platform authentication handles. The game identity/profile
+service privately maps a provider-scoped handle to `LocalUserStorageId`; gamertag,
+email, display name and raw provider tokens are never directory components. It owns
+the per-user profile catalog, active `GameProfileId`, account association and profile
+display metadata. Runtime Save owns slot operations, not user sign-in, profile
+creation/linking or profile-store state.
+
+When multi-device/cloud persistence is advertised, the backend must provide a stable
+opaque authenticated-user scope so the same platform account maps consistently on
+each device. If it cannot, cloud persistence is unavailable and local fallback uses
+an installation-local partition; mutable user text is never hashed as a substitute.
+
+Platform user capability is explicit:
+
+| Capability | Behavior |
+|---|---|
+| `SingleLocalUser` | Bind one installation-local user partition. Platform-user selection/switching returns `NotSupported`; multiple product profiles may still be allowed. |
+| `CurrentPlatformUser` | Bind only the authenticated current user; sign-out closes the binding and no new user inherits it. |
+| `MultiplePlatformUsers` | Select an explicit signed-in handle; each maps to a distinct local partition. |
+
+Guest/offline storage is its own installation-local user partition. Later sign-in does
+not merge or re-own it automatically. Cross-user/product profile movement is an
+explicit verified import/copy transaction that preserves source data until destination
+publication succeeds.
+
+### Slot, category and catalog identity
+
+`SaveGameSlotId` is an opaque nonzero UUID scoped to its namespace and remains stable
+across overwrites. ADR-112's `SlotGenerationId` instead identifies one durable
+publication to that slot. `SaveAddress { namespaceHandle, slot }` is the only runtime,
+UI and cloud-coordinator address; it contains no path or label.
+
+Manual, Quick, Auto, Checkpoint and registered product `SaveCategoryId` values are
+catalog policy controlling capacity, rotation, overwrite and presentation. Quicksave
+aliases and autosave rings map to slot IDs. Category, display name, list index and
+timestamp never identify a slot or form a filename. Reclassification changes catalog
+metadata transactionally without changing slot identity or archive bytes.
+
+The storage authority owns one immutable revisioned catalog projection per open
+namespace. Records include address, category, bounded presentation metadata, current
+generation/content/state identities and lifecycle state. UI retains addresses and
+expected catalog revisions; it never loads/deletes by label, timestamp or row index.
+
+### Physical mapping and safety
+
+Platform Abstraction resolves a product state root for the validated
+`ProductStorageId`. SaveStorageAdapter alone maps
+`SaveNamespaceId + SaveGameSlotId` to storage. The conceptual filesystem shape is:
+
+```text
+<product-state-root>/
+  <environment-id>/
+    <owner-id>/
+      catalog
+      slots/<save-slot-id>.horosave
+      staging/<owned-operation-id>.temporary
+```
+
+Every component uses a fixed lossless filesystem-safe encoding of its opaque identity.
+Free-form product/user/profile/category/slot labels are never path components. Secure
+console containers may map the same typed keys to records without exposing paths.
+
+The adapter enforces containment using safe handle-relative/no-follow platform
+operations, not a string prefix test. Reject symlink/reparse redirection, traversal,
+alternate-stream/device/path separators and unexpected file types. Never follow entry
+names or embedded paths from the archive into the filesystem. Authorized imports copy
+untrusted input through bounded verification into the destination namespace.
+
+Mutations acquire a namespace/slot lease covering final source/destination checks and
+publication; other processes/cloud coordination use the same locking/generation
+protocol. Credentials, scope authority and lock paths come from trusted composition,
+not archive metadata. Cleanup only targets owned temporary records under a valid
+lease; a wildcard sweep must not unlink another process's active work. Catalog,
+delete and import apply the same typed-ID, containment and generation checks.
+
+Foundation's path-based DurableFileSystem primitives are building blocks, not proof
+that no-follow/containment/outcome guarantees exist. SaveStorageAdapter must implement
+and qualify them before production saves are enabled. Profile/account storage, cloud
+retry journals, editor recovery, authored projects and PIE sandboxes remain distinct
+sibling/virtual namespaces with separate schemas and mutation leases.
+
+### Profile-switch transaction
+
+The application/session owner closes old save/load/delete/import/cloud-apply admission,
+cancels pre-commit work, boundedly settles or retains ownership for post-commit work,
+stops old cloud scheduling, releases catalog/slot leases and invalidates the old
+namespace handle generation. It then binds the selected user/profile, validates the
+product/environment, opens its catalog, publishes a new snapshot and reopens admission.
+
+Operations never change namespace in flight. Completion captures the old handle
+generation and can report/finalize only against that authority, never update the new
+profile's catalog/UI. A local save already past commit may finish in the old namespace
+but cannot upload under the new platform user. Sign-out uses the same close path.
+Failure to open the new catalog yields explicit `NoActiveProfile`; rollback/rebind is
+a fresh transaction, not a half-old/half-new binding.
 
 ## Host Environments, Account State And Cloud
 
 | Host | Required behavior |
 |---|---|
-| PIE | Unique session sandbox or bounded virtual store; never writes production slots, account profile or canonical .horo documents |
-| Packaged standalone | PlatformServices resolves trusted user/project save storage; manual/quicksave/rotating autosave catalog |
+| PIE | Unique `EnvironmentStorageId` sandbox or bounded virtual store; never writes production slots, account profile or canonical .horo documents |
+| Development/test | Explicit non-production product/environment partition; sharing requires reviewed product policy, never path/name coincidence |
+| Packaged standalone | Validated product environment plus installation/platform-user and active game-profile namespace; manual/quicksave/rotating autosave catalog |
 | Dedicated/headless | Server world namespace and authoritative gameplay state; no viewport, client prediction, HUD or client account preferences |
 
 The host decides signature policy from its trust needs; being a server alone is not
@@ -730,6 +826,13 @@ or account-wide stats. Account changes triggered by gameplay are independent typ
 profile operations. A successful save/load is not a transaction over external platform
 achievement/cloud-account APIs. Account policy may merge monotonic progression, but
 that is never an automatic rewind from slot_player_state.bin.
+
+Catalog UI consumes immutable records keyed by `SaveAddress`; no filesystem path or
+raw platform handle crosses the surface. The save/cloud coordinator derives a bounded
+`CloudSaveObjectKey` from the typed address and authenticated provider context.
+Platform Services treats that key and finalized archive bytes as opaque and cannot
+edit local storage. Provider timestamps remain presentation/provenance only. SAV-006
+owns cloud revisions, write preconditions, offline authority and divergence policy.
 
 Cloud adapters receive only final signed/unsigned archives allowed by the namespace
 policy. Conflict detection compares `SlotGenerationId` lineage and
@@ -757,9 +860,9 @@ migration; cloud availability cannot authorize unsigned downgrade.
 
 ## Failure, Cancellation And Shutdown Summary
 
-All failures follow ADR-008 Result/Error, retaining operation, slot, source revision
-and nested asset/provider/filesystem cause. Admission errors are distinct from later
-operation outcomes.
+All failures follow ADR-008 Result/Error, retaining operation, `SaveAddress`, source
+`SlotGenerationId`/`ArchiveContentHash` when available and nested asset/provider/
+filesystem cause. Admission errors are distinct from later operation outcomes.
 
 | Failure | Observable result |
 |---|---|
@@ -790,6 +893,12 @@ documentation change:
 
 - Authoring/recovery/workspace/account isolation, PIE namespace separation and
   headless exclusion of UI/client profile data.
+- Product/environment/user/profile collision tests, all three platform-user
+  capabilities, guest import, sign-out and restart with no display name/path identity.
+- Profile-switch races before/after commit, stale completion fencing, catalog-open
+  failure, production/development/PIE/server separation and UI/cloud path opacity.
+- Duplicate/renamed display names, category reclassification, quicksave/autosave
+  aliases and stable slot identity across overwrite.
 - Capture one tick across ECS/providers/world deltas; resume live mutation immediately
   after the safe point; race scene replacement, COW exhaustion and stale readbacks.
 - Byte fixtures for the 32-byte preamble, unsigned/signed trailer lengths, exact hash
@@ -844,4 +953,5 @@ and regression coverage.
 - [ADR-012](../../adr/012-world-streaming-partition-authority-and-subsystem-boundaries.md): Cell authority and barriers.
 - [ADR-008](../../adr/008-error-model-exception-boundary-and-registry.md): Typed error propagation.
 - [ADR-112](../../adr/112-save-archive-container-and-compatibility-policy.md): Portable container, canonical state, version axes, identities and compatibility horizon.
+- [ADR-113](../../adr/113-local-storage-user-profile-and-slot-ownership.md): Product/user/profile namespaces, logical slot addressing and physical storage ownership.
 - [Application Security](../security/application-security.md): Trust and untrusted-input boundaries.


### PR DESCRIPTION
## Summary

- Defines collision-safe product, environment, platform-user, game-profile, server-owner, and logical-slot namespaces.
- Separates `SaveGameSlotId`, save category, display metadata, physical path, and per-publication `SlotGenerationId`.
- Specifies single-user/current-user/multi-user capability fallback and a fenced profile-switch transaction.
- Gives UI and cloud coordination typed slot addresses without filesystem knowledge.

## Why

Product names, executable paths, gamertags, save labels, and free-form cloud keys are mutable or non-unique and cannot safely identify durable storage. Platforms also expose different user capabilities, so implicit “current user” behavior could mix profiles or let stale async work publish into a newly selected user.

## Decision and boundaries

- Adds ADR-113 and updates save, platform-services, platform-abstraction, and architecture indexes.
- `ProductStorageId` and `EnvironmentStorageId` partition production, development, tests, PIE, and deliberate product forks.
- Platform identity maps to private opaque local-user storage; unsupported multi-user platforms use one explicit installation-local partition rather than a guessed shared path.
- Categories and display names live in the catalog and never become filenames or slot identity.
- Profile switching closes admission, fences old namespace generations, settles in-flight work, opens the new catalog, and only then reopens save/cloud scheduling.

This PR defines identity and ownership. Concrete profile mapping, catalog schema, platform path encoding, and switching implementation are deferred.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Markdown lint passed
- [x] Added Markdown links resolve
- [x] Staged diff checks passed
- [x] CMake configure passed
- [ ] Full build/test suite not run; this is a documentation-only decision

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- <changed-markdown-files>
git diff --check
git diff --cached --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- Cross-device profile identity depends on a stable opaque provider user scope; platforms lacking it must keep cloud unavailable.
- Import/fork/profile-delete lifecycle details remain focused follow-up work.
- CMake reported the existing mbedTLS deprecation warning and skipped repository Python tests because pytest is unavailable.

## Issue links

- Jira: HORO-1425
- GitHub: Closes #1425

## Reviewer Notes

Review ADR-113 first, then the save namespace/catalog projection, then Platform Services and Platform Abstraction. The key invariant is that only `SaveStorageAdapter` can map a typed namespace and slot to physical storage.