### PR TITLE
docs(cinematic): define editor document ownership HORO-1661 #1702 [CIN-005.1]

### DIFF
--- a/docs/adr/121-cinematic-editor-document-and-authoring-context.md
+++ b/docs/adr/121-cinematic-editor-document-and-authoring-context.md
@@ -1,0 +1,289 @@
+# ADR-121: Cinematic Editor Document and Authoring Context
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Sequence asset document identity, tab and creation ownership, authoring scene context, reference staleness, command/history boundaries, save/autosave/recovery/external conflict and preview isolation
+- **Issue**: [CIN-005.1](https://github.com/abdullahbodur/horo-engine/issues/1702)
+- **Jira**: [HORO-1661](https://horo-engine.atlassian.net/browse/HORO-1661)
+- **Related**: [ADR-014](014-sequencer-ownership-clock-authority-and-binding-boundary.md), [ADR-093](093-prefab-override-property-identity-and-delta-operations.md), [ADR-094](094-prefab-nested-composition-and-variant-inheritance.md), [ADR-117](117-playback-ownership-frame-order-and-determinism.md), [ADR-119](119-camera-authority-during-cinematics.md)
+- **Normative documents**: [Editor Document Model](../architecture/editor/editor-document-model.md), [Cinematic Sequencer Architecture](../architecture/runtime/cinematic-sequencer-architecture.md), [Project Model](../architecture/editor/project-model.md)
+
+## Context
+
+Sequence assets are durable authored project content, but the cinematic architecture
+currently describes only a timeline/curve surface. It does not say whether that
+surface is a persistent document tab or a transient modal, which object owns dirty
+state/history/save, or whether editing a referenced scene object mutates the sequence
+document, scene document, or both.
+
+The generic Editor Document Model already defines session/revision/state identity,
+typed commands, semantic history, atomic save, recovery and external-file conflict.
+Creating a parallel sequencer undo stack, autosave file or file-watcher reload path
+would violate that contract. Conversely, treating a sequence as part of a scene
+document would make reusable sequence assets acquire scene lifetime and prevent
+authoring without an open scene.
+
+Live scene references also need explicit staleness. A stable object ID survives
+rename/reorder but not deletion, wrong-scene attachment, scene session replacement or
+component/property schema change. Automatically clearing or rebinding such a
+reference would silently change authored intent.
+
+## Decision
+
+### 1. A sequence asset is a first-class persistent document
+
+Each editable sequence asset opens as one `SequenceDocument` rooted at its stable
+`AssetId` and source revision. `EditorWorkspaceController` owns its
+`DocumentSessionId`, committed revision/state IDs, semantic history, dirty state,
+save/autosave/recovery/conflict state and derived compile/preview revisions. The
+document tab host owns the persistent visible route and supplies document command,
+query and subscription capabilities to the timeline, curve editor, details and
+binding panels.
+
+Only one writable document session for the same asset/revision is admitted in one
+workspace. Opening the asset focuses its existing tab. A deliberate read-only compare
+or historical view has separate typed identity and cannot submit commands or save as
+the canonical asset.
+
+The sequence document stores authored timeline/range/settings, stable track/key IDs,
+curves, binding declarations, payloads and logical asset references. It does not store
+tab layout, selection, zoom/scroll, playhead, open popup, preview player/lease, live
+scene/runtime handles, viewport camera state or backend objects. Workspace
+presentation state may remember the open document route and UI state by stable asset
+identity, but it is not sequence content.
+
+### 2. Creation is transient; editing is tab-owned
+
+`Create Sequence` is a transient modal/route owned by the editor workflow host. It
+collects name/location/template and validates project boundary, collision, permission
+and source-control policy. Confirmation runs one application asset-creation
+transaction, atomically publishes the initial valid sequence asset, registers its
+`AssetId`, then opens/focuses the persistent sequence document tab.
+
+Cancel or failure leaves no document, tab, partial file, registry entry or recovery
+record. The modal never becomes a hidden document and does not keep an independent
+undo stack. Rename/move/delete/import are ordinary Asset application use cases with
+open-document coordination; they are not raw tab/file mutations.
+
+Track/key creation, dragging, curve edits, binding changes, recording and property
+edits occur in the document tab through typed `SequenceEditorCommand` values. Popups
+and modals are limited to transient choices/confirmation such as selecting a binding,
+resolving a conflict or Save As.
+
+### 3. SequenceDocument owns one command/history source of truth
+
+Every authored sequence mutation validates and commits through the document command
+executor. Continuous drags/recording use preview overlays or one reversible
+transaction and create one semantic history entry on commit. Cancel restores the
+exact pre-interaction state. UI widgets, viewport tools, MCP handlers, file watchers,
+compile workers and runtime preview never mutate the document directly.
+
+Undo/redo, dirty-state identity, save, Save As, autosave, recovery and external
+conflict use the existing Editor Document Model unchanged. There is no sequencer-local
+undo array, dirty boolean, autosave timer/file, serializer-owned history or direct
+file save. Compilation/cook and preview snapshots are revision-correlated derived
+work; success does not clear dirty state or advance saved state.
+
+Save captures an immutable sequence revision, validates/cooks its source schema,
+serializes deterministically and atomically replaces the canonical asset. If newer
+edits commit while saving, only the captured state becomes saved and the document
+remains dirty. Autosave writes recovery state and never overwrites or redefines the
+canonical source.
+
+### 4. Authoring scene context is a detachable projection
+
+A `SequenceAuthoringContext` optionally attaches a SequenceDocument session to one
+editor `SceneDocument` session/revision and immutable binding-resolution snapshot:
+
+```cpp
+struct SequenceAuthoringContext {
+    DocumentSessionId sequenceSession;
+    AssetId sequenceAsset;
+    std::optional<DocumentSessionId> sceneSession;
+    std::optional<AssetId> sceneAsset;
+    DocumentRevision sceneRevision;
+    BindingRegistryRevision bindingRegistryRevision;
+    AuthoringContextGeneration generation;
+};
+```
+
+The context enables scene-object picking, validation, viewport preview, property
+enumeration and recording. It owns no sequence or scene content. A sequence remains
+editable without a scene context; object-bound tracks display unresolved contextual
+state while timeline/range/curve/payload edits remain available.
+
+Attaching/detaching/switching context changes editor presentation state, not authored
+sequence data, unless the user explicitly commits a binding command. Opening a scene
+does not rewrite bindings, and opening a sequence does not load or select an inferred
+scene. A declared preview fixture/template may be chosen explicitly but remains a
+logical asset reference, not a live session handle.
+
+### 5. References retain intent and publish resolution state
+
+Authored scene bindings store the sequence's declared scene-scope policy plus durable
+`StableObjectId`, component/property binding identity and expected schema revision.
+Resolution against the current context produces immutable `BindingInspectionState`:
+
+| State | Meaning |
+|---|---|
+| `Resolved` | Scene scope, object generation and component/property schema match |
+| `NoSceneContext` | No scene is attached; authored identity remains intact |
+| `WrongSceneScope` | Attached scene identity is incompatible with the binding policy |
+| `ObjectMissing` | Stable object identity is absent in the attached revision |
+| `ComponentMissing` | Object exists but required component is absent |
+| `SchemaIncompatible` | Property/binding identity exists with incompatible type/version |
+| `AmbiguousLegacyReference` | Imported legacy identity cannot resolve uniquely and requires repair |
+
+Rename, hierarchy reorder and component relocation preserve a reference when stable
+identity/schema still match. Delete, component removal, schema replacement, external
+reload and scene replacement increment their owner revisions/generations and
+re-resolve the inspection snapshot. Stale state is shown on the track/key/binding
+panel with cause and last-known bounded display context; it never clears, retargets by
+name, chooses a same-named object or mutates document dirty state.
+
+The user repairs a stale reference through an explicit typed binding command, which
+is undoable and marks the sequence document dirty. If the old identity becomes valid
+again before repair, a new snapshot may return to `Resolved` without an authored
+mutation. Runtime activation independently validates cooked bindings and does not
+trust editor inspection state.
+
+### 6. Scene and sequence commands keep their owners
+
+A timeline edit affects only `SequenceDocument` and enters its history. Creating,
+renaming, moving, deleting or changing a scene object affects only `SceneDocument`
+and enters scene history. Viewport recording samples immutable scene/editor evidence
+but commits generated keys through one Sequence command; it does not make the
+sequence history own the source scene transform.
+
+An action that intentionally changes both documents uses the existing staged
+multi-document application transaction. It pins both sessions/revisions, validates
+both candidates, commits both semantic command groups atomically and publishes linked
+transaction evidence. Failure/staleness leaves both unchanged. Each document retains
+its own history/dirty/save identity; UI cannot simulate atomicity by running two
+uncoordinated commands or maintain a third cross-document undo stack.
+
+Undo that would violate the other document's current dependency fails with a typed
+conflict and offers an explicit repair/rebase flow. It never silently rewrites the
+other document or a durable file.
+
+### 7. Reload and external conflict follow document policy
+
+Asset Registry/file-watch notifications are revision hints. The document service
+compares the canonical sequence file identity/hash and applies existing policy:
+
+- a clean document may offer or perform policy-approved reload into a new revision;
+- a dirty document offers compare, keep local, reload external or save local as;
+- an active save detects external replacement before atomic publication; and
+- reload starts a new history branch/clears redo unless an explicit semantic rebase
+  rebuilds valid history.
+
+External reload cannot inject a hidden command or replace an in-progress interaction.
+Pending save/autosave/compile/preview/binding results must match sequence session,
+document revision, source revision, authoring-context generation and relevant scene/
+registry revisions before publication. Stale results are discarded with a typed
+diagnostic.
+
+Scene external reload/replacement is handled by the SceneDocument owner. The
+SequenceDocument remains open and unchanged; its authoring context receives a new
+scene generation and recomputes binding inspection state.
+
+### 8. Preview is derived, isolated and disposable
+
+Scrub/play preview compiles an immutable snapshot of one sequence revision and binds
+it to one authoring-context generation. Preview player state, evaluation cursor,
+temporary authority leases, camera proposal, Audio/VFX handles and diagnostics are
+owned by the preview session, not the document/history. Closing the tab, changing
+context, committing a relevant edit, scene replacement or project close cancels and
+generation-fences the preview before retiring resources.
+
+Preview cannot persist runtime state back into the sequence or scene. `Record` is an
+explicit editor command workflow that samples permitted evidence and previews the
+candidate keys before committing them to SequenceDocument. ADR-119 keeps the editor
+viewport controller as final camera owner during preview.
+
+### 9. Close, project and lifecycle behavior are guarded
+
+A close request routes through the document tab host's dirty-document leave guard:
+save, discard or cancel. Save failure keeps the tab/session open. Discard drops only
+unsaved in-memory sequence changes after explicit confirmation; canonical files and
+recovery retention follow existing policy. Project close resolves every dirty
+document and running preview/operation before workspace teardown.
+
+Asset deletion while a sequence document is open requires explicit application-level
+coordination and cannot be inferred from closing the tab. Save As changes canonical
+location/identity only after durable publication and project registry update; Save
+Copy As does not change the active document identity.
+
+### 10. Qualification covers document and context independence
+
+Required implementation evidence includes:
+
+- create confirm/cancel/name collision/permission/publication failure with exactly one
+  asset and persistent tab only after successful commit;
+- repeat-open focus, one writable session, tab close save/discard/cancel and project
+  close with dirty documents and running previews;
+- command symmetry, grouped drag/record transactions, dirty state through undo/redo,
+  concurrent-save edits, Save As/Copy As and no alternate sequencer history/save;
+- autosave/recovery retention, corrupt recovery, external clean/dirty/save-in-flight
+  conflicts and reload history boundary;
+- no scene context, correct/wrong scene, rename/reorder, object/component deletion,
+  schema change, external scene reload/replacement and explicit undoable repair;
+- stale async save/autosave/compile/preview/binding results across every sequence,
+  scene, registry and authoring-context generation;
+- isolated sequence-only, scene-only and atomic cross-document commands, including
+  failure/undo conflicts without partial mutation; and
+- preview/scrub/record teardown proving no runtime handle, authority lease or preview
+  mutation enters source documents/history.
+
+## Consequences
+
+### Positive
+
+- Sequence assets behave like other persistent editor documents with one ownership,
+  history and persistence model.
+- Scene context improves authoring without giving live scene lifetime to the asset.
+- Stale references remain visible and repairable without silent data loss.
+- Preview and viewport behavior cannot become a second source of authored truth.
+
+### Costs
+
+- SequenceDocument needs a specialized command set, validator and derived compile/
+  preview projection within the shared document infrastructure.
+- Binding inspection must track sequence, scene, registry and context generations.
+- Cross-document actions require real staged coordination rather than two convenient
+  UI callbacks.
+
+## Rejected Alternatives
+
+### Put sequence editing in a modal or scene tab panel
+
+Rejected because a reusable durable asset needs persistent route identity, dirty
+guards, history, recovery and external-conflict lifecycle. Modals remain transient.
+
+### Store sequence data inside SceneDocument
+
+Rejected because sequences are reusable assets, must be editable without a scene and
+have independent save/revision/conflict identity.
+
+### Give Sequencer its own undo and autosave implementation
+
+Rejected because that duplicates Editor Document Model state and produces conflicting
+dirty/save/recovery truth. Sequence commands and persistence use shared services.
+
+### Clear or retarget stale references automatically
+
+Rejected because deletion/reload could destroy authored intent or bind a same-named
+wrong object. Inspection is derived; repair is an explicit undoable command.
+
+### Let viewport recording mutate both scene and sequence directly
+
+Rejected because two document owners could partially commit and cannot provide
+coherent undo. Recording writes sequence keys; deliberate two-document changes use
+the staged multi-document application transaction.
+
+### Store live scene/runtime handles in SequenceDocument
+
+Rejected because handles die on reload, scene replacement, PIE restart and project
+close. Documents store stable authored identities; context/preview owns disposable
+generation-checked resolution.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -132,6 +132,7 @@ to the replacement.
 | [118](118-animation-character-and-gameplay-authority-during-cinematics.md) | Animation, Character and Gameplay Authority During Cinematics | Proposed | 2026-09-02 |
 | [119](119-camera-authority-during-cinematics.md) | Camera Authority During Cinematics | Proposed | 2026-09-02 |
 | [120](120-cinematic-event-dispatch-and-audio-coupling-boundary.md) | Cinematic Event Dispatch and Audio Coupling Boundary | Proposed | 2026-09-02 |
+| [121](121-cinematic-editor-document-and-authoring-context.md) | Cinematic Editor Document and Authoring Context | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -366,6 +366,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Cinematic Event Dispatch and Audio Coupling Boundary](../adr/120-cinematic-event-dispatch-and-audio-coupling-boundary.md):
   cooked typed EventTrack bindings, application-owned safe-point dispatch, explicit
   failure outcomes and AudioFrontend coupling through AUD-family authority.
+- [Cinematic Editor Document and Authoring Context](../adr/121-cinematic-editor-document-and-authoring-context.md):
+  persistent sequence asset tabs, shared command/save/conflict ownership, detachable
+  scene authoring context, stale-reference inspection and disposable preview state.
 - [Post-Processing And Effects Architecture](./runtime/post-processing-and-effects-architecture.md):
   screen-space effects, HDR post chain, tonemapping, color grading, and
   accessibility pass ordering.

--- a/docs/architecture/editor/editor-document-model.md
+++ b/docs/architecture/editor/editor-document-model.md
@@ -381,6 +381,32 @@ Compilation is revision-correlated derived work and does not clear dirty state.
 Live PIE blackboards, nodes, tasks and query results never enter document history;
 importing reviewed runtime data requires a separate typed editor command.
 
+## Cinematic Sequence Asset Documents
+
+[ADR-121](../../adr/121-cinematic-editor-document-and-authoring-context.md)
+defines each sequence asset as a first-class persistent `SequenceDocument` rooted at
+its stable `AssetId`. `EditorWorkspaceController` and the document tab host own its
+session, route, typed command/history, dirty, save/autosave/recovery/conflict and
+derived compile/preview revisions through this document contract. The Create Sequence
+modal is only a transient asset-creation workflow; it opens the persistent tab after
+atomic publication and owns no hidden document or undo stack.
+
+An optional generation-checked `SequenceAuthoringContext` attaches the sequence
+session to an immutable SceneDocument binding-resolution snapshot. It enables scene
+picking, property enumeration, recording and preview but owns no authored content.
+The sequence remains editable without a scene. Rename/reorder preserve stable object
+bindings; wrong scene, deletion, component/schema change, reload or scene replacement
+publish derived typed stale states without clearing or name-retargeting the authored
+identity. Repair is an explicit undoable Sequence command.
+
+Sequence edits and scene edits remain in their owning documents. An intentional
+two-document action uses the staged multi-document application transaction; UI cannot
+run two direct mutations or maintain a third history. Scrub/play state, live handles,
+authority leases and viewport state belong to a disposable preview/session projection
+and never enter document storage. Save, autosave, recovery, external conflict, Save
+As/Copy As, close guards and stale worker-result rejection use the shared policies
+above unchanged.
+
 ## Runtime Conversion
 
 The document converts to `RuntimeSceneDefinition` through an editor service.
@@ -467,6 +493,12 @@ Required tests cover:
   one-entry history and no direct Inspector/file-watcher mutation
 - apply-to-prefab failure or uncertain external publication preserves instance
   intent and reports reconciliation state
+- sequence asset create/open/close uses a persistent document tab and shared command,
+  dirty, save, autosave, recovery and external-conflict ownership without a parallel
+  sequencer stack or serializer state
+- sequence authoring context covers no/wrong/replaced scene, stable rename/reorder,
+  missing object/component, schema mismatch, explicit repair and stale preview/
+  binding/compile results without mutating authored identity
 
 ## Related Documents
 
@@ -479,3 +511,4 @@ Required tests cover:
 - [Asset Pipeline](../runtime/asset-pipeline.md)
 - [Prefab Architecture](../runtime/prefab-architecture.md)
 - [Save Game And Persistence](../runtime/save-game-and-persistence.md)
+- [Cinematic Sequencer](../runtime/cinematic-sequencer-architecture.md)

--- a/docs/architecture/editor/project-model.md
+++ b/docs/architecture/editor/project-model.md
@@ -353,6 +353,14 @@ persisted on editor close or explicit save. Ownership of its runtime slices is:
 - `EditorViewportModel`: editor camera and navigation state
 - individual tabs: project-scoped presentation state under their stable tab ID
 
+Sequence-document tabs follow
+[ADR-121](../../adr/121-cinematic-editor-document-and-authoring-context.md).
+Workspace state may retain their open route, active tab, timeline selection,
+zoom/scroll/playhead and detachable authoring-scene route by stable asset/tab
+identity. It never stores sequence content, dirty/history/save state, live scene
+handles or preview authority leases. A restored missing sequence/scene asset produces
+a typed diagnostic and omits/detaches that route without modifying either document.
+
 `EditorViewportModel` owns a backend-neutral `EditorViewportCamera`, advances a
 monotonic viewport revision after committed navigation or explicit preview
 invalidation, and publishes `ViewportChangedEvent`. Camera navigation and gizmo

--- a/docs/architecture/runtime/cinematic-sequencer-architecture.md
+++ b/docs/architecture/runtime/cinematic-sequencer-architecture.md
@@ -21,6 +21,9 @@ validity and tiered transition/render contracts.
 [ADR-120](../../adr/120-cinematic-event-dispatch-and-audio-coupling-boundary.md)
 defines cooked typed EventTrack bindings, session-safe-point gameplay dispatch,
 failure outcomes and the AudioFrontend handoff governed by AUD-family decisions.
+[ADR-121](../../adr/121-cinematic-editor-document-and-authoring-context.md)
+defines persistent sequence documents/tabs, command and persistence ownership,
+detachable scene authoring context, stale-reference inspection and preview isolation.
 [ADR-068](../../adr/068-music-transport-and-cross-system-ownership.md) owns the
 AudioTrack handoff: Sequencer retains sequence clock, directed event traversal,
 seek/scrub and preroll intent while Audio alone maps accepted requests to sample
@@ -62,6 +65,9 @@ time and schedules the callback.
 - **One typed event path**: A session `CinematicEventDispatcher` invokes cooked,
   versioned gameplay adapters at destination owner boundaries. `EngineDataBus` is
   not gameplay EventTrack delivery, and AudioTrack submits intent through AudioFrontend.
+- **Document-owned authoring**: Sequence assets use persistent document tabs and the
+  shared typed command/history/save/conflict model. Scene context and preview are
+  detachable projections and never become a second source of authored truth.
 
 ## System Boundaries and Target Topology
 
@@ -743,7 +749,28 @@ The cinematic editor provides:
 
 ### Document and Asset Workflow
 
-Sequence assets are stored in the project's asset tree. Sequences reference scene objects by durable `StableObjectId`s, ensuring scene edits, renames, and reordering do not break sequence bindings.
+Sequence assets are stored in the project's asset tree and open as first-class
+`SequenceDocument` sessions in persistent document tabs. Create Sequence is a
+transient modal that atomically publishes the asset before opening the tab. Timeline,
+curve, recording and binding edits use typed Sequence commands, semantic transactions
+and the shared document history/dirty/save/autosave/recovery/external-conflict
+services. No sequencer-local undo stack, dirty flag or direct serializer save exists.
+
+An optional `SequenceAuthoringContext` attaches the document to one generation-
+checked SceneDocument snapshot for picking, property enumeration, recording and
+preview. The asset remains editable without it. Durable `StableObjectId`, component/
+property identity and schema expectations are never replaced by live handles.
+Rename/reorder can remain resolved; wrong scene, delete, component/schema change,
+reload or scene replacement produce derived typed stale states in tracks and binding
+inspection. They do not clear or retarget authored identity. Repair is an explicit
+undoable command.
+
+Scene mutations stay in SceneDocument history and sequence mutations stay in
+SequenceDocument history. Deliberate two-document edits use the editor's staged
+multi-document transaction. Preview players, cursors, leases, camera/audio/VFX state
+and viewport presentation are disposable revision-correlated state; closing the tab,
+changing context or committing a relevant edit cancels/fences them. ADR-121 owns the
+complete workflow and lifecycle.
 
 ## Evaluation Capacity And Admission
 
@@ -876,6 +903,9 @@ These are required implementation acceptance tests, not tests added by this ADR:
 - AudioTrack tests cover required/optional missing, corrupt, unloaded and replaced
   media; bounded preparation; schedule/seek/preroll acknowledgements; device loss;
   and native/middleware/Null adapters without sample/native identity in Sequencer.
+- Sequence editor tests cover atomic create/focus/close, shared command/history/dirty/
+  save/recovery/conflict behavior, no/wrong/replaced scene contexts, derived stale
+  binding states, explicit repair, cross-document atomicity and disposable preview.
 
 ## Related Documents
 
@@ -884,6 +914,7 @@ These are required implementation acceptance tests, not tests added by this ADR:
 - [ADR-118: Animation, Character and Gameplay Authority During Cinematics](../../adr/118-animation-character-and-gameplay-authority-during-cinematics.md)
 - [ADR-119: Camera Authority During Cinematics](../../adr/119-camera-authority-during-cinematics.md)
 - [ADR-120: Cinematic Event Dispatch and Audio Coupling Boundary](../../adr/120-cinematic-event-dispatch-and-audio-coupling-boundary.md)
+- [ADR-121: Cinematic Editor Document and Authoring Context](../../adr/121-cinematic-editor-document-and-authoring-context.md)
 - [Cinematic Sequencer UI Reference](./cinematic-sequencer.html)
 - [Scene Runtime Architecture](./scene-runtime.md)
 - [Animation Architecture](./animation-architecture.md)


### PR DESCRIPTION
## Summary

- Adds ADR-121 to define sequence assets as first-class persistent `SequenceDocument` sessions owned by the editor workspace/document tab host.
- Keeps Create Sequence as a transient modal that atomically publishes an asset before opening its persistent tab.
- Reuses the shared typed command/history, dirty, save, autosave, recovery, external-conflict, and close-guard infrastructure; no sequencer-local persistence or undo source is permitted.
- Defines `SequenceAuthoringContext` as an optional, detachable projection over one SceneDocument snapshot rather than document-owned live scene state.
- Defines typed scene-binding inspection states and explicit undoable repair across scene reload, replacement, deletion, and schema change.
- Separates sequence, scene, workspace, and disposable preview ownership, including the staged multi-document transaction seam.
- Projects the decision into Editor Document Model, Project Model, Cinematic Sequencer, and the architecture/ADR indexes.

## Why

The cinematic architecture described a timeline and curve editor but did not fully assign document identity, tab placement, creation flow, persistence, or the lifetime of live scene references. Without a decision, sequencer UI could grow its own undo/dirty/autosave path, sequence assets could become accidentally scene-owned, and reload could silently clear or retarget authored bindings.

The repository already has a normative document model for semantic commands, atomic save, recovery, external conflict, and derived preview state. This PR specializes that model for sequence assets while keeping an attached scene useful for picking/recording/preview without making it part of the sequence's durable ownership.

## Decision and boundaries

- `SequenceDocument` is rooted at stable `AssetId`; repeat open focuses the one writable workspace session.
- The persistent tab hosts timeline, curves, details, and binding inspection. Tab layout, selection, zoom/scroll, playhead, popups, preview handles, and viewport state are workspace/transient data, not sequence content.
- Create Sequence validates name/location/template and commits one asset transaction. Cancel/failure leaves no partial file, registry entry, tab, document, or recovery record.
- All authored edits use typed `SequenceEditorCommand` transactions. Drag/record interactions create preview state and one semantic history entry on commit.
- Save, Save As/Copy As, autosave, recovery, external reload/conflict, dirty-state identity, and stale worker fencing reuse Editor Document Model unchanged.
- `SequenceAuthoringContext` optionally pins a scene session/revision and binding-registry revision for picking, property enumeration, recording, and preview. The sequence remains editable without a scene.
- Bindings retain stable object/component/property/schema intent. Derived states distinguish no context, wrong scene, missing object/component, incompatible schema, and ambiguous legacy identity.
- Rename/reorder can remain resolved. Delete/reload/replacement never clears or name-retargets a binding; repair is an explicit undoable sequence command.
- Scene changes remain in SceneDocument history and sequence changes remain in SequenceDocument history. Intentional two-document actions use a staged atomic application transaction, not two UI callbacks or a third undo stack.
- Preview players, cursors, authority leases, camera/audio/VFX state, and live handles are revision-correlated disposable state and are cancelled/fenced on tab close, context change, relevant edit, or scene replacement.
- Implementation is intentionally deferred to CIN-005 delivery tickets; this PR defines the contract and qualification evidence.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Markdown lint passed for every changed document.
- [x] Added Markdown links resolve locally.
- [x] Staged diff whitespace validation passed.
- [x] CMake configuration passed with public-header inventory and dependency-direction checks.
- [ ] Editor interaction tests were not run because this PR changes architecture documentation only.
- [ ] Manual UI smoke testing is not applicable to this documentation-only decision.

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/121-cinematic-editor-document-and-authoring-context.md docs/adr/README.md docs/architecture/README.md docs/architecture/editor/editor-document-model.md docs/architecture/editor/project-model.md docs/architecture/runtime/cinematic-sequencer-architecture.md
git diff --check
git diff --cached --check
# Staged-added-link validation script (Ruby) over git diff --cached
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

CMake completed successfully with the existing mbedTLS minimum-CMake deprecation warning. Pytest is unavailable, so repository Python tests were skipped.

## Risk and rollout

- SequenceDocument is a specialization of shared infrastructure, not permission to fork that infrastructure. Implementation must avoid parallel dirty/history/autosave/conflict state.
- Cross-document operations require real staged atomicity and linked evidence. Two sequential commands would expose partial state and misleading undo behavior.
- Automatically recovering a same-named scene object is explicitly forbidden; content migration may require user-visible repair for legacy or unstable bindings.
- Authoring context and preview have several correlated generations. Downstream work must fence late binding/compile/save/preview results against all relevant identities.
- The contract describes future behavior; current editor code must not be represented as already satisfying it until implementation/qualification lands.

## Issue links

- Jira: [HORO-1661](https://horo-engine.atlassian.net/browse/HORO-1661)
- GitHub: Closes #1702

## Reviewer Notes

Suggested review order:

1. ADR-121 sections 1–3 for document/tab/creation and single command/persistence ownership.
2. ADR-121 sections 4–7 for authoring context, stale references, cross-document edits, and external reload.
3. ADR-121 sections 8–10 for preview/lifecycle and qualification.
4. Editor Document Model and Project Model projections.
5. Cinematic Sequencer projection and indexes.

Key review questions:

- Is SequenceDocument correctly independent from SceneDocument while still supporting scene-aware authoring?
- Are stale binding states preserved and surfaced without silent authored mutation?
- Is the boundary between sequence-only, scene-only, and multi-document commands unambiguous?
- Does any workspace or preview state accidentally become durable sequence content?
- Are shared save/autosave/recovery/external-conflict semantics reused without a parallel mechanism?

This PR is stacked on `docs/HORO-1660_cinematic_event_audio_boundary`; review only commit `cf83368` for the HORO-1661 delta.


[HORO-1661]: https://horo-engine.atlassian.net/browse/HORO-1661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ