### PR TITLE
docs(cinematic): define actor authority HORO-1658 #1699 [CIN-002.2]

### DIFF
--- a/docs/adr/118-animation-character-and-gameplay-authority-during-cinematics.md
+++ b/docs/adr/118-animation-character-and-gameplay-authority-during-cinematics.md
@@ -1,0 +1,342 @@
+# ADR-118: Animation, Character and Gameplay Authority During Cinematics
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Cinematic skeletal-pose composition, per-joint authority, Character movement/root ownership, gameplay control arbitration, pause behavior, typed conflicts, lifecycle and backend-neutral integration seams
+- **Issue**: [CIN-002.2](https://github.com/abdullahbodur/horo-engine/issues/1699)
+- **Jira**: [HORO-1658](https://horo-engine.atlassian.net/browse/HORO-1658)
+- **Related**: [ADR-014](014-sequencer-ownership-clock-authority-and-binding-boundary.md), [ADR-061](061-animation-ownership-update-order-and-clock.md), [ADR-089](089-character-controller-ownership-implementation-and-update-order.md), [ADR-090](090-character-dynamic-body-visibility-push-and-proxy-policy.md), [ADR-117](117-playback-ownership-frame-order-and-determinism.md)
+- **Normative documents**: [Cinematic Sequencer Architecture](../architecture/runtime/cinematic-sequencer-architecture.md), [Animation Architecture](../architecture/runtime/animation-architecture.md), [Character Controller Architecture](../architecture/runtime/character-controller-architecture.md), [Runtime Lifecycle](../architecture/runtime/runtime-lifecycle.md)
+
+## Context
+
+ADR-014 requires Cinematic Runtime to submit typed owner requests instead of writing
+Physics, Character, camera or gameplay state directly. ADR-061 makes Animation
+Runtime the only mutable pose-buffer owner and defines per-joint AnimationDriven,
+PhysicsDriven and Blended composition. ADR-089 makes Character the final collision-
+root and movement authority. ADR-117 owns sequence-player lifetime and stable
+multi-player ordering.
+
+Those decisions do not yet say what happens when cinematic and gameplay animation
+both target an actor, whether the graph is suspended, which joints can be overridden,
+how a cinematic movement path interacts with Character, or what result a gameplay
+write receives while cinematic authority is active. A broad `cinematicActive` boolean
+would spread policy checks through gameplay, Animation and Character, while direct
+transform/pose writes would create two owners.
+
+Gameplay pause is another distinct concern. ADR-014's pause token stops the complete
+simulation domain. An unscaled cinematic may continue presentation while paused, but
+there are no Character or Physics ticks in which to move a collision root. Products
+often want a cutscene to keep deterministic character movement running while player
+input and AI control are suppressed; using whole-game pause for that case is
+architecturally wrong.
+
+This ADR decides the owner and arbitration mode for skeletal pose, Character movement
+and gameplay control. Camera selection, event dispatch and Audio scheduling remain
+owned by their focused CIN-003/CIN-004 decisions.
+
+## Decision
+
+### 1. Cinematic Runtime proposes; domain owners decide and publish
+
+The responsibility split is:
+
+| State or decision | Final owner | Cinematic boundary |
+|---|---|---|
+| Sequence time, player order and sampled track values | `CinematicRuntimeService` | Produces stable generation/tick-addressed proposals under ADR-117 |
+| Mutable graph instance, joint poses and final committed pose | Animation Runtime | Validates and composes cinematic contributions; Cinematic never receives a mutable pose |
+| Collision root, desired displacement resolution, stance/jump and final movement | `CharacterWorld` | Admits a cinematic movement command under its ordinary fixed-tick solver |
+| Gameplay/AI/player control channel | Gameplay/application authority | Grants scoped cinematic-exclusive leases or keeps gameplay ownership |
+| Fixed simulation pause | Host Runtime pause authority | Grants a composed pause token; player never sets scheduler state |
+| Bodies, contacts, kinematic targets and ragdoll joint override | Physics | Existing typed Character/Animation seams; no cinematic native calls |
+| Presentation-only pose overlay | Animation presentation owner | Consumes committed state plus cinematic sample; cannot feed simulation |
+
+Cinematic Runtime depends only on Horo-owned model/runtime contracts and injected
+adapters. It does not include or expose Jolt, OpenGL, Metal, Vulkan, D3D12, platform
+input, native animation middleware or gameplay-module implementation types.
+
+### 2. Activation acquires one atomic authority plan
+
+A compiled sequence declares required claims for every actor/channel it may drive:
+
+```cpp
+enum class CinematicControlChannel : uint8_t {
+    SkeletalPose,
+    AnimationParameter,
+    CharacterTranslation,
+    CharacterHeading,
+    CharacterStance,
+    GameplayAction
+};
+
+enum class CinematicClaimMode : uint8_t {
+    ObserveOnly,
+    Exclusive,
+    Blend
+};
+```
+
+Claims include stable actor/channel/property/joint-mask identity, required/optional
+status, player priority/order identity, admitted evaluation seam, blend contract and
+handoff policy. Before a player enters Ready, the application requests one aggregate
+authority plan from Gameplay, Animation and Character owners. Required denial,
+incompatible mode, overlapping equal-authority claim, server/client mismatch or
+impossible phase fails activation and unwinds all granted claims. Optional denial
+disables that declared track with a typed diagnostic.
+
+Claims are generation-scoped leases owned by the ADR-117 player. Stop, failure,
+binding loss, scene replacement, network-authority change and shutdown close new
+proposals, remove the player from a later batch, then release each claim at its owner's
+safe point. Closing UI or losing a component does not mutate authority immediately.
+
+There is no process-global or component boolean that other systems poll. Each owner
+resolves proposals and ordinary gameplay commands against its immutable authority
+snapshot for the exact tick/boundary.
+
+### 3. Animation always owns pose state and composition
+
+A cinematic skeletal track submits immutable `CinematicPoseContribution` data with
+scene, player/generation, animation-instance/skeleton, tick or presentation boundary,
+stable order key, joint mask, mode, finite weight and sampled local transforms.
+Animation validates skeleton/joint identities and copies/composes into Animation-owned
+working storage. Cinematic never suspends an Animation thread, swaps pose pointers or
+writes a palette.
+
+The admitted pose modes are:
+
+| Mode | Meaning |
+|---|---|
+| `Override` | Cinematic contribution has weight 1 for the declared AnimationDriven joints; graph contribution for those output joints is masked during composition |
+| `Blend` | Animation combines graph/base and cinematic local transforms by a finite authored per-joint weight/curve in canonical joint order |
+| `PresentationOverlay` | Applies only to the immutable presentation pose after committed simulation; excluded from root motion, hit shapes, colliders, events and later ticks |
+
+There is no baseline `SuspendAnimationRuntime` mode. While fixed simulation runs, the
+underlying graph instance continues to evaluate once per attempted tick even when
+some of its output joints are overridden. Its state machines, cursors and permitted
+events therefore resume from the same tick history rather than from hidden elapsed
+time. When gameplay is paused, no authoritative Animation tick occurs and the graph
+holds with the rest of simulation; permitted presentation overlays may still sample
+an unscaled/external cinematic clock.
+
+Enter/exit can be `Cut` or a bounded `Blend(duration, curve)` selected in the compiled
+claim. Animation initializes a handoff from the last committed pose at the owner safe
+point and advances it only in the declared domain. A stopped player cannot leave an
+unowned frozen pose or restore a stale pre-cinematic snapshot.
+
+### 4. Per-joint Animation/Physics authority remains final
+
+Cinematic composition is part of the AnimationDriven side of ADR-061's existing
+per-joint authority model:
+
+1. Animation evaluates the underlying graph/base pose.
+2. Animation applies admitted cinematic Override/Blend contributions in ADR-117
+   player/order-key order.
+3. Simulation-affecting IK evaluates over that candidate.
+4. Character consumes the one admitted root-motion/movement request.
+5. Physics steps and publishes any `PhysicsPoseOverride`.
+6. Animation applies PhysicsDriven/Blended joint authority and finalizes the pose.
+
+A PhysicsDriven joint cannot be reclaimed by a cinematic track. A required cinematic
+claim that overlaps such a joint fails `ConflictsWithPhysicsAuthority` unless the
+Physics/Animation owner first performs an explicit safe-point mode transition.
+For ADR-061 `Blended` joints, Physics' declared final weight composes over the already
+combined graph/cinematic Animation-side candidate. Cinematic priority cannot bypass
+ragdoll/body authority.
+
+The skeleton root's visual joint is not the Character collision root. Cinematic pose
+translation/rotation affects visual skeleton composition only. Authoritative world
+movement must use the Character seam below; presentation overlay never produces
+consumable root motion.
+
+### 5. Character always owns collision-root movement
+
+For each actor and tick, Character admits exactly one effective control source:
+
+| Character control state | Accepted translation/heading/stance source |
+|---|---|
+| `GameplayControlled` | Ordinary gameplay/AI command plus admitted Animation root-motion policy |
+| `CinematicControlled` | One ADR-117-selected cinematic command; ordinary gameplay commands for claimed channels are suppressed |
+
+`CinematicControlled` is exclusive for each claimed Character channel. The baseline
+does not blend arbitrary gameplay and cinematic world displacement because collision,
+path timing and authored staging would no longer have one predictable authority.
+A sequence that wants gameplay locomotion leaves Character channels unclaimed and may
+use pose-only Blend. Products needing cooperative locomotion must define a separate
+typed owner-side reducer rather than summing vectors in Cinematic Runtime.
+
+The cinematic command carries desired world/local displacement intent, heading,
+stance/jump policy where admitted, root-motion composition mode and exact scene/
+controller/player/tick/generation/order identity. It carries no caller delta and no
+native body handle. Character applies platform carry, validates the command, resolves
+ordinary Horo sweeps/collision/dynamic interaction, stages Physics commands and
+publishes achieved/rejected movement exactly once under ADR-089. Cinematic cannot
+teleport or set the transform unless a distinct typed Character teleport capability
+was declared and admitted at a safe point.
+
+If multiple players claim the same Character channel, the owner uses the ADR-117
+priority/stable-player order fixed at activation. Required equal-priority incompatible
+claims fail aggregate activation rather than alternating winners per frame. Optional
+losers remain disabled and visible. Runtime arrival or evaluation order never steals a
+lease.
+
+### 6. Gameplay writes receive typed arbitration outcomes
+
+Gameplay, player input and AI continue to submit ordinary owner commands; they never
+write pose buffers or Character transforms directly. The receiving owner classifies
+each channel against the tick's authority snapshot:
+
+| Situation | Outcome |
+|---|---|
+| Channel is not claimed by Cinematic | `AcceptedGameplay` |
+| Exclusive cinematic claim owns the same parameter/movement/heading/stance/action | `SuppressedByCinematic` |
+| Declared Animation pose/parameter Blend accepts both contributions | `AcceptedForOwnerBlend` |
+| Command targets a different unclaimed channel | `AcceptedGameplay` |
+| Claim/command identity, generation, tick or network authority is stale/wrong | `StaleAuthority` / `AuthorityDenied` |
+| Required owner cannot honor the compiled mode | `UnsupportedAuthorityMode` and player activation/evaluation failure |
+
+Suppressed commands are not queued for replay after the cinematic, converted to zero
+values or reported as success. Their bounded typed result is available to the
+submitting gameplay system and diagnostics. Edge-triggered actions such as jump,
+attack or interact are consumed/suppressed according to product input policy for that
+tick; they do not burst on lease release. Persistent gameplay state unrelated to the
+claimed channel continues normally when simulation is running.
+
+Animation parameters may be claimed individually. A cinematic aim parameter does not
+silence unrelated locomotion parameters; a full-pose Override does not grant Gameplay
+action or Character movement authority. Joint masks and property/channel identities
+are validated at cook/activation, not discovered by string comparisons in the hot
+path.
+
+### 7. Whole-game pause and cinematic control are different tools
+
+When a cinematic owns a host gameplay-pause token:
+
+- no fixed simulation tick is attempted;
+- Gameplay/AI scripts, authoritative Animation, Character and Physics hold their
+  committed state;
+- no gameplay command, root-motion request, Character movement, collision query,
+  physics step or gameplay-mutating cinematic event is accumulated for later;
+- unscaled/wall/external playback may update permitted camera, Audio, Runtime UI and
+  presentation-only skeletal overlays at their service/presentation boundaries; and
+- one host single-step runs the complete ordinary fixed-tick authority pipeline once,
+  then returns to pause.
+
+Therefore a cinematic cannot move an authoritative Character while whole-game pause
+is active. A cutscene requiring collision-aware movement keeps fixed simulation
+running, acquires CinematicControlled leases for the selected actors/channels and
+suppresses player/AI control through the Gameplay authority. This is control transfer,
+not scheduler pause.
+
+Pause token release resumes the next ordinary fixed tick. It does not apply elapsed
+presentation motion to Character, catch up graph state, replay suppressed gameplay
+commands or synthesize a large root-motion interval.
+
+### 8. Network/world authority cannot be widened by playback
+
+The application resolves actor/world authority before granting claims. A client-side
+sequence may present cosmetic pose overlays for locally permitted views but cannot
+acquire Character, Physics, server-owned Animation parameter or gameplay-action
+authority for a server-owned actor. It submits a normal network/gameplay request where
+the product protocol permits one; local cinematic priority is not network authority.
+
+Server-authoritative cinematic commands join the same fixed-tick input/command frame
+and can be replicated as semantic control state or resulting authoritative state.
+Process-local player handles, mutable poses, wall clock and native controller objects
+are never replication identity. Authority transfer or disconnect invalidates affected
+leases by world/session generation before later player proposals can apply.
+
+### 9. Failure, conflict and lifecycle are explicit
+
+Stable outcomes include AuthorityPlanDenied, RequiredBindingMissing,
+ConflictsWithPhysicsAuthority, ConflictingCinematicClaim,
+UnsupportedAuthorityMode, SuppressedByCinematic, InvalidJointMask,
+InvalidBlendWeight, StaleAuthority, NetworkAuthorityDenied,
+EvaluationBudgetExceeded and OwnerUnavailable.
+
+A required claim/binding/owner failure before activation leaves the player unstarted.
+During playback, loss of a required actor/owner/authority holds or stops the player
+according to its declared failure policy; it cannot fall back to direct writes or
+silently give gameplay and cinematic simultaneous exclusive ownership. Optional
+tracks may disable with a bounded deduplicated diagnostic.
+
+All contributions and commands are staged for an attempted tick. Tick failure
+publishes no pose/graph cursor, Character movement or irreversible gameplay effect.
+Stop/cancel closes admission before releasing leases. Late animation/character/
+physics/provider results carry scene/session/player/owner generation and cannot
+restore old authority or pose state.
+
+### 10. Qualification proves every authority mode
+
+Required evidence includes:
+
+- pose-only Override, per-joint Blend and PresentationOverlay against a continuing
+  graph, with Cut/blended entry/exit and no stale-pose restoration;
+- AnimationDriven, PhysicsDriven and Blended joint masks, required overlap rejection,
+  safe-point mode transition and Physics final authority after cinematic composition;
+- visual root versus collision root separation, presentation overlay producing no root
+  motion and CinematicControlled movement resolving through ordinary Character sweeps;
+- GameplayControlled/CinematicControlled transitions, mid-cinematic parameter,
+  movement, heading, stance and action results for claimed/unclaimed channels;
+- multiple players with priority/stable-ID claim resolution, optional loser behavior,
+  required conflict failure and independence from worker/container order;
+- whole-game pause, single-step and resume proving no Character/Physics movement,
+  gameplay backlog, graph catch-up or presentation-to-simulation feedback;
+- running-simulation cutscene control transfer with player/AI suppression but ordinary
+  Physics, Character, Animation and unrelated gameplay still ticking;
+- scene travel, binding loss, component removal, stop/failure/cancel, network authority
+  change and shutdown with every lease/token/result generation safely retired; and
+- Null/recording Animation, Character, Gameplay and Physics adapters in headless tests,
+  with no concrete backend or editor dependency in Cinematic Runtime.
+
+## Consequences
+
+### Positive
+
+- Animation, Character, Gameplay and Physics retain one final authority each.
+- Pose override/blend is per joint and owner-composed rather than a mutable-buffer
+  handoff.
+- Gameplay writes have observable outcomes instead of silently fighting cinematic
+  values.
+- A cutscene can suppress actor control without stopping the complete simulation.
+
+### Costs
+
+- Player activation needs atomic multi-owner claim planning and rollback.
+- Animation requires stable joint-mask contribution plans and bounded handoff state.
+- Gameplay and Character command producers must consume typed suppression/denial
+  results and avoid edge-trigger backlogs.
+
+## Rejected Alternatives
+
+### Suspend Animation Runtime whenever a cinematic targets an actor
+
+Rejected because graph state, events, root motion, physics overrides and unrelated
+joints would lose their normal tick semantics. Animation continues owning/evaluating
+the graph and masks/blends only declared joints.
+
+### Let Cinematic Runtime write pose arrays or scene transforms
+
+Rejected because it would create a second mutable pose/collision-root owner and bypass
+generation, Character collision and Physics authority.
+
+### Sum gameplay and cinematic movement vectors
+
+Rejected because collision path, staging time and authored arrival become ambiguous.
+Character uses one exclusive control source unless a future owner-side reducer is
+separately specified.
+
+### Pause gameplay to suppress player input while characters keep moving
+
+Rejected because host gameplay pause intentionally stops all fixed simulation. Actor
+movement during a cutscene uses scoped control leases while simulation continues.
+
+### Queue suppressed gameplay commands until the cinematic ends
+
+Rejected because edge-triggered actions and stale movement would burst under a new
+world/authority state. Suppression is a typed terminal result for that command/tick.
+
+### Use concrete Animation or Physics backend APIs
+
+Rejected because cinematic policy must remain portable and testable with Null/
+recording adapters across all renderer, physics and platform compositions.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -129,6 +129,7 @@ to the replacement.
 | [115](115-cloud-save-authority-revision-and-conflict-policy.md) | Cloud Save Authority, Revision and Conflict Policy | Proposed | 2026-09-02 |
 | [116](116-save-data-threat-model-and-trust-policy.md) | Save Data Threat Model and Trust Policy | Proposed | 2026-09-02 |
 | [117](117-playback-ownership-frame-order-and-determinism.md) | Playback Ownership, Frame Order and Determinism | Proposed | 2026-09-02 |
+| [118](118-animation-character-and-gameplay-authority-during-cinematics.md) | Animation, Character and Gameplay Authority During Cinematics | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -357,6 +357,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Playback Ownership, Frame Order and Determinism](../adr/117-playback-ownership-frame-order-and-determinism.md):
   runtime-service player lifetime, stable activation identity, immutable evaluation
   batches, replay/headless evidence and random-access seek.
+- [Animation, Character and Gameplay Authority During Cinematics](../adr/118-animation-character-and-gameplay-authority-during-cinematics.md):
+  per-joint pose override/blend, Character collision-root authority, gameplay control
+  leases, typed suppression and whole-game pause semantics.
 - [Post-Processing And Effects Architecture](./runtime/post-processing-and-effects-architecture.md):
   screen-space effects, HDR post chain, tonemapping, color grading, and
   accessibility pass ordering.

--- a/docs/architecture/extensions/gameplay-module-boundary.md
+++ b/docs/architecture/extensions/gameplay-module-boundary.md
@@ -277,6 +277,21 @@ certification APIs directly. See
 [Platform Abstraction](../foundation/platform-abstraction.md) for path,
 directory, atomic file, and platform-service contracts.
 
+### Cinematic Control Outcomes
+
+[ADR-118](../../adr/118-animation-character-and-gameplay-authority-during-cinematics.md)
+requires gameplay modules to submit ordinary typed animation-parameter, movement,
+heading, stance and action commands even while a cinematic runs. The receiving owner
+resolves each channel against the tick's immutable authority claims and returns
+`AcceptedGameplay`, `AcceptedForOwnerBlend`, `SuppressedByCinematic`,
+`StaleAuthority` or `AuthorityDenied` as appropriate.
+
+Modules do not poll a global cinematic flag, write poses/transforms directly or queue
+suppressed edge actions until a sequence stops. Unclaimed channels and unrelated
+simulation continue when fixed ticks run. Whole-game pause attempts no Gameplay,
+Animation, Character or Physics tick; collision-aware cinematic movement instead
+uses scoped control transfer while simulation remains active.
+
 ## Services
 
 A game module may create project- or runtime-scoped services through explicit
@@ -413,3 +428,6 @@ game.<project>.save
 - [Ownership And Resource Lifetime](../foundation/ownership-and-resource-lifetime.md)
 - [ADR-114](../../adr/114-canonical-runtime-world-persistence-boundary.md): canonical
   runtime-state adapters and single semantic ownership.
+- [ADR-118](../../adr/118-animation-character-and-gameplay-authority-during-cinematics.md):
+  cinematic control claims, typed gameplay suppression and owner-preserving pose/
+  movement integration.

--- a/docs/architecture/runtime/animation-architecture.md
+++ b/docs/architecture/runtime/animation-architecture.md
@@ -52,6 +52,9 @@ Not covered:
 - Root motion is explicit: animation stages the exact fixed-tick interval delta;
   gameplay selects consumption policy and the character controller owns final
   collision-aware movement.
+- Cinematic skeletal tracks are owner-admitted per-joint contributions. Animation
+  continues to own/evaluate the graph and composes Override/Blend before Physics'
+  final per-joint authority; presentation overlays never feed simulation.
 - Retargeting is a cook/import-time process where possible. Runtime retargeting
   is supported but more expensive.
 - GPU skinning is the default for skinned meshes. CPU skinning is a fallback for
@@ -110,6 +113,33 @@ Rules:
   poses remain valid until presentation and render leases retire.
 - Render extraction receives a frame-owned immutable pose/palette projection
   tagged with scene, instance, tick, and pose-generation identity.
+
+### Cinematic Pose Authority
+
+[ADR-118](../../adr/118-animation-character-and-gameplay-authority-during-cinematics.md)
+defines cinematic pose composition. A sequence player submits immutable generation-
+checked contributions through the Animation adapter; it never receives mutable pose
+storage. Activation validates stable skeleton/joint-mask identity, required/optional
+claims, player priority/order, evaluation seam, finite weights and handoff policy.
+
+For every attempted fixed tick, Animation evaluates the underlying graph first. It
+then applies cinematic `Override` (weight 1 on declared AnimationDriven joints) or
+`Blend` contributions in canonical ADR-117 player/joint order. The graph is not
+suspended merely because its output is masked, so cursor/state/event progression
+remains tied to actual simulation ticks. Cut or bounded blend handoff begins from the
+last committed pose and cannot restore a stale pre-cinematic snapshot.
+
+PhysicsDriven joints reject required cinematic ownership unless Physics/Animation
+first perform an explicit safe-point authority transition. Existing `Blended` Physics
+authority composes over the graph-plus-cinematic Animation-side candidate after the
+step. A `PresentationOverlay` modifies only the immutable presentation pose and is
+excluded from root motion, events, hit shapes, colliders and later fixed-tick input.
+
+Gameplay animation-parameter commands targeting an exclusive cinematic claim return
+`SuppressedByCinematic`; unclaimed parameters remain admitted and declared blend
+parameters are owner-composed. Suppressed commands are not reported as success or
+queued until release. Stop, scene/actor generation loss and authority change close
+contribution admission before owner-safe-point handoff/lease retirement.
 
 ## Animation Clip
 
@@ -539,6 +569,8 @@ committed pose. Animation-to-physics handoff is explicit and generation-checked.
 - Retargeting tests comparing source and target poses.
 - Visual regression tests for skinned mesh playback.
 - Root-motion duplicate/stale request and physics-override authority tests.
+- Cinematic per-joint Override/Blend/PresentationOverlay, continuing underlying graph,
+  entry/exit handoff, PhysicsDriven conflict and typed gameplay-parameter suppression.
 - Preview/play isolation, stale pose lease, reload, scene replacement, and shutdown tests.
 - Performance tests for joint palette upload and GPU skinning throughput.
 
@@ -550,6 +582,7 @@ committed pose. Animation-to-physics handoff is explicit and generation-checked.
   extraction and joint palette binding.
 - [Cinematic Sequencer Architecture](./cinematic-sequencer-architecture.md): timeline,
   tracks, clock authority, and evaluation phase integration.
+- [ADR-118: Animation, Character and Gameplay Authority During Cinematics](../../adr/118-animation-character-and-gameplay-authority-during-cinematics.md)
 - [Physics Architecture](./physics-architecture.md): ragdoll, hit detection, and
   animation/physics handoff.
 - [Asset Pipeline](./asset-pipeline.md): clip import, compression, and cook.

--- a/docs/architecture/runtime/character-controller-architecture.md
+++ b/docs/architecture/runtime/character-controller-architecture.md
@@ -60,6 +60,9 @@ Not covered:
   defines explicit `Disabled`, `ObstacleOnly`, `OneWayPush` and
   `BidirectionalProxy` dynamic interaction modes. Character remains root authority
   in every mode; unsupported capability never silently changes the effective mode.
+- [ADR-118](../../adr/118-animation-character-and-gameplay-authority-during-cinematics.md)
+  keeps Character as collision-root authority during cinematics. Each claimed channel
+  is GameplayControlled or CinematicControlled; whole-game pause performs no move.
 
 ## Implementation And Ownership
 
@@ -178,6 +181,35 @@ Gameplay desired heading for that tick and applies root twist to the carried
 heading. Root translation uses the pre-root heading. Platform tilt and root/visual
 pitch or roll never rotate the capsule; changing the up basis is a typed safe-point
 command with clearance validation.
+
+## Cinematic Control Arbitration
+
+Before a sequence starts, the application requests generation-scoped Character
+claims for translation, heading, stance/jump or a separately admitted teleport
+capability. Required conflicts fail aggregate player activation; optional tracks
+disable visibly. The resulting per-tick authority snapshot selects exactly one source
+for each claimed channel:
+
+- `GameplayControlled` consumes the ordinary Gameplay/AI command and configured
+  Animation root-motion policy; or
+- `CinematicControlled` consumes the ADR-117-selected cinematic command and returns
+  `SuppressedByCinematic` for ordinary commands targeting the same channel.
+
+Suppressed movement, heading, jump, stance and actions are not queued for replay after
+the claim releases. Unclaimed channels remain accepted. The baseline does not sum
+gameplay and cinematic displacement; a future cooperative mode must be an explicit
+Character-owned reducer with its own collision/timing contract.
+
+A cinematic command carries exact scene/controller/player/tick/generation/order
+identity and no caller-selected delta or native body handle. Character performs the
+same platform carry, root-motion composition, bounded Horo sweeps, collision/dynamic
+interaction and Physics command staging used by gameplay. Cinematic Runtime never
+writes Scene Transform or bypasses the controller with a visual-root value.
+
+Host gameplay pause produces no Character tick or movement. Collision-aware cutscene
+movement therefore keeps simulation running and suppresses selected Gameplay/AI
+control through owner leases. Presentation pose motion while paused cannot update the
+capsule, accumulate root motion or become a resume-time catch-up displacement.
 
 ## Movement Resolution
 
@@ -537,6 +569,10 @@ Runtime variables:
 - Platform carry point rotation, dynamic point-velocity prediction, optional heading
   twist and no post-Physics second move.
 - Capsule up, Gameplay desired heading, root twist and visual pitch/roll ownership.
+- GameplayControlled/CinematicControlled claims, claimed/unclaimed command outcomes,
+  multi-player priority conflicts and no suppressed-command backlog.
+- Whole-game pause versus running-simulation cinematic control transfer, including no
+  presentation/root-motion catch-up and ordinary collision-aware movement.
 - Four-mode dynamic visibility/push/reaction truth table, including filtered,
   unsupported-capability and explicit-fallback cases.
 - One-way command canonicalization, proxy pair exclusivity, no double impulse,
@@ -555,6 +591,7 @@ Runtime variables:
   materials, rigid bodies, and fixed-step world.
 - [Animation Architecture](./animation-architecture.md): root motion and
   animation-driven movement.
+- [ADR-118: Animation, Character and Gameplay Authority During Cinematics](../../adr/118-animation-character-and-gameplay-authority-during-cinematics.md)
 - [Audio Architecture](./audio-architecture.md): audio event routing and
   variation containers.
 - [VFX And Particles Architecture](./vfx-and-particles-architecture.md): impact

--- a/docs/architecture/runtime/cinematic-sequencer-architecture.md
+++ b/docs/architecture/runtime/cinematic-sequencer-architecture.md
@@ -12,6 +12,9 @@ This subsystem is governed by [ADR-014: Sequencer Ownership, Clock Authority and
 [ADR-117](../../adr/117-playback-ownership-frame-order-and-determinism.md)
 refines live-player ownership, activation identity, multi-player batch order,
 replay/headless evidence, numeric determinism and random-access seek.
+[ADR-118](../../adr/118-animation-character-and-gameplay-authority-during-cinematics.md)
+defines Animation, Character and Gameplay authority while those players target
+skeletal pose or actor control.
 [ADR-068](../../adr/068-music-transport-and-cross-system-ownership.md) owns the
 AudioTrack handoff: Sequencer retains sequence clock, directed event traversal,
 seek/scrub and preroll intent while Audio alone maps accepted requests to sample
@@ -44,6 +47,9 @@ time and schedules the callback.
   by domain, descending priority and stable identity. Exact cross-platform float bits
   are not promised; identities/time/event order are exact and samples use declared
   tolerances across build/platform fingerprints.
+- **Owner-issued cinematic authority**: Animation composes per-joint pose claims,
+  Character resolves exclusive cinematic movement, and Gameplay returns typed
+  suppression/acceptance. Whole-game pause never moves an authoritative Character.
 
 ## System Boundaries and Target Topology
 
@@ -501,6 +507,45 @@ Unscaled/wall/external players similarly use presentation/service boundaries unl
 an authorized destination explicitly stages an effect for a later simulation tick.
 A physics-owned transform cannot be a presentation write target.
 
+## Animation, Character And Gameplay Authority
+
+Before activation, a player declares required/optional actor claims for skeletal
+pose/joint masks, animation parameters, Character translation/heading/stance and
+gameplay actions. The application obtains one aggregate generation-scoped authority
+plan from Animation, Character and Gameplay owners. Required conflicts fail and
+unwind activation; optional tracks disable with typed diagnostics. There is no global
+`cinematicActive` flag and Cinematic Runtime never writes pose or transform storage.
+
+Animation remains the mutable pose owner. It evaluates the underlying graph on every
+attempted simulation tick, then applies admitted cinematic `Override` or `Blend`
+contributions in the ADR-117 player order. Override masks only declared
+AnimationDriven joints; Blend uses finite owner-applied per-joint weights.
+PresentationOverlay affects only the render/preview pose and cannot produce root
+motion, hit shapes, events or later simulation input. PhysicsDriven joints retain
+final authority; required overlap fails unless their owner first admits a safe-point
+mode transition.
+
+Character admits either GameplayControlled or CinematicControlled input for each
+claimed channel. CinematicControlled is exclusive: Character consumes the winning
+tick-addressed cinematic command through ordinary platform-carry, root-motion,
+sweep/collision and Physics seams. Gameplay commands for claimed channels return
+`SuppressedByCinematic`; unclaimed channels remain `AcceptedGameplay`. Suppressed
+edge actions are not queued for release-time replay. Arbitrary gameplay/cinematic
+movement vectors are not summed.
+
+Host gameplay pause stops fixed ticks, so authoritative Animation, Character,
+Physics and Gameplay hold. Only admitted presentation/camera/Audio/UI work may use an
+unscaled/external clock. A cutscene that needs collision-aware actor movement keeps
+simulation running and transfers selected control channels through leases; it does
+not request whole-game pause. Resume never converts elapsed presentation time into a
+Character move or graph catch-up interval.
+
+All proposals identify exact session, scene, player, actor/instance, tick/boundary and
+generation. Stop, binding loss, scene travel, authority transfer and shutdown close
+admission before owner-safe-point lease release; late results cannot restore old
+control. Client playback cannot gain authority over server-owned actors. The full
+composition, conflict and qualification contract is ADR-118.
+
 ## Object Binding Resolution: `SequenceBindingAuthority`
 
 ### Identity Mapping
@@ -752,6 +797,10 @@ These are required implementation acceptance tests, not tests added by this ADR:
   mismatch rather than claiming bit identity.
 - Headless replay uses the production service with manual recorded clocks/Null
   adapters and reports missing activation, wall/provider or async evidence explicitly.
+- Per-joint cinematic Override/Blend/PresentationOverlay, Physics authority conflict,
+  GameplayControlled/CinematicControlled arbitration and typed suppression.
+- Whole-game pause produces no authoritative pose/root-motion/Character movement or
+  gameplay backlog; running-simulation control transfer keeps ordinary owners ticking.
 - Validate all clock/pause/dilation combinations, nested pause-token release, menu
   plus cinematic pause, host resume, provider capability/loss and discontinuities.
 - Value samples are history-independent; event tests cover forward/reverse endpoints,
@@ -771,6 +820,7 @@ These are required implementation acceptance tests, not tests added by this ADR:
 
 - [ADR-014: Sequencer Ownership, Clock Authority and Binding Boundary Decision](../../adr/014-sequencer-ownership-clock-authority-and-binding-boundary.md)
 - [ADR-117: Playback Ownership, Frame Order and Determinism](../../adr/117-playback-ownership-frame-order-and-determinism.md)
+- [ADR-118: Animation, Character and Gameplay Authority During Cinematics](../../adr/118-animation-character-and-gameplay-authority-during-cinematics.md)
 - [Cinematic Sequencer UI Reference](./cinematic-sequencer.html)
 - [Scene Runtime Architecture](./scene-runtime.md)
 - [Animation Architecture](./animation-architecture.md)

--- a/docs/architecture/runtime/runtime-lifecycle.md
+++ b/docs/architecture/runtime/runtime-lifecycle.md
@@ -327,8 +327,8 @@ Variable-rate update is not used for deterministic physics integration.
 One fixed tick executes:
 
 1. consume the input command state assigned to the tick
-2. stage Gameplay/AI/Nav movement/facing, animation parameters and kinematic-platform
-   targets
+2. stage Gameplay/AI/Nav and owner-admitted Cinematic movement/facing, animation
+   parameters and kinematic-platform targets under the effective authority snapshot
 3. evaluate authoritative Animation pose/root motion and freeze Physics-owned
    Character query/support/platform-motion evidence
 4. run Horo Character platform carry and bounded query movement, staging its root
@@ -439,6 +439,14 @@ returns to paused state. It uses the ordinary unchanged fixed quantum and comple
 subsystem order; it does not consume accumulated wall time. Authoritative animation
 therefore holds during pause and advances once during a successful step. Isolated
 editor preview may advance only under its separate preview controls.
+
+Under [ADR-118](../../adr/118-animation-character-and-gameplay-authority-during-cinematics.md),
+whole-game pause also means no authoritative cinematic pose advance, root-motion
+request, Character movement, Physics step or gameplay-action backlog. Permitted
+unscaled/external cinematic work is presentation/service-only. A cutscene that must
+move collision-aware actors leaves fixed simulation running and acquires scoped
+Gameplay/Animation/Character control claims; it does not use pause as selective input
+suppression. Resume cannot apply elapsed presentation motion as a catch-up tick.
 
 Runtime UI continues its ordinary VariableUpdate/input/layout/render path while
 gameplay is paused. Menus/navigation/accessibility feedback use declared unscaled
@@ -589,6 +597,7 @@ Required tests cover:
 - [Audio Architecture](./audio-architecture.md)
 - [Networking Architecture](./networking-architecture.md)
 - [ADR-117: Playback Ownership, Frame Order and Determinism](../../adr/117-playback-ownership-frame-order-and-determinism.md)
+- [ADR-118: Animation, Character and Gameplay Authority During Cinematics](../../adr/118-animation-character-and-gameplay-authority-during-cinematics.md)
 - [ADR-102: Runtime Network Modes and Authority Exposure](../../adr/102-runtime-network-modes-and-authority-exposure.md)
 - [Asset Pipeline](./asset-pipeline.md)
 - [Runtime Debug Console And Development Overlays](./debug-console-and-overlays.md)


### PR DESCRIPTION
## Summary

- Defines cinematic authority across skeletal Animation, Character movement, Gameplay/AI control, host pause, and Physics pose overrides.
- Keeps Animation as the sole mutable pose owner and composes cinematic Override/Blend contributions per joint.
- Keeps Character as the final collision-root authority with explicit GameplayControlled or CinematicControlled channels.
- Gives mid-cinematic gameplay writes typed accepted, blended, suppressed, stale, or denied outcomes.

## Why

The existing clock and update-order decisions required Cinematic Runtime to use owner seams, but they did not define how gameplay animation and cinematic pose tracks coexist, whether graphs suspend, or how Character movement behaves during a gameplay pause. A shared `cinematicActive` flag or direct pose/transform writes would create duplicate authority and unpredictable resume behavior.

## Decision and boundaries

- Adds ADR-118 and projects it into Cinematic Sequencer, Animation, Character Controller, Gameplay Module, Runtime Lifecycle, and the architecture indexes.
- Player activation acquires one aggregate generation-scoped authority plan for stable actor channels and joint masks; required conflicts fail atomically and optional tracks disable visibly.
- Animation always evaluates the underlying graph on attempted simulation ticks, then owner-composes cinematic `Override` or `Blend`; `PresentationOverlay` cannot feed root motion, hit shapes, colliders, events, or later ticks.
- PhysicsDriven joints retain final authority. Cinematic priority cannot bypass ragdoll/body ownership.
- CinematicControlled movement still uses Character platform carry, bounded sweeps, collision, dynamic interaction, and Physics staging. Gameplay and cinematic displacement are not summed implicitly.
- Whole-game pause performs no authoritative Animation, Character, Physics, or Gameplay tick. Collision-aware cutscene movement keeps simulation active and transfers only selected control channels.
- Suppressed gameplay commands are terminal for that tick and never accumulate into a release-time action burst.

This PR defines architecture contracts only. Authority-plan registries, typed adapters, joint-mask plans, gameplay result plumbing, and conformance tests remain focused implementation work.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Markdown lint passed
- [x] Added Markdown links resolve
- [x] Staged diff checks passed
- [x] CMake configure passed
- [ ] Full build/test suite not run; this is a documentation-only decision

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- <changed-markdown-files>
git diff --check
git diff --cached --check
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

## Risk and rollout

- Aggregate activation requires rollback-safe claim acquisition across Gameplay, Animation, Character, and Physics authority states.
- Continuing a masked underlying graph requires bounded evaluation capacity even when cinematic override hides its output.
- Products that need cooperative gameplay/cinematic locomotion require a separately specified Character-owned reducer; the baseline is exclusive.
- CMake reported the existing mbedTLS deprecation warning and skipped repository Python tests because pytest is unavailable.

## Issue links

- Jira: HORO-1658
- GitHub: Closes #1699

## Reviewer Notes

Review ADR-118 first, then the Cinematic authority projection, followed by Animation and Character. Finish with Gameplay Module and Runtime Lifecycle. Focus on per-joint owner composition, collision-root ownership, typed gameplay suppression, and the distinction between whole-game pause and scoped actor control transfer.