### PR TITLE
docs(cinematic): define camera authority during cinematics HORO-1659 #1700 [CIN-003.1]

### DIFF
--- a/docs/adr/119-camera-authority-during-cinematics.md
+++ b/docs/adr/119-camera-authority-during-cinematics.md
@@ -1,0 +1,274 @@
+# ADR-119: Camera Authority During Cinematics
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Runtime, play-in-editor and editor-viewport camera authority; cinematic cut admission and handoff; rendered-frame validity; tiered transition semantics; backend-neutral render extraction
+- **Issue**: [CIN-003.1](https://github.com/abdullahbodur/horo-engine/issues/1700)
+- **Jira**: [HORO-1659](https://horo-engine.atlassian.net/browse/HORO-1659)
+- **Related**: [ADR-014](014-sequencer-ownership-clock-authority-and-binding-boundary.md), [ADR-026](026-large-world-precision-and-floating-origin-strategy.md), [ADR-033](033-presentation-and-display-ownership.md), [ADR-040](040-reconstruction-frame-generation-and-latency-providers.md), [ADR-117](117-playback-ownership-frame-order-and-determinism.md)
+- **Normative documents**: [Cinematic Sequencer Architecture](../architecture/runtime/cinematic-sequencer-architecture.md), [Rendering Architecture](../architecture/runtime/rendering-architecture.md), [Runtime Lifecycle](../architecture/runtime/runtime-lifecycle.md)
+
+## Context
+
+ADR-014 establishes that Cinematic Runtime submits typed camera requests and that
+the camera subsystem retains final active-camera authority. ADR-117 gives concurrent
+sequence players a stable priority/identity order and immutable evaluation batches.
+The renderer already consumes immutable, backend-neutral camera data during render
+extraction.
+
+The remaining boundary is underspecified. A runtime game view, a play-in-editor
+(PIE) game view and an editor authoring viewport can coexist, but a process-global
+active-camera pointer cannot distinguish them. It is also unclear whether a sequence
+owns the camera before its first cut, whether the last cut remains active after the
+track ends, what early stop restores, and whether a cut may change between render
+passes in one displayed frame.
+
+Camera blending creates another ambiguity. A hard cut can publish one camera, while
+a true cross-fade can require two fully rendered views and additional composition
+cost. Treating both as one renderer-specific callback would leak backend policy into
+the sequencer and make capability fallback unpredictable.
+
+This ADR defines camera authority, handoff, frame validity and transition tiers. It
+does not implement the camera service or the camera-cut track; those remain owned by
+the focused CIN-003 delivery tickets.
+
+## Decision
+
+### 1. Authority is scoped to a view context
+
+The host creates a generation-checked `CameraViewContextId` for every independently
+rendered view. One owner publishes the final camera selection for each live context:
+
+| Execution context | Final selection owner | Permitted proposals |
+|---|---|---|
+| Runtime game view | Runtime `CameraService` for that game session/view | Gameplay base proposals and admitted cinematic overrides |
+| PIE game view | PIE session's isolated `CameraService` | PIE gameplay proposals and PIE cinematic overrides only |
+| Editor scene viewport | Editor viewport controller | Editor orbit/fly/focus state and an explicitly admitted editor-preview proposal |
+
+The editor camera is not a scene gameplay camera. Runtime or PIE cinematic players
+cannot acquire the editor viewport's authority. A sequencer preview is an editor
+request routed through the viewport controller; closing preview resolves the
+controller's current authoring-camera state instead of restoring a saved pointer.
+
+Each owner accepts immutable `CameraProposal` values and publishes exactly one
+`CameraSelectionSnapshot` per view context and render-extraction boundary. There is
+no process-global active camera, mutable camera pointer shared with the renderer, or
+authority transferred to Cinematic Runtime.
+
+### 2. Cinematic cuts are scoped override leases
+
+Before activation, Cinematic Runtime resolves every camera binding and asks the
+context owner for a generation-scoped `CameraOverrideLease`. The request identifies
+the session, scene, view context, player generation, track, target camera, priority,
+stable player identity, transition policy and whether the claim is required. It does
+not carry a backend handle or native viewport object.
+
+The lease grants permission to propose cuts; it does not make the player the final
+selector. For concurrent sequences the Camera owner resolves admitted requests by
+descending player priority and then ascending stable player identity, matching
+ADR-117. Gameplay and losing cinematic proposals remain live. When the winner
+releases, the owner resolves the current eligible proposal; it never restores a
+camera pointer captured at acquisition time.
+
+Required binding, context or capability failure prevents activation and unwinds the
+lease plan. An optional camera track may remain disabled with a bounded typed
+diagnostic. Evaluation order, worker completion or container iteration cannot change
+the selected camera.
+
+### 3. Entry and exit handoff are explicit
+
+A camera-cut track owns no effective override before its first admitted cut keyframe.
+The runtime/PIE Camera owner continues selecting the current gameplay proposal; the
+editor viewport controller continues selecting the authoring camera. At the first
+cut boundary the player submits its first candidate and the owner can admit it for
+the next camera commit.
+
+Every compiled camera-cut track declares one end policy:
+
+```cpp
+enum class CameraCutEndPolicy : uint8_t {
+    HoldLastUntilPlayerEnd,
+    ReleaseAtTrackEnd
+};
+```
+
+`HoldLastUntilPlayerEnd` is the default because a camera track can end before the
+rest of a sequence. `ReleaseAtTrackEnd` removes that track's proposal at its declared
+end boundary. Player completion, stop, cancellation, required binding loss, scene
+replacement, context destruction and shutdown always close proposal admission and
+release the player's lease at the Camera owner's safe point.
+
+After any release, the owner re-resolves the live proposal set. It normally selects
+the current gameplay camera, another cinematic winner or the editor controller's
+current authoring camera. It does not resurrect a destroyed camera or overwrite a
+gameplay selection that changed during the cinematic. If no valid base proposal
+exists, the context enters an explicit `CameraUnavailable`/suspended presentation
+state; it never retains unowned mutable state or chooses an arbitrary camera.
+
+### 4. One immutable camera decision covers one rendered frame
+
+The Camera owner drains eligible proposals and commits one selection snapshot after
+`VariableUpdate` and before `RenderExtraction`. The snapshot is immutable through
+all views, passes, `RenderExecution`, `RenderGui` and `Present` work that consume that
+rendered frame. A cut, stop, cancellation or async resolution arriving after this
+cutoff is considered at the next corresponding camera commit.
+
+If multiple fixed ticks cross camera keys before one rendered frame, only the final
+eligible result at the commit cutoff becomes that frame's camera. Intermediate cuts
+remain deterministic timeline history but are not promised a presented frame.
+Optional presentation-clock sequences use the same cutoff: they may change the next
+selection snapshot, never a camera already being rendered.
+
+The snapshot carries stable view/scene/session generations, camera identity,
+selection epoch, current backend-neutral transform and projection/lens values,
+transition state and typed discontinuity flags. Render extraction copies or derives
+frame-owned values from it. No later pass dereferences the source scene component.
+
+An invalid or destroyed target cannot partially replace the current frame's camera.
+The owner keeps the last committed valid snapshot for that already-open frame,
+reports `CameraTargetUnavailable`, and applies the track's required/optional failure
+policy at the next safe point. Later frames re-resolve current valid proposals; they
+do not silently render from a stale entity pointer.
+
+### 5. Transition semantics are capability-tiered
+
+Camera transitions are explicit product capabilities:
+
+| Tier | Contract | Render cost and fallback |
+|---|---|---|
+| Baseline `HardCut` | Publish one destination camera at the commit boundary with a discontinuity and new selection epoch | Mandatory; one rendered view; no hidden blend |
+| Standard `SingleViewBlend` | Camera owner evaluates a bounded curve and publishes one interpolated transform/projection snapshot | One rendered view; admitted only for compatible cameras and finite duration/curve |
+| Advanced `DualViewCrossFade` | Publish two immutable view snapshots plus a finite composition weight through an explicit frontend capability | Requires two qualified views, budget and compositor support; absence is a typed denial |
+
+A requested transition declares its minimum mode and fallback policy at cook/
+activation. The owner may use an explicitly authored `HardCut` fallback when the
+requested blend capability or budget is unavailable. It cannot silently substitute a
+single-view geometric blend for a dual-view cross-fade, or vice versa.
+
+`SingleViewBlend` interpolates camera pose and compatible projection/lens parameters
+in Camera-owned, backend-neutral code. Incompatible projection models or invalid
+parameters return a typed transition error and use only the declared fallback.
+`DualViewCrossFade` duplicates only the qualified render views; it does not advance
+simulation, sequence time or scene histories twice.
+
+### 6. Rendering consumes decisions but never selects cameras
+
+`RenderExtraction` receives a `CameraSelectionSnapshot` and emits a frame-owned
+`RenderCameraSnapshot`/view description. The renderer frontend may validate view
+count, extents, resource budgets and declared transition capabilities, but it cannot
+choose gameplay versus cinematic authority or query sequence state.
+
+A hard cut or incompatible camera transition increments the selection epoch and
+publishes generic discontinuity evidence. Temporal reconstruction, exposure,
+motion-history and other consumers decide how their own histories reset or migrate
+under their existing contracts. Cinematic Runtime does not call OpenGL, Metal,
+Vulkan, D3D12 or provider-specific reset functions.
+
+Native matrices, command buffers, images and blend passes remain private to concrete
+render backends. All backends, including Null, consume the same Horo-owned view and
+transition descriptions. Backend availability cannot change cut ordering, camera
+identity, handoff or fallback policy.
+
+### 7. Camera selection does not imply other domain authority
+
+A camera lease grants no transform-write authority. Animated camera entities still
+use the ordinary Scene/Animation/transform owner seams and ADR-026 floating-origin
+rules. The Camera owner samples their committed state into its selection snapshot;
+the renderer never follows a mutable component.
+
+Camera selection also does not automatically choose the Audio listener, input focus,
+player controller, gameplay visibility or network authority. Those owners may consume
+the published camera identity through an explicit product policy, but they retain
+their own final decisions and lifecycle generations.
+
+### 8. Failures and lifecycle outcomes are stable
+
+Stable outcomes include `CameraContextUnavailable`, `CameraTargetUnavailable`,
+`CameraLeaseDenied`, `StaleCameraGeneration`, `ConflictingRequiredCameraClaim`,
+`UnsupportedCameraTransition`, `CameraTransitionBudgetExceeded` and
+`CameraPresentationSuspended`.
+
+Stop/cancel first closes new proposals, removes the player from a later immutable
+camera batch, then releases its lease at the owner safe point. Late binding,
+preparation or renderer-capability results carry context/session/scene/player
+generations and cannot revive a released override. Context teardown retires snapshots
+only after frame consumers finish, following ordinary frames-in-flight lifetime
+rules.
+
+### 9. Qualification covers authority, frame order and every tier
+
+Required implementation evidence includes:
+
+- simultaneous runtime, PIE and editor view contexts with independent final owners;
+- no cut before the first key, both track-end policies, completion, early stop,
+  cancellation, binding loss, scene replacement and viewport-preview closure;
+- gameplay camera changes during an override followed by release to the current
+  proposal rather than a saved pointer;
+- concurrent players with priority/stable-ID arbitration independent of allocation,
+  arrival, worker-completion and container order;
+- multiple fixed-tick cut crossings before one render, requests immediately before/
+  after cutoff, and one immutable camera selection for every pass in a frame;
+- destroyed/stale camera targets and context generations with typed failure and no
+  stale dereference or arbitrary selection;
+- baseline hard cut, compatible/incompatible single-view blend, admitted/denied
+  dual-view cross-fade, explicit hard-cut fallback and budget exhaustion;
+- selection-epoch/discontinuity propagation to temporal consumers without native
+  backend callbacks in Cinematic or Camera APIs; and
+- OpenGL, Metal, Vulkan-capable and Null/recording adapters consuming identical
+  backend-neutral snapshots, including headless authority tests.
+
+## Consequences
+
+### Positive
+
+- Every independently rendered context has one final, lifecycle-scoped camera owner.
+- Cinematic entry and every exit path resolve current live state instead of restoring
+  stale pointers.
+- A complete rendered frame sees one immutable camera decision.
+- Hard cuts, geometric blends and true cross-fades have honest capability and budget
+  requirements without backend leakage.
+
+### Costs
+
+- Runtime, PIE and editor preview need separate context generations and proposal sets.
+- The Camera owner needs bounded transition state and a frame-boundary commit seam.
+- Dual-view cross-fade requires explicit frontend composition, resource admission and
+  history qualification beyond the baseline camera-cut implementation.
+
+## Rejected Alternatives
+
+### Let Sequencer write a global active-camera pointer
+
+Rejected because runtime, PIE and editor views can coexist, scene objects have
+generations, and rendering needs an immutable per-frame value rather than mutable
+cross-owner state.
+
+### Let runtime cinematics take over the editor viewport
+
+Rejected because the editor authoring camera is not a gameplay component. Preview is
+an editor-controller proposal scoped to that viewport and cannot transfer authority
+to the runtime session.
+
+### Restore the camera that was active when playback began
+
+Rejected because gameplay or another sequence may legitimately change its proposal
+during playback, and the saved camera may be destroyed. Release re-resolves live
+proposals.
+
+### Apply cuts immediately during render execution
+
+Rejected because passes in one frame could observe different cameras and incompatible
+history. Camera selection commits once before render extraction.
+
+### Treat every blend duration as a renderer cross-fade
+
+Rejected because single-view interpolation and two-view composition have different
+visual meaning, resource cost and capability requirements. The tier and fallback are
+explicit.
+
+### Put backend-specific cut and history-reset hooks in Cinematic Runtime
+
+Rejected because authority and sequencing must remain identical across OpenGL, Metal,
+Vulkan, future peers and Null tests. Render consumers receive generic immutable
+transition evidence and own their backend-private execution.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -130,6 +130,7 @@ to the replacement.
 | [116](116-save-data-threat-model-and-trust-policy.md) | Save Data Threat Model and Trust Policy | Proposed | 2026-09-02 |
 | [117](117-playback-ownership-frame-order-and-determinism.md) | Playback Ownership, Frame Order and Determinism | Proposed | 2026-09-02 |
 | [118](118-animation-character-and-gameplay-authority-during-cinematics.md) | Animation, Character and Gameplay Authority During Cinematics | Proposed | 2026-09-02 |
+| [119](119-camera-authority-during-cinematics.md) | Camera Authority During Cinematics | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -360,6 +360,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Animation, Character and Gameplay Authority During Cinematics](../adr/118-animation-character-and-gameplay-authority-during-cinematics.md):
   per-joint pose override/blend, Character collision-root authority, gameplay control
   leases, typed suppression and whole-game pause semantics.
+- [Camera Authority During Cinematics](../adr/119-camera-authority-during-cinematics.md):
+  per-view runtime/PIE/editor authority, cut entry and exit handoff, immutable
+  frame selection, tiered transitions and backend-neutral render snapshots.
 - [Post-Processing And Effects Architecture](./runtime/post-processing-and-effects-architecture.md):
   screen-space effects, HDR post chain, tonemapping, color grading, and
   accessibility pass ordering.

--- a/docs/architecture/runtime/cinematic-sequencer-architecture.md
+++ b/docs/architecture/runtime/cinematic-sequencer-architecture.md
@@ -15,6 +15,9 @@ replay/headless evidence, numeric determinism and random-access seek.
 [ADR-118](../../adr/118-animation-character-and-gameplay-authority-during-cinematics.md)
 defines Animation, Character and Gameplay authority while those players target
 skeletal pose or actor control.
+[ADR-119](../../adr/119-camera-authority-during-cinematics.md) defines per-view
+runtime, PIE and editor camera authority, cinematic cut handoff, frame-commit
+validity and tiered transition/render contracts.
 [ADR-068](../../adr/068-music-transport-and-cross-system-ownership.md) owns the
 AudioTrack handoff: Sequencer retains sequence clock, directed event traversal,
 seek/scrub and preroll intent while Audio alone maps accepted requests to sample
@@ -50,6 +53,9 @@ time and schedules the callback.
 - **Owner-issued cinematic authority**: Animation composes per-joint pose claims,
   Character resolves exclusive cinematic movement, and Gameplay returns typed
   suppression/acceptance. Whole-game pause never moves an authoritative Character.
+- **Per-view camera authority**: Runtime and PIE Camera services resolve gameplay
+  plus cinematic proposals independently; the editor viewport controller retains
+  authoring-camera authority. One immutable selection covers one rendered frame.
 
 ## System Boundaries and Target Topology
 
@@ -233,12 +239,28 @@ struct CameraCutKeyframe {
 
 Camera cuts carry camera identity and blend metadata, not world-space positions.
 A host-injected typed camera adapter requests an owner-issued, generation-safe
-cinematic override token. The Camera subsystem resolves the final active camera
-from gameplay proposals and admitted cinematic requests; the sequencer never writes
-a global active-camera pointer. Conflicts use explicit priority then stable player
-identity, independent of update order. Stop, cancellation, binding loss, scene
-replacement and failed activation release only this player's token. Restoring an
-older gameplay camera pointer is forbidden: the owner resolves the current proposal.
+override lease for one `CameraViewContextId`. Runtime and PIE sessions own isolated
+Camera services; the editor viewport controller retains its authoring camera and
+admits preview only through an editor-scoped proposal. The sequencer never writes a
+global active-camera pointer or takes editor viewport authority.
+
+The track has no effective override before its first cut. Its compiled end policy is
+either the default `HoldLastUntilPlayerEnd` or explicit `ReleaseAtTrackEnd`. Stop,
+cancellation, completion, binding loss, scene replacement and context destruction
+close proposal admission and release only that player's lease at the owner safe
+point. The owner then resolves the current gameplay, cinematic or editor proposal;
+restoring an older pointer is forbidden. Conflicts use descending priority then
+stable player identity, independent of evaluation order.
+
+The Camera owner commits one immutable selection after `VariableUpdate` and before
+`RenderExtraction`; late changes apply to the next rendered frame. The baseline is a
+one-view `HardCut`. `SingleViewBlend` is a Camera-owned backend-neutral pose/
+projection interpolation, while `DualViewCrossFade` requires an explicitly admitted
+two-view frontend capability and budget. Fallback to a hard cut must be authored;
+transition modes are never silently substituted. Rendering consumes the resulting
+camera snapshot, selection epoch and generic discontinuity evidence without choosing
+camera authority or exposing backend APIs to Cinematic Runtime. ADR-119 owns the
+complete contract.
 
 ### 4. Event Track
 
@@ -801,6 +823,12 @@ These are required implementation acceptance tests, not tests added by this ADR:
   GameplayControlled/CinematicControlled arbitration and typed suppression.
 - Whole-game pause produces no authoritative pose/root-motion/Character movement or
   gameplay backlog; running-simulation control transfer keeps ordinary owners ticking.
+- Runtime, PIE and editor view contexts retain isolated camera owners; exercise first/
+  last cut handoff, both track-end policies, current-proposal restoration and every
+  stop/cancel/binding-loss/scene-replacement path without stale camera state.
+- Camera selection commits once before render extraction; test multiple cuts between
+  rendered frames, before/after-cutoff arrival, hard cut, single-view blend and
+  admitted/denied two-view cross-fade with explicit fallback and Null adapters.
 - Validate all clock/pause/dilation combinations, nested pause-token release, menu
   plus cinematic pause, host resume, provider capability/loss and discontinuities.
 - Value samples are history-independent; event tests cover forward/reverse endpoints,
@@ -821,6 +849,7 @@ These are required implementation acceptance tests, not tests added by this ADR:
 - [ADR-014: Sequencer Ownership, Clock Authority and Binding Boundary Decision](../../adr/014-sequencer-ownership-clock-authority-and-binding-boundary.md)
 - [ADR-117: Playback Ownership, Frame Order and Determinism](../../adr/117-playback-ownership-frame-order-and-determinism.md)
 - [ADR-118: Animation, Character and Gameplay Authority During Cinematics](../../adr/118-animation-character-and-gameplay-authority-during-cinematics.md)
+- [ADR-119: Camera Authority During Cinematics](../../adr/119-camera-authority-during-cinematics.md)
 - [Cinematic Sequencer UI Reference](./cinematic-sequencer.html)
 - [Scene Runtime Architecture](./scene-runtime.md)
 - [Animation Architecture](./animation-architecture.md)

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -1011,6 +1011,31 @@ remain pending and must not be represented as implemented UI behavior.
 
 ## Render Snapshot
 
+### Cinematic camera selection boundary
+
+[ADR-119](../../adr/119-camera-authority-during-cinematics.md) keeps active-camera
+selection outside the renderer. Runtime and PIE Camera services each resolve their
+view-context proposals, while the editor viewport controller owns its authoring
+camera. After `VariableUpdate` and before extraction, each owner publishes one
+generation-checked immutable `CameraSelectionSnapshot`. All passes and outputs for
+that rendered frame use the same selection; render execution cannot query sequence
+state or replace the camera mid-frame.
+
+Extraction projects the selection into frame-owned backend-neutral camera/view data.
+The projection includes stable view/scene generations, camera identity, selection
+epoch, transform and projection/lens values, transition state and generic
+discontinuity evidence. It never retains a scene-component pointer or includes a
+native graphics handle. Hard cuts publish one destination view. Camera-owned
+single-view blends publish one interpolated view. An advanced two-view cross-fade is
+accepted only through a declared frontend capability, qualified budget and explicit
+fallback policy; no backend may silently change the selected transition mode.
+
+Camera cuts and incompatible transitions change the generic selection epoch/
+discontinuity evidence. Reconstruction, exposure, motion and other temporal
+consumers apply their own history policy from that evidence. Cinematic Runtime never
+calls backend/provider-specific reset hooks, and rendering never decides whether a
+gameplay, cinematic or editor proposal wins.
+
 The scene runtime produces frame-owned render data:
 
 ```cpp

--- a/docs/architecture/runtime/runtime-lifecycle.md
+++ b/docs/architecture/runtime/runtime-lifecycle.md
@@ -187,6 +187,15 @@ descending priority and stable identity. Commands or worker completions after th
 cutoff cannot alter the active batch. Failed attempted ticks discard staged cinematic
 cursors/values/occurrences; tick commit advances them and releases occurrences.
 
+[ADR-119](../../adr/119-camera-authority-during-cinematics.md) adds no runtime phase.
+After `VariableUpdate` and before `RenderExtraction`, each live camera-view context
+drains eligible gameplay/cinematic/editor proposals and commits one immutable camera
+selection. Every pass for that rendered frame consumes that selection; a cut, stop,
+cancel or late completion after the cutoff is eligible only for the next commit.
+Multiple fixed ticks may cross multiple cut keys, but only the final eligible
+selection at this boundary is promised a rendered frame. Context teardown retires
+the snapshot only after frame consumers complete.
+
 [ADR-078](../../adr/078-runtime-ui-input-context-and-player-routing.md) also adds no
 phase. `BuildInputSnapshot` publishes device/action/assignment evidence; Runtime UI
 VariableUpdate applies one ordered context stack against the last presented


### PR DESCRIPTION
## Summary

- Adds ADR-119 to define who owns active-camera selection during cinematics in runtime game, play-in-editor (PIE), and editor viewport contexts.
- Defines camera-cut entry and exit handoff, including the period before the first cut, track-end policies, player completion, early stop, cancellation, binding loss, scene replacement, and context teardown.
- Establishes a single immutable camera selection per view context and rendered frame, committed after `VariableUpdate` and before `RenderExtraction`.
- Separates baseline hard cuts, Camera-owned single-view interpolation, and capability/budget-gated dual-view cross-fades without exposing renderer-specific APIs to Cinematic Runtime.
- Projects the decision into the cinematic sequencer, runtime lifecycle, rendering architecture, ADR index, and architecture index.

## Why

ADR-014 assigned final active-camera authority to the Camera subsystem, and ADR-117 established deterministic ordering for concurrent sequence players. The architecture still left several observable behaviors undefined: runtime, PIE, and the editor viewport could appear to share one active camera; a sequence's ownership before its first key and after its last key was ambiguous; stopping a sequence could restore a stale camera pointer; and a cut could theoretically become visible to only part of a rendered frame.

Blend semantics were also overloaded. A geometric interpolation that produces one camera view and a true cross-fade that renders and composes two views have materially different resource, history, and capability requirements. This decision makes those modes explicit so later implementation tickets cannot hide renderer-dependent fallback or cost behind the sequencer contract.

## Decision and boundaries

- Camera authority is scoped by generation-checked `CameraViewContextId`, not a process-global active-camera pointer.
  - Runtime game views use their session Camera service.
  - PIE game views use an isolated PIE Camera service.
  - Editor scene viewports retain editor-controller authority; sequencer preview is an editor-scoped proposal and never a runtime takeover.
- Cinematic camera tracks receive scoped override leases. The Camera owner resolves gameplay and admitted cinematic proposals by descending priority and stable player identity; evaluation or worker-completion order cannot choose the winner.
- A camera track has no effective override before its first cut. Its explicit end policy is either default `HoldLastUntilPlayerEnd` or `ReleaseAtTrackEnd`.
- Every release path re-resolves the current live proposal set. The design explicitly rejects restoring a camera pointer captured when playback began.
- The owner commits camera selection once per rendered frame before extraction. Requests after the cutoff apply to the next frame; multiple cut keys crossed between rendered frames produce only the final eligible presented selection.
- Transition tiers are intentionally distinct:
  - `HardCut`: mandatory baseline, one destination view, new selection epoch/discontinuity.
  - `SingleViewBlend`: one Camera-owned interpolated pose/projection view.
  - `DualViewCrossFade`: two qualified immutable views plus compositor support and explicit budget admission.
- Fallback must be authored. Missing dual-view capability cannot silently become a geometric blend or hard cut.
- Render extraction receives only immutable Horo-owned camera/view data, selection epoch, transition state, and generic discontinuity evidence. Temporal consumers own their history response; Cinematic Runtime never invokes OpenGL, Metal, Vulkan, D3D12, or provider-specific reset hooks.
- Camera selection grants no transform, Audio-listener, input-focus, gameplay, or network authority. Those domains retain their existing owners.
- Implementation remains intentionally deferred to CIN-003.2 through CIN-003.5; this PR defines the contract and required qualification evidence only.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Markdown lint passed for every changed document.
- [x] Added Markdown links resolve locally.
- [x] Staged diff whitespace validation passed.
- [x] CMake configuration passed with public-header inventory and dependency-direction checks.
- [ ] Runtime/backend tests were not run because this PR changes architecture documentation only and introduces no executable implementation.
- [ ] Manual editor smoke testing is not applicable to this documentation-only decision.

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/119-camera-authority-during-cinematics.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/cinematic-sequencer-architecture.md docs/architecture/runtime/rendering-architecture.md docs/architecture/runtime/runtime-lifecycle.md
git diff --check
git diff --cached --check
# Staged-added-link validation script (Ruby) over git diff --cached
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

CMake completed successfully. It retained the repository's existing mbedTLS minimum-CMake deprecation warning and reported that pytest is unavailable, so repository Python tests were skipped.

## Risk and rollout

- `HoldLastUntilPlayerEnd` is a product-visible default. Reviewers should confirm that camera tracks ending before other sequence tracks are expected to retain their last admitted cut unless authors explicitly choose `ReleaseAtTrackEnd`.
- `SingleViewBlend` interpolates only compatible Camera-owned pose/projection values; implementation tickets must define exact projection compatibility and numeric interpolation rules without widening renderer authority.
- `DualViewCrossFade` is deliberately not baseline behavior. Later work must provide explicit frontend capability negotiation, resource budgeting, history qualification, and an authored fallback before enabling it.
- The new contract describes future implementation. Until CIN-003.2–CIN-003.5 land, existing editor/runtime code must not be represented as already satisfying these authority and transition guarantees.
- No executable code changed, so this PR validates document consistency and build configuration rather than runtime behavior.

## Issue links

- Jira: [HORO-1659](https://horo-engine.atlassian.net/browse/HORO-1659)
- GitHub: Closes #1700

## Reviewer Notes

Suggested review order:

1. `docs/adr/119-camera-authority-during-cinematics.md` sections 1–4 for authority, lease, handoff, and frame-cutoff decisions.
2. ADR-119 sections 5–7 for transition tiers, renderer boundary, and authority exclusions.
3. `docs/architecture/runtime/cinematic-sequencer-architecture.md` for the concise track-level projection.
4. `docs/architecture/runtime/runtime-lifecycle.md` and `docs/architecture/runtime/rendering-architecture.md` for phase and immutable-snapshot consistency.
5. ADR/architecture indexes for discoverability.

The most important review questions are:

- Is `HoldLastUntilPlayerEnd` the correct default when the camera track ends before its sequence player?
- Is the after-`VariableUpdate`, before-`RenderExtraction` commit seam precise enough for both fixed-clock and presentation-clock players?
- Are hard cut, single-view blend, and dual-view cross-fade separated at the right capability boundary?
- Does any stated camera responsibility accidentally overlap transform, Audio-listener, editor viewport, temporal-history, or renderer ownership?

This PR is stacked on `docs/HORO-1658_cinematic_animation_authority`; review only commit `b033c97` for the HORO-1659 delta.


[HORO-1659]: https://horo-engine.atlassian.net/browse/HORO-1659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ