### PR TITLE
docs(save): define save threat policy HORO-1495 #1495 [SAV-008.1]

### DIFF
--- a/docs/adr/116-save-data-threat-model-and-trust-policy.md
+++ b/docs/adr/116-save-data-threat-model-and-trust-policy.md
@@ -1,0 +1,348 @@
+# ADR-116: Save Data Threat Model and Trust Policy
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Protected save assets, attacker capabilities, source trust classification, bounded admission, integrity/authenticity/replay policy, tool authority, credentials, development/shipping profiles and security non-goals
+- **Issue**: [SAV-008.1](https://github.com/abdullahbodur/horo-engine/issues/1495)
+- **Jira**: [HORO-1495](https://horo-engine.atlassian.net/browse/HORO-1495)
+- **Related**: [ADR-002](002-credential-handling.md), [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-112](112-save-archive-container-and-compatibility-policy.md), [ADR-113](113-local-storage-user-profile-and-slot-ownership.md), [ADR-114](114-canonical-runtime-world-persistence-boundary.md), [ADR-115](115-cloud-save-authority-revision-and-conflict-policy.md)
+- **Normative documents**: [Save Game And Persistence](../architecture/runtime/save-game-and-persistence.md), [Application Security](../architecture/security/application-security.md), [Platform Services](../architecture/runtime/platform-services-architecture.md), [CLI Architecture](../architecture/interfaces/cli-architecture.md), [MCP Architecture](../architecture/interfaces/mcp-architecture.md), [Release Security](../architecture/release/release-security.md)
+
+## Context
+
+A `.horosave` may have been created locally, copied from another installation,
+downloaded through a provider, emitted by an older migration, modified for a modded
+game, signed by a server or selected by a tool. Its path and source label do not prove
+that its bytes are structurally safe, compatible, authentic, current or authorized
+for the requested namespace.
+
+The existing save decisions define canonical state, immutable archives, namespace
+ownership, transactional restore and revision-aware cloud conflicts. They do not by
+themselves state one threat model across the parser, storage adapter, UI, CLI, MCP,
+cloud provider, migration process, release profile and credential boundary. In
+particular, a content hash detects accidental or deliberate byte changes but does not
+authenticate an author; a valid signature authenticates a permitted key and scope but
+does not prove freshness; encryption provides confidentiality only when separately
+selected and correctly keyed.
+
+Treating local files as inherently trusted exposes the runtime to malformed lengths,
+decompression bombs, path races, wrong-profile substitution and replay. Conversely,
+claiming that signature checks, capability checks or native plugin permissions create
+a general anti-cheat boundary or sandbox would promise protection the engine cannot
+provide inside a user-controlled process.
+
+This ADR defines the protected assets, attacker model, source classification,
+admission pipeline, owning controls, host profiles, tool surfaces and deliberate
+non-goals. It does not choose a product-specific anti-cheat system, encrypt ordinary
+local saves or make a compromised client authoritative over server gameplay.
+
+## Decision
+
+### 1. Protected assets and authorities are explicit
+
+The policy protects:
+
+- process memory safety and bounded CPU, memory, disk and decompression work;
+- the last-known-good local slot and every conflict/migration recovery generation;
+- product, environment, platform-user, game-profile, server-world and logical-slot
+  namespace separation;
+- canonical gameplay/world state from partial, incompatible or wrong-scope restore;
+- provider-account and cloud-revision isolation across users and devices;
+- signing private keys, cloud credentials and credential-provider references;
+- diagnostic and tool surfaces from leaking raw save content or private identity; and
+- availability of local save/load when cloud or external tooling is unavailable.
+
+Authority remains divided:
+
+| Decision or asset | Owner |
+|---|---|
+| Framing, archive integrity, schema compatibility and participant decode | Runtime Save codecs and compatibility policy |
+| Physical roots, containment, slot leases, atomic publication and quarantine storage | `SaveStorageAdapter` |
+| Semantic participant validation and detached restore candidate | Owning canonical adapter and `RuntimeSaveService` |
+| Signature requirement, trusted key/scope and replay floor | Trusted host/product/namespace policy |
+| Cloud session, provider revision and opaque blob transport | Platform Services backend |
+| Cloud lineage, download admission, conflicts and recovery copies | `CloudSaveCoordinator` |
+| Capability approval and operation admission for UI/CLI/MCP | Application host and security policy |
+| Key use and provider authentication | Credential/signing provider |
+| Presentation and confirmation | UI, CLI or MCP adapter; never persistence authority |
+
+No parser, archive field, filename, provider timestamp, UI choice or tool caller may
+select its own trust root, weaken the host profile or publish directly into a live
+slot.
+
+### 2. The attacker model covers bytes, storage and invocation
+
+The baseline assumes an attacker or fault may:
+
+- supply arbitrary, truncated, oversized, contradictory or non-canonical bytes;
+- forge counts, offsets, codecs, compression ratios, hashes, metadata, identifiers,
+  schema versions, lineage, timestamps and signature descriptors;
+- replace or mutate a file between discovery, verification and publication;
+- exploit symlinks, reparse points, case/Unicode aliases, traversal, hard links,
+  duplicate normalized names and storage exhaustion;
+- replay an old but validly signed generation or copy data across product, profile,
+  slot, server-world or provider-user scopes;
+- race local writers, other processes, cloud devices, profile switching, deletion,
+  cancellation and shutdown;
+- return malformed, stale, reordered or attacker-controlled cloud bytes and metadata;
+- invoke inspection, import, export, migration, load, delete or conflict commands
+  through UI, CLI or MCP without the required capability; and
+- induce parsers/migrations to consume excessive memory, CPU, recursion, temporary
+  storage or diagnostic output.
+
+The ordinary client process, operating-system account and storage provider are not
+assumed uncompromised anti-cheat authorities. A malicious native module running in
+the host can inspect process memory and call operating-system APIs outside Horo's
+interfaces. That case is addressed by code trust, process isolation where applicable
+and server authority, not by pretending the save parser is a sandbox.
+
+### 3. Every archive starts as untrusted bytes
+
+Trust is classified by evidence and requested use, never by directory or transport:
+
+| State | Meaning | Permitted use |
+|---|---|---|
+| `UntrustedBytes` | Origin is known at most as bounded provenance; contents are not admitted | Bounded acquisition, framing probe and quarantine only |
+| `IntegrityVerified` | Exact framed bytes match `ArchiveContentHash` and decoded entries match their declared hashes | Compatibility and semantic validation; not proof of author or freshness |
+| `AuthenticatedScope` | A required/present signature verifies under a host-selected key authorized for the declared product/user/world/slot scope | Continue policy evaluation; not proof of latest generation |
+| `CompatibleCandidate` | Versions, required participants, dependencies and deterministic migrations are admitted | Detached decode/prepare only; no live mutation |
+| `SemanticallyPrepared` | Every required owner validated a complete detached candidate for one expected runtime/base revision | Aggregate no-fail restore commit at the owning safe point |
+| `LocallyPublished` | A complete archive generation was atomically durably published under the expected slot lease | Eligible local source; bytes are reverified when later read |
+| `Quarantined` | Verification, scope, policy or identity failed, or provenance must be retained for investigation | No load/migrate/sync winner use; bounded metadata-only inspection |
+
+`LocallyPublished` describes a completed storage transaction, not permanent trust in
+future reads. External mutation, disk faults or policy changes require the archive to
+pass admission again. Catalog membership, a `.horosave` suffix, location under a save
+root, cloud authentication and a platform “download complete” result grant no higher
+state.
+
+### 4. Source policy is classified before admission
+
+| Source | Required baseline policy |
+|---|---|
+| Local slot | Open only through typed address and storage lease; reverify framing/integrity/signature/scope/compatibility on read |
+| Imported/copy/guest save | Explicit import capability and source provenance; verify in operation-owned staging; publish as a new destination generation without modifying the source |
+| Cloud download | Treat bytes and provider metadata as untrusted; enforce size limits before/during transfer, then local verification, scope checks and CAS-aware coordinator publication |
+| Migration input | Verify the original under its source policy first; migrate detached with bounded work; finalize and sign a new generation under destination policy |
+| Modded save | Admit only under an explicit product/mod profile and isolated namespace; never weaken a secure production/server namespace or trust native mod code |
+| Server-signed save | Require a scope-authorized server key and requested world/account binding; separately enforce trusted replay/generation policy where rollback matters |
+| Tool-inspected save | Bounded metadata/framing inspection may run without load authority; inspection success does not admit migration, import, restore, export or mutation |
+
+Unknown origin is permitted only where the selected import/inspection policy explicitly
+accepts it as untrusted input. Provenance labels help audit and user decisions but do
+not substitute for cryptographic or semantic evidence.
+
+### 5. One bounded admission pipeline owns all sources
+
+Every load, import, migrated output and cloud download follows these stages:
+
+1. Resolve a trusted operation profile, requested typed source/destination address,
+   capability set, byte/work budgets and cancellation policy.
+2. Acquire an operation-owned handle or staging object through the storage/transport
+   adapter; do not follow archive-supplied paths.
+3. Read the fixed framing with checked arithmetic and enforce total/stored byte limits
+   before payload allocation.
+4. Verify exact framing, `ArchiveContentHash` and trailer form before trusting payload
+   control fields; reject trailing, overlapping, duplicate or unreferenced bytes.
+5. Apply host-selected signature/key/scope and optional anti-replay policy. The
+   archive cannot request `Disabled`/`Optional`, add a trust root or lower a floor.
+6. Parse deterministic metadata and entry tables with limits on counts, lengths,
+   compression expansion, nesting, strings, diagnostics and total work.
+7. Preflight archive/save/participant compatibility and build one complete bounded
+   migration plan; unknown required semantics fail closed.
+8. Decode and semantically validate every required participant in detached storage.
+9. Revalidate source/destination identities, expected generations, leases, profile
+   epoch and cancellation gate before the no-fail restore or atomic publication.
+10. Publish one typed result and safe audit summary, then retire staging/recovery data
+    according to policy.
+
+Parser or migration failure never mutates the active runtime, live catalog or source
+archive. A resource-limit result is not retried with an automatically larger/unbounded
+profile. High-risk third-party codecs may run in a restricted helper process, but
+process isolation does not remove the same format, integrity and semantic checks.
+
+### 6. Integrity, authenticity, confidentiality and freshness stay separate
+
+`ArchiveContentHash` and participant hashes detect changed bytes; they are not a MAC,
+identity proof or permission. `SaveSignaturePolicy::Optional` authenticates every
+present valid signature but cannot detect signature stripping from an otherwise
+unsigned-acceptable source. `Required` provides tamper/authorship protection only for
+keys and scopes selected by the host.
+
+A valid signature does not prove that a generation is newest, authorized to overwrite
+another generation or free of hostile-but-schema-valid data. Replay-sensitive products
+use a separately trusted monotonic generation/receipt/ledger bound to the namespace;
+attacker-controlled timestamps and archive counters are not anti-rollback state.
+
+The v1 runtime save container provides no confidentiality. Product policy that stores
+sensitive data must avoid it, minimize it or introduce a separately reviewed
+authenticated-encryption envelope with key rotation, recovery and platform backup
+behavior. Release `.horo` archive encryption policy does not implicitly encrypt
+`.horosave` files.
+
+### 7. Credentials never cross the save data boundary
+
+Archives, catalogs, sync journals, recovery copies, migration metadata, CLI/MCP
+requests/results and diagnostics contain no raw credential, private key, reusable
+authorization header, provider token or machine-local secret value. Portable policy
+may name a stable public key/trust-policy requirement; private bindings remain in the
+credential/signing provider.
+
+The consuming operation obtains a short-lived scope-limited credential/key lease only
+after capability and namespace admission. Platform Services uses provider credentials
+only inside the selected backend request. Runtime Save submits a bounded signing or
+verification request without receiving private key material. Cancellation, sign-out,
+profile switch and shutdown revoke/retire leases before operation state is released.
+
+Errors and audit records use safe stable key/provider/policy IDs only when policy
+allows them. They never echo credential handles, paths into credential stores or raw
+archive data.
+
+### 8. UI, CLI and MCP are adapters over the same use cases
+
+Surfaces may expose separate capabilities such as `save.inspect`, `save.import`,
+`save.export`, `save.migrate`, `save.load`, `save.delete` and
+`save.conflict.resolve`. A capability authorizes one bounded operation; inspection
+does not imply load/mutation, and project trust does not imply access to another user,
+environment or server namespace.
+
+Tools pass typed addresses or explicitly admitted external-file handles to application
+use cases. They never pass archive-selected destination paths, call codecs directly,
+hold slot/provider leases, access credentials or mutate the catalog/runtime from a
+transport/UI thread. Destructive or external-source operations follow confirmation
+policy and optimistic generation/revision checks.
+
+Inspection returns bounded allowlisted metadata, validation state and safe diagnostics.
+Raw participant bytes, complete decoded gameplay state, credentials, private platform
+identity and unrestricted filesystem paths are excluded by default. Development-only
+raw export requires a distinct capability, explicit destination root and audit policy;
+it cannot be enabled by an archive or remote caller.
+
+### 9. Development and shipping profiles differ only in admitted authority
+
+All profiles enforce framing, checked arithmetic, parser/decompression/work budgets,
+path containment, cancellation, transactional publication, credential isolation and
+safe diagnostics. Debug builds cannot disable memory-safety or storage invariants.
+
+Development/test profiles may enable metadata inspection, isolated unsigned/modded
+namespaces, deterministic fixture generation, raw developer export and verbose safe
+diagnostics through explicit local capabilities. Their product/environment IDs and
+roots remain separate from shipping/server data. A file is never promoted between
+profiles by rename or directory copy.
+
+Shipping profiles expose only product-declared import/mod/tool operations, use fixed
+fail-closed compatibility and signature policies, deny remote MCP save mutation unless
+explicitly configured/authenticated, and omit parser bypasses or arbitrary raw export.
+Secure server/account namespaces require scope-authorized signatures and any declared
+anti-replay authority. User-controlled local single-player products may deliberately
+accept unsigned saves, but must describe that as lack of tamper protection rather than
+as a trusted or secure-save mode.
+
+### 10. Failures are typed, quarantined and safely observable
+
+Stable policy outcomes include CorruptOrMalformed, ResourceLimitExceeded,
+IntegrityMismatch, SignatureRequired, SignatureInvalid, UntrustedSigner, WrongScope,
+ReplayRejected, UnsupportedVersion, MigrationUnavailable, PolicyDenied,
+CapabilityDenied, StaleGeneration, ProviderPreconditionFailed and Quarantined.
+Adapters map them to their stable CLI/MCP/UI envelopes without collapsing security
+denial into ordinary not-found or silently falling back to a weaker policy.
+
+Security events record bounded source kind, requested operation, typed namespace
+identity, safe archive/generation hash correlation, effective policy ID, result and
+actor/session identity allowed by privacy policy. They do not retain raw save bytes,
+decoded state, labels/free text, local paths, credentials or private provider metadata.
+Repeated malformed/resource-limit/authentication failures are rate-limited without
+hiding the terminal operation outcome.
+
+### 11. Qualification proves the boundary and non-goals
+
+Required evidence covers:
+
+- each source kind entering as `UntrustedBytes`, including a file already present in
+  the canonical save directory and a provider-authenticated download;
+- truncated/oversized/overflowing framing, duplicate/overlap/gap/trailing bytes,
+  hostile counts/strings/nesting/codecs and decompression/work/disk exhaustion;
+- symlink/reparse/hard-link, Unicode/case alias, replacement-after-open and
+  source/destination namespace traversal races;
+- hash/signature stripping/wrong key/wrong scope, old valid replay, copied slot/profile/
+  world data and attacker-controlled timestamp/generation claims;
+- malformed, signed-but-semantically-invalid and compatible-but-prepare-failing
+  participants leaving active runtime and prior local generation unchanged;
+- import/migration/cloud failure and cancellation at every staging, verification,
+  signing, CAS, local-publication and recovery-retention boundary;
+- capability separation across inspect/import/export/migrate/load/delete/conflict,
+  including GUI/CLI/MCP equivalence and remote denial in shipping policy;
+- no credential/raw-state/path leakage through results, logs, history, crash bundles
+  or conflict UI; and
+- development/shipping, unsigned/modded/secure-server and no-cloud profiles with no
+  cross-namespace promotion or automatic policy downgrade.
+
+## Consequences
+
+### Positive
+
+- Local, imported, migrated, modded and cloud saves share one fail-closed admission
+  contract instead of inheriting trust from their location.
+- Integrity, signature, confidentiality and anti-replay claims are precise.
+- Tooling can inspect hostile inputs without gaining restore or mutation authority.
+- Development flexibility cannot silently weaken shipping/server namespaces.
+
+### Costs
+
+- Hosts must define concrete budgets, capability maps, key/scope policy and optional
+  anti-replay storage per product profile.
+- Import, cloud and migration paths require staging/quarantine and fault-injection
+  coverage instead of reusing a direct local-file load shortcut.
+- Products needing confidentiality or adversarial client enforcement need additional
+  reviewed systems beyond the v1 save container.
+
+## Rejected Alternatives
+
+### Trust files inside the save directory
+
+Rejected because local malware, users, sync tools, other processes and storage faults
+can replace those bytes. Directory containment limits path authority; it does not
+validate content.
+
+### Treat a matching SHA-256 digest as authenticated
+
+Rejected because an attacker who changes the archive can recompute an unkeyed digest.
+The hash is integrity identity, while authorship requires host-selected signature
+policy.
+
+### Treat every valid signature as current and safe
+
+Rejected because a valid old generation can be replayed and schema-valid content can
+still violate semantic or resource policy. Scope, compatibility, semantic validation
+and optional anti-replay state remain independent gates.
+
+### Give inspection tools direct codec or filesystem access
+
+Rejected because adapters would bypass capability, budget, namespace, credential,
+lease and audit ownership. Tools use the same bounded application use cases.
+
+### Disable parser limits in development builds
+
+Rejected because malformed fixtures, imported projects and compromised dependencies
+can still attack the developer host. Development may add explicit capabilities and
+diagnostics, not remove memory-safety and transactional invariants.
+
+### Describe save signing as anti-cheat or sandboxing
+
+Rejected because a user-controlled native process can bypass client-side interfaces
+and a trusted native module is not isolated by capability checks. Competitive truth
+belongs to an authoritative server or a separately designed anti-cheat system.
+
+## Non-Goals
+
+- Preventing a local user or native code with equivalent operating-system authority
+  from reading or modifying all client process/storage state.
+- Providing general malware scanning, DRM, anti-cheat or a sandbox for native mods.
+- Encrypting v1 `.horosave` content or guaranteeing confidentiality from local/cloud
+  administrators.
+- Recovering data after every copy, recovery generation and provider backup is lost or
+  maliciously deleted.
+- Proving freshness from timestamps, archive counters, filenames or signatures without
+  a separately trusted anti-replay authority.
+- Making client saves authoritative for server-owned competitive state.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -127,6 +127,7 @@ to the replacement.
 | [113](113-local-storage-user-profile-and-slot-ownership.md) | Local Storage, User Profile and Slot Ownership | Proposed | 2026-09-02 |
 | [114](114-canonical-runtime-world-persistence-boundary.md) | Canonical Runtime World Persistence Boundary | Proposed | 2026-09-02 |
 | [115](115-cloud-save-authority-revision-and-conflict-policy.md) | Cloud Save Authority, Revision and Conflict Policy | Proposed | 2026-09-02 |
+| [116](116-save-data-threat-model-and-trust-policy.md) | Save Data Threat Model and Trust Policy | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -320,6 +320,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Cloud Save Authority, Revision and Conflict Policy](../adr/115-cloud-save-authority-revision-and-conflict-policy.md):
   local authority, provider CAS/lease revisions, offline lineage classification,
   conflict preservation and coordinator-owned resolution.
+- [Save Data Threat Model and Trust Policy](../adr/116-save-data-threat-model-and-trust-policy.md):
+  untrusted save sources, bounded admission, integrity/authenticity/replay policy,
+  tool capabilities, credentials and development/shipping profiles.
 - [Navigation And AI Architecture](./runtime/navigation-and-ai-architecture.md):
   NavMesh, pathfinding, dynamic obstacle overlays, perception, crowd, blackboard,
   and editor bake tooling.

--- a/docs/architecture/interfaces/cli-architecture.md
+++ b/docs/architecture/interfaces/cli-architecture.md
@@ -168,6 +168,10 @@ horo-engine package restore
 horo-engine package verify
 horo-engine package cache list
 horo-engine package cache clean
+horo-engine save inspect
+horo-engine save import
+horo-engine save export
+horo-engine save migrate
 horo-engine build
 horo-engine release
 horo-engine test
@@ -179,6 +183,22 @@ horopak verify
 
 Duplicate command paths and option names are startup errors. Help is generated
 from the typed registry.
+
+### Save Command Boundary
+
+Save commands are application adapters under
+[ADR-116](../../adr/116-save-data-threat-model-and-trust-policy.md), not direct
+filesystem or codec utilities. `inspect`, `import`, `export`, `migrate`, `load`,
+`delete` and conflict resolution use distinct capabilities and host confirmation
+policy. A command receives a typed save address or an explicitly admitted external
+file handle; archive bytes cannot choose their destination root, trust policy or
+credential binding.
+
+Inspection applies fixed framing/parser/work budgets and returns bounded allowlisted
+metadata plus safe diagnostics. It grants no load, migration or publication authority.
+Raw participant export is development-only, requires a separate capability and a
+validated output root, and is absent from shipping profiles unless the product
+explicitly admits it. `horopak` never parses or mutates runtime `.horosave` files.
 
 ## Command Contributions & Adapter Equivalence
 
@@ -340,6 +360,8 @@ Rules:
 - response/config files require an explicit supported format
 - paths are normalized by the platform adapter
 - credentials are never accepted in positional arguments
+- external save inputs are untrusted and use the same bounded application admission
+  pipeline as GUI/MCP; a canonical save-directory path does not skip verification
 
 Common options such as project, output format, logging, and non-interactive mode
 use shared descriptors.
@@ -588,6 +610,8 @@ Required tests cover:
 - redaction of arguments and credentials in logs and diagnostics
 - headless commands executing without GUI or renderer targets
 - equivalence of GUI, CLI, and MCP use-case results
+- save inspect/import/export/migrate capability separation, bounded hostile input,
+  shipping-profile denial and raw-state/path/credential redaction
 - `horopak` isolation (absence of GUI/RenderApi linkage)
 
 ## Related Documents
@@ -598,6 +622,8 @@ Required tests cover:
 - [Error And Diagnostics](../foundation/error-and-diagnostics.md)
 - [Configuration System](../foundation/configuration-system.md)
 - [Concurrency And Job System](../foundation/concurrency-and-jobs.md)
+- [Save Game And Persistence](../runtime/save-game-and-persistence.md)
+- [ADR-116: Save Data Threat Model and Trust Policy](../../adr/116-save-data-threat-model-and-trust-policy.md)
 - [MCP Architecture](./mcp-architecture.md)
 - [Runtime Debug Console And Development Overlays](../runtime/debug-console-and-overlays.md)
 - [Application Security](../security/application-security.md)

--- a/docs/architecture/interfaces/mcp-architecture.md
+++ b/docs/architecture/interfaces/mcp-architecture.md
@@ -392,6 +392,27 @@ Secrets, credentials, raw file contents, and large payloads are never retained
 in history by default. History retention is policy-bounded by count, age, and
 storage budget.
 
+## Save Tool Boundary
+
+MCP save tools follow
+[ADR-116](../../adr/116-save-data-threat-model-and-trust-policy.md). Inspect, import,
+export, migrate, load, delete and conflict resolution declare separate capabilities,
+side-effect policy, confirmation policy and shipping-profile availability. Project
+trust or an authenticated MCP session does not imply access to another product,
+environment, user, profile, server-world or slot namespace.
+
+Tool handlers pass typed addresses or explicitly admitted external-file handles to
+application-owned save use cases. They do not call archive codecs, read arbitrary
+paths, select trust roots, access provider/signing credentials, retain leases or
+publish runtime/catalog state from an MCP thread. Every source, including a local save
+path or authenticated cloud result, follows bounded untrusted-input admission.
+
+Inspection results contain bounded allowlisted metadata, verification state and safe
+diagnostics. Raw archive/participant content, unrestricted paths, credentials and
+private provider identity are excluded from request history and ordinary results.
+Development-only raw export requires a distinct local capability and cannot be
+enabled by a remote caller or archive field.
+
 ## Security
 
 - MCP transport does not accept anonymous remote connections in production.
@@ -435,6 +456,8 @@ Required additional coverage:
 - rate-limit and body-size enforcement
 - bounded query pagination and stable ordering
 - history redaction of secrets and large payloads
+- save inspect/import/export/migrate/load/delete/conflict capability separation,
+  hostile-input budgets, shipping remote denial and no raw save/path/credential history
 
 Run MCP tests:
 
@@ -497,5 +520,8 @@ import logic, build behavior, or release policy.
 - [Release Security](../release/release-security.md): transport and signing trust.
 - [Application Security](../security/application-security.md): runtime authentication,
   capability, project trust, rate-limit, and remote-binding policy.
+- [Save Game And Persistence](../runtime/save-game-and-persistence.md): save authority,
+  archive admission, transactional publication and cloud coordination.
+- [ADR-116: Save Data Threat Model and Trust Policy](../../adr/116-save-data-threat-model-and-trust-policy.md)
 - [Observability Architecture](../observability/observability.md): levels, categories, MDC,
   storage, and protocol-log redaction.

--- a/docs/architecture/release/release-security.md
+++ b/docs/architecture/release/release-security.md
@@ -147,6 +147,33 @@ controls.
 Encryption without authentication, nonce reuse, hardcoded keys, and silent
 downgrade to an unprotected archive are prohibited.
 
+This section governs protected release/project `.horo` archives. It does not imply
+that runtime `.horosave` files are encrypted. Runtime save integrity, signatures,
+scope, replay and confidentiality claims are independently defined by
+[ADR-116](../../adr/116-save-data-threat-model-and-trust-policy.md).
+
+## Runtime Save Security Profile
+
+A shipping release publishes a versioned save security profile containing only
+public policy:
+
+- admitted local/import/mod/cloud/tool operations and their capability IDs;
+- `SaveSignaturePolicy`, allowed algorithms and public trust-policy/key IDs;
+- product/environment/server namespace rules and any required anti-replay policy ID;
+- archive/parser/decompression/migration/staging/diagnostic budgets; and
+- whether raw inspection/export or remote MCP save mutation is unavailable.
+
+The release manifest never contains signing private keys, provider tokens, reusable
+credentials or machine-local credential bindings. CI validates that secure namespaces
+cannot resolve to Optional/Disabled signing, development roots or unbounded tool
+profiles. Development policy may add isolated unsigned/modded fixtures and inspection
+capabilities, but cannot be copied or renamed into a shipping namespace.
+
+Hash verification is not authentication, signature verification is not freshness or
+confidentiality, and provider transport authentication is not archive admission. Save
+signing uses the credential provider through a short-lived scoped operation; private
+material never enters the archive builder, manifest, logs or diagnostic artifacts.
+
 ## Artifact Integrity And Signing
 
 Every published artifact has a cryptographic hash recorded in the release
@@ -296,6 +323,8 @@ Security validation includes:
 - command and path injection tests
 - secret redaction tests
 - wrong-key and tamper-detection archive tests
+- runtime save-profile validation, signature stripping/wrong scope/valid-old replay,
+  and development-to-shipping downgrade rejection
 - nonce uniqueness and KDF parameter tests
 - manifest and signature verification tests
 - interrupted staging and cleanup tests
@@ -316,6 +345,9 @@ verification stop the release.
 
 - [Application Security](../security/application-security.md): running editor/CLI trust,
   plugin, project, path, process, and MCP policy.
+- [Save Game And Persistence](../runtime/save-game-and-persistence.md): runtime save
+  archive, signature, restore and cloud authority.
+- [ADR-116: Save Data Threat Model and Trust Policy](../../adr/116-save-data-threat-model-and-trust-policy.md)
 - [Distribution And Update](./distribution-and-update.md): signed update
   manifests, package verification, activation, and rollback.
 - [Release Architecture](./release.md): authoritative release jobs and

--- a/docs/architecture/runtime/platform-services-architecture.md
+++ b/docs/architecture/runtime/platform-services-architecture.md
@@ -374,6 +374,14 @@ coordinator owns durable intent, lineage,
 preconditions and divergent-generation resolution; UI may present a choice but never
 becomes sync authority.
 
+Provider authentication, TLS success, object ownership and a completed download do
+not make archive bytes trusted. Under ADR-116, Platform Services enforces transport
+byte/time bounds and returns operation-owned opaque bytes plus provider metadata. The
+save/cloud coordinator then applies local framing, integrity, signature/scope,
+compatibility, semantic and namespace policy before any local publication or load.
+The backend cannot select a trust root, request a parser exception or reinterpret a
+verification failure as an empty/older remote object.
+
 ### Presence
 
 Presence is best-effort and non-critical. The frontend batches rapid presence
@@ -604,8 +612,13 @@ events.
   invoked from a trusted server path. See
   [Release Security](../release/release-security.md) for the broader trust and
   signing model that governs backend packages.
-- Cloud save data is opaque to the platform service layer. Encryption and
-  tamper detection are the responsibility of the local save system.
+- Cloud save data is opaque untrusted input to the platform service layer. Transport
+  authentication does not establish archive trust. Integrity, signature/scope,
+  compatibility and optional confidentiality policy belong to Runtime Save and the
+  host-selected save security profile under ADR-116.
+- Provider tokens and account credentials remain inside the backend's short-lived
+  credential lease. They never enter archive bytes, coordinator journals, tool
+  results, logs or conflict metadata.
 - Friends and presence data are subject to platform privacy policies and user
   consent. The frontend does not cache or expose this data beyond what the
   backend provides.
@@ -767,6 +780,9 @@ Required tests cover:
 - conditional write/delete and precondition failure; uncoordinated providers never
   receive background mutations
 - cloud archive writes/deletes never enter the generic offline queue
+- authenticated-provider downloads remain untrusted until local bounded admission;
+  malformed/oversized results cannot publish or replace a local generation
+- cloud credential/provider metadata is redacted from save diagnostics and tools
 - session sign-in/out triggers queue replay and state callbacks
 - unavailable services return `not_supported`
 - presence updates coalesce to the most recent state
@@ -816,5 +832,7 @@ Platform-specific backend tests live in the private platform repositories.
   user/profile and logical-slot addressing across local and cloud boundaries.
 - [ADR-115](../../adr/115-cloud-save-authority-revision-and-conflict-policy.md): local
   authority, provider preconditions, offline journal and conflict preservation.
+- [ADR-116](../../adr/116-save-data-threat-model-and-trust-policy.md): untrusted cloud
+  bytes, bounded local admission, credential isolation and save tool policy.
 - [Extension System](../extensions/plugin-system.md)
 - [Release Security](../release/release-security.md)

--- a/docs/architecture/runtime/save-game-and-persistence.md
+++ b/docs/architecture/runtime/save-game-and-persistence.md
@@ -14,6 +14,8 @@ ADR-114 freezes authoring/runtime state composition and subsystem-owned canonica
 adapters for HORO-1438 #1438 [SAV-004.1].
 ADR-115 freezes local/cloud authority, provider revisions and conflict preservation
 for HORO-1466 #1466 [SAV-006.1].
+ADR-116 freezes save-source trust, bounded admission, tool capabilities, credentials
+and development/shipping security profiles for HORO-1495 #1495 [SAV-008.1].
 
 - RuntimeSaveService coordinates one runtime save/restore authority under the
   application/session lifetime. It never retains an unleased reference to a scene
@@ -433,6 +435,37 @@ a valid signature also does not prevent replay of an old valid save. Titles need
 anti-rollback require separately trusted generation/anti-replay state, not a
 timestamp inside the attacker-controlled file. The archive is not encrypted by this
 protocol.
+
+### Untrusted Input And Threat Policy
+
+Every archive begins as untrusted bytes, including a file already present in the
+canonical save directory, a provider-authenticated cloud download, a migrated output,
+a modded save and a server-signed save. Path containment, catalog membership,
+transport authentication, a filename suffix, a content hash or a signature is only
+the evidence it specifically claims; none skips later compatibility, semantic,
+namespace or freshness checks.
+
+[ADR-116](../../adr/116-save-data-threat-model-and-trust-policy.md) defines the common
+admission pipeline. The host resolves the operation profile, capability, namespace,
+budgets and cancellation policy before acquiring bytes. Framing and total length are
+checked before payload allocation; outer integrity precedes trust in payload control
+fields; signature/scope policy precedes decode; compatibility and migrations operate
+on bounded detached candidates; and all owners prepare before one no-fail restore or
+atomic publication. Failure leaves the active runtime, source and last-known-good
+local generation unchanged.
+
+Import, export, inspection, migration, load, delete and conflict resolution are
+separate capabilities. UI, CLI and MCP invoke application-owned operations with typed
+addresses or admitted external handles; they never call codecs, choose trust roots,
+hold leases, access signing/cloud credentials or publish a live slot directly.
+Inspection returns bounded allowlisted metadata and safe diagnostics, not raw
+participant state by default.
+
+Development profiles may admit isolated unsigned/modded namespaces, fixture tools and
+explicit raw developer export. They retain the same framing, parser/decompression
+limits, path containment, transactional publication and credential isolation as
+shipping. Shipping/server policy is fail-closed and cannot be weakened by archive
+fields, debug flags, directory copies or a remote tool request.
 
 ## Save Pipeline, Publication And Cancellation
 
@@ -973,6 +1006,15 @@ documentation change:
   `ArchiveContentHash`.
 - Required signature stripping, wrong project/account/world, untrusted key, signer
   timeout, malformed inputs, decompression bombs and unsupported schema versions.
+- Every local/imported/cloud/migrated/modded/server-signed source enters as untrusted;
+  catalog location, provider authentication and inspection success never skip
+  integrity, scope, compatibility or semantic validation.
+- Per-operation byte/count/string/nesting/decompression/work/disk budgets; hostile
+  archives cannot trigger unbounded retry, diagnostic output or automatic budget
+  escalation.
+- Inspect/import/export/migrate/load/delete/conflict capability separation across
+  UI, CLI and MCP, including shipping remote denial and no raw state/path/credential
+  leakage.
 - Snapshot admission versus eventual worker failure, per-operation sticky outcomes,
   cancellation races on both commit gates and no UI-thread filesystem calls.
 - Disk-full/flush/rename/directory-sync fault injection, especially rename-success plus
@@ -1023,4 +1065,5 @@ and regression coverage.
 - [ADR-113](../../adr/113-local-storage-user-profile-and-slot-ownership.md): Product/user/profile namespaces, logical slot addressing and physical storage ownership.
 - [ADR-114](../../adr/114-canonical-runtime-world-persistence-boundary.md): Authoring/runtime composition, state classification and subsystem-owned canonical adapters.
 - [ADR-115](../../adr/115-cloud-save-authority-revision-and-conflict-policy.md): Local/cloud authority, provider CAS revisions, offline lineage and conflict preservation.
+- [ADR-116](../../adr/116-save-data-threat-model-and-trust-policy.md): Save-source trust classification, bounded admission, tool capabilities, credentials and profile policy.
 - [Application Security](../security/application-security.md): Trust and untrusted-input boundaries.

--- a/docs/architecture/security/application-security.md
+++ b/docs/architecture/security/application-security.md
@@ -51,6 +51,9 @@ editor and CLI hosts.
 | Runtime console local user | Product-profile and project-policy scoped |
 | Runtime console remote client | Denied unless diagnostics policy enables authenticated access |
 | Imported asset | Untrusted parser input |
+| Local, imported, migrated or modded save archive | Untrusted parser input; source policy selects permitted operation |
+| Cloud-downloaded save archive | Untrusted parser input even after provider authentication/transport success |
+| Scope-authorized signed save archive | Authenticated bytes for that scope; compatibility, semantics and freshness remain unproven |
 | Toolchain executable | Allowed only through resolved trusted profile |
 
 Trust is scoped by project identity, plugin identity/version, capability, and
@@ -103,6 +106,27 @@ bound to the exact canonical digest returned by the parser.
 
 High-risk or historically unsafe third-party parsers may run in a restricted
 helper process with bounded I/O.
+
+## Save Data Trust
+
+[ADR-116](../../adr/116-save-data-threat-model-and-trust-policy.md) defines the
+application threat model for runtime save data. No save becomes trusted because it is
+inside a save root, listed in a catalog, downloaded under an authenticated provider
+session, produced by a migration or signed by some key. Every read begins with bounded
+untrusted bytes and advances only through explicit integrity, host-selected
+signature/scope, compatibility, semantic preparation and generation/lease gates.
+
+The save operation profile separates inspect, import, export, migrate, load, delete
+and conflict-resolution capabilities. UI, CLI and MCP are adapters over the same
+application use cases; inspection authority cannot publish or restore a slot. Raw
+participant state, unrestricted local paths, provider identity and credentials are
+excluded from ordinary tool results and history.
+
+Development may admit isolated unsigned/modded namespaces and additional inspection
+tools, but it never disables framing arithmetic, parser/decompression/work limits,
+path containment, transactional publication or credential isolation. Shipping and
+secure server namespaces reject policy downgrade. A valid signature is not anti-replay
+state, encryption, semantic validity, anti-cheat or a native-code sandbox.
 
 ## Process Execution
 
@@ -228,6 +252,8 @@ Security-relevant events include:
 - rejected executable or process request
 - MCP authentication and rate-limit failures
 - update signature failure
+- rejected save integrity/signature/scope/replay policy
+- denied save inspection/import/export/load/delete/conflict capability
 
 Records contain stable identities and safe reasons, not secrets or unnecessary
 user content. Diagnostic bundle generation shows the user what categories will
@@ -264,6 +290,9 @@ Required tests cover:
 - pre-active gameplay denial, bounded malformed admission input, timeout, revocation and shutdown races
 - parser resource limits and malformed input
 - update signature rejection
+- local/imported/cloud/migrated/modded/server-signed save admission and quarantine
+- save framing, decompression/work budgets, wrong-scope substitution and valid-old replay
+- GUI/CLI/MCP save capability separation and raw-state/path/credential redaction
 
 ## Related Documents
 
@@ -277,3 +306,5 @@ Required tests cover:
 - [Networking Architecture](../runtime/networking-architecture.md)
 - [ADR-098: Protocol, Session and Trust Policy](../../adr/098-protocol-session-and-trust-policy.md)
 - [ADR-103: Network Project Configuration and Build-Profile Ownership](../../adr/103-network-project-configuration-and-build-profile-ownership.md)
+- [ADR-116: Save Data Threat Model and Trust Policy](../../adr/116-save-data-threat-model-and-trust-policy.md)
+- [Save Game And Persistence](../runtime/save-game-and-persistence.md)


### PR DESCRIPTION
## Summary

- Defines one save-data threat model for local, imported, cloud, migrated, modded, server-signed, and tool-inspected archives.
- Makes every archive begin as untrusted bytes regardless of its directory, catalog entry, provider session, migration origin, or signature.
- Separates integrity, authenticity, confidentiality, semantic validity, and anti-replay evidence.
- Maps parser, storage, cloud, UI, CLI, MCP, release-profile, and credential controls to explicit owners and capabilities.

## Why

The existing save architecture defines framing, hashing, signatures, transactional restore, namespaces, and cloud conflicts, but it did not collect their security assumptions into one source-based threat model. That left room for unsafe shortcuts such as trusting a save-directory file, treating an authenticated cloud download as admitted data, or granting inspection tools implicit load/mutation authority.

## Decision and boundaries

- Adds ADR-116 with protected assets, attacker capabilities, trust-state progression, source policy, bounded admission stages, typed failures, qualification evidence, and explicit non-goals.
- Projects the decision into Runtime Save, Application Security, Platform Services, CLI, MCP, Release Security, and the architecture indexes.
- Every source follows framing, checked arithmetic, integrity, host-selected signature/scope, compatibility, bounded migration, semantic preparation, and lease/generation revalidation before publication or restore.
- `save.inspect`, `save.import`, `save.export`, `save.migrate`, `save.load`, `save.delete`, and conflict resolution remain separate capabilities across GUI, CLI, and MCP.
- Development may enable isolated unsigned/modded namespaces and additional tools, but cannot remove parser, path, transaction, or credential invariants or promote data into shipping by rename/copy.
- Save signing is explicitly not encryption, freshness proof, anti-cheat, or native-code sandboxing.

This PR defines architecture and security contracts only. Concrete codecs, security profiles, capability descriptors, quarantine stores, tool adapters, and fault-injection tests remain focused implementation work.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Markdown lint passed
- [x] Added Markdown links resolve
- [x] Staged diff checks passed
- [x] CMake configure passed
- [ ] Full build/test suite not run; this is a documentation-only decision

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- <changed-markdown-files>
git diff --check
git diff --cached --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- Products must still choose concrete parser/work budgets, capability maps, signing scope, and any anti-replay authority per release profile.
- Import, migration, cloud, and inspection implementations will require quarantine/staging storage and adversarial fault-injection coverage.
- The v1 runtime save container provides no confidentiality; products requiring it need a separate reviewed authenticated-encryption design.
- CMake reported the existing mbedTLS deprecation warning and skipped repository Python tests because pytest is unavailable.

## Issue links

- Jira: HORO-1495
- GitHub: Closes #1495

## Reviewer Notes

Review ADR-116 first, then the Runtime Save and Application Security projections. Follow with Platform Services, CLI/MCP, and Release Security. Focus on the rule that location or transport never grants archive trust, and on keeping inspection, integrity, signature, semantic admission, and anti-replay authority distinct.