### PR TITLE
docs(cinematic): define playback determinism HORO-1657 #1698 [CIN-002.1]

### DIFF
--- a/docs/adr/117-playback-ownership-frame-order-and-determinism.md
+++ b/docs/adr/117-playback-ownership-frame-order-and-determinism.md
@@ -1,0 +1,330 @@
+# ADR-117: Playback Ownership, Frame Order and Determinism
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Sequence-player instance ownership, scene/application lifetime scopes, activation identity, same-boundary multi-player order, replay/headless guarantees, numeric determinism and random-access seek
+- **Issue**: [CIN-002.1](https://github.com/abdullahbodur/horo-engine/issues/1698)
+- **Jira**: [HORO-1657](https://horo-engine.atlassian.net/browse/HORO-1657)
+- **Related**: [ADR-010](010-job-waiting-and-operation-store-ownership.md), [ADR-014](014-sequencer-ownership-clock-authority-and-binding-boundary.md), [ADR-061](061-animation-ownership-update-order-and-clock.md), [ADR-077](077-runtime-ui-animation-clock-and-time-domain.md), [ADR-088](088-physics-determinism-capability-and-support-tiers.md)
+- **Normative documents**: [Cinematic Sequencer Architecture](../architecture/runtime/cinematic-sequencer-architecture.md), [Runtime Lifecycle](../architecture/runtime/runtime-lifecycle.md)
+
+## Context
+
+ADR-014 assigns clocks, bindings and bounded evaluation to Cinematic Runtime and
+separates fixed-tick authoritative output from presentation sampling. The architecture
+also states that aggregate evaluation visits players in priority/stable-ID order and
+that value sampling is history-independent. Those constraints do not yet decide who
+owns a live player, how scene-authored and application-triggered instances differ,
+where activation IDs come from, which commands join a frame/tick batch, or exactly
+what “deterministic” means across builds and platforms.
+
+Storing a full player inside a scene component would couple clocks, provider requests,
+pause/camera tokens, nested players and event cursors to component relocation and scene
+mutation. A process-global player service would survive beyond the runtime session and
+risk retaining scene bindings or external callbacks through travel and shutdown.
+Assigning IDs by allocation order or visiting an unordered container would make
+overlapping outputs depend on thread scheduling.
+
+Timeline position uses checked rational/fixed-point representation, but curve values
+and downstream property adapters use floating-point math. Requiring bit-identical
+results across all CPUs, compilers and platforms would therefore be untruthful without
+a separately qualified deterministic-math contract. At the same time, replay and
+headless tests need exact rules for input capture, ordering, event identity and numeric
+comparison.
+
+This ADR refines ADR-014 without changing its clock or domain-authority decisions.
+
+## Decision
+
+### 1. The runtime session service owns every live player
+
+`CinematicRuntimeService` is an application/session-owned service. It owns the player
+registry, player state, clock, event cursor, binding cache, nested-player tree,
+capacity reservation, asset/provider leases, domain tokens and asynchronous request
+lifetimes. It is created after the runtime session and required scene services are
+available and closes before those dependencies are destroyed.
+
+Scene components do not contain or own `SequencePlayer` objects. An optional
+`SequencePlaybackComponent` is inert authored configuration and a lifecycle trigger:
+asset identity, stable authored activation identity, clock/settings, priority,
+autoplay policy and declared lifetime scope. Runtime conversion submits a typed start
+request and retains only a generation-checked handle for observation/control.
+Component removal releases its request/observation relationship; the service performs
+the actual stop and token/lease retirement at an owning boundary.
+
+Application/gameplay code uses the same start/stop/seek API for non-component players.
+No caller receives a mutable player reference or stores a callback into component
+memory.
+
+```cpp
+struct SequencePlayerHandle {
+    RuntimeSessionId session;
+    SequencePlayerId id;
+    uint32_t generation;
+};
+
+enum class SequencePlayerScope : uint8_t {
+    SceneBound,
+    ApplicationBound
+};
+```
+
+A `SceneBound` player is fenced by the source `SceneRuntimeId` and stops before scene
+replacement publishes. An `ApplicationBound` player may survive scene travel only
+when its descriptor declares no required old-scene binding and all retained adapters
+support travel; otherwise activation fails or the player stops with a typed
+`SceneScopeEnded` result. Neither scope outlives the runtime session. Editor preview
+uses a separate preview session/registry and cannot share players, tokens or binding
+caches with PIE or packaged runtime.
+
+### 2. Player lifetime is a generation-fenced state machine
+
+The service owns these conceptual states:
+
+```text
+Requested -> Preparing -> Ready -> Playing <-> Held
+     |           |          |         |
+     +-----------+----------+---------+-> Stopping -> Stopped
+                              \-------> Failed
+all non-terminal states ----------------> Closing -> Stopped
+```
+
+Preparation validates the asset and nested graph, compiles the evaluation plan,
+reserves aggregate capacity, resolves required adapters/bindings and acquires tokens
+in a rollback-safe order. Only a completely prepared player becomes visible in an
+evaluation batch. Failure unwinds acquired resources and publishes one sticky result.
+
+Stop closes new evaluation/effect admission, removes the player from a later batch,
+releases only its own pause/camera/domain tokens, cancels owned provider/jobs where
+possible and retains assets/payloads until queued occurrences and callbacks retire.
+Late completions carry session/player generation and are ignored after retirement.
+Destroying a component, closing a UI, dropping a handle or losing a requester does not
+free a live player synchronously.
+
+Nested sequence players are registry-owned children with a stable parent/track/key
+path, not heap-owned objects hidden in a track. Parent stop closes child admission
+depth-first, while lease destruction occurs only after already committed child effects
+retire. A child cannot select an independent session, budget pool or lifetime scope
+beyond its root.
+
+### 3. Activation identity is supplied before scheduling
+
+Every root start request contains a stable `SequenceActivationId` from the initiating
+authority:
+
+- a scene-authored component derives it from `SceneRuntimeId`, stable authored object
+  identity and component-local playback slot;
+- a deterministic gameplay/event request uses its recorded command/event occurrence
+  identity; and
+- a tool/manual start receives an application-issued operation identity that must be
+  recorded when replay of that session is required.
+
+The registry maps the activation identity to a generation-checked `SequencePlayerId`.
+Duplicate active activation IDs return `AlreadyActive` or target the declared
+idempotent operation; they never allocate a second player implicitly. Dynamic ID
+allocation order, pointer value, hash seed, worker completion order, thread arrival
+order and container iteration are not semantic identity.
+
+A nested player's identity is the root activation ID plus the ordered stable
+sub-sequence track/key path and loop/instance ordinal. Cook/activation rejects path or
+identity collisions rather than using insertion order as a tie-breaker.
+
+### 4. Each boundary evaluates one immutable ordered batch
+
+Before a fixed-tick or presentation/service boundary, the owner drains commands up to
+the boundary cutoff, validates them, publishes player state changes, snapshots the
+eligible registry and constructs one immutable `SequenceEvaluationBatch`. Commands
+arriving after the cutoff apply no earlier than the next corresponding boundary.
+Workers may prepare bounded read-only samples, but they cannot add/remove players,
+publish values or dispatch events into the current batch.
+
+The root order key is:
+
+1. evaluation seam/domain;
+2. declared priority, highest first;
+3. `SequencePlayerId`, ascending stable byte order; and
+4. player generation, ascending, only to distinguish retained diagnostic/replay data.
+
+Nested players immediately follow their parent position ordered by stable track ID,
+key ID, nested instance ordinal and recursion path. Within a player, ADR-014's compiled
+dependency DAG and track/key order applies. The same order is used in packaged,
+editor-play, deterministic replay and headless execution.
+
+Ordering evaluation does not by itself authorize last-writer-wins. All player
+contributions retain their order key and target owner. For an exclusive property, the
+owner accepts the highest-priority candidate and uses lowest stable player ID only as
+the declared equal-priority tie-break. A registered blend/reducer consumes inputs in
+the canonical order and defines its own numeric rule. Conflicting incompatible modes
+return a typed activation/evaluation error rather than relying on visit order.
+
+Global event occurrence order is destination seam, directed crossing time,
+root/nested player order, track ID and keyframe ID. Irreversible effects remain staged
+until tick commit as ADR-014 requires. Parallel evaluation merges only by preassigned
+order slots; job completion time cannot affect values, errors or event order.
+
+### 5. Attempted ticks publish all-or-none cinematic state
+
+For `CommittedSimulation`, the batch captures the exact attempted tick ID, unchanged
+fixed quantum, input/command cutoff and player set. Each player stages next cursor,
+loop/traversal identity, values and occurrences. Budget, binding, authority or
+evaluation failure holds/fails the affected player according to its typed policy
+without publishing a partial interval. A failed overall simulation tick discards all
+staged cinematic state and occurrences for that attempt.
+
+After the owning simulation participants succeed, tick commit atomically advances the
+accepted player cursors and releases committed occurrences to bounded destination
+queues. Optional presentation evaluation reads the last committed snapshot and cannot
+advance authoritative cursors or repair a skipped fixed batch. Zero, one or multiple
+fixed ticks in a rendered frame therefore produce the same semantic history as the
+same ticks spread across different render cadences.
+
+UnscaledFixedControl, MonotonicWall and External players use their ADR-014 service/
+presentation boundaries. Their batch ordering remains deterministic for supplied
+inputs, but elapsed wall time and live provider arrival are not reproducible inputs by
+themselves.
+
+### 6. Determinism is defined by evidence tier
+
+The baseline guarantees:
+
+| Evidence | Requirement |
+|---|---|
+| Identical execution fingerprint and recorded inputs | Exact player/batch/event identities, state transitions and ordering; bit-identical `SequenceTime`; floating outputs repeat under the same qualified compiler/CPU/FP configuration |
+| Different supported platforms/build fingerprints | Same admitted graph, value/event topology and stable order; floating values compare under documented absolute/relative/ULP tolerances, not bit identity |
+| Live wall/external source without recording | No replay guarantee; only bounded monotonic/discontinuity behavior from ADR-014 |
+
+`SequenceDeterminismFingerprint` records engine/cinematic schema revision, cooked asset
+digests, evaluation-policy revision, build/compiler/CPU architecture, floating-point
+mode and relevant adapter/provider versions. It contains no pointer, wall timestamp or
+process-random value. A mismatch is visible to the replay/test harness and cannot be
+silently described as exact replay.
+
+Cross-platform bit-level floating-point determinism is explicitly **not required** for
+the baseline. Curve interpolation, quaternion/transform operations and downstream
+owner adapters use floating point and may differ across instruction sets, contraction,
+library implementations and compiler modes. Sequence time, IDs, ordering, interval
+membership and event occurrences remain exact; sampled floats use type/track-specific
+tolerances. Products that need bit-identical cross-platform results require a separate
+fixed/deterministic math profile and qualification of every receiving subsystem.
+
+Within one fingerprint, builds disable nondeterministic fast-math/FP-environment drift
+for qualified replay tests and use a specified interpolation operation order. A
+floating mismatch outside tolerance, ordering mismatch, missing event, extra event or
+different terminal outcome is a failure; tests do not retry until one result passes.
+
+### 7. Replay records every nondeterministic input
+
+A replayable sequence session records or derives:
+
+- runtime/scene session and activation identities;
+- exact ordered start/stop/pause/rate/seek commands with boundary/tick admission IDs;
+- cooked asset/revision and determinism fingerprint;
+- committed simulation ticks or unscaled-control quanta;
+- monotonic-wall/external provider samples, epochs, acknowledgements and
+  discontinuities when those sources are replayed;
+- binding/authority availability revisions and typed failures that can change output;
+- asynchronous effect admission/completion outcomes when their timing is observed; and
+- product policy, budget profile and declared adapter versions.
+
+Replay feeds these records through the ordinary command/batch/service boundary. It
+does not patch player internals, reuse a captured render frame or invoke event effects
+from a log. Missing required evidence returns `ReplayEvidenceIncomplete`.
+
+Headless tests compose the same Cinematic Runtime service, Null/recording destination
+adapters and a manual recorded clock. They create no hidden window/renderer and do not
+substitute a bespoke evaluator. Golden tests compare exact identities/order/events and
+typed terminal results plus tolerance-based numeric samples according to the recorded
+fingerprint.
+
+### 8. Seek is random-access for values and explicit for occurrences
+
+`Seek(target)` never advances value evaluation incrementally from the current cursor
+or replays from sequence start. It validates target/loop mapping, resolves nested local
+time, performs bounded indexed key lookup and samples every affected value directly at
+the target. The result depends on immutable asset/settings/bindings and target time,
+not prior sample count, frame cadence, direction changes or seek path.
+
+The service stages the complete seek result, preflights binding/capacity and publishes
+all accepted player cursor/value changes at one owner boundary. Failure leaves the old
+cursor and values. Nested mapping is a pure checked time transform; cycles and
+unbounded depth were rejected at activation.
+
+Events remain interval state, not value samples. Default seek resets cursor,
+traversal/loop identity and presentation/provider baseline without emitting skipped
+occurrences. Explicit `DispatchCrossedEvents` uses one bounded directed interval and
+ordinary authority/budget/commit rules; it is not replay-from-zero. Audio, VFX and
+other stateful destinations receive typed seek/resynchronize intent or Unsupported and
+never reconstruct state by executing historical side effects.
+
+### 9. Qualification covers ordering, lifetime and numeric scope
+
+Required evidence includes:
+
+- component-authored and application-started players sharing one service registry,
+  with component relocation/removal, dropped handles and UI close unable to free or
+  retain live state incorrectly;
+- SceneBound/ApplicationBound travel, preview/PIE isolation, stop/failure/cancel/
+  shutdown, nested retirement and late provider/job completion generation fencing;
+- activation-ID duplicate/collision behavior and randomized map/allocation/worker
+  completion order producing the same batch/output order;
+- priority and stable-ID ties, nested order, exclusive-owner selection, canonical
+  blends and global event occurrence order across serial/parallel evaluation;
+- zero/one/many fixed ticks at 30/60/144 Hz presentation, failed tick discard and
+  identical committed history independent of render cadence;
+- same-fingerprint repeat runs with exact IDs/time/order/events and bit-repeatable
+  floats; cross-platform fixtures using documented tolerances and explicit fingerprint
+  mismatch reporting;
+- recorded wall/external inputs, missing evidence, provider discontinuity and
+  asynchronous effect outcomes in ordinary headless service composition; and
+- forward/reverse/loop/ping-pong/random seek sequences proving direct target sampling,
+  default silent occurrence reset, bounded explicit crossings and failure atomicity.
+
+## Consequences
+
+### Positive
+
+- Scene authoring can trigger playback without making relocatable components lifetime
+  authorities.
+- Same-boundary results no longer depend on allocation, container or worker order.
+- Replay and headless tests share the production service and state precise numeric
+  expectations.
+- Random seek remains bounded and independent of playback history.
+
+### Costs
+
+- The runtime service needs a generation registry, boundary command queue, immutable
+  evaluation batches and retained-effect retirement.
+- Deterministic replay requires explicit fingerprints and capture of wall/provider/
+  asynchronous inputs.
+- Cross-platform tests need semantic tolerances unless a future deterministic-math
+  tier is qualified.
+
+## Rejected Alternatives
+
+### Store the live player in a scene component
+
+Rejected because component relocation/removal would own clocks, tokens, nested
+players, providers and queued effects whose lifetimes cross scene mutation boundaries.
+
+### Use a process-global player manager
+
+Rejected because players must not survive their application/runtime session or retain
+scene/provider resources through shutdown and host replacement.
+
+### Use update or allocation order as the tie-breaker
+
+Rejected because container layout, thread arrival and worker completion are not stable
+semantic inputs. Priority and preassigned stable identity define the order.
+
+### Require cross-platform bit-identical floating results now
+
+Rejected because the current interpolation and receiving systems use floating point
+without a closed deterministic-math profile across compilers, CPUs and libraries.
+Exact time/order/events plus documented numeric tolerances are truthful and testable.
+
+### Replay from zero to implement seek
+
+Rejected because work and side effects would depend on timeline length and prior
+history. Indexed target sampling and explicit bounded event crossing define separate
+contracts.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -128,6 +128,7 @@ to the replacement.
 | [114](114-canonical-runtime-world-persistence-boundary.md) | Canonical Runtime World Persistence Boundary | Proposed | 2026-09-02 |
 | [115](115-cloud-save-authority-revision-and-conflict-policy.md) | Cloud Save Authority, Revision and Conflict Policy | Proposed | 2026-09-02 |
 | [116](116-save-data-threat-model-and-trust-policy.md) | Save Data Threat Model and Trust Policy | Proposed | 2026-09-02 |
+| [117](117-playback-ownership-frame-order-and-determinism.md) | Playback Ownership, Frame Order and Determinism | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -354,6 +354,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Cinematic Sequencer Architecture](./runtime/cinematic-sequencer-architecture.md):
   timeline, tracks, clock authority, typed property bindings, evaluation phase,
   and playback integration.
+- [Playback Ownership, Frame Order and Determinism](../adr/117-playback-ownership-frame-order-and-determinism.md):
+  runtime-service player lifetime, stable activation identity, immutable evaluation
+  batches, replay/headless evidence and random-access seek.
 - [Post-Processing And Effects Architecture](./runtime/post-processing-and-effects-architecture.md):
   screen-space effects, HDR post chain, tonemapping, color grading, and
   accessibility pass ordering.

--- a/docs/architecture/runtime/cinematic-sequencer-architecture.md
+++ b/docs/architecture/runtime/cinematic-sequencer-architecture.md
@@ -9,6 +9,9 @@ The goal is to provide a bounded, data-oriented cinematic runtime capable of dri
 ## Normative Decision Reference
 
 This subsystem is governed by [ADR-014: Sequencer Ownership, Clock Authority and Binding Boundary Decision](../../adr/014-sequencer-ownership-clock-authority-and-binding-boundary.md).
+[ADR-117](../../adr/117-playback-ownership-frame-order-and-determinism.md)
+refines live-player ownership, activation identity, multi-player batch order,
+replay/headless evidence, numeric determinism and random-access seek.
 [ADR-068](../../adr/068-music-transport-and-cross-system-ownership.md) owns the
 AudioTrack handoff: Sequencer retains sequence clock, directed event traversal,
 seek/scrub and preroll intent while Audio alone maps accepted requests to sample
@@ -34,6 +37,13 @@ time and schedules the callback.
 - **Coordinate and capacity contracts**: Local transform tracks use durable parent
   or sequence anchors. Typed CPU/memory budgets bound players, nested tracks,
   events, binding retries and per-boundary work independently of graphics APIs.
+- **Runtime-service player ownership**: Scene components are inert authored start
+  descriptors. One session-owned service retains live players, tokens, leases,
+  nested instances, event cursors and late-completion fences.
+- **Stable batch order and qualified determinism**: Boundary snapshots order players
+  by domain, descending priority and stable identity. Exact cross-platform float bits
+  are not promised; identities/time/event order are exact and samples use declared
+  tolerances across build/platform fingerprints.
 
 ## System Boundaries and Target Topology
 
@@ -63,6 +73,38 @@ time and schedules the callback.
 | `HoroEngine::EditorServices` | Presentation / Tooling | Timeline workspace controllers, property recording, curve editing services, track solo/mute adapters, and Problems panel integration. | `CinematicRuntime`, `CinematicModel`, `SceneModel`, `EditorModel` |
 
 `HoroEngine::CinematicRuntime` contains zero dependencies on `HoroEngine::EditorServices`, `HoroEngine::Gui`, or ImGui.
+
+## Player Ownership And Lifetime
+
+`CinematicRuntimeService` is owned by one application/runtime session and owns every
+live `SequencePlayer`. Its registry retains clocks, event cursors, binding caches,
+nested-player trees, capacity reservations, asset/provider leases, domain tokens and
+queued-effect lifetime. It closes before Scene/Runtime dependencies and no player
+survives the session.
+
+An optional scene `SequencePlaybackComponent` contains only authored configuration:
+sequence asset identity, stable activation identity, settings, priority, autoplay and
+`SceneBound`/`ApplicationBound` scope. Runtime conversion submits a typed request and
+receives a generation-checked handle; the component does not embed a player or retain
+callbacks into its own memory. Application/gameplay starts use the same service API.
+
+SceneBound players stop before their `SceneRuntimeId` is replaced. ApplicationBound
+players survive travel only when the descriptor has no required old-scene binding and
+every retained adapter admits travel. Preview, PIE and packaged runtime use separate
+session registries. Component removal, UI close or dropping a handle requests stop;
+only the service retires tokens, leases and queued effects at an owning boundary.
+
+Preparation validates assets/nesting, compiles the plan, reserves aggregate capacity,
+resolves required adapters and acquires tokens before the player enters a batch. Stop
+closes admission, removes it from a later batch, releases only its tokens, cancels
+owned work where possible and ignores late completions by session/player generation.
+Nested players are registry-owned children identified by root activation plus stable
+track/key/instance path; they cannot acquire an independent session or budget pool.
+
+Root activation IDs come from stable scene object/playback-slot identity, a recorded
+gameplay command/event occurrence or a recorded application operation identity.
+Allocation order, pointers, thread arrival, worker completion, unordered-map order and
+process-random hash seeds are never player identity or tie-breakers.
 
 ## Sequencer Data Model
 
@@ -369,6 +411,15 @@ establishes stricter guarantees. Same committed ticks, assets, settings and orde
 inputs reproduce semantic samples and event order regardless of render cadence.
 Wall/external histories must be recorded explicitly to reproduce their inputs.
 
+Within one qualified determinism fingerprint (engine/schema, cooked asset digest,
+evaluation policy, compiler/CPU/FP mode and adapter versions), replay requires exact
+player/time/order/event identity and repeatable float outputs. Across supported
+platform/build fingerprints, exact IDs, interval membership and order still hold, but
+float/vector/quaternion outputs compare with declared absolute/relative/ULP tolerances.
+Bit-identical cross-platform sampling is not a baseline claim because interpolation
+and receiving systems use floating-point operations without a closed deterministic-
+math profile.
+
 Event dispatch is stateful directed-interval processing:
 
 - Forward advance crosses `(previous, current]`; reverse crosses `[current, previous)`
@@ -385,6 +436,12 @@ Event dispatch is stateful directed-interval processing:
 - Preflight the complete bounded interval before applying values or advancing the
   cursor. If the event/loop work budget cannot admit it, return `EvaluationBudgetExceeded`
   and hold the player without partial effects. Never silently drop authoritative events.
+
+Seek maps target/loop/nested time directly and samples by indexed lookup. It never
+steps from the current cursor or replays from zero. The complete seek result is staged
+and published at one owner boundary; failure preserves the prior cursor/values. Audio,
+VFX and other stateful destinations receive typed seek/resynchronize intent or
+Unsupported rather than historical side-effect playback.
 
 ## Frame Evaluation Phase
 
@@ -621,7 +678,19 @@ Binary key lookup bounds sample work by active tracks and keys per track. Cubic
 segments require monotonic time tangents and a fixed iteration limit, not an
 unbounded numeric solver. Event/loop preflight enforces runtime interval limits.
 
-Aggregate evaluation visits admitted players in priority then stable-ID order.
+Before each fixed or service/presentation boundary, the service drains commands up to
+the cutoff and snapshots one immutable eligible batch. Late commands join the next
+corresponding boundary. Root order is evaluation seam/domain, priority descending,
+then `SequencePlayerId` ascending stable byte order. Nested players follow their root
+by track ID, key ID, instance ordinal and recursion path. Parallel jobs merge only
+through preassigned order slots; completion order cannot change output.
+
+Exclusive target owners select the highest-priority contribution and use the lowest
+stable player ID as the declared equal-priority tie-break. Registered reducers/blends
+consume contributions in canonical order. Global occurrences order by destination
+seam, directed crossing time, player order, track ID and keyframe ID. Iteration order
+is never a conflict resolver.
+
 Gameplay-authoritative sampling is never skipped according to elapsed wall time;
 if deterministic work cannot be admitted, reject/hold with a typed outcome. Optional
 presentation-only work may use an explicit lower sampling rate, without changing
@@ -673,6 +742,16 @@ These are required implementation acceptance tests, not tests added by this ADR:
 
 - Compare identical committed tick/input histories under 30/60/144 Hz presentation;
   authoritative values/event order match under documented numeric tolerances.
+- Component/application players share one service registry; test component removal,
+  dropped handles, scene travel, preview/PIE isolation, nested stop and late completion
+  fencing without leaked or prematurely destroyed state.
+- Randomize allocation, container, command-arrival-before-cutoff and worker completion
+  order; immutable batches, priority/stable-ID winners and event order stay identical.
+- Same-fingerprint replays require exact time/identity/order/events and repeatable
+  floats; cross-platform fingerprints use declared numeric tolerances and report the
+  mismatch rather than claiming bit identity.
+- Headless replay uses the production service with manual recorded clocks/Null
+  adapters and reports missing activation, wall/provider or async evidence explicitly.
 - Validate all clock/pause/dilation combinations, nested pause-token release, menu
   plus cinematic pause, host resume, provider capability/loss and discontinuities.
 - Value samples are history-independent; event tests cover forward/reverse endpoints,
@@ -691,6 +770,7 @@ These are required implementation acceptance tests, not tests added by this ADR:
 ## Related Documents
 
 - [ADR-014: Sequencer Ownership, Clock Authority and Binding Boundary Decision](../../adr/014-sequencer-ownership-clock-authority-and-binding-boundary.md)
+- [ADR-117: Playback Ownership, Frame Order and Determinism](../../adr/117-playback-ownership-frame-order-and-determinism.md)
 - [Cinematic Sequencer UI Reference](./cinematic-sequencer.html)
 - [Scene Runtime Architecture](./scene-runtime.md)
 - [Animation Architecture](./animation-architecture.md)

--- a/docs/architecture/runtime/runtime-lifecycle.md
+++ b/docs/architecture/runtime/runtime-lifecycle.md
@@ -179,6 +179,14 @@ simulation, unscaled, screen-transition, preview, deterministic-test and manual
 domains and evaluates every active UI timeline exactly once before style/layout
 publication. Render extraction/execution never advances them.
 
+[ADR-117](../../adr/117-playback-ownership-frame-order-and-determinism.md) refines
+Cinematic Runtime without adding a phase. Before each fixed or permitted service/
+presentation boundary, the session-owned service drains commands through that
+boundary's cutoff and publishes one immutable player batch ordered by domain,
+descending priority and stable identity. Commands or worker completions after the
+cutoff cannot alter the active batch. Failed attempted ticks discard staged cinematic
+cursors/values/occurrences; tick commit advances them and releases occurrences.
+
 [ADR-078](../../adr/078-runtime-ui-input-context-and-player-routing.md) also adds no
 phase. `BuildInputSnapshot` publishes device/action/assignment evidence; Runtime UI
 VariableUpdate applies one ordered context stack against the last presented
@@ -550,6 +558,8 @@ Required tests cover:
 - startup success and partial-initialization failure unwind
 - fixed-step accumulator and catch-up bounds
 - fixed-state determinism under 30, 60, and 144 Hz variable frame cadences
+- cinematic immutable-batch cutoff/order, failed-tick discard and same-history replay
+  across zero/one/multiple fixed ticks per presentation frame
 - interpolation alpha at equivalent accumulator positions
 - presentation gating after extraction, execution, and GUI failures
 - dropped-time and clamp counter observability
@@ -578,6 +588,7 @@ Required tests cover:
 - [Physics Architecture](./physics-architecture.md)
 - [Audio Architecture](./audio-architecture.md)
 - [Networking Architecture](./networking-architecture.md)
+- [ADR-117: Playback Ownership, Frame Order and Determinism](../../adr/117-playback-ownership-frame-order-and-determinism.md)
 - [ADR-102: Runtime Network Modes and Authority Exposure](../../adr/102-runtime-network-modes-and-authority-exposure.md)
 - [Asset Pipeline](./asset-pipeline.md)
 - [Runtime Debug Console And Development Overlays](./debug-console-and-overlays.md)


### PR DESCRIPTION
## Summary

- Makes one application/runtime-session service the owner of every live sequence player.
- Keeps scene components as inert authored playback descriptors with generation-checked handles.
- Defines immutable same-boundary evaluation batches ordered by domain, descending priority, and stable player identity.
- Establishes replay/headless determinism guarantees and direct random-access seek semantics.

## Why

ADR-014 defines clock, binding, phase, and domain-authority boundaries, but player lifetime and determinism still had ambiguous edges. Embedding live players in relocatable scene components would make tokens, providers, nested players, and queued effects follow the wrong lifetime. Allocation/container/worker order also could not be allowed to decide overlapping same-frame output.

## Decision and boundaries

- Adds ADR-117 and projects it into the Cinematic Sequencer and Runtime Lifecycle architecture.
- `CinematicRuntimeService` owns player state, clocks, event cursors, bindings, nested trees, capacity, leases, tokens, and asynchronous retirement for one runtime session.
- SceneBound players stop before scene replacement; ApplicationBound players survive travel only when bindings/adapters explicitly permit it. Preview, PIE, and packaged runtime use separate registries.
- Root activation IDs come from stable scene, gameplay-event, or recorded operation identity; allocation order, pointers, hash seeds, thread arrival, and job completion are non-semantic.
- Batch cutoffs make late commands wait for the next boundary, while preassigned order slots keep parallel evaluation deterministic.
- Cross-platform bit-identical float sampling is not claimed. Exact time/identity/interval/event order is preserved; numeric samples use documented tolerances across determinism fingerprints.
- Seek samples the requested target directly through indexed lookup and does not replay from zero or execute historical side effects.

This PR defines architecture contracts only. Runtime registries, command queues, replay capture, fingerprints, adapters, and conformance tests remain focused implementation work.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Markdown lint passed
- [x] Added Markdown links resolve
- [x] Staged diff checks passed
- [x] CMake configure passed
- [ ] Full build/test suite not run; this is a documentation-only decision

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- <changed-markdown-files>
git diff --check
git diff --cached --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- ApplicationBound travel support requires each retained binding/adapter to declare and qualify its lifecycle behavior.
- Exact same-fingerprint float repeatability depends on controlling compiler, CPU, floating-point mode, and interpolation operation order.
- Replay must capture wall/external samples and observed asynchronous outcomes; incomplete evidence fails explicitly.
- CMake reported the existing mbedTLS deprecation warning and skipped repository Python tests because pytest is unavailable.

## Issue links

- Jira: HORO-1657
- GitHub: Closes #1698

## Reviewer Notes

Review ADR-117 first, then Player Ownership And Lifetime and Evaluation Capacity in the Cinematic architecture, followed by the Runtime Lifecycle projection. Focus on service-owned lifetime, stable activation/order identity, the cross-platform numeric guarantee, and seek independence from playback history.