### PR TITLE
docs(cinematic): define trigger capability policy HORO-1662 #1703 [CIN-006.1]

### DIFF
--- a/docs/adr/122-cinematic-trigger-sources-and-capability-policy.md
+++ b/docs/adr/122-cinematic-trigger-sources-and-capability-policy.md
@@ -1,0 +1,276 @@
+# ADR-122: Cinematic Trigger Sources and Capability Policy
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Gameplay-script, scene-autoplay, gameplay-event, editor, MCP and remote cinematic triggers; typed capability/trust/authority admission; packaged-build availability; approval reuse; denial and lifecycle outcomes
+- **Issue**: [CIN-006.1](https://github.com/abdullahbodur/horo-engine/issues/1703)
+- **Jira**: [HORO-1662](https://horo-engine.atlassian.net/browse/HORO-1662)
+- **Related**: [ADR-014](014-sequencer-ownership-clock-authority-and-binding-boundary.md), [ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md), [ADR-054](054-extension-and-package-authority-boundary.md), [ADR-117](117-playback-ownership-frame-order-and-determinism.md), [ADR-120](120-cinematic-event-dispatch-and-audio-coupling-boundary.md)
+- **Normative documents**: [Cinematic Sequencer Architecture](../architecture/runtime/cinematic-sequencer-architecture.md), [Gameplay Module Boundary](../architecture/extensions/gameplay-module-boundary.md), [MCP Architecture](../architecture/interfaces/mcp-architecture.md), [Editor AI Agent Architecture](../architecture/editor/editor-ai-agent-architecture.md), [Runtime Lifecycle](../architecture/runtime/runtime-lifecycle.md)
+
+## Context
+
+ADR-117 makes scene-authored playback components inert start descriptors and gives a
+session `CinematicRuntimeService` ownership of live players. The architecture does
+not yet define every caller allowed to submit a start request, the capability and
+world authority each caller needs, or whether editor/MCP/remote triggers ship in a
+retail executable.
+
+A trigger is security-sensitive because a sequence can request gameplay events,
+camera authority, Character control, Audio/VFX work or gameplay pause. Treating every
+caller as trusted because it can reach Cinematic Runtime would let a client, script,
+MCP connection or remote debug endpoint widen its authority. Conversely, inventing a
+cinematic-specific approval database would duplicate host capability, project trust,
+MCP approval and debug-command permission infrastructure.
+
+This ADR enumerates admitted sources and makes every source submit the same typed
+request to the same owner. It specializes existing authorization mechanisms; it does
+not create a new trust or approval system.
+
+## Decision
+
+### 1. All triggers submit one typed application request
+
+No source constructs or starts a `SequencePlayer` directly. Each submits a bounded
+`SequenceStartRequest` through an injected `ICinematicPlaybackCapability` into the
+session-owned `CinematicRuntimeService`:
+
+```cpp
+struct SequenceStartRequest {
+    SequenceAssetId sequence;
+    SequenceTriggerSource source;
+    TriggerPrincipalId principal;
+    RuntimeSessionId session;
+    SceneRuntimeId scene;
+    StableActivationId activation;
+    SequencePlaybackSettings settings;
+    CapabilityGrantRef capabilityGrant;
+    AuthorityEvidenceRef authority;
+    CancellationToken cancellation;
+};
+```
+
+The application adapter validates caller provenance, product/build profile, project/
+package trust, capability grant, session/scene scope, gameplay/network authority,
+asset/cook revision, requested sequence effects and budgets. Admission then follows
+ADR-117's stable activation and immutable batch rules. A source receives a typed
+`SequenceStartResult`; possession of an asset ID, component, event name, endpoint or
+service pointer is never authority.
+
+Capabilities are narrow and composable: `cinematic.playback.start`,
+`cinematic.playback.stop-own`, `cinematic.playback.control-any`,
+`cinematic.preview`, and effect-specific grants inferred from the compiled sequence
+plan. A start grant cannot implicitly confer gameplay pause, server mutation, remote
+administration or control over another principal's player.
+
+### 2. Source policy is explicit
+
+| Trigger source | Required provenance/capability | Authority and packaged policy |
+|---|---|---|
+| Gameplay script/native behavior | Activated trusted gameplay module/script context plus `cinematic.playback.start` | May start only in its runtime session and world authority. Included in Development/Profile/Shipping/Server when the module and cooked sequence are product content. Client cannot gain server-owned effects. |
+| Scene-load auto-play | Validated cooked `SequencePlaybackComponent`/scene activation descriptor | RuntimeScene submits after successful aggregate scene activation. Allowed in packaged content profiles, including Shipping, because it is authored product behavior rather than a remote command. Effect plan still needs all owner capabilities. |
+| Gameplay event | Registered typed adapter under ADR-120 plus `cinematic.playback.start` for its destination principal | Enqueued after the source occurrence commits; recursion/nesting/player budgets apply. Allowed in packaged content profiles when the event binding and target sequence are cooked/allowlisted. |
+| Editor Play/Preview UI | Active trusted editor project, document/context scope and `cinematic.preview` or local play capability | Editor profile only. Preview is non-authoritative and isolated; PIE play uses PIE world authority and ordinary runtime admission. Direct user action is intent, not blanket future approval. |
+| MCP/agent tool | Registered MCP tool, authenticated caller where applicable, trusted project, scoped capability and operation approval | Editor/local development tooling only by default. Mutating start requires the existing visible revision-bound approval unless an existing user/project policy has explicitly pre-authorized that exact bounded tool class. Absent from Retail Shipping. |
+| Local debug/CLI adapter | ADR-018 descriptor, matching permission/availability and owner-thread dispatch | Development profiles only unless a separate product-safe local trigger is compiled as ordinary gameplay UI. `AdminCheat` plus world/server authority is required for gameplay-mutating debug playback. No Shipping debug backdoor. |
+| Authenticated remote tooling/admin | Existing authenticated remote transport, exact registered tool/command capability, audit policy and target-world authority | Disabled for Retail Shipping clients. Diagnostics is opt-in and bounded. Dedicated Server may admit an explicitly registered `Restricted` server operation with authenticated session and server authority; headless compatibility is required. |
+
+Unlisted sources are denied. Extensions/packages may contribute an adapter only
+through their declared application/MCP/command capability descriptors, package trust
+approval and selected product profile. They do not register a raw Cinematic callback
+or receive a service locator.
+
+### 3. Scene auto-play is authored activation, not implicit trust
+
+Runtime conversion emits an inert start descriptor containing sequence identity,
+autoplay condition, stable activation slot, lifetime scope, required/optional policy
+and compiled capability summary. RuntimeScene submits it only after the scene
+candidate and required assets/services are ready. Failed aggregate scene activation
+starts nothing.
+
+The descriptor is admitted against the same owner capabilities as every other
+request. Auto-play cannot bypass missing gameplay/camera/Audio authority merely
+because it came from cooked content. Required denial fails or disables the scene
+candidate according to declared scene policy; optional denial produces a visible
+typed diagnostic. Scene replacement/cancellation generation-fences pending starts.
+
+### 4. Gameplay scripts and events cannot widen authority
+
+Gameplay modules receive `ICinematicPlaybackCapability` in their validated runtime
+context only when declared and granted. Scripts use the same typed binding; string
+lookup of a global Cinematic service is forbidden. The capability scopes requests to
+the caller's session, world role, allowed sequence set/effect classes and owned-player
+control policy.
+
+A client-side caller may start cosmetic/local presentation content explicitly
+qualified for that client view, but it cannot acquire server Character, gameplay,
+Physics or pause authority. A server-authoritative sequence begins from server-owned
+gameplay or an authenticated server operation and replicates semantic/resulting state
+through normal network contracts.
+
+ADR-120 gameplay events may request a sequence only after the occurrence's source
+tick commits. The request creates a distinct stable activation identity derived from
+the occurrence ID and authored trigger slot. Loops, recursion and sub-sequences count
+against ADR-117's shared capacities; an event cycle cannot manufacture unbounded
+players or bypass preflight.
+
+### 5. Tooling reuses existing authorization and approval
+
+MCP, agent, CLI, debug-console and remote adapters are presentation/protocol layers
+over the same application capability. Their existing infrastructure remains final:
+
+- MCP owns tool schema, authenticated connection, context scope, rate limits and
+  cancellation under MCP Architecture;
+- editor-agent writes retain visible revision-bound proposal/approval under Editor AI
+  Agent Architecture;
+- debug/CLI/remote commands use ADR-018 `CommandPermission`,
+  `CommandAvailability`, thread policy, server-authority check and audit/redaction;
+- package/extension adapters require manifest-declared capability and the exact
+  publisher/package/artifact trust approval under ADR-054; and
+- the application capability registry owns final operation admission and result.
+
+Authentication proves caller identity, not authorization. Project trust proves the
+project/package may load, not that every mutation is approved. User approval is
+bound to the exact tool/request, document/session revision and visible effect scope;
+it is not a reusable bearer token. A project setting may streamline prompts only via
+the existing policy engine and cannot enable a descriptor absent from the build.
+
+There is no `cinematic_approvals.json`, global `trustedRemote` boolean, approval in
+sequence assets, or special bypass for localhost/agent-generated calls.
+
+### 6. Build availability and runtime permission are independent
+
+Build composition first determines whether an adapter/descriptor exists. Runtime
+authorization only evaluates descriptors present in that product profile:
+
+| Product profile | Cinematic content triggers | Tooling triggers |
+|---|---|---|
+| Editor | Scene, gameplay, PIE and isolated preview | Local editor UI/MCP/agent/debug tools subject to trust, capability and approval |
+| Game Development | Scene and gameplay | Local debug/CLI; loopback only where existing policy permits; mutating requests need declared permission/authority |
+| Game Profile | Scene and gameplay | Read-only diagnostics only; no gameplay-mutating cinematic debug trigger |
+| Diagnostics | Qualified scene/gameplay if product includes them | Explicit authenticated diagnostic adapter only; no implicit cheat capability |
+| Game Shipping/Retail | Cooked scene/gameplay/product UI triggers | MCP, agent, debug cinematic start and remote triggers absent; runtime flags cannot enable them |
+| Dedicated Server | Headless-compatible scene/gameplay/server triggers | Explicit authenticated `Restricted` server adapter only, with server authority, audit and product registration |
+
+A product-facing menu/button that starts a cinematic in Shipping is ordinary trusted
+gameplay UI calling a granted gameplay use case, not a compiled debug/MCP allowlist
+exception. It receives only the capability designed for that product flow.
+
+### 7. Admission is atomic and side-effect free on denial
+
+Before acquiring any player/domain lease, admission validates the complete request
+and compiled effect plan. Denial returns one stable result and creates no player,
+cursor, event occurrence, pause token, camera/Character lease, Audio/VFX request,
+operation or partial diagnostic subscription.
+
+Typed outcomes include `TriggerSourceUnsupported`, `TriggerAdapterUnavailable`,
+`ProductProfileDenied`, `ProjectTrustDenied`, `CapabilityDenied`,
+`ApprovalRequired`, `ApprovalDenied`, `ApprovalStale`, `WrongSession`,
+`WorldAuthorityDenied`, `SequenceNotAllowed`, `SequenceAssetUnavailable`,
+`EffectCapabilityDenied`, `ActivationConflict`, `CapacityExceeded` and
+`HeadlessIncompatible`.
+
+Failures preserve the boundary that rejected the request. They are not collapsed to
+`PlayFailed`, and permission-sensitive details are redacted according to the existing
+security/observability policy. Unauthorized callers cannot probe unavailable sequence
+names, capabilities or world state through different timing/error detail.
+
+### 8. Start identity, ownership and cancellation are source-scoped
+
+Each admitted request receives a stable `SequencePlayerHandle` scoped to caller,
+session and player generation. `stop-own` can stop only players created by that
+principal/owned activation slot. `control-any` is a separate high-privilege grant and
+still requires target-world authority. Dropping a handle does not destroy the service-
+owned player under ADR-117.
+
+Caller disconnect, script/module unload, scene replacement, editor preview close,
+approval revocation or remote session expiry closes new admission and follows the
+request's declared lifetime policy. Scene-owned autoplay stops with its scene scope;
+application-owned gameplay sequences may survive component removal if their compiled
+lifetime permits it. Late approvals, asset loads or start completions carry all
+principal/session/scene/request generations and cannot revive a revoked request.
+
+### 9. Observability is bounded and auditable
+
+Every attempt records source kind, safe principal identity, product profile, target
+session/world, sequence/activation identity where disclosure is permitted, requested
+capability class, decision, denial boundary, audit correlation and latency. Sensitive
+tool arguments, tokens and private content are redacted. High-cardinality raw remote
+identity and asset paths are excluded from metric labels.
+
+Gameplay-authored successful starts use ordinary bounded diagnostics. MCP, remote,
+Restricted/AdminCheat and repeated denied attempts emit security audit records through
+existing HostObservability. Logging or EngineDataBus delivery never performs the
+start or becomes approval evidence.
+
+### 10. Qualification covers every source/profile pairing
+
+Required implementation evidence includes:
+
+- gameplay script/native module with granted/missing/revoked capability, module
+  reload and client/server authority combinations;
+- scene autoplay after successful/failed activation, required/optional owner
+  capability denial, scene replacement and duplicate activation fencing;
+- ADR-120 gameplay-event trigger commit/failure/loop identity, recursion cycle and
+  shared player/nesting budget exhaustion;
+- editor preview versus PIE isolation, direct UI intent and revision-stale preview;
+- MCP/agent authenticated/unauthenticated, trusted/untrusted, approval
+  required/granted/denied/stale and disconnect/cancellation paths;
+- local debug/CLI and remote descriptor availability, permission, server authority,
+  rate/audit policy and owner-thread dispatch;
+- build inspection proving Retail Shipping omits MCP/agent/debug/remote start
+  descriptors and cannot enable them with runtime flags;
+- Dedicated Server headless-compatible success and visual/unauthorized denial; and
+- every denial producing zero player/domain effects with stable typed/redacted result.
+
+## Consequences
+
+### Positive
+
+- All sources reach one admission boundary and cannot construct players directly.
+- Shipping product behavior remains available without shipping debug/MCP backdoors.
+- Tooling reuses established trust, permission and approval infrastructure.
+- Denials identify the failed boundary and guarantee zero partial effects.
+
+### Costs
+
+- Gameplay, scene conversion, events and tooling need narrow adapters over the common
+  capability rather than direct service access.
+- Build-profile descriptor manifests and effect-capability summaries require
+  qualification across editor, client and server compositions.
+- Principal/session ownership and late approval/load results need generation fencing.
+
+## Rejected Alternatives
+
+### Expose CinematicRuntimeService as a global service
+
+Rejected because reachability would become authority and callers could bypass product,
+world, effect and capacity admission.
+
+### Treat cooked scene autoplay as pre-approved for every effect
+
+Rejected because authored content still cannot grant unavailable gameplay pause,
+camera, Character, Audio or network authority. It uses the common admission plan.
+
+### Allow localhost or authenticated MCP to start any sequence
+
+Rejected because authentication/trust identify a caller/project but do not grant
+mutation capability, world authority or user approval. Existing MCP/agent policy
+remains mandatory.
+
+### Ship remote cinematic debug triggers behind a runtime flag
+
+Rejected because Retail Shipping must omit the descriptors/handlers. A flag cannot
+restore code that the product profile deliberately excludes.
+
+### Store cinematic-specific approvals in project or sequence files
+
+Rejected because project content cannot grant its own trust or user authorization.
+The existing host policy owns revision-bound approval and audit.
+
+### Let event-triggered sequences start reentrantly
+
+Rejected because the current occurrence batch/player registry could mutate during
+dispatch and cycles could bypass budgets. ADR-120 submits a later owner-boundary start
+request with stable occurrence-derived identity.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -133,6 +133,7 @@ to the replacement.
 | [119](119-camera-authority-during-cinematics.md) | Camera Authority During Cinematics | Proposed | 2026-09-02 |
 | [120](120-cinematic-event-dispatch-and-audio-coupling-boundary.md) | Cinematic Event Dispatch and Audio Coupling Boundary | Proposed | 2026-09-02 |
 | [121](121-cinematic-editor-document-and-authoring-context.md) | Cinematic Editor Document and Authoring Context | Proposed | 2026-09-02 |
+| [122](122-cinematic-trigger-sources-and-capability-policy.md) | Cinematic Trigger Sources and Capability Policy | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -369,6 +369,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Cinematic Editor Document and Authoring Context](../adr/121-cinematic-editor-document-and-authoring-context.md):
   persistent sequence asset tabs, shared command/save/conflict ownership, detachable
   scene authoring context, stale-reference inspection and disposable preview state.
+- [Cinematic Trigger Sources and Capability Policy](../adr/122-cinematic-trigger-sources-and-capability-policy.md):
+  common typed start admission for gameplay, scene, event and tooling sources;
+  capability/trust/authority checks, packaged-build gating and typed denials.
 - [Post-Processing And Effects Architecture](./runtime/post-processing-and-effects-architecture.md):
   screen-space effects, HDR post chain, tonemapping, color grading, and
   accessibility pass ordering.

--- a/docs/architecture/extensions/gameplay-module-boundary.md
+++ b/docs/architecture/extensions/gameplay-module-boundary.md
@@ -292,6 +292,22 @@ simulation continue when fixed ticks run. Whole-game pause attempts no Gameplay,
 Animation, Character or Physics tick; collision-aware cinematic movement instead
 uses scoped control transfer while simulation remains active.
 
+### Cinematic Playback Capability
+
+[ADR-122](../../adr/122-cinematic-trigger-sources-and-capability-policy.md)
+forbids gameplay modules and scripts from discovering `CinematicRuntimeService` or
+constructing players. A module that declares and receives
+`cinematic.playback.start` gets a narrow `ICinematicPlaybackCapability` in its runtime
+context. Requests are scoped to the caller principal, runtime session, world role,
+allowed sequence/effect set and owner authority; knowing an asset ID is not a grant.
+
+The same typed application admission serves native/script gameplay, cooked scene
+autoplay and committed gameplay-event adapters in development and packaged profiles.
+A client capability cannot acquire server-owned Character/gameplay/Physics/pause
+authority. Module/script unload and grant revocation close admission and generation-
+fence late preparation/start results. Denial returns a typed result and creates no
+player, lease, event, Audio/VFX request or partial effect.
+
 ## Services
 
 A game module may create project- or runtime-scoped services through explicit

--- a/docs/architecture/interfaces/mcp-architecture.md
+++ b/docs/architecture/interfaces/mcp-architecture.md
@@ -415,6 +415,21 @@ enabled by a remote caller or archive field.
 
 ## Security
 
+[ADR-122](../../adr/122-cinematic-trigger-sources-and-capability-policy.md)
+specializes cinematic start/control tools. A registered tool remains an MCP adapter
+over the common application `ICinematicPlaybackCapability`; it never receives the
+runtime service. Mutating start requires authenticated/scoped caller identity where
+applicable, trusted project, exact capability, target-world authority and the existing
+operation approval. Authentication, localhost access or project trust alone is not
+authorization, and approval is bound to the visible request/revision rather than
+stored in sequence/project content.
+
+Cinematic MCP start tools are Editor/local-development tooling by default and are
+absent from Retail Shipping builds. Remote policy below still applies; a non-loopback
+transport cannot widen the tool set. Denial uses the application typed result, creates
+no player/effects and is redacted/audited without disclosing unavailable sequence or
+world details.
+
 - MCP transport does not accept anonymous remote connections in production.
 - The SSE transport requires authentication when exposed beyond localhost.
 - Tool arguments are validated against JSON Schema before execution.

--- a/docs/architecture/runtime/cinematic-sequencer-architecture.md
+++ b/docs/architecture/runtime/cinematic-sequencer-architecture.md
@@ -24,6 +24,9 @@ failure outcomes and the AudioFrontend handoff governed by AUD-family decisions.
 [ADR-121](../../adr/121-cinematic-editor-document-and-authoring-context.md)
 defines persistent sequence documents/tabs, command and persistence ownership,
 detachable scene authoring context, stale-reference inspection and preview isolation.
+[ADR-122](../../adr/122-cinematic-trigger-sources-and-capability-policy.md)
+defines the common typed start request and capability/trust/authority/product-profile
+policy for gameplay, scene autoplay, event, editor, MCP and remote trigger sources.
 [ADR-068](../../adr/068-music-transport-and-cross-system-ownership.md) owns the
 AudioTrack handoff: Sequencer retains sequence clock, directed event traversal,
 seek/scrub and preroll intent while Audio alone maps accepted requests to sample
@@ -68,6 +71,9 @@ time and schedules the callback.
 - **Document-owned authoring**: Sequence assets use persistent document tabs and the
   shared typed command/history/save/conflict model. Scene context and preview are
   detachable projections and never become a second source of authored truth.
+- **Capability-gated triggers**: Every source submits the same typed application start
+  request. Authored Shipping triggers remain product behavior; debug/MCP/remote start
+  adapters are omitted from Retail Shipping and cannot be enabled by runtime flags.
 
 ## System Boundaries and Target Topology
 
@@ -129,6 +135,34 @@ Root activation IDs come from stable scene object/playback-slot identity, a reco
 gameplay command/event occurrence or a recorded application operation identity.
 Allocation order, pointers, thread arrival, worker completion, unordered-map order and
 process-random hash seeds are never player identity or tie-breakers.
+
+## Trigger Sources And Admission
+
+Gameplay scripts/native behaviors, scene-load autoplay descriptors, committed
+gameplay events, editor UI/preview, MCP/agent tools, local debug/CLI and authenticated
+remote/server adapters all submit one bounded `SequenceStartRequest` through an
+injected `ICinematicPlaybackCapability`. No caller constructs a player or discovers a
+global service. Admission validates source/principal, build profile, project/package
+trust, capability grant, session/scene/world authority, cooked asset revision, full
+effect capability plan and shared budgets before acquiring any player/domain state.
+
+Gameplay and cooked scene/event triggers are ordinary product behavior and may ship
+when their modules/assets and effect plans are admitted. Scene autoplay begins only
+after successful aggregate scene activation. Event-triggered starts occur after the
+source occurrence commits and use occurrence-derived stable activation identity;
+cycles/nesting share ADR-117 capacity. Client requests cannot gain server authority.
+
+Editor preview is isolated; PIE uses PIE world authority. MCP/agent/debug/remote
+adapters reuse their existing tool schema, project trust, permission, product-profile,
+server-authority, revision-bound approval and audit infrastructure. Authentication or
+localhost is not authorization. Retail Shipping omits these tooling start descriptors;
+a runtime flag cannot restore them. Dedicated Server admits only explicitly registered,
+authenticated `Restricted`, server-authoritative and headless-compatible operations.
+
+Denial creates no player, cursor, lease/token or downstream Audio/VFX/event request.
+Stable results distinguish unsupported source/adapter, product-profile/trust/
+capability/approval/world denial, unavailable asset, effect denial, conflict, capacity
+and headless incompatibility. ADR-122 owns the complete source matrix and lifecycle.
 
 ## Sequencer Data Model
 
@@ -906,6 +940,9 @@ These are required implementation acceptance tests, not tests added by this ADR:
 - Sequence editor tests cover atomic create/focus/close, shared command/history/dirty/
   save/recovery/conflict behavior, no/wrong/replaced scene contexts, derived stale
   binding states, explicit repair, cross-document atomicity and disposable preview.
+- Trigger tests cover every gameplay/scene/event/editor/MCP/debug/remote source across
+  product profiles, trust/capability/approval/world authority, Shipping descriptor
+  absence, server headless policy, revocation and zero-side-effect typed denial.
 
 ## Related Documents
 
@@ -915,6 +952,7 @@ These are required implementation acceptance tests, not tests added by this ADR:
 - [ADR-119: Camera Authority During Cinematics](../../adr/119-camera-authority-during-cinematics.md)
 - [ADR-120: Cinematic Event Dispatch and Audio Coupling Boundary](../../adr/120-cinematic-event-dispatch-and-audio-coupling-boundary.md)
 - [ADR-121: Cinematic Editor Document and Authoring Context](../../adr/121-cinematic-editor-document-and-authoring-context.md)
+- [ADR-122: Cinematic Trigger Sources and Capability Policy](../../adr/122-cinematic-trigger-sources-and-capability-policy.md)
 - [Cinematic Sequencer UI Reference](./cinematic-sequencer.html)
 - [Scene Runtime Architecture](./scene-runtime.md)
 - [Animation Architecture](./animation-architecture.md)

--- a/docs/architecture/runtime/runtime-lifecycle.md
+++ b/docs/architecture/runtime/runtime-lifecycle.md
@@ -205,6 +205,15 @@ Handlers cannot reenter the active sequence batch or imply same-tick mutation.
 AudioTrack bundles follow ADR-062's existing Audio control/callback publication
 boundaries and ADR-068 sample correlation; render interpolation never emits them.
 
+[ADR-122](../../adr/122-cinematic-trigger-sources-and-capability-policy.md) adds no
+phase and no direct player-construction path. Every gameplay, scene-autoplay, event or
+tooling source enqueues the same typed start request. Owner commands validate the
+complete principal/profile/trust/capability/approval/session/world/effect plan before
+the next eligible Cinematic batch; denial publishes no player or domain side effect.
+Scene autoplay becomes eligible only after aggregate scene activation, and gameplay-
+event starts only after their source occurrence commits. Late approval/preparation
+results join a later boundary only when every request generation remains current.
+
 [ADR-078](../../adr/078-runtime-ui-input-context-and-player-routing.md) also adds no
 phase. `BuildInputSnapshot` publishes device/action/assignment evidence; Runtime UI
 VariableUpdate applies one ordered context stack against the last presented


### PR DESCRIPTION
## Summary

- Adds ADR-122 to enumerate gameplay script/native behavior, scene-load autoplay, gameplay-event, editor preview/PIE, MCP/agent, local debug/CLI, and authenticated remote/server cinematic trigger sources.
- Requires every source to submit the same typed `SequenceStartRequest` through a narrow application `ICinematicPlaybackCapability`; no caller constructs a player or discovers a global runtime service.
- Separates build availability from runtime authorization and defines the exact packaged-profile policy for each source.
- Reuses existing gameplay capability, project/package trust, MCP schema/session, editor approval, ADR-018 permission/availability/threading, server-authority, and audit infrastructure.
- Defines zero-side-effect typed denial, source-scoped player ownership/control, generation-fenced revocation/cancellation, and qualification across profiles.
- Projects the decision into Cinematic Sequencer, Gameplay Module Boundary, MCP Architecture, Runtime Lifecycle, and architecture/ADR indexes.

## Why

ADR-117 establishes service-owned sequence players but previously left caller admission underspecified. A trigger can indirectly request camera/Character/gameplay authority, pause, events, or Audio/VFX work, so mere access to an asset ID, component, MCP connection, or runtime service cannot be treated as authority.

The project already has capability, trust, permission, product-profile, remote authentication, operation approval, and audit contracts. Creating a cinematic-specific approval store would duplicate them and allow project content to grant its own trust. This decision makes Cinematic a consumer of those systems and ensures Retail Shipping retains authored product playback without carrying debug/MCP/remote backdoors.

## Decision and boundaries

- Admission validates source/principal, build profile, project/package trust, exact capability grant, session/scene/world authority, cooked asset revision, complete effect plan, and budgets before acquiring player/domain state.
- Capabilities are narrow: start, stop-own, control-any, preview, plus effect-specific grants. Start does not imply pause, server mutation, remote admin, or control of another principal's player.
- Gameplay scripts/native modules may ship with product content when explicitly granted and scoped to their runtime/world authority. Clients cannot acquire server-owned effects.
- Scene autoplay is cooked authored behavior admitted after successful aggregate scene activation; it is not blanket approval for unavailable effects.
- Gameplay-event triggers become eligible only after the source occurrence commits and use occurrence-derived stable activation identity. Recursion/nesting share the existing player budgets.
- Editor preview is isolated; PIE retains PIE world authority.
- MCP/agent mutations retain existing authenticated/scoped tool admission and visible revision-bound approval. Authentication, localhost, project trust, or model intent alone is not authorization.
- Debug/CLI/remote adapters use ADR-018 descriptors, permission/availability, owner-thread dispatch, server-authority checks, and audit/redaction.
- Retail Shipping includes cooked scene/gameplay/product-UI triggers but omits MCP, agent, cinematic debug-start, and remote-start descriptors/handlers. Runtime flags cannot re-enable absent code.
- Dedicated Server permits only explicitly registered, authenticated `Restricted`, server-authoritative, audited, headless-compatible operations.
- Denials distinguish unsupported source/adapter, profile/trust/capability/approval/world/effect/asset/capacity/headless boundaries and create no player, token/lease, event, or Audio/VFX work.
- Implementation remains deferred to CIN-006 delivery tickets; this PR defines the policy and evidence contract.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Markdown lint passed for every changed document.
- [x] Added Markdown links resolve locally.
- [x] Staged diff whitespace validation passed.
- [x] CMake configuration passed with public-header inventory and dependency-direction checks.
- [ ] Runtime authorization/profile tests were not run because this PR changes architecture documentation only.
- [ ] Manual tooling/packaged-player testing is not applicable to this documentation-only decision.

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/122-cinematic-trigger-sources-and-capability-policy.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/cinematic-sequencer-architecture.md docs/architecture/extensions/gameplay-module-boundary.md docs/architecture/interfaces/mcp-architecture.md docs/architecture/runtime/runtime-lifecycle.md
git diff --check
git diff --cached --check
# Staged-added-link validation script (Ruby) over git diff --cached
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

CMake completed successfully with the existing mbedTLS minimum-CMake deprecation warning. Pytest is unavailable, so repository Python tests were skipped.

## Risk and rollout

- The source/profile matrix is product-visible security policy. Downstream descriptors and build manifests must prove Shipping absence rather than rely on runtime booleans.
- `control-any` is intentionally separate from start/stop-own; collapsing them would allow one principal to control another's sequence.
- Scene autoplay is allowed in Shipping but still requires complete effect admission. Implementation must not mistake cooked content for owner authority.
- Dedicated Server remote playback is deliberately narrow and requires both existing Restricted authentication and target-world/server authority.
- Approval is request/revision-bound and host-owned. Storing it in project or sequence content would violate the decision.
- Current runtime/tooling code must not be represented as already satisfying this future contract until focused implementation and profile qualification land.

## Issue links

- Jira: [HORO-1662](https://horo-engine.atlassian.net/browse/HORO-1662)
- GitHub: Closes #1703

## Reviewer Notes

Suggested review order:

1. ADR-122 sections 1–2 for the common request and full source matrix.
2. Sections 3–6 for autoplay, gameplay authority, tooling approval reuse, and build-profile separation.
3. Sections 7–10 for denial atomicity, source ownership, audit, and qualification.
4. Cinematic Sequencer and Gameplay Module Boundary projections.
5. MCP Architecture, Runtime Lifecycle, and indexes.

Key review questions:

- Does every requested trigger source have a precise capability, authority, and packaged-build policy?
- Is authored Shipping playback clearly separated from debug/MCP/remote tooling?
- Does the policy reuse existing trust/approval/permission machinery without creating cinematic-specific authority?
- Are denial and revocation guaranteed to leave zero partial player/domain effects?
- Are client/server and editor-preview/PIE boundaries sufficiently explicit?

This PR is stacked on `docs/HORO-1661_cinematic_editor_document`; review only commit `b46e6d2` for the HORO-1662 delta.


[HORO-1662]: https://horo-engine.atlassian.net/browse/HORO-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ