### PR TITLE
docs(save): define cloud conflict policy HORO-1466 #1466 [SAV-006.1]

### DIFF
--- a/docs/adr/115-cloud-save-authority-revision-and-conflict-policy.md
+++ b/docs/adr/115-cloud-save-authority-revision-and-conflict-policy.md
@@ -1,0 +1,267 @@
+# ADR-115: Cloud Save Authority, Revision and Conflict Policy
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Local versus cloud authority, provider revision/write preconditions, offline/startup/upload/download/delete states, lineage classification, clock treatment, conflict preservation and UI decision boundary
+- **Issue**: [SAV-006.1](https://github.com/abdullahbodur/horo-engine/issues/1466)
+- **Jira**: [HORO-1466](https://horo-engine.atlassian.net/browse/HORO-1466)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-112](112-save-archive-container-and-compatibility-policy.md), [ADR-113](113-local-storage-user-profile-and-slot-ownership.md), [ADR-114](114-canonical-runtime-world-persistence-boundary.md)
+- **Normative documents**: [Save Game And Persistence](../architecture/runtime/save-game-and-persistence.md), [Platform Services](../architecture/runtime/platform-services-architecture.md), [Platform Abstraction](../architecture/foundation/platform-abstraction.md)
+
+## Context
+
+Local Runtime Save produces one validated durable archive generation and remains
+usable without Platform Services. Cloud backends transport opaque blobs under an
+authenticated provider account, but provider capabilities differ: timestamps may be
+skewed, revisions may be opaque, and some stores cannot perform conditional writes.
+
+Unconditional upload, download-newest or timestamp-based last-write-wins can erase an
+offline device's complete generation. A generic retry queue can also replay an older
+upload after a newer local save. `SlotGenerationId` identifies a logical publication,
+while a provider ETag/revision identifies one remote object state; neither substitutes
+for the other.
+
+Conflict UI may collect a user's choice, but a panel cannot own durable state, retain
+leases or apply a provider/local write. The sync coordinator needs an explicit state
+machine, persisted intent, lineage comparison and compare-and-swap boundary that
+preserves recoverable archives.
+
+## Decision
+
+### 1. Local storage is gameplay authority; cloud is a replica
+
+Runtime Save reads, writes, validates, migrates and publishes only through the local
+ADR-113 namespace/storage authority. A successful local `PublishedDurable` result is
+gameplay-save success even when cloud is disabled, unavailable, offline, signed out,
+quota-limited or failed. Cloud state is reported separately and never relabels local
+success as rollback/failure.
+
+Platform Services owns authenticated provider session and opaque blob transport. It
+does not parse archives, inspect gameplay state, choose a winner, mutate the local
+catalog or expose local paths. `CloudSaveCoordinator`, owned by the application/profile
+session, is the single sync state authority. It consumes immutable local catalog/
+archive leases and the narrow platform backend.
+
+Game load always uses a locally published validated archive. A remote archive must be
+downloaded, boundedly verified under local scope/signature/compatibility policy and
+published through the local storage transaction before Runtime Save can load it.
+
+### 2. Local generation, archive identity and provider revision are distinct
+
+```cpp
+struct ProviderObjectRevision { BoundedOpaqueBytes value; };
+struct CloudSyncRecordRevision { uint64_t value; };
+
+struct CloudReplicaHead {
+    SaveAddress address;
+    SlotGenerationId generation;
+    OptionalSlotGenerationId parentGeneration;
+    ArchiveContentHash archive;
+    CanonicalStateHash state;
+    ProviderObjectRevision providerRevision;
+};
+```
+
+`SlotGenerationId` and parent lineage come from the signed/verified archive and identify
+one logical slot publication. `ArchiveContentHash` identifies immutable archive bytes.
+`ProviderObjectRevision` is an opaque provider-scoped compare-and-swap token for the
+current remote object; it is not ordered, portable, gameplay-visible or stored as
+archive identity. `CloudSyncRecordRevision` orders local coordinator snapshots only.
+
+Provider modified time, local wall clock, play duration and device clock are bounded
+presentation/provenance. They may help a human recognize a generation but never prove
+causality, ancestry, freshness or overwrite permission.
+
+### 3. Conflict-safe cloud capability requires conditional mutation
+
+A backend reports one of:
+
+| Capability | Sync behavior |
+|---|---|
+| `ConditionalRevision` | Read/list returns an opaque revision; write/delete require expected revision or create-if-absent. |
+| `UncoordinatedBlob` | No safe remote write concurrency primitive; background upload/delete is disabled. Local saves still work; explicit export/import may be offered. |
+
+Automatic sync is admitted only for `ConditionalRevision` and only after backend
+qualification proves the precondition is enforced atomically. A read-then-
+unconditional write is not compare-and-swap. Process-local mutexes or advisory leases
+do not coordinate other devices. Provider last-modified time is never an expected
+revision.
+
+Writes return the new provider revision and preserve an idempotency key for retries of
+that exact expected-revision/content tuple. `PreconditionFailed` is a normal signal to
+refetch and reclassify, never permission to retry unconditionally.
+
+### 4. A namespace owns a durable sync journal
+
+After local save publication, the coordinator durably journals an upload intent
+containing exact address, generation, parent, archive hash, expected provider revision
+and retry identity. The intent pins or revalidates the archive before every attempt.
+A later local save creates/supersedes intent explicitly; successful upload of an older
+archive cannot mark the newer generation synced.
+
+The journal also records last verified local/remote heads, provider account/session
+scope, pending download/conflict/delete work, retry/backoff state and immutable typed
+outcomes. It contains no credentials or raw platform handles. Profile switch/sign-out
+closes scheduling for the old namespace as ADR-113 requires; queued work cannot replay
+under a new provider user.
+
+Platform Services' generic offline queue does not persist cloud archive writes or
+deletes. Their payload lease, expected revision and lineage are owned by this journal.
+The frontend may retry one idempotent request while the coordinator remains alive,
+but only the coordinator decides durable replay.
+
+### 5. Startup and offline behavior are explicit
+
+Cloud sync has typed states such as Disabled, Unavailable, SignedOut, Offline,
+Reconciling, InSync, UploadPending, DownloadPending, Conflict, Failed and Closing.
+These are a projection of coordinator state, not slot lifecycle or Runtime Save result.
+
+Startup opens and validates the local catalog first. Local save/load remains admitted
+according to local policy without waiting for network. When cloud becomes available,
+the coordinator lists/reads remote heads, validates provider user/product/profile
+scope and reconciles against the journal. A host may present a bounded “checking cloud”
+state before a slot-selection UX, but it cannot make local durability depend on remote
+availability or silently replace local data during that window.
+
+Offline saves advance local lineage normally and journal upload intent. Retry uses
+bounded exponential backoff/jitter and visible quota/auth/permanent failure. Network
+recovery triggers reconciliation, not blind FIFO upload.
+
+### 6. Reconciliation classifies verified complete generations
+
+For each `CloudSaveObjectKey`, the coordinator verifies remote metadata and downloads
+the blob when lineage/content evidence is needed. An unverified/malformed remote is
+CorruptOrUntrusted and quarantined/reported; it is not a conflict candidate or local
+overwrite source.
+
+Given verified local and remote heads:
+
+| Relationship | Result |
+|---|---|
+| Same `SlotGenerationId` and `ArchiveContentHash` | InSync; refresh provider revision only |
+| Same generation, different archive hash | Identity/integrity violation; quarantine, never choose automatically |
+| Remote is a known ancestor of local | Upload local with expected provider revision |
+| Local is a known ancestor of remote | Stage/verify and durably apply remote to local as the same logical publication |
+| Neither is a known ancestor, or retained history cannot prove ancestry | Conflict; preserve both complete archives |
+| One side absent with no verified tombstone/history | Unknown/Conflict; absence alone is not deletion authority |
+
+`CanonicalStateHash` may prove two generations contain equivalent logical state, but
+does not grant overwrite permission or collapse publication lineage. It may let UI
+explain that the conflict is content-equivalent.
+
+Lineage evidence is bounded. Each catalog/journal retains a configured chain of recent
+generation-parent/hash records. If ancestry has aged out, the coordinator classifies
+conservatively rather than inferring from timestamp or generation bytes.
+
+### 7. Download/apply is a local storage transaction
+
+A downloaded archive is untrusted until framing, bounds, `ArchiveContentHash`,
+signature/scope, product/profile/logical-slot identity and compatibility preflight all
+pass. It remains operation-owned staging. The coordinator acquires the local slot
+lease and revalidates the expected local generation before atomic durable publication
+and catalog update.
+
+Replicating the same remote logical publication preserves its embedded
+`SlotGenerationId`; it does not allocate a new one. Migration or import into another
+slot/namespace creates a new archive/publication through Runtime Save. Failed download,
+verification, local quota or atomic replace leaves the prior local generation intact.
+
+### 8. Divergent conflicts require explicit resolution and preservation
+
+The baseline performs no field/record/participant semantic merge and no automatic
+last-write-wins. A conflict operation pins exact local generation/hash and remote
+provider revision/generation/hash. Before any destructive replacement, both verified
+archive byte sets are durably retained: the current local slot plus an operation-owned
+conflict recovery record/blob for the other side. Signed bytes are not rewritten merely
+to make a new filename.
+
+Host policy or UI may submit one typed command:
+
+- `KeepLocal`: retain remote in conflict recovery, then conditionally upload local;
+- `KeepRemote`: retain local in conflict recovery, then publish remote locally;
+- `KeepBoth`: retain both and, when scope/signing policy permits, import one through
+  Runtime Save as a newly finalized slot publication; or
+- `Defer`: keep Conflict state and both copies without mutation.
+
+The UI owns only presentation/confirmation. `CloudSaveCoordinator` revalidates all
+captured revisions under local lease and provider CAS, executes the command and
+publishes result. Any stale/precondition failure returns to reconciliation. Closing a
+dialog cannot resolve, cancel ownership unsafely or delete a copy.
+
+Conflict recovery retention is budgeted and visible. Capacity failure blocks a
+destructive resolution; it does not authorize discarding the losing generation.
+Explicit later deletion of a recovery copy follows product retention/confirmation
+policy and is not part of automatic sync.
+
+### 9. Delete is a revisioned intent, not remote absence
+
+Local slot deletion records a durable coordinator delete intent with last known
+generation/hash and expected provider revision. Remote deletion uses revision CAS. If the
+remote head advanced, deletion becomes Conflict. A provider returning NotFound does
+not prove another device intended deletion unless verified journal/tombstone policy
+does so.
+
+Until the product's slot-lifecycle contract defines synchronized tombstones, the
+baseline does not automatically propagate remote absence into local deletion or local
+absence into remote deletion. Explicit confirmed delete may remove both only after
+revalidation and recovery/retention policy.
+
+### 10. Qualification covers races, clocks and preservation
+
+Required evidence includes:
+
+- local save/load while cloud is disabled, missing, offline, signed out, quota-full or
+  permanently failed;
+- conditional create/write/delete, precondition failure and rejection of
+  uncoordinated background mutation;
+- device A/B offline branches, upload reordering, stale retry after newer local save,
+  process crash at each journal/provider/local-publication boundary and profile switch;
+- same, ancestor, divergent, unknown-history, same-generation/different-hash, corrupt/
+  untrusted and absent-without-tombstone classification;
+- arbitrary provider/device clock skew proving timestamps never select a winner;
+- KeepLocal/KeepRemote/KeepBoth/Defer with stale revisions, failure injection, signing/
+  scope restrictions and both complete archives recoverable; and
+- UI close/reopen/headless policy using coordinator snapshots/commands with no path,
+  credential, provider object or semantic merge authority.
+
+## Consequences
+
+### Positive
+
+- Local persistence remains reliable independently of cloud support.
+- Provider concurrency and logical publication identity cannot be conflated.
+- Offline branches are classified without trusting clocks.
+- Conflict resolution cannot silently discard both recoverable generations.
+
+### Costs
+
+- Providers need qualified revision CAS capability for automatic mutation.
+- The coordinator owns a durable journal, ancestry evidence and recovery storage.
+- Some simple blob stores support explicit export/import only.
+
+## Rejected Alternatives
+
+### Newest provider timestamp wins
+
+Rejected because clocks are skewable presentation data and do not prove lineage or
+write authority.
+
+### Always prefer local or always prefer cloud
+
+Rejected because either rule silently destroys valid offline work on the other side.
+
+### Read then unconditionally write
+
+Rejected because another device may mutate between calls; only provider-enforced
+revision CAS closes that race.
+
+### Merge participant records automatically
+
+Rejected for the baseline because subsystem invariants, cross-participant transactions
+and deletes cannot be reconstructed safely by a generic cloud layer.
+
+### Let the conflict dialog perform writes
+
+Rejected because presentation does not own durable journal, local leases, provider
+preconditions or operation lifetime.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -126,6 +126,7 @@ to the replacement.
 | [112](112-save-archive-container-and-compatibility-policy.md) | Save Archive Container and Compatibility Policy | Proposed | 2026-09-02 |
 | [113](113-local-storage-user-profile-and-slot-ownership.md) | Local Storage, User Profile and Slot Ownership | Proposed | 2026-09-02 |
 | [114](114-canonical-runtime-world-persistence-boundary.md) | Canonical Runtime World Persistence Boundary | Proposed | 2026-09-02 |
+| [115](115-cloud-save-authority-revision-and-conflict-policy.md) | Cloud Save Authority, Revision and Conflict Policy | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -317,6 +317,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Canonical Runtime World Persistence Boundary](../adr/114-canonical-runtime-world-persistence-boundary.md):
   authoring-base/runtime-override composition, state classification,
   subsystem-owned canonical adapters and aggregate capture/restore.
+- [Cloud Save Authority, Revision and Conflict Policy](../adr/115-cloud-save-authority-revision-and-conflict-policy.md):
+  local authority, provider CAS/lease revisions, offline lineage classification,
+  conflict preservation and coordinator-owned resolution.
 - [Navigation And AI Architecture](./runtime/navigation-and-ai-architecture.md):
   NavMesh, pathfinding, dynamic obstacle overlays, perception, crowd, blackboard,
   and editor bake tooling.

--- a/docs/architecture/runtime/platform-services-architecture.md
+++ b/docs/architecture/runtime/platform-services-architecture.md
@@ -107,11 +107,11 @@ public:
     PlatformServiceRequest<LeaderboardEntries>
     GetLeaderboardEntries(LeaderboardId id, const LeaderboardQuery& query);
 
-    PlatformServiceRequest<CloudSaveMetadata>
+    PlatformServiceRequest<CloudReadResult>
     ReadCloudSave(CloudSaveObjectKey key);
 
-    PlatformServiceRequest<void>
-    WriteCloudSave(CloudSaveObjectKey key, std::span<const std::byte> data);
+    PlatformServiceRequest<CloudMutationResult>
+    WriteCloudSave(CloudWriteRequest request);
 
     PlatformServiceRequest<void>
     SetPresence(const PresenceState& state);
@@ -199,6 +199,8 @@ not_signed_in     -- no authenticated user
 forbidden         -- platform policy or user consent blocks the call
 not_supported     -- the active backend does not implement this service
 rate_limited      -- call must be retried later
+precondition_failed -- remote revision changed; caller must refetch/reclassify
+quota_exceeded    -- provider cannot retain the requested object
 platform_error    -- backend-specific error, diagnostic detail available
 request_cancelled -- caller cancelled
 timeout           -- frontend timeout before backend completion
@@ -206,17 +208,10 @@ timeout           -- frontend timeout before backend completion
 
 ### Ordering And Coalescing
 
-Independent requests may complete out of order. Dependent operations must be
-chained explicitly by the caller:
-
-```cpp
-frontend.ReadCloudSave(slot)
-    .OnComplete([&](Result<CloudSaveMetadata> meta) {
-        if (meta) {
-            frontend.WriteCloudSave(slot, newData);
-        }
-    });
-```
+Independent requests may complete out of order. Dependent operations are chained by
+their owning coordinator. In particular, cloud mutation always carries the exact
+provider revision returned by the reconciled read/list (or create-if-absent); generic
+callers cannot turn a read completion into an unconditional write.
 
 Presence updates are coalesced. If `SetPresence` is called many times before
 the backend finishes the previous update, only the most recent state is sent.
@@ -314,6 +309,11 @@ local save files.
 struct CloudSaveObjectKey { BoundedOpaqueBytes value; };
 struct ProviderObjectRevision { BoundedOpaqueBytes value; };
 
+enum class CloudConcurrencyCapability : uint8_t {
+    ConditionalRevision,
+    UncoordinatedBlob
+};
+
 struct CloudSaveMetadata {
     CloudSaveObjectKey key;
     ProviderObjectRevision revision;
@@ -321,19 +321,41 @@ struct CloudSaveMetadata {
     uint64_t sizeBytes;
 };
 
+using CloudWritePrecondition =
+    Variant<RequireObjectAbsent, MatchProviderRevision>;
+
+struct CloudReadResult {
+    CloudSaveMetadata metadata;
+    OwnedImmutableBytes archive;
+};
+
+struct CloudWriteRequest {
+    CloudSaveObjectKey key;
+    OwnedImmutableBytes archive;
+    CloudWritePrecondition precondition;
+    IdempotencyKey retryIdentity;
+};
+
+struct CloudMutationResult {
+    std::optional<ProviderObjectRevision> resultingRevision;
+    std::optional<CloudSaveMetadata> metadata;
+};
+
 class ICloudSaveService {
 public:
+    virtual CloudConcurrencyCapability ConcurrencyCapability() const = 0;
+
     virtual PlatformServiceRequest<std::vector<CloudSaveMetadata>>
     List() = 0;
 
-    virtual PlatformServiceRequest<std::vector<std::byte>>
+    virtual PlatformServiceRequest<CloudReadResult>
     Read(CloudSaveObjectKey key) = 0;
 
-    virtual PlatformServiceRequest<void>
-    Write(CloudSaveObjectKey key, std::span<const std::byte> data) = 0;
+    virtual PlatformServiceRequest<CloudMutationResult>
+    Write(CloudWriteRequest request) = 0;
 
-    virtual PlatformServiceRequest<void>
-    Delete(CloudSaveObjectKey key) = 0;
+    virtual PlatformServiceRequest<CloudMutationResult>
+    Delete(CloudSaveObjectKey key, ProviderObjectRevision expected) = 0;
 };
 ```
 
@@ -345,9 +367,12 @@ erased scope. The backend treats both key and finalized archive bytes as opaque 
 never edits the local format or catalog.
 
 Provider revisions and timestamps are returned as transport metadata. They do not
-select a winning local/cloud generation automatically. SAV-006 owns write
-preconditions, offline authority and divergent-generation resolution; UI may present
-a choice but never becomes sync authority.
+select a winning local/cloud generation automatically. Under ADR-115, automatic
+mutation requires qualified `ConditionalRevision` semantics. `UncoordinatedBlob`
+disables background write/delete while local saves remain available. The save/cloud
+coordinator owns durable intent, lineage,
+preconditions and divergent-generation resolution; UI may present a choice but never
+becomes sync authority.
 
 ### Presence
 
@@ -496,7 +521,6 @@ safely retried:
 - achievement progress updates
 - leaderboard score submissions
 - stat writes
-- cloud save writes
 
 Each queued operation carries an `IdempotencyKey`. The key is generated once
 when the operation enters the frontend and is preserved across persistence,
@@ -514,6 +538,12 @@ When the backend reports `offline` or `not_signed_in`, the frontend:
 
 Operations that cannot be safely replayed, such as cloud save reads or
 leaderboard queries, fail immediately with the appropriate error.
+
+Cloud archive writes/deletes are deliberately absent from this generic queue. Their
+immutable payload lease, slot lineage, expected provider revision, retry identity and
+profile-session scope are durably owned by ADR-115's `CloudSaveCoordinator`. After
+offline recovery it reconciles remote state before conditional mutation; it never
+replays a stale FIFO upload under a later local generation or different user.
 
 Replay rules:
 
@@ -734,6 +764,9 @@ Required tests cover:
 - stable ID registries reject unregistered names
 - typed cloud-object addressing, provider revision propagation and no timestamp-based
   automatic winner selection
+- conditional write/delete and precondition failure; uncoordinated providers never
+  receive background mutations
+- cloud archive writes/deletes never enter the generic offline queue
 - session sign-in/out triggers queue replay and state callbacks
 - unavailable services return `not_supported`
 - presence updates coalesce to the most recent state
@@ -781,5 +814,7 @@ Platform-specific backend tests live in the private platform repositories.
 - [Platform Abstraction Architecture](../foundation/platform-abstraction.md)
 - [ADR-113](../../adr/113-local-storage-user-profile-and-slot-ownership.md): product,
   user/profile and logical-slot addressing across local and cloud boundaries.
+- [ADR-115](../../adr/115-cloud-save-authority-revision-and-conflict-policy.md): local
+  authority, provider preconditions, offline journal and conflict preservation.
 - [Extension System](../extensions/plugin-system.md)
 - [Release Security](../release/release-security.md)

--- a/docs/architecture/runtime/save-game-and-persistence.md
+++ b/docs/architecture/runtime/save-game-and-persistence.md
@@ -12,6 +12,8 @@ ADR-113 freezes product/environment/user/profile namespaces, logical slot addres
 and storage mapping for HORO-1425 #1425 [SAV-003.1].
 ADR-114 freezes authoring/runtime state composition and subsystem-owned canonical
 adapters for HORO-1438 #1438 [SAV-004.1].
+ADR-115 freezes local/cloud authority, provider revisions and conflict preservation
+for HORO-1466 #1466 [SAV-006.1].
 
 - RuntimeSaveService coordinates one runtime save/restore authority under the
   application/session lifetime. It never retains an unleased reference to a scene
@@ -499,12 +501,13 @@ from a synchronous EnumerateSaveSlots call. No portable crash guarantee is assum
 for an unqualified filesystem/platform container.
 
 Cloud registration occurs only for the final validated local slot generation after
-PublishedDurable. It pins that generation or revalidates its `ArchiveContentHash`
-before transfer so a concurrent later save cannot be uploaded under an older
-generation. A bounded
-pending-sync record is reconstructed from the catalog on restart if the process dies
-between durable save and registration. Completed means local durability; cloud state
-(Pending/Synced/Failed) is separate and cannot turn local success into false rollback.
+PublishedDurable. The coordinator durably journals the exact address, generation,
+parent, archive hash, expected provider revision and retry identity, then pins or
+revalidates that archive before transfer. A concurrent later save explicitly
+supersedes intent; an older upload cannot be reported as the newer generation.
+Startup reconciles the journal rather than blindly replaying a generic FIFO. Completed
+means local durability; cloud state is separate and cannot turn local success into
+false rollback.
 
 ## Transactional Restore
 
@@ -874,32 +877,49 @@ Catalog UI consumes immutable records keyed by `SaveAddress`; no filesystem path
 raw platform handle crosses the surface. The save/cloud coordinator derives a bounded
 `CloudSaveObjectKey` from the typed address and authenticated provider context.
 Platform Services treats that key and finalized archive bytes as opaque and cannot
-edit local storage. Provider timestamps remain presentation/provenance only. SAV-006
-owns cloud revisions, write preconditions, offline authority and divergence policy.
+edit local storage. The application/profile-owned `CloudSaveCoordinator` is the one
+sync state authority; Platform Services and UI are transport/presentation adapters.
 
-Cloud adapters receive only final signed/unsigned archives allowed by the namespace
-policy. Conflict detection compares `SlotGenerationId` lineage and
-`ArchiveContentHash`; `CanonicalStateHash` may show logical equivalence but cannot win
-a compare-and-swap. Timestamps are presentation metadata, not causality or authority
-to overwrite local data. Conflict UI or headless host policy consumes typed
-local/remote generations, content/state hashes, times and play duration. Optional
-game-specific summaries come from a bounded host presenter; engine code does not
-assume character levels or a Main Menu.
+Automatic remote mutation requires provider-enforced conditional revision. A read
+followed by unconditional write, a process-local mutex, advisory lease or provider
+timestamp is insufficient. An uncoordinated blob backend disables background
+upload/delete while local save/load remains functional.
+The provider's opaque revision is only a compare-and-swap token; it is not
+`SlotGenerationId`, ordered gameplay state or portable archive identity.
 
-Before choosing a remote copy, verify it under the same signature/scope/schema rules.
-Preserve the losing valid copy in a new opaque conflict-slot ID (with original archive
-identity/provenance retained in the catalog) before replacement. Recheck source and
-destination revisions under the lease; preserve failure/quota outcomes. Signed
-content's embedded slot identity cannot be rewritten to fit a conflict filename:
-backup catalog records distinguish storage ID from the signed logical slot identity,
-and only an explicit restore/import mapping can authorize that association. No archive
-bytes are modified in place to update display/conflict metadata.
+On startup/reconnect the coordinator opens local state first, then reconciles verified
+local and remote heads. Same generation/hash is InSync. A known remote ancestor of
+local permits conditional upload; a known local ancestor of remote permits verified
+download and local durable application preserving that remote generation. Same
+generation/different hash is an integrity violation. Unknown ancestry, absent data
+without verified deletion evidence, or two non-ancestor complete heads is Conflict.
+`CanonicalStateHash` may report logical equivalence but cannot authorize overwrite.
+Provider/device timestamps and play duration remain presentation/provenance only.
 
-Local durability and cloud durability are separate status domains. Upload failure
-keeps a bounded retry intent and visible diagnostics; a later local save does not
-silently relabel an older upload as current. Startup reconciles pending sync from
-validated local revisions. Required-signature policy also applies to downloads and
-migration; cloud availability cannot authorize unsigned downgrade.
+Downloaded data is untrusted until bounds, content hash, signature/scope and
+compatibility checks pass. It enters local storage only through a slot lease, expected
+generation recheck and atomic durable transaction; Platform Services never edits a
+local file. Failed verification/publication leaves the previous local generation.
+
+Divergent complete generations are never field/record merged and never resolved by
+automatic last-write-wins. Before KeepLocal or KeepRemote can replace anything, both
+verified byte sets must be durable: the active local slot plus a conflict recovery
+record/blob carrying exact archive identity and provenance. KeepBoth may import one as
+a newly finalized slot publication when scope/signing policy permits. Quota/retention
+failure blocks destructive resolution instead of discarding the losing archive.
+
+Conflict UI or headless host policy sees immutable coordinator snapshots and submits
+a typed KeepLocal, KeepRemote, KeepBoth or Defer command capturing local generation/
+hash and remote provider revision/generation/hash. The coordinator revalidates local
+lease and provider CAS before applying it; stale input returns to reconciliation.
+Closing UI changes no state. Signed slot identity is never rewritten merely to fit a
+conflict filename.
+
+Offline saves advance local lineage and retain bounded visible retry state. Profile
+switch/sign-out closes old scheduling so intent never replays under a new provider
+user. Required-signature policy also applies to downloads and migration; cloud
+availability cannot authorize unsigned downgrade. Remote absence is not automatic
+delete authority until a synchronized tombstone contract exists.
 
 ## Failure, Cancellation And Shutdown Summary
 
@@ -970,7 +990,11 @@ documentation change:
 - Slot ID/path attack cases, symlink/reparse races, active-temp cleanup exclusion,
   other-process mutation, named-slot import and signed conflict-copy identity mapping.
 - Busy autosave coalescing, bounded retry exhaustion, rotation only after success,
-  cloud upload/download conflicts, crash between save and sync registration.
+  cloud conditional upload/download conflicts, offline lineage branches, clock skew,
+  stale retries and crashes at journal/provider/local-publication boundaries.
+- Same/ancestor/divergent/unknown/same-generation-different-hash classification;
+  KeepLocal/KeepRemote/KeepBoth/Defer preserve both verified conflict archives and do
+  not perform semantic record merge.
 - Shutdown while a save is past commit, while candidates hold modules/assets, and
   while optional GPU thumbnails are pending; no early free or silent incomplete unload.
 
@@ -998,4 +1022,5 @@ and regression coverage.
 - [ADR-112](../../adr/112-save-archive-container-and-compatibility-policy.md): Portable container, canonical state, version axes, identities and compatibility horizon.
 - [ADR-113](../../adr/113-local-storage-user-profile-and-slot-ownership.md): Product/user/profile namespaces, logical slot addressing and physical storage ownership.
 - [ADR-114](../../adr/114-canonical-runtime-world-persistence-boundary.md): Authoring/runtime composition, state classification and subsystem-owned canonical adapters.
+- [ADR-115](../../adr/115-cloud-save-authority-revision-and-conflict-policy.md): Local/cloud authority, provider CAS revisions, offline lineage and conflict preservation.
 - [Application Security](../security/application-security.md): Trust and untrusted-input boundaries.


### PR DESCRIPTION
## Summary

- Makes the local save store the gameplay authority and treats cloud storage as a verified replica transport.
- Separates provider object revisions from slot generations and canonical/archive hashes.
- Requires compare-and-swap revision semantics for coordinated cloud writes and deletes.
- Defines lineage-aware conflict classification that preserves both recoverable generations until an explicit resolution.

## Why

Timestamp-based last-write-wins cannot establish causality and can silently discard a valid offline generation. Retried uploads can also overwrite newer remote data when provider revisions are not checked. The cloud boundary therefore needs explicit authority, revision, recovery, and conflict contracts before implementation begins.

## Decision and boundaries

- Adds ADR-115 and projects the decision into the save-game and platform-services architecture.
- Providers expose either qualified `ConditionalRevision` semantics or `UncoordinatedBlob`; uncoordinated providers cannot perform background writes or deletes.
- A durable coordinator journal records synchronization intent and recovery state; generic offline queues no longer own cloud save mutations.
- Startup restores verified local state first, while remote candidates are downloaded, validated, and transactionally published before becoming eligible.
- Divergent complete generations require `KeepLocal`, `KeepRemote`, `KeepBoth`, or `Defer`; semantic record merging and unconditional last-write-wins are prohibited.
- Provider timestamps remain presentation metadata and never determine ancestry or conflict winners.

This PR defines architecture contracts only. Provider adapters, coordinator persistence, recovery flows, and conflict UI remain focused implementation work.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Markdown lint passed
- [x] Added Markdown links resolve
- [x] Staged diff checks passed
- [x] CMake configure passed
- [ ] Full build/test suite not run; this is a documentation-only decision

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- <changed-markdown-files>
git diff --check
git diff --cached --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- Platforms without compare-and-swap revision support remain local-save-only until a stronger coordination service exists.
- The durable sync journal, crash recovery, and both-copy preservation rules require implementation-level fault-injection coverage.
- CMake reported the existing mbedTLS deprecation warning and skipped repository Python tests because pytest is unavailable.

## Issue links

- Jira: HORO-1466
- GitHub: Closes #1466

## Reviewer Notes

Review ADR-115 first, then the cloud synchronization section in the save architecture, followed by the platform-services API projection. Focus on local authority, provider revision qualification, and the invariant that conflict handling cannot silently discard both complete recoverable generations.