### PR TITLE
docs(save): define canonical world persistence HORO-1438 #1438 [SAV-004.1]

### DIFF
--- a/docs/adr/114-canonical-runtime-world-persistence-boundary.md
+++ b/docs/adr/114-canonical-runtime-world-persistence-boundary.md
@@ -1,0 +1,289 @@
+# ADR-114: Canonical Runtime World Persistence Boundary
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Authoring defaults versus saved overrides, durable/derived/transient state classification, subsystem-owned canonical adapters, participant descriptors, capture and restore authority across PIE, packaged, server and client worlds
+- **Issue**: [SAV-004.1](https://github.com/abdullahbodur/horo-engine/issues/1438)
+- **Jira**: [HORO-1438](https://horo-engine.atlassian.net/browse/HORO-1438)
+- **Related**: [ADR-012](012-world-streaming-partition-authority-and-subsystem-boundaries.md), [ADR-024](024-perception-ownership-sense-policy-and-budget.md), [ADR-068](068-music-transport-and-cross-system-ownership.md), [ADR-092](092-character-controller-determinism-and-state-composition.md), [ADR-112](112-save-archive-container-and-compatibility-policy.md), [ADR-113](113-local-storage-user-profile-and-slot-ownership.md)
+- **Normative documents**: [Save Game And Persistence](../architecture/runtime/save-game-and-persistence.md), [Scene Runtime](../architecture/runtime/scene-runtime.md), [Gameplay Module Boundary](../architecture/extensions/gameplay-module-boundary.md), [World Streaming](../architecture/runtime/world-streaming-architecture.md)
+
+## Context
+
+Runtime Save owns one coherent capture/restore transaction, but the current language
+still names an `EcsSaveSnapshot`, asks components to declare serialization and uses a
+generic gameplay-state provider. That makes it easy to treat every component field or
+service object as independently serializable, duplicate subsystem state in ECS and a
+service chunk, or persist native/transient execution state because it is reachable.
+
+Scene documents and cooked assets define authored defaults. A runtime world contains
+mutated semantic state, derived caches, in-flight work, presentation objects and
+external account state with different owners and lifetimes. A save must reconstruct a
+valid gameplay world, not reproduce an object graph or memory image.
+
+Subsystems already have focused rules: Character saves a complete Horo checkpoint
+paired with Physics, World Streaming owns dormant deltas, Audio permits semantic music
+state but not voices/devices, and AI distinguishes stable execution meaning from jobs
+and cooked indices. These rules need one common opt-in adapter contract and an explicit
+composition model.
+
+## Decision
+
+### 1. State is classified before persistence is admitted
+
+| Category | Authority | Save behavior |
+|---|---|---|
+| Authoring definition/default | SceneDocument, source asset and cook pipeline | Referenced as the immutable base; never copied back from runtime save state |
+| Runtime canonical state | Owning Scene/gameplay subsystem | Opt-in through exactly one canonical state adapter |
+| Derived/rebuildable state | Owning runtime subsystem/cache | Excluded; rebuilt from base assets and restored canonical state |
+| Transient execution state | Scheduler, operation, transport or subsystem runtime | Excluded unless a schema explicitly promotes semantic state into the canonical category |
+| Presentation state | Renderer, Audio device/voice, Runtime UI presentation | Excluded; semantic intent may be saved only by its gameplay/domain owner |
+| Asset/cooked content | Asset Registry and package/cook authorities | Stable identities/revisions are dependencies; payloads are not embedded as runtime state |
+| Account/profile state | Profile/account authority | Separate store and transaction; slot restore cannot rewind it |
+| External/platform/network state | Platform service or network authority | Excluded; reconnect/revalidate through that authority after restore |
+
+Reachability, trivially-copyable layout, reflection metadata or presence in ECS does
+not change category. The default for runtime data is not durable. Persistence is an
+explicit schema decision owned by the subsystem that owns the semantic invariant.
+
+### 2. Authoring base and saved runtime overrides never become peers
+
+Restore first resolves and validates the exact compatible cooked scene/world base.
+It then composes canonical saved state by stable identity:
+
+- an authored entity absent from saved overrides uses current compatible defaults;
+- a persisted field override replaces only the schema-declared authored default;
+- deletion of an authored entity is an explicit tombstone;
+- a runtime-spawned durable entity records a stable `PersistentEntityId`, declared
+  archetype/prefab/definition identity and canonical owned values; and
+- references resolve by stable persistent identity inside the detached candidate.
+
+Runtime `EntityRef`, slot/generation indices, pointers, hierarchy addresses and
+component storage order never persist. A base revision change requires a declared
+base/delta migration or typed incompatibility; readers do not guess that same paths or
+names mean same authored objects.
+
+Saved overrides never mutate SceneDocument, source assets, cooked packages or current
+authoring defaults. Editor Apply/Keep Changes is a separate reviewed authoring command
+that may translate selected runtime facts into document edits; loading/saving a slot
+does not invoke it.
+
+### 3. Each durable semantic field has exactly one adapter owner
+
+Composition seals one registry of inert descriptors and adapter bindings:
+
+```cpp
+enum class CanonicalStateScope : uint8_t {
+    World,
+    Session,
+    SlotPlayer,
+    ServerWorld
+};
+
+struct CanonicalStateParticipantDescriptor {
+    StableTypeId participant;
+    ParticipantSchemaVersion schema;
+    CanonicalStateScope scope;
+    RequiredParticipantPolicy required;
+    StableTypeId ownerSubsystem;
+    std::vector<StableTypeId> dependencies;
+    CanonicalStateLimits limits;
+};
+
+class ICanonicalStateAdapter {
+public:
+    virtual Result<OwnedCanonicalSnapshot> Capture(
+        const CanonicalCaptureContext&) = 0;
+    virtual Result<PreparedCanonicalState> PrepareRestore(
+        CanonicalStateReader&, const CanonicalRestoreContext&) = 0;
+    virtual void PublishPrepared(PreparedCanonicalState&&) noexcept = 0;
+};
+```
+
+Descriptors are inert metadata. Creating/validating them performs no registration,
+service lookup, capture or lifecycle callback. Host composition binds adapters,
+validates unique participant/field ownership, schema/migration paths, required/
+optional policy, dependency DAG, scopes, affinity, resource limits and no-fail
+publication before a session can save.
+
+A component descriptor may declare stable fields belonging to an adapter, but it does
+not receive an independent generic `Serialize(Component&)` escape hatch. A gameplay
+service, ECS component and world ledger cannot each emit authoritative copies of the
+same health, quest, inventory, transform or spawn state. Duplicate ownership rejects
+composition.
+
+### 4. The core Scene adapter owns identity and structural world state only
+
+The Horo Scene canonical adapter owns:
+
+- compatible base scene/world identity and structural revision evidence;
+- persistent authored/spawned entity identity, existence and tombstones;
+- canonical hierarchy/ownership relationships and stable cross-entity remaps; and
+- Horo core component fields explicitly assigned to Scene ownership.
+
+It does not walk arbitrary component memory, serialize gameplay-module fields, own
+Physics/Character/AI state or capture native handles. Gameplay modules and built-in
+subsystems contribute separate participants for their owned canonical semantics.
+Their stable entity references join the core identity map during aggregate prepare.
+
+Slot-player state is a distinct participant for slot-scoped player facts not already
+owned by another gameplay participant. Account-global preferences, achievements and
+statistics remain outside. Persistent World owns dormant cell deltas/tombstones; the
+core Scene adapter does not duplicate them from unloaded cells.
+
+### 5. Adapters define semantic inclusion and exclusion
+
+An adapter schema lists durable stable IDs/values, canonical defaults, scope,
+dependencies, maximum counts/bytes and migration behavior. It also documents derived
+rebuild rules and explicitly excluded state. Unknown fields or missing required data
+follow ADR-112 compatibility policy.
+
+Always excluded unless converted by the semantic owner into a different canonical
+value are:
+
+- pointers, native/library objects, allocator/container capacity and compiler layout;
+- runtime handles/generations, registry indices and provider objects;
+- jobs, futures, cancellation tokens, queues, callbacks and pending command/event
+  buffers;
+- renderer/GPU resources, extraction buffers, fences, views and frame history;
+- Audio voices/devices/decoders/DSP/ring buffers and sample-device epochs;
+- Physics solver bodies/manifolds/broadphase/proxies/query caches and Jolt state;
+- Navigation query handles, open lists, Detour runtime pointers and rebuild scratch;
+- network sockets/connections/keys, replication queues, prediction buffers and remote
+  authority state on clients;
+- UI focus/hover/animation/layout caches, modal/panel state and localized text; and
+- wall-clock time as simulation progression or restore causality.
+
+RNG streams, timers, AI execution frames, musical position, physics motion or similar
+facts are durable only when their owner defines stable semantic representation and
+restore behavior. Persisting them once does not authorize copying adjacent transient
+implementation state.
+
+### 6. Adjacent subsystems map to explicit participants
+
+| Owner | Canonical participant responsibility | Rebuilt/excluded examples |
+|---|---|---|
+| Scene/ECS core | Persistent entity identity, existence, hierarchy, core owned values, spawns/tombstones | ECS slot/generation, storage order, system queues |
+| Gameplay module/service | Its declared component/service semantics and stable references | Behavior objects, callbacks, module pointers, hot-reload machinery |
+| Character + Physics | ADR-092 complete Horo Character state and paired canonical Physics/world checkpoint | Jolt bodies, proxy/manifold/query-cache state |
+| World Streaming | ADR-012 persistent active/inactive cell deltas, relocations and tombstones | Residency attempts, PartitionEpoch, loader jobs and spill paths |
+| Navigation | Session-persistent semantic obstacle/link intent when product policy requires it | NavMesh artifacts, Detour queries, local avoidance scratch and tile candidates |
+| Gameplay AI | Stable plan/schema identity, approved blackboard/perception and bounded semantic execution state | Jobs, path/query handles, cooked indices and scheduler buckets |
+| Audio/domain gameplay | Semantic music/narrative cue and admitted musical position under ADR-068 | Voice/device/provider handles, decoder/DSP state and output samples |
+| Runtime UI/game flow | Gameplay-owned route/model state only when explicitly declared | Widget tree, focus, hover, animation and render state |
+| Networked world | Authoritative server-owned canonical gameplay/world participants | Client copies of server truth, connections, keys and packet queues |
+| Profile/account | No slot participant for global settings/progression | Separate profile-store transaction |
+
+The table assigns boundaries, not one mandatory save policy for every product. A
+product may omit optional semantic state and rebuild/reset it, but cannot give another
+subsystem ownership merely to avoid writing the proper adapter.
+
+### 7. Capture is one aggregate canonical cut
+
+RuntimeSaveService coordinates but does not interpret subsystem state. At the owner
+lifecycle safe point it pins one scene/session incarnation, fixed tick, structural
+revision, origin, participant-registry revision and dependency revisions, then asks
+all required adapters for owned immutable snapshots under their admitted capture
+contracts. Large state uses bounded copy-on-write/versioned roots; workers receive no
+live mutable object.
+
+Every required participant belongs to the same `CanonicalCaptureEpoch`. An adapter
+that cannot provide a coherent snapshot defers/fails the whole capture; the service
+does not combine prior-tick state or omit a required participant. Optional omission
+must be descriptor-approved and represented in the manifest. RuntimeSaveService
+orders dependencies, enforces aggregate budgets and builds ADR-112 canonical state,
+but never reflects over SceneDocument or arbitrary ECS storage.
+
+### 8. Restore prepares all owners and publishes once
+
+Restore validates the archive/base/dependencies, migrates detached participant data,
+builds the core stable entity map and calls each adapter's fallible `PrepareRestore`
+in dependency order. Adapters resolve assets/current implementation resources and
+create private candidate roots; they do not mutate active state.
+
+Required candidates plus Scene, slot-player and Persistent World roots join the one
+aggregate bundle. The owner revalidates session/base/registry generations at
+`CommitDeferredLifecycleChanges` and invokes only prevalidated noexcept ownership
+transfers. No observer can see a Scene/entity structure without its required gameplay,
+Physics/Character/world state. Derived caches and asynchronous work restart after
+publication from the new authoritative roots.
+
+Failure/cancellation before commit retires candidates and leaves the active runtime
+unchanged. Post-publication failure is an owner-contract violation, not permission to
+partially roll back. Profile/account/platform side effects are never part of this
+bundle.
+
+### 9. Host/authority policy changes admitted participants, not ownership
+
+- PIE uses the same descriptor/adapter contracts in its isolated ADR-113 namespace.
+  Play restart/hot reload transfer is a separate transient preservation operation and
+  cannot silently become durable save schema.
+- Packaged standalone saves the authoritative local world plus product-approved
+  slot-player/session participants.
+- Dedicated/headless hosts admit server-world participants and omit presentation/
+  client-only state without linking renderer, Audio device or UI implementations.
+- A multiplayer server may capture authoritative world state under host quiescence.
+  A client may save only locally authoritative/product-approved state and references;
+  it never archives replicated server state as restorable authority.
+
+The manifest records required participant IDs/scopes. Loading under a host that lacks
+required authority/capability rejects before preparation; it does not reinterpret a
+server participant as client-local data or silently drop it.
+
+### 10. Qualification proves classification and single ownership
+
+Required evidence includes:
+
+- descriptor composition rejects duplicate participant/field ownership, dependency
+  cycles, missing required adapters, invalid scopes and unbounded declarations;
+- authoring base plus override/tombstone/spawn composition, base migration and proof
+  that save/load never edits SceneDocument or cooked assets;
+- one-tick aggregate capture across Scene/gameplay/Physics/Character/AI/world ledger,
+  including inactive cells and optional omission policy;
+- failure of every required prepare stage with active runtime unchanged, followed by
+  one observable no-fail aggregate publication;
+- reflection/trivial-copy/native-memory attempts rejected and golden canonical
+  fixtures for each participant schema;
+- rebuilt caches/resources/jobs after restore and absence of pointers, native handles,
+  queues, presentation state and wall-clock progression in archives; and
+- PIE/packaged/headless/server/client composition matrices with forbidden replicated
+  client authority and no presentation dependency in headless saves.
+
+## Consequences
+
+### Positive
+
+- Authoring data, canonical runtime state and derived/transient state have explicit
+  non-overlapping owners.
+- Subsystems preserve semantic invariants instead of exposing object memory.
+- Aggregate capture/restore remains coherent across component, service and world data.
+- Adjacent subsystem contracts map to one extensible participant model.
+
+### Costs
+
+- Every durable subsystem needs a descriptor, canonical codec, migration and adapter.
+- Composition must validate field ownership and dependency order.
+- Restore must rebuild implementation/native state instead of loading memory images.
+
+## Rejected Alternatives
+
+### Serialize every reflected or trivially copyable component
+
+Rejected because component storage does not own every semantic invariant and native
+layout is neither portable nor sufficient for service/world state.
+
+### Store the full runtime object graph
+
+Rejected because pointers, handles, jobs, caches and native resources have invalid
+lifetimes and hide dependency-aware reconstruction.
+
+### Save only SceneDocument plus runtime transforms
+
+Rejected because authoring defaults are not mutated gameplay truth and omit durable
+service, spawn/tombstone, inactive-world and subsystem state.
+
+### Let RuntimeSaveService decide fields centrally
+
+Rejected because it cannot own subsystem semantics, schema evolution or safe native
+reconstruction; it coordinates adapters and the aggregate transaction only.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -125,6 +125,7 @@ to the replacement.
 | [111](111-gameplay-ai-document-panel-and-runtime-debug-ownership.md) | Gameplay AI Document, Panel and Runtime-Debug Ownership | Proposed | 2026-09-02 |
 | [112](112-save-archive-container-and-compatibility-policy.md) | Save Archive Container and Compatibility Policy | Proposed | 2026-09-02 |
 | [113](113-local-storage-user-profile-and-slot-ownership.md) | Local Storage, User Profile and Slot Ownership | Proposed | 2026-09-02 |
+| [114](114-canonical-runtime-world-persistence-boundary.md) | Canonical Runtime World Persistence Boundary | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -314,6 +314,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Local Storage, User Profile and Slot Ownership](../adr/113-local-storage-user-profile-and-slot-ownership.md):
   product/environment/user/profile namespaces, slot/category identity, path
   authority, multi-user fallback and profile-switch fencing.
+- [Canonical Runtime World Persistence Boundary](../adr/114-canonical-runtime-world-persistence-boundary.md):
+  authoring-base/runtime-override composition, state classification,
+  subsystem-owned canonical adapters and aggregate capture/restore.
 - [Navigation And AI Architecture](./runtime/navigation-and-ai-architecture.md):
   NavMesh, pathfinding, dynamic obstacle overlays, perception, crowd, blackboard,
   and editor bake tooling.

--- a/docs/architecture/extensions/gameplay-behavior-authoring.md
+++ b/docs/architecture/extensions/gameplay-behavior-authoring.md
@@ -882,9 +882,10 @@ schedulers or divergent blackboard structures:
      deterministic empty snapshot and cannot inspect another player's actions.
 
 7. **Decision State Persistence**:
-   - The AI subsystem participates in runtime save/restore through
-     `IGameplayStateProvider`. It serializes stable plan/node identity, compatible
-     execution frames, timers, and schema-approved blackboard values.
+   - Under ADR-114, the AI subsystem participates through its owned canonical state
+     adapter. It captures stable plan/node identity, compatible execution frames,
+     timers, and schema-approved blackboard values; component/graph serialization is
+     not a second runtime-save authority.
    - Runtime jobs, cancellation tokens, query handles, pointers, and cooked array
      indices are never persistent state; they are re-resolved or restarted after
      the restore transaction commits.
@@ -959,6 +960,8 @@ play-session or process restart rather than attempting unsafe live mutation.
 - [Gameplay Module Boundary](./gameplay-module-boundary.md)
 - [Gameplay Runtime Integration](./gameplay-runtime-integration.md)
 - [Save Game And Persistence](../runtime/save-game-and-persistence.md): durable behavior and AI state capture
+- [ADR-114](../../adr/114-canonical-runtime-world-persistence-boundary.md): canonical
+  state adapter and derived/transient exclusion policy.
 - [Editor Document Model](../editor/editor-document-model.md)
 - [Extension System](./plugin-system.md)
 - [Horo Package System](../packages/package-system.md): library-provided behaviors

--- a/docs/architecture/extensions/gameplay-module-boundary.md
+++ b/docs/architecture/extensions/gameplay-module-boundary.md
@@ -297,6 +297,26 @@ services outlive scene-scoped systems and behaviors that depend on them;
 scene-scoped services are created before dependent scene instances and destroyed
 after dependent behaviors, systems, and jobs are drained.
 
+## Canonical Runtime Persistence
+
+Gameplay modules contribute runtime-save state only through the subsystem-owned
+`CanonicalStateParticipantDescriptor` and `ICanonicalStateAdapter` contract in
+[ADR-114](../../adr/114-canonical-runtime-world-persistence-boundary.md). The
+descriptor is inert metadata declaring stable participant/schema identity, scope,
+required policy, dependencies, bounds and owned field/type IDs. Host composition
+binds the adapter and rejects duplicate semantic ownership.
+
+A component or service does not gain persistence authority from reflection, a
+serialized authoring field or trivially-copyable layout. Its owning gameplay adapter
+captures stable semantic values/references at the aggregate save safe point and
+prepares detached restore state for one no-fail publication. Pointers, behavior/service
+instances, callbacks, jobs, queues, native handles and module-local indices are never
+durable payloads. Unknown or incompatible required adapters fail before live mutation.
+
+One semantic field belongs to one participant. A gameplay service and ECS component
+cannot both save authoritative copies. Account/profile values remain outside runtime
+slots, and client modules cannot persist replicated server state as local authority.
+
 ## Native Hot Reload
 
 Data, scene, shader, and asset hot reload follow their owning subsystem
@@ -306,7 +326,7 @@ Native gameplay code reload, when enabled in development:
 
 - occurs only at a runtime safe point
 - stops affected systems and joins module-owned jobs
-- serializes only explicitly preservable state
+- transfers only explicitly preservable state through a hot-reload adapter
 - invalidates all module-owned callbacks and function pointers
 - reloads through a versioned module boundary
 - recreates systems and restores compatible state
@@ -334,6 +354,9 @@ If any unload precondition cannot be proven, the editor requests a play-session
 or process restart instead of unloading unsafe C++ code.
 
 Shipping builds do not load unsigned replacement gameplay code.
+
+Hot-reload preservation is an implementation/session migration and does not
+implicitly register a durable canonical participant, schema or compatibility promise.
 
 ## Errors And Diagnostics
 
@@ -388,3 +411,5 @@ game.<project>.save
 - [Horo Package System](../packages/package-system.md): imported game library modules
 - [Build System](../delivery/build-system.md)
 - [Ownership And Resource Lifetime](../foundation/ownership-and-resource-lifetime.md)
+- [ADR-114](../../adr/114-canonical-runtime-world-persistence-boundary.md): canonical
+  runtime-state adapters and single semantic ownership.

--- a/docs/architecture/runtime/navigation-and-ai-architecture.md
+++ b/docs/architecture/runtime/navigation-and-ai-architecture.md
@@ -1405,7 +1405,7 @@ public:
    - Stale or invalid plans never replace the active runtime plan and log typed compiler diagnostics.
 
 1. **Save And Restore**:
-   - The AI subsystem contributes an `IGameplayStateProvider` to `RuntimeSaveService` and captures state only at the save snapshot safe point.
+   - Under ADR-114, the AI subsystem contributes one owned canonical state adapter to `RuntimeSaveService` and captures state only at the aggregate save snapshot safe point. Component reflection and Scene serialization are not alternate authorities.
    - Durable state includes plan asset/schema identity, bounded execution-frame stacks keyed by stable `DecisionNodeId`, serializable decorator/timer memory, and schema-approved blackboard values.
    - `JobHandle`, cancellation tokens, path/query handles, pointers, and cooked array indices are transient and never serialized. Restore resolves plans in staging and restarts asynchronous work only after atomic state application. Missing or incompatible plans reset the affected agent to its root with a typed diagnostic.
 
@@ -1435,8 +1435,8 @@ and executed by the navigation system.
 
 ### Perception Save And Restore
 
-The AI subsystem contributes a versioned perception chunk through
-`IGameplayStateProvider`. `PreserveMemory` captures durable sense/tag data,
+The AI subsystem's ADR-114 canonical adapter contributes its versioned perception
+state. `PreserveMemory` captures durable sense/tag data,
 stable source references where available, last-known position/velocity, strength,
 and simulation age; `ResetOnRestore` explicitly opts ambient agents out.
 
@@ -1783,6 +1783,7 @@ These are required downstream runtime/CI tests, not tests implemented by this AD
 - [Scene Runtime](./scene-runtime.md): Agent entity and component model
 - [Concurrency And Jobs](../foundation/concurrency-and-jobs.md): Parallel crowd and perception jobs
 - [Save Game And Persistence](./save-game-and-persistence.md): durable perception-memory capture and staged restore
+- [ADR-114: Canonical Runtime World Persistence Boundary](../../adr/114-canonical-runtime-world-persistence-boundary.md)
 - [Navigation Bake UI HTML Reference](./navigation-bake.html): non-normative
   static UI reference
 - [Debug Console And Overlays](./debug-console-and-overlays.md): AI debug visualization

--- a/docs/architecture/runtime/save-game-and-persistence.md
+++ b/docs/architecture/runtime/save-game-and-persistence.md
@@ -10,6 +10,8 @@ ADR-112 freezes the portable archive, canonical state, identity and compatibilit
 policy for HORO-1410 #1410 [SAV-002.1].
 ADR-113 freezes product/environment/user/profile namespaces, logical slot addressing
 and storage mapping for HORO-1425 #1425 [SAV-003.1].
+ADR-114 freezes authoring/runtime state composition and subsystem-owned canonical
+adapters for HORO-1438 #1438 [SAV-004.1].
 
 - RuntimeSaveService coordinates one runtime save/restore authority under the
   application/session lifetime. It never retains an unleased reference to a scene
@@ -30,7 +32,7 @@ and storage mapping for HORO-1425 #1425 [SAV-003.1].
 
 | Domain | Authority | Stored content | Isolation |
 |---|---|---|---|
-| Runtime save (.horosave) | RuntimeSaveService | Dynamic ECS, stable entity identities, gameplay state, slot player state, persistent world deltas | User/server save namespace, never authored .horo files |
+| Runtime save (.horosave) | RuntimeSaveService plus subsystem canonical adapters | Stable entity structure and subsystem-owned canonical gameplay/world participants | User/server save namespace, never authored .horo files or runtime memory images |
 | Scene document (.horo) | SceneDocumentPersistence | Authored hierarchy/defaults/assets and editor semantics | Project asset tree; no runtime mutation on save/load |
 | Editor recovery (.horo_recovery) | ProjectSceneRecoveryRecord | Dirty document snapshot, revisions and recovery context | Bounded recovery namespace; cannot replace canonical data implicitly |
 | Project/workspace metadata | ProjectSession / Workspace | Project configuration and editor layout/state | Separate JSON schemas, authority and transactions |
@@ -72,6 +74,42 @@ Account/profile service -> separate account store (not restored by slot load)
 Editor document/recovery/workspace writers -> separate namespaces and schemas
 ```
 
+## Runtime State Classification And Composition
+
+Persistence is opt-in by semantic owner, not inferred from reflection, component
+membership, trivial copyability or object reachability:
+
+| State category | Owner | Runtime-save treatment |
+|---|---|---|
+| Authoring definition/default | SceneDocument, source asset and cook pipeline | Immutable compatible base reference; never rewritten by slot save/load |
+| Runtime canonical state | Scene or owning gameplay subsystem | One registered canonical adapter may capture it |
+| Derived/rebuildable | Owning runtime subsystem/cache | Excluded and rebuilt from base assets plus restored canonical state |
+| Transient execution | Scheduler/operation/subsystem runtime | Excluded unless the owner promotes a semantic value through a versioned schema |
+| Presentation | Renderer, Audio device/voice, Runtime UI | Excluded; gameplay/domain owner may persist semantic intent separately |
+| Asset/cooked content | Asset Registry and cook/package authorities | Stable identity/revision dependency only, not copied into runtime-state chunks |
+| Account/profile | Profile/account service | Separate store/transaction; slot restore cannot rewind it |
+| Platform/network external state | Platform/network authority | Excluded and revalidated/reconnected after restore |
+
+Restore resolves the compatible cooked Scene/world base, then applies saved state by
+stable identity. Authored entities without saved overrides use compatible defaults;
+declared overrides replace only owned fields; deletion is an explicit tombstone.
+Durable runtime spawns carry `PersistentEntityId`, declared archetype/prefab/definition
+identity and canonical owned values. A changed base requires declared migration or a
+typed incompatibility. Runtime state never writes back to SceneDocument/cooked assets.
+
+The Horo Scene adapter owns persistent entity existence, authored/spawn identity,
+tombstones, hierarchy/ownership, stable reference remaps and explicitly assigned core
+component fields. It does not walk arbitrary component memory or own gameplay,
+Physics, Character, AI or dormant world state. Each such subsystem owns its canonical
+participant; duplicate field/semantic ownership rejects composition.
+
+Always excluded unless a semantic owner defines a different canonical value are
+pointers/native objects, runtime handles/indices, container capacity, jobs/futures/
+cancellation/callbacks, pending queues/events, GPU/render extraction/fences, Audio
+voice/device/decoder/DSP state, native Physics solver/manifold/proxy/query state,
+Navigation queries/rebuild scratch, network connections/keys/packet queues, UI widget/
+focus/animation state and wall-clock progression.
+
 ## Authority, Lifetime And Public Operation Contract
 
 RuntimeSaveService is application-owned. SaveGameAuthority is its internal
@@ -83,11 +121,13 @@ A scene borrow is valid only inside its owner callback. Workers receive immutabl
 snapshots, candidates, asset/provider leases and generation-scoped completion data,
 never SceneRuntime references or callbacks capturing raw scene pointers.
 
-Gameplay provider descriptors are inert, stable-type-ID keyed metadata. Composition
-validates schemas, capture/restore roles, required/optional behavior, cost bounds
-and dependency DAG, then seals a registry revision. An operation pins that revision
-and module leases. Registry changes require an explicit host quiescent rebind; they
-cannot unload codecs under a worker or register through ambient service discovery.
+Canonical participant descriptors are inert, stable-type-ID keyed metadata.
+Composition binds one `ICanonicalStateAdapter` per participant, validates unique
+semantic ownership, schemas, scopes, capture/restore roles, required/optional
+behavior, cost bounds and dependency DAG, then seals a registry revision. An operation
+pins that revision and module leases. Registry changes require an explicit host
+quiescent rebind; they cannot unload codecs under a worker or register through ambient
+service discovery.
 
 Schematic interface shapes (not new installed headers):
 
@@ -135,7 +175,7 @@ struct SaveRequest {
 
 class RuntimeSaveService final {
 public:
-    RuntimeSaveService(IRuntimeSessionHost&, SaveProviderRegistry&,
+    RuntimeSaveService(IRuntimeSessionHost&, CanonicalStateParticipantRegistry&,
                        SaveStorageAdapter&, SaveNamespaceBinding&,
                        PlatformServices&, JobSystem&, OperationStore&);
     Result<SaveOperationHandle> SaveSlotAsync(
@@ -153,7 +193,7 @@ public:
 ```
 
 Initial `Result<SaveOperationHandle>` / `Result<RestoreOperationHandle>` reports only
-admission. Disk-full, signing, migration or provider failure later becomes Failed
+admission. Disk-full, signing, migration or participant-adapter failure later becomes Failed
 with the original typed cause in that operation's snapshot. It cannot retroactively
 change the return value of SaveSlotAsync. Handles use the application-owned ADR-010
 OperationStore/OperationId; no independent save job scheduler/store is created.
@@ -193,28 +233,29 @@ No worker invokes the pump, commits Scene state, calls UI, or waits on nested jo
 SaveLimits validates finite positive limits for archive/decoded bytes, chunk/string
 counts, snapshot/COW and candidate memory, queue/completion slots, per-pump work,
 retry counts and stage/readback/signing deadlines. Aggregate admission counts old
-and new snapshots/runtimes/retired resources together; declared local provider limits
-are not extra capacity. Exceeding a bound fails or defers explicitly, never silently
-unbounds a worker or guarantees a frame-time target.
+and new snapshots/runtimes/retired resources together; declared local participant
+limits are not extra capacity. Exceeding a bound fails or defers explicitly, never
+silently unbounds a worker or guarantees a frame-time target.
 Serialization, compression, hashing, signing, quota queries, directory scans, flush,
 AtomicReplace, deletion and cleanup run on admitted worker/storage roles. No normal
 owner/render/transport frame waits for them. ADR-010 governs allowed teardown drains.
 
 ## Coherent Immutable Capture
 
-RuntimeSaveSnapshot owns an EcsSaveSnapshot, provider snapshots, SlotPlayerState,
-PersistentWorldSnapshot, base asset/dataset revisions and a coherent SaveCaptureEpoch.
-It contains stable persisted identities and owned/copy-on-write payload leases,
-never EntityRef addresses, live component spans, renderer handles or editor objects.
+RuntimeSaveSnapshot owns a StableTypeId-sorted set of `OwnedCanonicalSnapshot` values,
+the core Scene identity snapshot, SlotPlayerState and PersistentWorld participants,
+base asset/dataset revisions and a coherent CanonicalCaptureEpoch. It contains stable
+persisted identities and owned/copy-on-write payload leases, never EntityRef addresses,
+live component spans, renderer handles or editor objects.
 
-At the owner safe point the session validates scene incarnation, provider registry
+At the owner safe point the session validates scene incarnation, participant registry
 revision and capture budget, then copies bounded state or pins a versioned immutable/
-COW root for **one logical tick**. Every required provider/world-delta root belongs
-to that same capture epoch. Independent native owners prepare immutable capture
-versions asynchronously before that boundary; unavailable coherent versions defer
-or fail capture instead of mixing ticks.
+COW root for **one logical tick**. Every required participant/world-delta root belongs
+to that same capture epoch. Independent native owners prepare immutable semantic
+capture versions asynchronously before that boundary; unavailable coherent versions
+defer or fail capture instead of mixing ticks.
 
-Capture never leaves live ECS pools, gameplay providers or streaming state locked or
+Capture never leaves live ECS pools, gameplay adapters or streaming state locked or
 frozen after the safe point. Workers serialize only the detached snapshot. Large
 captures require admitted COW/pages or versioned chunks with bounded owner work;
 naive partial copies across subsequent live ticks are not coherent snapshots. COW
@@ -310,10 +351,10 @@ JSON reserialized by the reader.
 |---|---|
 | header.json | Logical slot ID, `SlotGenerationId`, optional parent generation, producing `ProductSaveCompatibilityVersion`, project/world/account scope, baseSceneAsset and bounded provenance timestamps |
 | manifest.json | `SaveSchemaVersion`, `CanonicalStateHash`, StableTypeId-sorted participant/chunk IDs, each `ParticipantSchemaVersion`, required flags, lengths, codecs and per-chunk SHA-256 |
-| runtime_ecs.bin | Stable authored/spawn identities, dynamic components, tombstones and reference remap records |
-| gameplay module entries | Each registered module's versioned state |
-| slot_player_state.bin | Slot-scoped player state only; no global settings/achievements |
-| world_state.bin / cell delta entries | Persistent state of active and inactive cells with base dataset revision |
+| core Scene participant | Stable authored/spawn entity identities, owned core fields, tombstones, hierarchy and reference remaps |
+| subsystem participant entries | One canonical payload per registered owner/StableTypeId, including gameplay services/components |
+| slot-player participant | Slot-scoped player state only; no global settings/achievements or duplicated subsystem fields |
+| Persistent World participant/cell deltas | Persistent state of active and inactive cells with base dataset revision |
 | thumbnail.png | Optional bounded image; source capture/view metadata |
 
 These names describe entry roles, not directories to extract on disk. Header metadata
@@ -474,24 +515,26 @@ between durable save and registration. Completed means local durability; cloud s
    with all length/hash/schema/identity checks. Verify project/account/world scope and
    base AssetId/dataset/package dependencies. Browsing unverified headers shows
    untrusted metadata, not an authenticated playable slot.
-2. Migrate only detached staging data if needed. Workers deserialize ECS records,
-   provider state, SlotPlayerState and persistent world deltas into a private
-   PreparedRuntimeBundle. Pin provider registry and AssetRegistry revisions/leases.
+2. Migrate only detached staging data if needed. Workers decode the core Scene and
+   subsystem canonical participants, SlotPlayerState and persistent world deltas into
+   a private PreparedRuntimeBundle. Pin participant registry and AssetRegistry
+   revisions/leases.
    Persisted stable IDs are remapped to new runtime identities; old EntityRef and
    streaming epochs are never restored from disk.
 3. The owner queues RuntimeSceneService::QueuePreparation through the existing
-   scene activation admission path; heavy preparation still runs in background. Required provider PrepareRestore stages independent candidate
-   state on its declared worker/native role and returns Pending/Prepared or typed
-   failure. Native resources obey ADR-012/011 admission and retirement barriers.
+   scene activation admission path; heavy preparation still runs in background. Each
+   required adapter's PrepareRestore stages independent candidate state on its
+   declared worker/native role and returns Pending/Prepared or typed failure. Native
+   resources obey ADR-012/011 admission and retirement barriers.
    No worker creates a published RuntimeScene identity or mutates the live scene.
-4. Prepare the entire commit ticket: candidate Scene storage, gameplay/provider
+4. Prepare the entire commit ticket: candidate Scene storage, gameplay/participant
    roots, slot player state, persistent world ledger, reference remaps and admitted
    lifecycle events/retirement capacity. Required initial cells must reach their
    Ready/Prepared barrier; remaining dormant deltas need not load every world cell.
 
-Each provider exposes fallible PrepareRestore and a bounded no-fail PublishPrepared
+Each adapter exposes fallible PrepareRestore and a bounded no-fail PublishPrepared
 (or equivalent noexcept ownership transfer), plus asynchronous candidate retirement.
-A provider that can only mutate live state through a fallible commit cannot join an
+An adapter that can only mutate live state through a fallible commit cannot join an
 atomic required restore; reject the composition before accepting a load. Optional
 participants need an explicit validated absence/substitute policy, not a swallowed
 required failure. Account/profile services and unrelated external side effects do
@@ -505,14 +548,14 @@ This is a required extension of the commit integration, not a claim that SCN-001
 already supports a composite gameplay restore. The current one-pending-scene-operation
 rule remains enforced. The scene candidate must remain behind the shared bundle
 commit gate: its own readiness cannot trigger early automatic scene activation while
-a required gameplay provider is still Pending. A host lacking that integration
+a required gameplay participant is still Pending. A host lacking that integration
 rejects composite restore rather than applying the scene first.
 
 At CommitDeferredLifecycleChanges, under the exclusive owner mutation boundary,
 revalidate the operation cancellation gate, expected session/scene incarnation,
-source/archive and provider/asset registry revisions, and all Prepared acknowledgements.
+source/archive and participant/asset registry revisions, and all Prepared acknowledgements.
 A mismatch rejects the candidate before publication. Then publish Scene and all
-candidate provider/world/player roots as one unobservable-to-readers transaction.
+candidate participant/world/player roots as one unobservable-to-readers transaction.
 Publication performs only prevalidated ownership transfers: no allocation, I/O,
 blocking wait, arbitrary callback or new recoverable failure. Runtime identity is
 created/published by the Scene service at this boundary, not by a worker candidate.
@@ -525,7 +568,7 @@ Logical success may precede physical old-resource release, with all leases charg
 
 Cancellation wins only before the final commit gate. After publication, report
 Committed/Completed and TooLate for late cancel. Recoverable preparation failure
-retires the candidate and leaves the active bundle unchanged. An unexpected provider
+retires the candidate and leaves the active bundle unchanged. An unexpected adapter
 violation after publication is a host/session fault, not a fictional safe rollback;
 contain/fail the session under host policy and retain unsafe-to-free dependencies.
 The normal atomicity guarantee relies on validating the no-fail publish contract.
@@ -871,7 +914,7 @@ filesystem cause. Admission errors are distinct from later operation outcomes.
 | Write/full/signing failure before commit | Failed/NotCommitted; previous archive intact; owned temp eventually retired |
 | AtomicReplace or durability outcome uncertain | Failed/Unknown; reconcile/quarantine slot, no cloud publication or blind retry |
 | Corrupt archive-content hash/chunk / missing or invalid required signature | Failed before restore staging/publication |
-| Missing asset / incompatible schema / required provider failure | Retire candidate; active runtime preserved |
+| Missing asset / incompatible schema / required participant failure | Retire candidate; active runtime preserved |
 | Stale scene/registry/archive before commit | Reject candidate; never publish into a replacement incarnation |
 | Cancellation before commit gate | Cancelled/NotCommitted after owned work reaches safe terminal cleanup |
 | Cancellation after commit gate | TooLate; report actual commit success/failure/unknown outcome |
@@ -899,7 +942,7 @@ documentation change:
   failure, production/development/PIE/server separation and UI/cloud path opacity.
 - Duplicate/renamed display names, category reclassification, quicksave/autosave
   aliases and stable slot identity across overwrite.
-- Capture one tick across ECS/providers/world deltas; resume live mutation immediately
+- Capture one tick across Scene/subsystem adapters/world deltas; resume live mutation immediately
   after the safe point; race scene replacement, COW exhaustion and stale readbacks.
 - Byte fixtures for the 32-byte preamble, unsigned/signed trailer lengths, exact hash
   ranges and signature message. Tamper header, lengths, compressed bytes, raw chunks,
@@ -914,7 +957,7 @@ documentation change:
   cancellation races on both commit gates and no UI-thread filesystem calls.
 - Disk-full/flush/rename/directory-sync fault injection, especially rename-success plus
   sync-failure; process-crash recovery and no false old-file-preserved guarantee.
-- Restore all required providers from isolated candidates; fail each prepare stage;
+- Restore all required participants from isolated candidates; fail each prepare stage;
   prove no observer sees partial Scene/inventory/quest publication. Validate no-fail
   commit and asynchronous retirement under native fence delay.
 - Save/restore unloaded/resident/evicting cells, dropped-item/tombstone/cross-cell cases,
@@ -931,7 +974,7 @@ documentation change:
 - Shutdown while a save is past commit, while candidates hold modules/assets, and
   while optional GPU thumbnails are pending; no early free or silent incomplete unload.
 
-The v1 container's entry-table codec, provider/session commit integration, secure
+The v1 container's entry-table codec, participant/session commit integration, secure
 storage adapter and platform-specific durability qualification are implementation
 work under these contracts. They must be completed before enabling runtime saves;
 this specification does not claim that current Foundation/Scene APIs alone implement
@@ -954,4 +997,5 @@ and regression coverage.
 - [ADR-008](../../adr/008-error-model-exception-boundary-and-registry.md): Typed error propagation.
 - [ADR-112](../../adr/112-save-archive-container-and-compatibility-policy.md): Portable container, canonical state, version axes, identities and compatibility horizon.
 - [ADR-113](../../adr/113-local-storage-user-profile-and-slot-ownership.md): Product/user/profile namespaces, logical slot addressing and physical storage ownership.
+- [ADR-114](../../adr/114-canonical-runtime-world-persistence-boundary.md): Authoring/runtime composition, state classification and subsystem-owned canonical adapters.
 - [Application Security](../security/application-security.md): Trust and untrusted-input boundaries.

--- a/docs/architecture/runtime/scene-runtime.md
+++ b/docs/architecture/runtime/scene-runtime.md
@@ -290,8 +290,14 @@ Components are typed state carriers. They:
 - avoid hidden thread synchronization
 - do not invoke GUI or transport services
 - do not own system scheduling
-- declare serialization and runtime-only status
+- declare authoring-schema and runtime persistence participation metadata
 - use stable asset and entity references
+
+Components do not self-serialize arbitrary memory for runtime saves. Under
+[ADR-114](../../adr/114-canonical-runtime-world-persistence-boundary.md), exactly one
+subsystem-owned canonical adapter owns each durable semantic field. Reflection and
+component storage support authoring/runtime access but do not grant persistence
+authority.
 
 Polymorphic gameplay behavior is owned through explicit behavior components
 registered by the gameplay module boundary, not hidden in arbitrary component
@@ -363,14 +369,21 @@ not new `RuntimePhase` values.
 [Runtime persistence](./save-game-and-persistence.md) is coordinated by an
 application/session-owned service, not a service retaining a replaceable scene
 reference. Capture hands workers an owned immutable, revision-consistent snapshot;
-live ECS pools are not held frozen after the lifecycle safe point. Slot restore
-prepares a private bundle of Scene, gameplay, slot player and persistent world state
-through the existing QueuePreparation admission seam. CommitDeferredLifecycleChanges
-publishes all prepared roots without fallible work or intermediate observers. Its scene
-candidate cannot auto-activate while the composite bundle gate is pending; account
-settings/achievements remain outside that transaction. This composite commit is an
-implementation requirement beyond SCN-001, not a second public activation path.
-Old scene/provider resources retire asynchronously with their leases preserved.
+live ECS pools are not held frozen after the lifecycle safe point. ADR-114 assigns the
+core Scene adapter only persistent entity existence, authored/spawn identity,
+tombstones, hierarchy/reference remaps and explicitly owned core fields. Gameplay,
+Physics/Character and Persistent World adapters retain their own canonical semantics;
+Scene never reflects over their component memory.
+
+Slot restore resolves a compatible cooked authoring base, composes stable-ID keyed
+overrides/spawns/tombstones and prepares a private bundle of Scene, gameplay, slot
+player and persistent world state through the existing QueuePreparation admission
+seam. It never edits SceneDocument or cooked assets. CommitDeferredLifecycleChanges
+publishes all prepared roots without fallible work or intermediate observers. Its
+scene candidate cannot auto-activate while the composite bundle gate is pending;
+account settings/achievements remain outside that transaction. This composite commit
+is an implementation requirement beyond SCN-001, not a second public activation path.
+Old scene/participant resources retire asynchronously with their leases preserved.
 
 [ADR-092](../../adr/092-character-controller-determinism-and-state-composition.md)
 requires the Character provider snapshot to share the exact committed tick, scene/
@@ -461,7 +474,8 @@ Reload strategy is explicit per state category:
 | Physics state | Rebuild unless preservation contract exists |
 
 Reload does not copy arbitrary component memory by type name. Preservation uses
-typed adapters and stable object IDs.
+typed adapters and stable object IDs. Development hot-reload/restart preservation is
+not automatically a durable ADR-114 participant or save-schema promise.
 
 ## Scene References
 
@@ -580,3 +594,5 @@ Required tests cover:
 - [Rendering Architecture](./rendering-architecture.md)
 - [Editor Document Model](../editor/editor-document-model.md)
 - [Save Game And Persistence](./save-game-and-persistence.md)
+- [ADR-114](../../adr/114-canonical-runtime-world-persistence-boundary.md): canonical
+  state classification, Scene base/override composition and adapter ownership.

--- a/docs/architecture/runtime/world-streaming-architecture.md
+++ b/docs/architecture/runtime/world-streaming-architecture.md
@@ -395,7 +395,9 @@ retired layers and query leases remain charged to the existing world ledger.
 
 [Runtime persistence](./save-game-and-persistence.md) captures a coherent revision of
 active ECS plus session-owned persistent cell deltas/tombstones, including Unloaded
-cells. That ledger is not another residency authority. Before releasing the last live
+cells. Under ADR-114, Persistent World is the sole canonical adapter owner for those
+deltas; the core Scene adapter does not serialize a second copy from components or
+resident cells. That ledger is not another residency authority. Before releasing the last live
 copy during eviction, providers publish dirty state under the same owner safe point
 and registered retirement DAG. Failed delta capture/admission retains the source and
 keeps retirement charged; it cannot silently discard a dropped item or deletion.
@@ -909,6 +911,7 @@ See [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin
 - [ADR-017: Prefab Ownership](../../adr/017-prefab-role-ownership-and-capability-tiers.md): Offline expansion versus runtime spawn admission.
 - [ADR-018: Command Policy](../../adr/018-command-registration-permissions-threading-and-packaged-build-policy.md): wst/network authority and owner-thread dispatch.
 - [ADR-023: World Index and Cell Format](../../adr/023-world-index-and-cell-format-architecture-decision.md): Unchanged canonical wire formats.
+- [ADR-114: Canonical Runtime World Persistence Boundary](../../adr/114-canonical-runtime-world-persistence-boundary.md): persistent-world adapter ownership and derived/transient exclusions.
 - [ADR-010: Job and Operation Ownership](../../adr/010-job-waiting-and-operation-store-ownership.md): Bounded lifecycle drains and shared OperationStore.
 
 - [ADR-012: World Streaming Partition Authority and Subsystem Boundaries](../../adr/012-world-streaming-partition-authority-and-subsystem-boundaries.md): Partition ownership, provider barriers and resource admission.


### PR DESCRIPTION
## Summary

- Classifies authoring defaults, canonical runtime state, derived caches, transient execution, presentation, assets, profiles, and external/network state.
- Replaces component-centric save serialization with one subsystem-owned canonical adapter per durable semantic field.
- Defines stable-ID composition of a cooked Scene base with saved overrides, spawns, and tombstones.
- Maps Scene/ECS, gameplay, Physics/Character, World Streaming, Navigation, AI, Audio, Runtime UI, network, and profile boundaries to the adapter model.

## Why

Treating reflected or trivially-copyable components as save units would duplicate subsystem authority and persist invalid native/runtime state. A save must reconstruct a valid semantic world from an authored base plus owned canonical state, not reproduce an object graph or memory image.

## Decision and boundaries

- Adds ADR-114 and updates save, Scene Runtime, gameplay module/behavior, Navigation/AI, and World Streaming contracts.
- The core Scene adapter owns persistent entity identity/existence, hierarchy, core fields, spawns, tombstones, and reference remaps only.
- Each required subsystem adapter captures the same canonical epoch, prepares detached restore state, and joins one no-fail aggregate publication.
- Pointers, native solver/GPU/audio objects, jobs, queues, callbacks, runtime handles, caches, UI presentation, network connections, and wall-clock progression are excluded by default.
- PIE, packaged, dedicated-server, and client authority matrices use the same adapter contract without transferring server truth to clients.

This PR is architectural. Adapter APIs, registries, codecs, migrations, and subsystem fixtures are not implemented here.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Markdown lint passed
- [x] Added Markdown links resolve
- [x] Staged diff checks passed
- [x] CMake configure passed
- [ ] Full build/test suite not run; this is a documentation-only decision

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- <changed-markdown-files>
git diff --check
git diff --cached --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- Duplicate semantic-field ownership validation and aggregate no-fail publication require non-trivial implementation work.
- Product-specific adapter inclusion policies still need concrete schema and migration decisions.
- CMake reported the existing mbedTLS deprecation warning and skipped repository Python tests because pytest is unavailable.

## Issue links

- Jira: HORO-1438
- GitHub: Closes #1438

## Reviewer Notes

Review ADR-114 first, then the save classification/adapter projection, followed by Scene Runtime and gameplay/AI/world-streaming projections. Focus on the “one semantic field, one owner” invariant and the derived/transient exclusion list.