### PR TITLE
docs(cinematic): define event dispatch and audio boundary HORO-1660 #1701 [CIN-004.1]

### DIFF
--- a/docs/adr/120-cinematic-event-dispatch-and-audio-coupling-boundary.md
+++ b/docs/adr/120-cinematic-event-dispatch-and-audio-coupling-boundary.md
@@ -1,0 +1,338 @@
+# ADR-120: Cinematic Event Dispatch and Audio Coupling Boundary
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: EventTrack binding, typed payloads, committed occurrence dispatch, gameplay adapter ownership, AudioTrack request coupling, missing binding/media behavior, lifecycle and diagnostics
+- **Issue**: [CIN-004.1](https://github.com/abdullahbodur/horo-engine/issues/1701)
+- **Jira**: [HORO-1660](https://horo-engine.atlassian.net/browse/HORO-1660)
+- **Related**: [ADR-014](014-sequencer-ownership-clock-authority-and-binding-boundary.md), [ADR-017](017-prefab-role-ownership-and-capability-tiers.md), [ADR-062](062-audio-runtime-ownership-and-update-order.md), [ADR-064](064-audio-asset-and-cook-boundary.md), [ADR-068](068-music-transport-and-cross-system-ownership.md), [ADR-117](117-playback-ownership-frame-order-and-determinism.md)
+- **Normative documents**: [Cinematic Sequencer Architecture](../architecture/runtime/cinematic-sequencer-architecture.md), [Audio Architecture](../architecture/runtime/audio-architecture.md), [Runtime Lifecycle](../architecture/runtime/runtime-lifecycle.md), [Engine Data Bus](../architecture/foundation/engine-data-bus.md)
+
+## Context
+
+ADR-014 gives Cinematic Runtime ownership of directed interval crossing and stable
+event occurrences, while domain owners retain authority over the effects those
+occurrences request. ADR-117 fixes player/order identity, commit behavior and
+late-completion fencing. The cinematic architecture already states that event and
+Audio tracks use typed adapters rather than direct state writes.
+
+The dispatch contract remains incomplete. Event names could be treated as generic
+`EngineDataBus` notifications, resolved into arbitrary callbacks during playback, or
+compiled into narrow application-owned handlers. Those choices have different
+ordering, failure, payload, lifetime and authority semantics. A timeline event that
+requests quest progress or a prefab spawn cannot be silently dropped like an
+ordinary notification, and it must not invoke gameplay reentrantly while Sequencer
+is advancing its cursor.
+
+Audio tracks also need a strict cross-family seam. Sequencer owns time and directed
+traversal, but Audio owns media readiness, sample-clock conversion, callback command
+publication and voice lifetime. Repeating those policies in the CIN family would
+create a second Audio contract and let the documents drift.
+
+This ADR selects one event-delivery path, defines payload and failure behavior, and
+records the AUD-family decisions that remain authoritative for Audio coupling.
+
+## Decision
+
+### 1. One application dispatcher owns cinematic event delivery
+
+The application composition root owns one `CinematicEventDispatcher` per runtime or
+PIE session. It binds cooked EventTrack identities to narrow, injected
+`ICinematicEventHandler` adapters supplied by authorized gameplay/application
+modules. Cinematic Runtime produces occurrences; the dispatcher owns admission,
+destination lookup, safe-point invocation, result publication and handler-lifetime
+fencing. The gameplay adapter owns the domain effect.
+
+```text
+EventTrack interval crossing
+    -> immutable CinematicEventOccurrence
+    -> session CinematicEventDispatcher queue
+    -> destination owner boundary
+    -> registered typed gameplay/application adapter
+    -> CinematicEventDispatchResult
+```
+
+This is the only gameplay EventTrack delivery path. Sequencer does not publish
+gameplay occurrences to `EngineDataBus`, call game-module functions directly from
+evaluation, use reflection by function name, or mutate scene/gameplay state. An
+adapter may submit a normal domain command or operation, but the dispatcher does not
+become that domain's state authority.
+
+Editor preview owns an isolated preview dispatcher whose handlers are explicitly
+preview-safe. It cannot invoke runtime gameplay adapters or commit authoritative
+effects. Headless hosts use the same production dispatcher with registered headless
+adapters; missing presentation capabilities do not define a second path.
+
+### 2. Bindings and payloads are typed and cooked
+
+Authoring may display a stable qualified event name, but cook resolves it through a
+host/package event descriptor registry into an `EventBindingId` and immutable
+`EventPayloadSchemaId`/version. A descriptor declares:
+
+- stable module-qualified event identity and compatibility version;
+- destination domain and owner boundary;
+- fixed, bounded payload schema and maximum encoded size;
+- permitted runtime, PIE, preview, headless and packaged-build contexts;
+- required capability/authority and handler result schema; and
+- whether the effect is required or optional for player activation.
+
+Payloads are schema-validated during authoring/cook and stored as bounded immutable
+cooked values or handles. Runtime occurrences carry binding/schema identity,
+payload reference, session/scene/player/track/keyframe generations, traversal/loop/
+direction identity, source clock evidence and committed tick/boundary identity.
+They do not contain JSON/maps, script function names, raw object pointers, native
+handles or unbounded strings.
+
+The registry detects duplicate names, ID collisions, incompatible schema versions
+and forbidden build contexts before descriptors activate. A module may retain a
+stable binding identity while changing its C++ implementation; changing payload
+meaning requires a versioned schema/migration rather than reinterpretation.
+
+### 3. Occurrences dispatch only after their source commits
+
+EventTrack evaluation stages the complete directed interval under ADR-014/117.
+Authoritative gameplay occurrences become eligible only after the originating fixed
+tick commits. Failed attempted ticks, presentation interpolation, editor scrubbing
+and default seek never dispatch gameplay events.
+
+The dispatcher drains a bounded immutable batch at the destination owner's next
+permitted boundary. Within a destination it preserves Sequencer's canonical order:
+directed crossing time, player order, track ID and keyframe ID. Handlers cannot
+reenter the active Sequencer evaluation or change the already-committed occurrence
+batch. Commands produced by a handler follow that domain's ordinary later commit
+rules; same-tick effect is not implied.
+
+`CinematicEventOccurrenceId` is the idempotency identity. It includes the player
+generation plus traversal/loop/direction, track and key identity. The dispatcher
+records a bounded terminal/admitted result per live generation so a retried queue
+submission cannot invoke the same handler twice. It does not deduplicate by event
+name, payload or timestamp.
+
+Queue capacity is preflighted before the player cursor/value state commits. Required
+occurrences are never silently dropped. Exhaustion returns
+`EventDispatchCapacityExceeded` and holds/fails the player according to its compiled
+policy without partial interval publication. Optional presentation-only signals may
+use a separately declared coalescing policy, but they are not gameplay EventTrack
+occurrences.
+
+### 4. EngineDataBus remains a notification plane
+
+`EngineDataBus` may publish a small coalesced revision/availability notification
+after the dispatcher records results, so diagnostics or editor surfaces can re-query
+their owning store. That notification is not the event occurrence, does not carry the
+gameplay payload, does not select/invoke the handler and cannot establish timeline
+ordering or success.
+
+Generic bus dead-event and backpressure policies are therefore irrelevant to
+gameplay EventTrack correctness. No subscriber appearing or disappearing changes
+whether a required cinematic event is considered delivered. EventTrack uses the
+session dispatcher and explicit adapter lifetime tokens.
+
+### 5. Handler outcomes and lifecycle are explicit
+
+A handler returns one bounded typed outcome such as:
+
+| Outcome | Meaning |
+|---|---|
+| `Accepted` | Destination accepted a synchronous domain command/value for later owner processing |
+| `OperationStarted` | Destination returned a stable application-owned `OperationId`; completion is asynchronous |
+| `SuppressedByAuthority` | Current gameplay/network/cinematic authority rejects the requested effect |
+| `CapabilityUnavailable` | Required destination capability is absent in this context/build |
+| `InvalidTarget` | Generation-checked scene/gameplay target cannot be resolved |
+| `Backpressured` | Destination's bounded queue cannot admit the request |
+| `HandlerFailed` | Adapter contained an exception or returned a domain failure |
+
+`Accepted` means accepted by the receiving owner, not that an asynchronous effect
+completed. Long-running operations use the application `OperationStore` under
+ADR-010; the dispatcher does not create a competing job/result store or block the
+simulation thread.
+
+Player stop/cancel closes new occurrence admission, cancels only operations whose
+domain contract supports cancellation and fences all later results by session/scene/
+player/handler generation. Effects already committed are not generally reversible.
+Module unload first revokes handler admission, drains or cancels owned work, and
+retires the adapter after in-flight calls finish. It cannot leave a callable raw
+function pointer in a compiled sequence.
+
+Default required-event failure stops future effects from that track and reports the
+typed result; it does not roll back a tick whose other owner effects already
+committed. Retry is allowed only when the descriptor declares bounded idempotent
+retry and reuses the same occurrence ID. Optional-event failure disables or skips
+according to its explicit compiled policy and remains observable.
+
+### 6. Unknown events fail before playback whenever possible
+
+An authored event name absent from the target registry is
+`UnknownCinematicEventName` and fails cook with asset path, track/key location and
+requested qualified name. A schema mismatch is `CinematicEventSchemaMismatch` and
+also fails cook. Cook never hashes an unknown string into a binding that can appear
+valid at runtime.
+
+At activation, a cooked binding whose module/handler/capability is unavailable or
+whose registry generation is incompatible returns `CinematicEventBindingUnavailable`.
+A required binding prevents player activation and unwinds acquired resources; an
+optional binding disables only its declared track with a deduplicated diagnostic.
+
+After activation, unload/reload, scene travel or authority change invalidates the
+handler generation. Pending occurrences return `StaleCinematicEventBinding` or the
+specific authority result. The dispatcher never searches again by string, calls a
+different same-named handler or reports success because the generic bus had a
+subscriber.
+
+### 7. AudioTrack submits intent only through AudioFrontend
+
+AudioTrack evaluation emits a bounded generation-tagged schedule/cancel/seek/preroll
+bundle through the application Audio/Cinematic adapter into `AudioFrontend`.
+Sequencer owns sequence time, interval traversal, loop/direction identity, scrub/seek
+intent and stable ordering. Audio owns media leases, source-to-sample correlation,
+sample targets, queue admission, voice/transport state, callback publication and
+actual playback observations.
+
+The bundle contains stable session/player/track/key/occurrence identities, resolved
+Audio asset/cue identity and revision, `SequenceTime` plus source clock generation,
+intent, late/pause/seek policy and cancellation token. It contains no device sample
+index, callback buffer, voice handle, decoder pointer, middleware ID or backend type.
+Render-frame interpolation cannot emit an Audio command.
+
+The cross-family ownership dependencies are normative and are not re-decided here:
+
+| AUD decision | Authority consumed by this CIN boundary |
+|---|---|
+| [AUD-001.1 #525](https://github.com/abdullahbodur/horo-engine/issues/525) / ADR-062 | Audio runtime/control/callback ownership, command publication phases, generation and teardown order |
+| [AUD-002.1 #537](https://github.com/abdullahbodur/horo-engine/issues/537) / ADR-064 | Audio-domain cook metadata, runtime media payload/readiness and asset lease boundary |
+| [AUD-008.1 #607](https://github.com/abdullahbodur/horo-engine/issues/607) / ADR-068 | Sequence-to-sample correlation, schedule horizon, music transport, seek/scrub/preroll, late policy and acknowledgements |
+
+Future AUD-family decisions may refine Audio-internal formats, mixers, providers or
+middleware. CIN consumes their published Horo-owned AudioFrontend contract; it does
+not duplicate those outcomes or branch on the selected backend.
+
+### 8. Missing Audio media is typed and policy-driven
+
+Cooked AudioTrack keys reference stable `AssetId`/cue identity and expected cooked
+revision. An unknown source reference, invalid Audio payload or incompatible target
+profile fails cook under AUD-002.1 as `AudioTrackAssetInvalid`. Cook does not preserve
+an unresolved path for runtime lookup.
+
+Activation requests Audio preparation and retains the admitted media lease for the
+track's required horizon. Outcomes are explicit:
+
+| Condition | Outcome and policy |
+|---|---|
+| Required media absent, unpublished, corrupt or incompatible | `AudioTrackAssetUnavailable`; player activation fails and unwinds |
+| Optional media absent under an authored silent/skip policy | Track is disabled/skipped, diagnostic emitted, non-Audio tracks may continue |
+| Media not yet resident but load is permitted | `AudioTrackPreparing` with bounded operation/deadline; playback does not start until acknowledged |
+| Preparation deadline or queue horizon missed | AUD-008.1 late policy yields typed reject/next-boundary/immediate-with-ramp behavior |
+| Asset revision replaced or lease invalidated during playback | Old leased generation finishes if policy permits, otherwise typed cancel/reprepare; never a stale pointer |
+| Audio device/backend unavailable | Audio runtime's typed suspended/unavailable result; an authored no-Audio product policy decides whether the sequence continues |
+
+Missing media never triggers synchronous I/O on the evaluation or callback thread,
+direct decoder construction, filename fallback, an arbitrary replacement clip or an
+implicit successful silent voice. A deliberately silent cinematic outcome must be an
+authored optional/no-Audio policy and remains visible in diagnostics.
+
+### 9. Audio acknowledgements are observations, not gameplay events
+
+Audio publishes admitted, actual-start, stop, marker, rejection and completion
+observations through its bounded control-side channel using the original request/
+occurrence identity. The application adapter may translate a declared observation
+into a later gameplay/domain command through the same typed event dispatcher, but the
+Audio callback never invokes gameplay and `EngineDataBus` delivery never becomes an
+exact sample-boundary action.
+
+Captions, dialogue semantics and narrative progression remain their own domain
+authorities under AUD-008.1. Muting, virtualization, missing hardware or Audio failure
+cannot silently erase a required semantic event; products fan out semantic intent to
+Audio and non-Audio destinations independently.
+
+### 10. Diagnostics preserve the failed boundary
+
+Diagnostics include stable session/scene/player/track/key/occurrence or Audio request
+identity, binding/schema/asset revision, source clock/tick, destination domain,
+outcome and bounded causal context. They exclude raw payload secrets, unbounded asset
+paths, native handles and backend/vendor strings from metric dimensions.
+
+Unknown name/schema is reported at authoring/cook. Missing handler/capability appears
+at activation. Queue/authority/target/handler outcomes appear at destination drain.
+Audio preparation/scheduling/callback observations retain their Audio provenance.
+The dispatcher does not collapse these into one `EventFailed` boolean.
+
+### 11. Qualification proves ordering, isolation and failure behavior
+
+Required implementation evidence includes:
+
+- cook-time known/unknown names, duplicate/colliding identities, compatible/
+  incompatible payload versions, size limits and packaged-context capability checks;
+- fixed-tick commit/failure, forward/reverse/loop/seek semantics and no dispatch from
+  presentation sampling or editor scrub;
+- stable ordering and exactly-once occurrence identity under randomized player,
+  allocation, queue-arrival and worker-completion order;
+- required/optional handler absence, authority suppression, invalid target,
+  backpressure, contained handler failure, bounded idempotent retry and async
+  operation completion;
+- runtime/PIE/editor-preview/headless dispatcher isolation, module reload/unload,
+  scene travel, stop/cancel and late generation-fenced results;
+- proof that generic `EngineDataBus` subscriber/dead-event/backpressure changes do not
+  affect gameplay EventTrack delivery or ordering;
+- Audio preparation and schedule admission for required/optional missing, corrupt,
+  unloaded, replaced and stale media plus device/backend loss;
+- continuous playback, pause, seek, scrub, loop, preroll, missed horizon and external
+  discontinuity through AUD-008.1 acknowledgements; and
+- native, middleware and Null/recording Audio adapters receiving the same Horo-owned
+  bundles without Sequencer computing sample indices or storing voice/native handles.
+
+## Consequences
+
+### Positive
+
+- Gameplay events have one ordered, typed, observable path instead of generic bus
+  delivery or reentrant arbitrary callbacks.
+- Payload and handler incompatibility fail at cook/activation wherever possible.
+- Audio keeps sole ownership of readiness, sample scheduling and playback lifetime.
+- Unknown events and missing media have stable outcomes rather than silent loss.
+
+### Costs
+
+- Application composition must register versioned event descriptors and narrow
+  handler adapters for each supported runtime context.
+- The dispatcher needs bounded occurrence/result storage, safe-point draining and
+  module-lifetime fencing.
+- Audio tracks require preparation/lease planning and explicit optional/no-Audio
+  policy instead of best-effort playback.
+
+## Rejected Alternatives
+
+### Publish gameplay EventTrack payloads on EngineDataBus
+
+Rejected because the bus is a notification plane with subscriber-dependent delivery
+and configurable backpressure. It cannot own required effect admission, directed
+timeline ordering, exactly-once occurrence results or domain authority.
+
+### Call gameplay callbacks directly while Sequencer evaluates
+
+Rejected because arbitrary reentrancy can mutate the scene/player mid-interval,
+bypass owner safe points and leave no bounded admission/result/lifetime contract.
+Only the session dispatcher invokes registered adapters at destination boundaries.
+
+### Resolve event function names and payload maps at runtime
+
+Rejected because string/reflection lookup and dynamic maps are unbounded, difficult
+to version and can bind differently after module reload. Cook produces stable typed
+binding and schema identities.
+
+### Let Sequencer start voices or calculate device sample positions
+
+Rejected because sequence time is not the Audio callback clock. AUD-001.1 and
+AUD-008.1 keep command publication and sample conversion in Audio.
+
+### Treat missing Audio as successful silence
+
+Rejected because required content loss would be invisible and narrative timing could
+diverge. Silence/skip is permitted only as an explicit optional product policy with a
+typed result and diagnostic.
+
+### Duplicate Audio scheduling rules in the CIN family
+
+Rejected because Audio owns runtime phases, media payloads and transport semantics.
+This decision names AUD-family dependencies and constrains only the Cinematic-facing
+request boundary.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -131,6 +131,7 @@ to the replacement.
 | [117](117-playback-ownership-frame-order-and-determinism.md) | Playback Ownership, Frame Order and Determinism | Proposed | 2026-09-02 |
 | [118](118-animation-character-and-gameplay-authority-during-cinematics.md) | Animation, Character and Gameplay Authority During Cinematics | Proposed | 2026-09-02 |
 | [119](119-camera-authority-during-cinematics.md) | Camera Authority During Cinematics | Proposed | 2026-09-02 |
+| [120](120-cinematic-event-dispatch-and-audio-coupling-boundary.md) | Cinematic Event Dispatch and Audio Coupling Boundary | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -363,6 +363,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Camera Authority During Cinematics](../adr/119-camera-authority-during-cinematics.md):
   per-view runtime/PIE/editor authority, cut entry and exit handoff, immutable
   frame selection, tiered transitions and backend-neutral render snapshots.
+- [Cinematic Event Dispatch and Audio Coupling Boundary](../adr/120-cinematic-event-dispatch-and-audio-coupling-boundary.md):
+  cooked typed EventTrack bindings, application-owned safe-point dispatch, explicit
+  failure outcomes and AudioFrontend coupling through AUD-family authority.
 - [Post-Processing And Effects Architecture](./runtime/post-processing-and-effects-architecture.md):
   screen-space effects, HDR post chain, tonemapping, color grading, and
   accessibility pass ordering.

--- a/docs/architecture/foundation/engine-data-bus.md
+++ b/docs/architecture/foundation/engine-data-bus.md
@@ -32,9 +32,18 @@ It is **not**:
 
 - a request/response mechanism
 - a state authority (it does not own `SceneDocument`, project model, or assets)
+- a gameplay command/event-occurrence dispatcher; required cinematic events use the
+  session `CinematicEventDispatcher` and typed destination adapters under
+  [ADR-120](../../adr/120-cinematic-event-dispatch-and-audio-coupling-boundary.md)
 - a substitute for direct parent/child UI callbacks
 - a logging, profiler, or telemetry buffer (those systems own bounded queryable
   stores and publish availability notifications)
+
+The bus may carry a coalesced availability/revision notification after a cinematic
+event result is recorded. It never carries the authoritative EventTrack payload,
+selects a gameplay handler, establishes timeline ordering or determines dispatch
+success. Bus subscribers and dead-event/backpressure policy therefore cannot change
+cinematic gameplay behavior.
 
 ## Ownership
 

--- a/docs/architecture/runtime/audio-architecture.md
+++ b/docs/architecture/runtime/audio-architecture.md
@@ -849,6 +849,24 @@ create action before the feature can create valid runtime data.
 
 ## Real-Time Command Queue
 
+[ADR-120](../../adr/120-cinematic-event-dispatch-and-audio-coupling-boundary.md)
+specializes the cinematic producer seam without changing Audio ownership. EventTrack
+gameplay occurrences use the application-owned `CinematicEventDispatcher`; an
+AudioTrack instead submits a bounded generation-tagged schedule/cancel/seek/preroll
+bundle through the Audio/Cinematic adapter into `AudioFrontend`. Sequencer supplies
+stable occurrence identity, source `SequenceTime` and intent. Audio alone validates
+prepared media, correlates source time to sample time, admits the schedule, publishes
+callback commands, owns voice/transport lifetime and reports actual observations.
+
+The seam consumes AUD-001.1/ADR-062 for runtime/callback phases,
+AUD-002.1/ADR-064 for cooked media and readiness, and AUD-008.1/ADR-068 for transport,
+sequence-to-sample mapping, seek/preroll, late policy and acknowledgement. CIN does
+not create alternate Audio rules. Required unavailable media fails cinematic
+activation with a typed result. Optional silence/skip must be authored; unloaded media
+uses bounded asynchronous preparation. No missing-media path performs synchronous I/O
+on sequence evaluation or the callback, substitutes a filename/clip, or reports an
+implicit successful silent voice.
+
 Audio commands may originate from gameplay systems, animation events, timeline
 playback, editor preview, asset hot reload, streaming services, scene unload, or
 device lifecycle services. These producers do not write directly into the audio

--- a/docs/architecture/runtime/cinematic-sequencer-architecture.md
+++ b/docs/architecture/runtime/cinematic-sequencer-architecture.md
@@ -18,6 +18,9 @@ skeletal pose or actor control.
 [ADR-119](../../adr/119-camera-authority-during-cinematics.md) defines per-view
 runtime, PIE and editor camera authority, cinematic cut handoff, frame-commit
 validity and tiered transition/render contracts.
+[ADR-120](../../adr/120-cinematic-event-dispatch-and-audio-coupling-boundary.md)
+defines cooked typed EventTrack bindings, session-safe-point gameplay dispatch,
+failure outcomes and the AudioFrontend handoff governed by AUD-family decisions.
 [ADR-068](../../adr/068-music-transport-and-cross-system-ownership.md) owns the
 AudioTrack handoff: Sequencer retains sequence clock, directed event traversal,
 seek/scrub and preroll intent while Audio alone maps accepted requests to sample
@@ -56,6 +59,9 @@ time and schedules the callback.
 - **Per-view camera authority**: Runtime and PIE Camera services resolve gameplay
   plus cinematic proposals independently; the editor viewport controller retains
   authoring-camera authority. One immutable selection covers one rendered frame.
+- **One typed event path**: A session `CinematicEventDispatcher` invokes cooked,
+  versioned gameplay adapters at destination owner boundaries. `EngineDataBus` is
+  not gameplay EventTrack delivery, and AudioTrack submits intent through AudioFrontend.
 
 ## System Boundaries and Target Topology
 
@@ -275,16 +281,24 @@ struct EventKeyframe {
 };
 ```
 
-Host composition maps each binding to a narrow gameplay/audio/VFX adapter. Cook
-and activation reject missing adapters, incompatible payload schemas or insufficient
-capabilities. The evaluation queue contains fixed-size occurrence records and
-payload handles, with asset residency retained until drain/cancellation. Neither
-string lookup nor dynamic payload-map construction occurs during sampling.
+Host composition registers versioned descriptors and maps each cooked binding to a
+narrow gameplay/application adapter. Cook rejects unknown qualified names, duplicate
+or colliding identities, incompatible payload schemas, oversized payloads and
+forbidden build contexts. Activation rejects a required missing handler/capability;
+an optional binding may disable only under its explicit policy.
 
-Camera and event requests use typed domain queues, not `EngineDataBus` dispatch.
-ADR-015 restricts accessibility traffic specifically; it does not reserve the whole
-bus for accessibility. The broader bus principle still forbids using it to establish
-per-tick ordering or carry high-frequency timeline data.
+After the source tick commits, one session `CinematicEventDispatcher` drains fixed-
+size occurrence records at each destination owner's next safe point and invokes the
+registered adapter in canonical occurrence order. The handler may submit an ordinary
+domain command or application operation; it cannot reenter active sequence
+evaluation. Occurrence IDs provide exactly-once/idempotent retry identity, and every
+admission, authority, target, backpressure or handler outcome is typed and retained
+within bounded generation-scoped result storage.
+
+Gameplay EventTrack delivery never uses `EngineDataBus`. The bus may announce that
+result state changed, but subscribers, dead-event policy and bus backpressure cannot
+alter delivery/order/success. Neither string lookup nor dynamic payload-map
+construction occurs during sampling or dispatch. ADR-120 owns the full boundary.
 
 ### 5. Audio Track
 
@@ -308,6 +322,19 @@ voice handle or computes a device sample index. Render-frame sampling and editor
 scrub do not replay cues. Seek/scrub invalidate stale schedules, request prepared
 Audio positioning/preroll, and resume only under the typed acknowledgement policy
 defined by ADR-068.
+
+Audio preparation resolves stable cooked asset/cue identity and retains an admitted
+media lease. Required missing/corrupt/incompatible media fails activation with
+`AudioTrackAssetUnavailable`; optional silence/skip must be authored and remains
+diagnostic. Not-yet-resident media uses bounded asynchronous preparation, never
+synchronous evaluation/callback I/O. Device/backend loss and missed schedule horizons
+retain Audio-owned typed outcomes and policy.
+
+This seam consumes [AUD-001.1 #525](https://github.com/abdullahbodur/horo-engine/issues/525)
+for runtime/callback ownership, [AUD-002.1 #537](https://github.com/abdullahbodur/horo-engine/issues/537)
+for cooked media/readiness, and [AUD-008.1 #607](https://github.com/abdullahbodur/horo-engine/issues/607)
+for sequence-to-sample correlation, transport, seek/preroll and acknowledgements.
+Cinematic does not duplicate or override those Audio decisions.
 
 ### 6. Sub-Sequence Track
 
@@ -843,6 +870,12 @@ These are required implementation acceptance tests, not tests added by this ADR:
   keyframes or applying the origin offset twice.
 - Async spawn tests cover AssetNotLoaded, cancellation, late completion and duplicate
   occurrence delivery without synchronous waits or unbounded retries.
+- EventTrack tests cover unknown/schema-incompatible bindings at cook, required/
+  optional missing handlers, commit-only canonical dispatch, exactly-once retry,
+  authority/backpressure/handler outcomes and isolation from EngineDataBus policy.
+- AudioTrack tests cover required/optional missing, corrupt, unloaded and replaced
+  media; bounded preparation; schedule/seek/preroll acknowledgements; device loss;
+  and native/middleware/Null adapters without sample/native identity in Sequencer.
 
 ## Related Documents
 
@@ -850,6 +883,7 @@ These are required implementation acceptance tests, not tests added by this ADR:
 - [ADR-117: Playback Ownership, Frame Order and Determinism](../../adr/117-playback-ownership-frame-order-and-determinism.md)
 - [ADR-118: Animation, Character and Gameplay Authority During Cinematics](../../adr/118-animation-character-and-gameplay-authority-during-cinematics.md)
 - [ADR-119: Camera Authority During Cinematics](../../adr/119-camera-authority-during-cinematics.md)
+- [ADR-120: Cinematic Event Dispatch and Audio Coupling Boundary](../../adr/120-cinematic-event-dispatch-and-audio-coupling-boundary.md)
 - [Cinematic Sequencer UI Reference](./cinematic-sequencer.html)
 - [Scene Runtime Architecture](./scene-runtime.md)
 - [Animation Architecture](./animation-architecture.md)

--- a/docs/architecture/runtime/runtime-lifecycle.md
+++ b/docs/architecture/runtime/runtime-lifecycle.md
@@ -196,6 +196,15 @@ Multiple fixed ticks may cross multiple cut keys, but only the final eligible
 selection at this boundary is promised a rendered frame. Context teardown retires
 the snapshot only after frame consumers complete.
 
+[ADR-120](../../adr/120-cinematic-event-dispatch-and-audio-coupling-boundary.md)
+also adds no phase. Cinematic EventTrack evaluation stages bounded occurrences; only
+a successfully committed source tick makes authoritative gameplay occurrences
+eligible. The session dispatcher drains them at each destination owner's next
+permitted boundary, where a typed adapter may submit a normal command/operation.
+Handlers cannot reenter the active sequence batch or imply same-tick mutation.
+AudioTrack bundles follow ADR-062's existing Audio control/callback publication
+boundaries and ADR-068 sample correlation; render interpolation never emits them.
+
 [ADR-078](../../adr/078-runtime-ui-input-context-and-player-routing.md) also adds no
 phase. `BuildInputSnapshot` publishes device/action/assignment evidence; Runtime UI
 VariableUpdate applies one ordered context stack against the last presented


### PR DESCRIPTION
## Summary

- Adds ADR-120 to define the only supported gameplay EventTrack delivery path: cooked typed binding → session `CinematicEventDispatcher` → destination owner safe point → narrow application/gameplay adapter → typed result.
- Keeps `EngineDataBus` as a notification plane instead of using subscriber-dependent bus delivery for required cinematic gameplay effects.
- Defines versioned payload schemas, committed occurrence ordering, exactly-once/idempotency identity, bounded admission, handler lifetime, and failure behavior.
- Defines AudioTrack as an intent producer for `AudioFrontend`, with Audio retaining media readiness, sample-clock conversion, schedule admission, callback publication, and voice/transport ownership.
- Records AUD-001.1, AUD-002.1, and AUD-008.1 as normative cross-family dependencies rather than duplicating Audio decisions in CIN.
- Makes unknown event names, missing handlers/capabilities, and missing/unloaded/corrupt Audio media typed and visible at the earliest valid boundary.
- Projects the decision into Cinematic Sequencer, Audio, Runtime Lifecycle, Engine Data Bus, and architecture/ADR indexes.

## Why

ADR-014 and ADR-117 already define directed event crossing, stable occurrence identity, player ordering, and tick-commit behavior. They did not fully choose how an occurrence reaches gameplay. Publishing required timeline effects through `EngineDataBus` would make correctness depend on live subscribers and configurable dead-event/backpressure policy, while calling a gameplay function directly during sequence evaluation would permit reentrant scene/player mutation and bypass destination safe points.

Audio had a related ownership risk. Sequencer must express timing intent, but it cannot safely calculate device sample positions, start voices, load media synchronously, or own callback state. Those concerns are already decided by the AUD family. This PR makes the CIN-facing seam explicit and links to the owning Audio tickets instead of creating a competing scheduling model.

## Decision and boundaries

- The application composition root owns one dispatcher per runtime/PIE session; editor preview uses an isolated preview-safe dispatcher and cannot invoke authoritative runtime handlers.
- Authoring names compile to stable `EventBindingId` plus versioned payload schema. Unknown names, ID collisions, schema mismatch, oversized payloads, and forbidden packaged contexts fail cook.
- Runtime occurrences contain immutable bounded payload references and stable session/scene/player/track/key/traversal identities. They do not contain JSON maps, function names, raw pointers, or native handles.
- Gameplay occurrences become eligible only after their source tick commits. The dispatcher drains at the destination owner's next boundary, preserving canonical crossing/player/track/key order without reentering Sequencer or promising same-tick mutation.
- Occurrence identity is the idempotency key. Required events are preflighted against bounded queue capacity and cannot be silently dropped; retry is permitted only when the descriptor declares bounded idempotent retry using the same identity.
- `EngineDataBus` may announce a coalesced result-store revision, but it never carries the authoritative payload, selects a handler, establishes order, or determines success.
- Handler results distinguish accepted owner command, async operation, authority suppression, capability absence, invalid target, backpressure, and contained handler failure. Long-running work stays in the application `OperationStore`.
- AudioTrack submits stable source time and schedule/cancel/seek/preroll intent through `AudioFrontend`; Audio owns all media leases, source-to-sample mapping, schedule horizon, callback commands, live voice/transport state, and observations.
- Cross-family dependencies are explicit:
  - AUD-001.1 / ADR-062: Audio runtime/control/callback ownership and lifecycle phases.
  - AUD-002.1 / ADR-064: cooked Audio payload, readiness, revisions, and media leases.
  - AUD-008.1 / ADR-068: sequence-to-sample correlation, music transport, seek/scrub/preroll, late policy, and acknowledgements.
- Required missing/corrupt/incompatible media fails activation. Optional silence/skip must be authored. Not-yet-resident media uses bounded async preparation; no evaluation/callback path performs synchronous I/O or invents a replacement clip.
- Audio callback observations do not directly mutate gameplay. If product policy needs a gameplay reaction, the application adapter submits a later typed domain command through the same dispatcher boundary.
- CIN-004.2 and later Audio/Cinematic delivery tickets remain responsible for implementation; this PR defines policy and qualification evidence only.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Markdown lint passed for every changed document.
- [x] Added Markdown links resolve locally.
- [x] Staged diff whitespace validation passed.
- [x] CMake configuration passed with public-header inventory and dependency-direction checks.
- [ ] Runtime dispatcher and Audio adapter tests were not run because this PR changes architecture documentation only.
- [ ] Manual editor/Audio smoke testing is not applicable to this documentation-only decision.

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/120-cinematic-event-dispatch-and-audio-coupling-boundary.md docs/adr/README.md docs/architecture/README.md docs/architecture/foundation/engine-data-bus.md docs/architecture/runtime/cinematic-sequencer-architecture.md docs/architecture/runtime/audio-architecture.md docs/architecture/runtime/runtime-lifecycle.md
git diff --check
git diff --cached --check
# Staged-added-link validation script (Ruby) over git diff --cached
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

CMake completed successfully. It retained the repository's existing mbedTLS minimum-CMake deprecation warning and reported that pytest is unavailable, so repository Python tests were skipped.

## Risk and rollout

- The dispatcher becomes a required session-level application service. Implementation must preserve bounded queues, handler-generation fencing, and destination safe points without turning it into a second gameplay state authority.
- `Accepted` means the destination accepted a command, not that an asynchronous effect completed. Callers and diagnostics must preserve this distinction to avoid premature sequence progression.
- Required event failures stop future effects for the affected track by default but cannot roll back unrelated work from an already committed tick. Downstream implementation must not promise transactional rollback it cannot provide.
- Optional silence/skip is intentionally explicit. Existing content that implicitly tolerated missing Audio will need an authored policy or fail qualification.
- Audio scheduling details remain owned by AUD decisions. Review should reject any wording that accidentally lets CIN calculate sample indices, manage voices, or reinterpret Audio late/seek policy.
- This is a future contract; current code must not be presented as already satisfying it until the focused implementation and qualification tickets land.

## Issue links

- Jira: [HORO-1660](https://horo-engine.atlassian.net/browse/HORO-1660)
- GitHub: Closes #1701

## Reviewer Notes

Suggested review order:

1. `docs/adr/120-cinematic-event-dispatch-and-audio-coupling-boundary.md` sections 1–6 for the single event-delivery path, payloads, commit semantics, bus exclusion, and failure handling.
2. ADR-120 sections 7–9 for the AudioFrontend handoff, explicit AUD dependencies, missing-media policy, and observation boundary.
3. `docs/architecture/runtime/cinematic-sequencer-architecture.md` for the concise EventTrack/AudioTrack projection.
4. `docs/architecture/foundation/engine-data-bus.md`, `docs/architecture/runtime/audio-architecture.md`, and `docs/architecture/runtime/runtime-lifecycle.md` for cross-document ownership consistency.
5. ADR/architecture indexes for discoverability.

Key review questions:

- Does the session dispatcher cleanly choose narrow adapter invocation over generic bus delivery and reentrant direct callback?
- Are cook-time, activation-time, and runtime binding failures separated at the earliest boundary that can know them?
- Are committed occurrence ordering, exactly-once identity, retry, and partial-failure semantics strong enough for gameplay effects?
- Does the Audio seam consume AUD-001.1, AUD-002.1, and AUD-008.1 without re-deciding their internal policy?
- Is optional silent/skip behavior explicit enough to prevent missing required Audio from becoming invisible?

This PR is stacked on `docs/HORO-1659_cinematic_camera_authority`; review only commit `1711671` for the HORO-1660 delta.


[HORO-1660]: https://horo-engine.atlassian.net/browse/HORO-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ