### PR TITLE
docs(vfx): define CPU simulation stage contract HORO-1707 #1750 [VFX-002.1]

### DIFF
--- a/docs/adr/123-vfx-cpu-stage-order-determinism-and-gameplay-coupling.md
+++ b/docs/adr/123-vfx-cpu-stage-order-determinism-and-gameplay-coupling.md
@@ -1,0 +1,311 @@
+# ADR-123: VFX CPU Stage Order, Determinism and Gameplay Coupling
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Gameplay-coupled CPU particle step stages, stage authority/access, deterministic particle identity and random streams, parallel scheduling/reductions, typed gameplay payloads, commit/failure semantics and CPU/GPU equivalence baseline
+- **Issue**: [VFX-002.1](https://github.com/abdullahbodur/horo-engine/issues/1750)
+- **Jira**: [HORO-1707](https://horo-engine.atlassian.net/browse/HORO-1707)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-011](011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md), [ADR-022](022-ai-fixed-tick-order-authority-and-simulation-budget.md), [ADR-026](026-large-world-precision-and-floating-origin-strategy.md), [ADR-088](088-physics-determinism-capability-and-support-tiers.md)
+- **Normative documents**: [VFX and Particles Architecture](../architecture/runtime/vfx-and-particles-architecture.md), [Runtime Lifecycle](../architecture/runtime/runtime-lifecycle.md), [Gameplay Module Boundary](../architecture/extensions/gameplay-module-boundary.md)
+
+## Context
+
+ADR-011 assigns logical VFX/CPU state to scene-owned `VfxWorld`, requires real CPU
+simulation for gameplay-coupled/headless emitters and forbids authoritative GPU
+readback. It establishes fixed versus presentation clock domains, bounded queue
+admission and immutable extraction, but not the exact CPU kernel order or which stage
+may read/write each attribute.
+
+The current VFX graph groups spawn, update and output contexts. Independent compiler
+or runtime implementations could therefore integrate before applying forces, kill
+before collision events, compact in worker-completion order or extract a partially
+failed step. A mutable emitter-wide random generator would also make results depend
+on job partitioning, branch/call count and particle death/reuse.
+
+Gameplay coupling needs a narrower boundary than mutable custom particle storage.
+Allowing gameplay code to inspect or write the CPU SoA during a step would violate
+VfxWorld ownership, make parallel scheduling unsafe and give headless/GPU paths
+different authority. This ADR fixes the CPU baseline used by gameplay and future
+CPU/GPU equivalence qualification.
+
+## Decision
+
+### 1. One attempted CPU step has seven ordered stages
+
+Every gameplay-coupled CPU emitter executes exactly this logical order for one
+admitted fixed tick:
+
+```text
+Spawn -> Initialize -> Forces -> Integrate -> Collide -> Kill -> Extract
+```
+
+`Extract` follows successful simulation commit and is read-only; it is included in
+the pipeline order but is not a mutable particle stage. Cosmetic CPU emitters use the
+same stage semantics in their selected presentation clock. One emitter unit is never
+advanced on both clocks, and render view count never repeats a stage.
+
+The compiled kernel plan declares stage reads/writes, required inputs, bounded output
+counts and scratch. Cook validates every dependency before publication. Runtime may
+fuse adjacent kernels or vectorize/parallelize ranges only when the observable result
+is identical to this stage barrier order under the asset's qualified numeric contract.
+
+### 2. Stage authority and access are fixed
+
+| Stage | Final owner and permitted mutation | Inputs | Published/staged output |
+|---|---|---|---|
+| `Spawn` | `VfxWorld` queue/admission and emitter allocator | Frozen accepted request prefix, rate/burst state, committed emitter age/tick, capacity | Deterministic birth count, monotonic spawn ordinals and reserved inactive slots; no partially live particles |
+| `Initialize` | `CpuParticleSimulator` compiled initialization kernels | Emitter descriptor, typed parameter snapshot, spawn ordinal/particle ID, transform/origin snapshot, semantic RNG channels | Every required attribute for each new particle initialized exactly once and marked live in staging |
+| `Forces` | `CpuParticleSimulator` force kernels | Previous committed/new initialized attributes, immutable field/input snapshots, fixed delta | Staged acceleration/velocity contributions only; no position, collision, death or gameplay publication |
+| `Integrate` | `CpuParticleSimulator` integration kernel | Initialized attributes plus completed force result and fixed delta | Staged velocity, position, age, rotation/size/curve state; no environment query |
+| `Collide` | `CpuParticleSimulator` with injected immutable query adapter | Integrated candidate, captured Physics/scene query snapshot and origin epoch | Deterministically ordered collision facts and staged response state; no Physics/ECS mutation |
+| `Kill` | `CpuParticleSimulator` lifecycle/compaction owner | Post-collision state, age/lifetime, explicit kill flags and admitted capacity | Stable survivor set, death/collision/sub-emitter occurrences and canonical packed order |
+| `Extract` | `VfxRenderExtractor` | Successfully committed post-kill state and matching scene/step/origin generation | Immutable frame-owned render data and typed committed gameplay event/aggregate snapshots; no SoA mutation |
+
+Requests or sub-emitter births produced during Initialize/Collide/Kill enter the
+appropriate bounded queue for the next eligible tick; they never reenter `Spawn` in
+the active step. Audio/VFX/gameplay outputs are occurrence records staged until
+commit, not callbacks from a particle kernel.
+
+### 3. The whole simulation portion commits atomically
+
+Spawn through Kill operate on an exclusive candidate/staging generation. The
+previous committed generation remains readable until every required stage succeeds.
+At tick commit, VfxWorld atomically publishes the new particle generation, emitter
+cursors/spawn ordinal, RNG evidence, survivor order and external occurrence batch.
+`Extract` reads only that committed generation.
+
+If an attempted fixed tick fails/cancels, no new live particle, cursor/age, position,
+collision/death occurrence, gameplay result or extracted generation becomes visible.
+The host follows its normal failed-tick policy; VFX does not advance independently or
+retry with a larger delta. A cosmetic presentation emitter may apply only an authored
+drop/hold/reset policy, with a typed diagnostic; it cannot partially publish stages.
+
+Capacity and required scratch are admitted before the step. A required gameplay
+emitter cannot drop births, collisions or outputs mid-step. Insufficient capacity is
+`VfxStepCapacityExceeded` and preserves the previous committed generation.
+
+### 4. Stable particle identity is independent of storage
+
+Each admitted emitter activation has stable asset/emitter/activation identity and a
+monotonic 64-bit spawn ordinal. A `ParticleSimulationId` is derived from those stable
+identities plus the ordinal; it is not a SoA index, pointer, freelist slot, thread ID
+or renderer instance. Killed slots may be reused only after retirement, but reuse
+never reuses particle identity or RNG sequence. Checked ordinal exhaustion terminates
+the emitter with a typed failure rather than wrapping.
+
+Simulation iteration and final compaction use ascending `ParticleSimulationId` unless
+a compiled stage declares another stable semantic key with particle ID as final
+tie-break. Worker partition, SIMD width, slot allocation, unordered containers and
+completion order cannot change identity or survivor/event ordering.
+
+### 5. Randomness uses versioned counter-based per-particle streams
+
+The baseline is not one mutable per-emitter PRNG. Cook assigns stable semantic
+`VfxRngChannelId` values to every stochastic property/node. `VfxRngV1` is a specified
+counter-based integer generator whose input tuple is:
+
+```text
+project/effect seed
++ effect asset and compiled emitter identity
++ stable activation identity
++ ParticleSimulationId (or emitter step/spawn lane before identity exists)
++ RngChannelId
++ sample ordinal
++ algorithm version
+```
+
+The tuple produces the same unsigned integer bits across supported CPU platforms,
+builds, runs, job counts and SIMD widths. Uniform integer/range mapping and integer-
+to-`[0,1)` float conversion are specified by the cooked runtime version; they do not
+use standard-library distributions, platform entropy, wall time, pointers or native
+floating random functions.
+
+Each property requests a semantic channel/sample ordinal, so adding a random sample
+to an unrelated node does not shift existing streams. Repeated samples within one
+node use increasing local sample ordinals. Emitter-level spawn decisions use a
+separate counter tuple keyed by activation, committed step, trigger/request identity,
+channel and sample ordinal; they cannot consume particle streams.
+
+The cooked effect records RNG algorithm/version, channel map, project/effect seed
+policy and determinism fingerprint. Changing any of them is a compatibility change
+requiring recook/migration. Save/replay stores stable activation, committed step,
+spawn ordinal and semantic state; it never serializes a mutable engine PRNG object.
+
+### 6. Determinism guarantees are qualified precisely
+
+With identical cooked effect digest, RNG version/channel map, stable activation,
+ordered inputs, committed fixed ticks/deltas, query snapshots, numeric mode and
+capacity policy:
+
+- particle IDs, RNG integer outputs, stage/event order, births, deaths and typed
+  control decisions are exact across supported CPU platforms and runs;
+- integer and explicitly quantized payload fields are exact;
+- floating particle attributes and collision math are bit-exact only within a
+  separately qualified deterministic-math/Physics fingerprint; otherwise supported
+  platform fingerprints compare using declared absolute/relative/ULP tolerances; and
+- wall time, render cadence, view count and worker completion never affect results.
+
+This is the CPU reference contract for future CPU/GPU equivalence. GPU kernels must
+match identity, RNG integer/channel mapping, stage barriers and observable event/
+aggregate outputs exactly where the asset claims equivalence; float attributes use
+the declared tolerance/fingerprint tier. A visual-only GPU effect may declare no
+authoritative equivalence, but it cannot feed gameplay.
+
+### 7. Parallel execution preserves semantic order
+
+Jobs receive disjoint candidate slices and immutable snapshots. They cannot append to
+a shared variable-order event list, allocate identities, mutate live VfxWorld/ECS or
+call Physics/gameplay. Spawn IDs and output slots are preassigned in semantic order.
+Each job writes its fixed range and bounded local occurrence slots.
+
+Stage barriers join through the host scheduler before the next stage consumes data.
+Reductions use a compiler-declared stable tree/range order and specified accumulator/
+numeric policy. Collision candidates are normalized by particle ID, stable collider/
+shape identity and feature index before response selection. Equal-time/equal-distance
+ties never use native query or worker return order.
+
+Required job failure cancels the remaining candidate work and fails the step. The
+owner never publishes completed partitions while another partition failed or timed
+out. There is no nested wait from a worker or unbounded fallback to serial replay.
+
+### 8. Gameplay input is typed, bounded and pre-step
+
+Gameplay submits effect spawn/parameter commands through `VfxEventQueue` and declared
+VFX parameter capabilities. At the tick cutoff VfxWorld copies admitted values into
+an immutable `VfxGameplayInputSnapshot` keyed by request/emitter/schema revision.
+Only compiled channels marked `GameplayInput` are writable by gameplay, with typed
+range/size/update-frequency and owner-phase validation.
+
+Gameplay cannot receive mutable particle spans, SoA indices or stage callbacks. It
+cannot set position/velocity/lifetime/custom flags during a step, inject arbitrary
+force/collision code, choose job partitions or call Spawn/Initialize/Forces/
+Integrate/Collide/Kill/Extract. A desired behavior must be a registered compiled node
+or typed parameter consumed at its declared stage.
+
+Late commands become eligible next tick. Stale scene/emitter/schema generations,
+wrong authority, invalid/nonfinite values and capacity failure return typed results
+without altering the active input snapshot.
+
+### 9. Gameplay output is post-commit and schema-limited
+
+Custom payload channels are classified at cook:
+
+| Class | Visibility and authority |
+|---|---|
+| `SimulationInternal` | Private CPU candidate/committed state; VFX kernels only |
+| `RenderOnly` | Copied to immutable extraction for materials/sort/render; never gameplay input/output |
+| `GameplayInput` | Immutable typed tick snapshot from admitted gameplay commands; read only by declared stages |
+| `GameplayOutput` | Bounded typed collision/death/threshold/aggregate occurrence produced by CPU simulation and published only after commit |
+
+GameplayOutput descriptors define schema/version, maximum occurrences per emitter/
+tick, source stage, stable order, target owner boundary and required/cosmetic policy.
+They expose semantic values such as particle/event identity, stable hit target,
+quantized/qualified position/normal and authored payload fields—not arbitrary SoA,
+renderer data, pointers or native Physics handles.
+
+After commit, an application adapter drains the immutable batch at the gameplay
+owner's next safe point. Delivery cannot reenter the current VFX step or retroactively
+change it. Required output capacity is reserved at activation/step preflight;
+overflow fails the candidate rather than dropping gameplay events. GPU readback,
+RenderOnly channels, extraction and Null simulation never produce authoritative
+GameplayOutput.
+
+Gameplay may query only declared immutable effect-level aggregate snapshots from the
+last committed generation. Per-particle queries are not baseline gameplay API; a
+feature requiring them must define bounded snapshot/query capability and CPU-
+mandatory cost explicitly.
+
+### 10. Contract violations fail at the earliest boundary
+
+Cook rejects stage cycles/backward dependencies, undeclared attribute access,
+uninitialized reads, multiple conflicting writers, gameplay access to private/render
+channels, GPU authoritative output, unbounded occurrences, unknown RNG channels and
+missing CPU kernels. The invalid effect is not published.
+
+Runtime admission rejects incompatible schema/capability/domain/determinism/budget
+with no instance or partial reservation. A gameplay module request against a private,
+wrong-stage, stale or unauthorized channel returns `VfxGameplayAccessDenied`,
+`VfxPayloadSchemaMismatch`, `StaleVfxGeneration` or `VfxStageContractViolation` and
+has zero effect. Public capabilities do not expose unsafe memory APIs, so native and
+script modules follow the same enforcement path.
+
+An internal compiled-kernel violation detected during execution contains the fault,
+discards the candidate and reports effect/emitter/stage/kernel/generation identity.
+Development builds may assert after recording the typed fault; Shipping returns the
+declared required/cosmetic failure policy without continuing corrupt state. It never
+silently skips the node, reorders stages, clamps required gameplay output or exposes a
+half-updated buffer.
+
+### 11. Qualification proves order, RNG and isolation
+
+Required implementation evidence includes:
+
+- stage sentinels proving Spawn -> Initialize -> Forces -> Integrate -> Collide ->
+  Kill -> commit -> Extract and no same-tick reentrant sub-emitter/event spawn;
+- failure/cancel/capacity injection at every stage with unchanged previous generation,
+  no extracted candidate and no gameplay/Audio/VFX occurrence leakage;
+- stable particle identity across slot reuse, deaths, compaction, SIMD widths, worker
+  counts, allocation patterns and randomized completion order;
+- golden `VfxRngV1` integer/range/float-conversion vectors on every supported CPU,
+  independent semantic channels and recook/migration on version/channel changes;
+- identical recorded tick/input/query histories across 30/60/144 Hz presentation,
+  graphical/headless and supported CPU platforms with exact/tolerant fields matched
+  to the declared fingerprint;
+- stable parallel reductions/collision ties and contained worker failure;
+- every payload class, valid/invalid/stale gameplay input, bounded required/cosmetic
+  output, next-owner-boundary delivery and no mutable/per-particle private access;
+- cook/runtime rejection for every stage/schema/domain/RNG violation with zero partial
+  publication; and
+- CPU/GPU reference fixtures proving claimed identity/RNG/stage/event equivalence while
+  GPU/Null/RenderOnly paths cannot drive authoritative gameplay.
+
+## Consequences
+
+### Positive
+
+- CPU VFX has one testable stage order and one owner for every mutation.
+- Counter-based per-particle randomness is independent of jobs, deaths and call order.
+- Gameplay coupling is typed and post-commit without exposing particle storage.
+- The CPU reference gives later GPU equivalence work precise exact/tolerant fields.
+
+### Costs
+
+- Compiled graphs need stage access metadata, semantic RNG channel IDs and bounded
+  payload schemas.
+- Atomic candidate state and deterministic parallel merge/reduction require admitted
+  scratch and may limit some aggressive in-place optimizations.
+- Gameplay-visible emitters must reserve worst-case output capacity and real CPU work.
+
+## Rejected Alternatives
+
+### Use one mutable PRNG per emitter
+
+Rejected because branching, deaths, job partitioning and unrelated node samples would
+shift all later values. Versioned counter-based semantic streams are order-independent.
+
+### Let graph topology choose arbitrary stage order
+
+Rejected because force/integration/collision/death meaning and gameplay output would
+differ across compilers. Graph dependencies must fit the fixed stage DAG.
+
+### Let gameplay read or mutate the CPU SoA
+
+Rejected because it creates two owners, defeats parallel/lifetime safety and cannot
+match GPU/headless policy. Gameplay uses typed snapshots and post-commit occurrences.
+
+### Publish completed worker partitions incrementally
+
+Rejected because a later failure would expose a half-step and completion order would
+change compaction/events. The candidate commits atomically.
+
+### Generate gameplay events from GPU readback
+
+Rejected by ADR-011 because asynchronous renderer/device timing cannot be the
+authoritative gameplay clock. Gameplay-output units are CPU-mandatory.
+
+### Promise bit-identical floating simulation on every platform
+
+Rejected until deterministic math and Physics fingerprints prove it. IDs, RNG bits,
+order and integer/quantized fields are exact; floats use declared qualification
+tolerances outside a bit-exact profile.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -134,6 +134,7 @@ to the replacement.
 | [120](120-cinematic-event-dispatch-and-audio-coupling-boundary.md) | Cinematic Event Dispatch and Audio Coupling Boundary | Proposed | 2026-09-02 |
 | [121](121-cinematic-editor-document-and-authoring-context.md) | Cinematic Editor Document and Authoring Context | Proposed | 2026-09-02 |
 | [122](122-cinematic-trigger-sources-and-capability-policy.md) | Cinematic Trigger Sources and Capability Policy | Proposed | 2026-09-02 |
+| [123](123-vfx-cpu-stage-order-determinism-and-gameplay-coupling.md) | VFX CPU Stage Order, Determinism and Gameplay Coupling | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -372,6 +372,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Cinematic Trigger Sources and Capability Policy](../adr/122-cinematic-trigger-sources-and-capability-policy.md):
   common typed start admission for gameplay, scene, event and tooling sources;
   capability/trust/authority checks, packaged-build gating and typed denials.
+- [VFX CPU Stage Order, Determinism and Gameplay Coupling](../adr/123-vfx-cpu-stage-order-determinism-and-gameplay-coupling.md):
+  ordered CPU particle stages, atomic commit, counter-based per-particle RNG,
+  qualified cross-platform reproduction and typed gameplay payload boundaries.
 - [Post-Processing And Effects Architecture](./runtime/post-processing-and-effects-architecture.md):
   screen-space effects, HDR post chain, tonemapping, color grading, and
   accessibility pass ordering.

--- a/docs/architecture/extensions/gameplay-module-boundary.md
+++ b/docs/architecture/extensions/gameplay-module-boundary.md
@@ -308,6 +308,22 @@ authority. Module/script unload and grant revocation close admission and generat
 fence late preparation/start results. Denial returns a typed result and creates no
 player, lease, event, Audio/VFX request or partial effect.
 
+### VFX Gameplay Payload Capability
+
+[ADR-123](../../adr/123-vfx-cpu-stage-order-determinism-and-gameplay-coupling.md)
+keeps CPU particle storage and stage execution inside `VfxWorld`. Gameplay modules and
+scripts can submit only declared schema/range-checked `GameplayInput` parameters before
+the VFX tick cutoff and consume bounded `GameplayOutput` occurrences or effect-level
+aggregate snapshots after VFX commit at their owner boundary. They never receive a
+mutable SoA span, particle slot/index, stage callback or arbitrary force/collision
+kernel hook.
+
+Private/render channel access, wrong-stage writes, stale scene/emitter/schema identity,
+nonfinite values and output-capacity failure return typed results with zero mutation.
+GPU readback and Null/visual output cannot drive authoritative gameplay. A behavior
+needing particle-derived gameplay declares a CPU-mandatory compiled unit and admits
+its worst-case work/output capacity.
+
 ## Services
 
 A game module may create project- or runtime-scoped services through explicit

--- a/docs/architecture/runtime/runtime-lifecycle.md
+++ b/docs/architecture/runtime/runtime-lifecycle.md
@@ -214,6 +214,15 @@ Scene autoplay becomes eligible only after aggregate scene activation, and gamep
 event starts only after their source occurrence commits. Late approval/preparation
 results join a later boundary only when every request generation remains current.
 
+[ADR-123](../../adr/123-vfx-cpu-stage-order-determinism-and-gameplay-coupling.md)
+specializes each gameplay-coupled VFX fixed step without adding a host phase. Within
+the VFX scheduler node, one candidate runs Spawn, Initialize, Forces, Integrate,
+Collide and Kill in order against the tick's immutable inputs/query snapshots. The
+candidate particle generation and bounded gameplay occurrences publish only with
+successful tick commit. RenderExtraction later reads the committed post-Kill state.
+Failure/cancel discards all stages, and gameplay consumes committed output at its next
+permitted owner boundary rather than reentering the source tick.
+
 [ADR-078](../../adr/078-runtime-ui-input-context-and-player-routing.md) also adds no
 phase. `BuildInputSnapshot` publishes device/action/assignment evidence; Runtime UI
 VariableUpdate applies one ordered context stack against the last presented

--- a/docs/architecture/runtime/vfx-and-particles-architecture.md
+++ b/docs/architecture/runtime/vfx-and-particles-architecture.md
@@ -8,6 +8,11 @@ extraction and renderer scheduling. [ADR-011](../../adr/011-vfx-effect-ownership
 records the proposed decision. These are implementation contracts, not claims that
 all paths or qualification tests already exist.
 
+[ADR-123](../../adr/123-vfx-cpu-stage-order-determinism-and-gameplay-coupling.md)
+specializes the gameplay-coupled CPU path: seven ordered stages, atomic candidate
+commit, stable particle identity, versioned counter-based randomness, deterministic
+parallel merge and schema-limited gameplay input/output.
+
 DCC workflows, full fluid solvers, atmospheric scattering and screen-space
 post-processing remain outside this subsystem; see
 [Advanced Rendering Architecture](./advanced-rendering-architecture.md).
@@ -63,9 +68,11 @@ the same request once for each emitter or clock.
    its declared clock update. Drain at most maxEventsPerTick accepted requests in
    FIFO order; requests produced during the drain/update become eligible next tick.
    No backend invokes a spawn completion inline from submission.
-2. Advance CPU state and logical decal/effect timers. CPU work may use Foundation
-   JobSystem/JobId over exclusive staging slices. Completion records are applied
-   on the declared owner phase, never by worker callbacks mutating live ECS.
+2. Advance CPU candidate state in the ADR-123 order `Spawn -> Initialize -> Forces ->
+   Integrate -> Collide -> Kill`, with a barrier between semantic stages. CPU work may
+   use Foundation JobSystem/JobId over exclusive preassigned staging slices. Completion
+   records are applied on the declared owner phase, never by worker callbacks mutating
+   live ECS. The whole candidate commits atomically or is discarded.
 3. GPU emitters produce bounded GpuVfxSimulationWork with scene/effect/emitter
    generation, step ID, delta/seed, parameters and typed input/output resource IDs.
    They do not encode GPU dispatches during VfxWorld::Update.
@@ -76,6 +83,64 @@ the same request once for each emitter or clock.
    bounded CPU data, and builds the graph: VFX Compute -> per-view Sort/Cull ->
    consuming depth/shadow/opaque/decal/volume/translucent passes. Backend encoding
    and native synchronization stay on the renderer's permitted execution roles.
+
+### CPU Stage Order And Atomic Commit
+
+Every gameplay-coupled CPU emitter uses this exact logical pipeline for one admitted
+fixed tick:
+
+```text
+Spawn -> Initialize -> Forces -> Integrate -> Collide -> Kill -> Extract
+```
+
+`VfxWorld` owns queue cutoff, capacity admission, deterministic birth count, monotonic
+spawn ordinal and slot reservation in Spawn. `CpuParticleSimulator` initializes every
+required new-particle attribute once; force kernels produce staged acceleration/
+velocity contributions; Integrate advances candidate motion/age; Collide consumes an
+immutable generation-matched Physics/scene query snapshot; and Kill selects survivors,
+stable compaction and bounded death/collision/sub-emitter occurrences. Requests born
+during a stage enter next tick's queue. No stage invokes gameplay, Audio or another
+emitter reentrantly.
+
+Spawn through Kill mutate one exclusive candidate generation. VfxWorld publishes
+particle state, emitter cursor/spawn ordinal and occurrence batches together only when
+the source tick commits. Failure/cancellation/capacity exhaustion preserves the prior
+generation and publishes no partial state/effect. `VfxRenderExtractor` then reads the
+committed post-Kill generation into immutable frame-owned data; it never mutates the
+SoA or repairs a failed stage. Kernel fusion/vectorization is allowed only when it is
+observably equivalent to these barriers.
+
+Cooked kernels declare stage reads/writes, required snapshots, scratch and bounded
+outputs. Cook rejects backward/cyclic dependencies, uninitialized reads, conflicting
+writers, private/render payload access from gameplay, GPU authoritative output and
+unbounded occurrences. Runtime violations discard the candidate and return a typed
+stage/schema/access result; Shipping never continues a half-updated buffer.
+
+### Stable Identity, RNG And Parallel Reproduction
+
+`ParticleSimulationId` derives from effect/emitter/activation identity and a checked
+monotonic spawn ordinal, not from a SoA/freelist slot, pointer or worker. Slot reuse
+never reuses identity. Iteration, compaction and occurrence merge use stable particle
+identity (or a declared semantic key with particle identity as final tie-break).
+
+Randomness uses versioned counter-based `VfxRngV1` per-particle semantic streams.
+Cook assigns each stochastic property/node a stable `VfxRngChannelId`; samples derive
+from project/effect seed, effect/emitter/activation and particle identity, channel,
+sample ordinal and algorithm version. Emitter spawn decisions use a separate tuple
+keyed by activation, committed step, request/trigger and channel. There is no mutable
+shared emitter PRNG, platform entropy, wall time or standard-library distribution.
+
+RNG integer/range mapping and integer-to-`[0,1)` conversion have golden cross-platform
+vectors. IDs, RNG bits, stage/event order, births/deaths and integer/quantized fields
+are exact across supported CPU runs with identical cooked digest and ordered inputs.
+Floating simulation/collision attributes are bit-exact only for a separately qualified
+deterministic-math/Physics fingerprint; otherwise they use declared numeric tolerances.
+This exact/tolerant split is the reference for later CPU/GPU equivalence claims.
+
+Parallel jobs receive disjoint preassigned candidate/output ranges. Stable barriers,
+merge slots, reduction trees and particle/collider/feature tie-breaks make job count,
+SIMD width, allocation and completion order irrelevant. One failed partition fails the
+whole candidate; completed ranges never publish incrementally.
 
 [ADR-010](../../adr/010-job-waiting-and-operation-store-ownership.md) governs jobs,
 operation tracking and allowed teardown drains. No ordinary owner/render/transport
@@ -467,6 +532,10 @@ struct CpuParticleBufferSoA {
 };
 ```
 
+The SoA is never a gameplay capability. `customFlags` and additional compiled channels
+remain private unless their schema class explicitly projects a bounded immutable value
+through the gameplay seam below.
+
 ### GPU Compute Simulation Layout
 
 The renderer owns GPU device buffers and runs the cooked kernels in declared graph
@@ -566,6 +635,29 @@ struct VfxSpawnRequest {
 };
 ```
 
+### Gameplay Payload Boundary
+
+Cook classifies every custom channel as `SimulationInternal`, `RenderOnly`,
+`GameplayInput` or `GameplayOutput`. Gameplay writes only declared typed/ranged
+GameplayInput parameters through bounded VFX commands before the tick cutoff;
+VfxWorld copies them into an immutable generation/schema-keyed input snapshot. Late,
+stale, nonfinite, unauthorized or private-channel writes return typed failure and do
+not alter the active step.
+
+GameplayOutput is available only from committed real CPU simulation. Its schema fixes
+source stage, maximum occurrences, stable order, target owner boundary and required/
+cosmetic policy. It exposes semantic IDs and bounded authored hit/position/normal/
+payload values, never mutable spans, SoA indices, render fields, pointers or native
+Physics handles. The application adapter drains it at the gameplay owner's next safe
+point; delivery cannot reenter or rewrite the source step. Required output capacity is
+reserved before stepping, so overflow fails the candidate instead of dropping events.
+
+Gameplay may read only declared last-committed effect-level aggregate snapshots.
+Per-particle queries are not baseline API. GPU readback, RenderOnly fields, extraction
+and Null cannot produce authoritative GameplayOutput. Invalid stage/private/schema
+access returns `VfxGameplayAccessDenied`, `VfxPayloadSchemaMismatch`,
+`StaleVfxGeneration` or `VfxStageContractViolation` with zero mutation.
+
 ### Audio Routing
 
 VFX graphs trigger audio events on spawn, collision, or sub-emitter creation. Audio
@@ -622,6 +714,14 @@ architecture-only change:
 - Run gameplay CPU kernels with identical seed/tick inputs in graphical and headless
   hosts; verify Null's accepted FIFO, next-tick results, pause/cancel/lifetime timing.
   Fake delayed submission/fences rather than assuming Null matches device latency.
+- Record every ADR-123 stage boundary and verify exact stage order, no reentrant
+  spawn/output delivery, atomic rollback on a stage failure and read-only extraction.
+- Reproduce identical RNG words, particle identities, collision tie-breaks and stable
+  merge order across repeated runs, worker counts and supported CPU platforms. Treat
+  float-state equivalence as exact only under the same deterministic-math fingerprint.
+- Attempt undeclared gameplay fields, private SoA access, render-only reads, schema
+  mismatches and authoritative GPU/Null output; require typed rejection with no
+  partial state mutation or gameplay publication.
 - Fill instance/particle/event/result/frame pools. Verify incoming rejection, gameplay
   reserve, stable ordering, no old-entry overwrite, cleanup progress and zero hot-path
   heap growth, including bounded typed parameter copying and diagnostics.
@@ -642,6 +742,8 @@ architecture-only change:
 
 - [ADR-011: Effect Ownership, Simulation Domain Policy and Renderer Boundary](../../adr/011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md):
   Proposed ownership, simulation and renderer-boundary decision.
+- [ADR-123: VFX CPU Stage Order, Determinism and Gameplay Coupling](../../adr/123-vfx-cpu-stage-order-determinism-and-gameplay-coupling.md):
+  Normative CPU stage, RNG, payload and gameplay publication contract.
 - [Particle Editor UI Reference](./particle-editor.html): Emitter stack, curve editing,
   and live preview panel.
 - [Material And Shader Model](./material-and-shader-model.md): Particle and decal materials.


### PR DESCRIPTION
## Summary

- Adds ADR-123 to define the authoritative CPU VFX pipeline as `Spawn -> Initialize -> Forces -> Integrate -> Collide -> Kill -> Extract`.
- Assigns mutation and publication authority to each stage, makes Spawn-through-Kill an atomic candidate commit, and keeps extraction read-only.
- Defines stable particle identity, versioned counter-based semantic RNG streams, deterministic parallel partition/merge rules, and the exact-versus-tolerant CPU reproduction contract.
- Restricts gameplay coupling to typed, bounded pre-step inputs and post-commit outputs; private SoA state, render-only fields, GPU readback, and Null output cannot become authoritative gameplay data.
- Projects the decision into the VFX architecture, runtime lifecycle, gameplay module boundary, and architecture/ADR indexes with explicit qualification scenarios.

## Why

ADR-011 established VFX ownership and required real CPU simulation for gameplay-coupled effects, but it did not fix the order of particle stages, define how random streams survive parallel execution, or specify which custom payloads gameplay may access. Without those constraints, implementations could integrate before forces, publish partial worker results, derive randomness from mutable emitter state, or expose particle storage directly to gameplay. Those choices would make repeated runs depend on scheduling and storage details and would undermine the CPU reference needed for later GPU-equivalence work.

ADR-123 closes that gap by defining one staged and atomic CPU contract whose observable identity, random values, ordering, and gameplay publication can be qualified across supported hosts.

## Decision and boundaries

- `VfxWorld` owns queue cutoff, birth admission, stable activation/spawn identity, candidate commit, and bounded occurrence publication.
- `CpuParticleSimulator` runs the declared stage plan against immutable tick/query snapshots; requests created during a stage become eligible on a later tick and never reenter the current Spawn stage.
- `ParticleSimulationId` is derived from stable effect/emitter/activation identity plus a checked spawn ordinal, never from a slot, pointer, worker, or renderer instance.
- `VfxRngV1` uses versioned counter-based tuples and stable semantic channel IDs. Integer RNG evidence and ordering are exact; floating simulation equivalence is bit-exact only under a qualified deterministic-math/Physics fingerprint and otherwise uses declared tolerances.
- Jobs receive disjoint preassigned ranges. Stable barriers, merge slots, reduction trees, and collision tie-breaks remove worker-count and completion-order authority.
- Cook classifies custom channels as `SimulationInternal`, `RenderOnly`, `GameplayInput`, or `GameplayOutput`. Required gameplay output capacity is reserved before stepping; overflow or a stage/schema violation discards the candidate with no partial publication.
- This is an architecture-only change; it defines implementation and regression obligations without claiming the runtime support already exists.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/123-vfx-cpu-stage-order-determinism-and-gameplay-coupling.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/vfx-and-particles-architecture.md docs/architecture/extensions/gameplay-module-boundary.md docs/architecture/runtime/runtime-lifecycle.md`
- `git diff --check`
- `git diff --cached --check`
- Added-Markdown-link resolution check over the staged diff
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. It reported the existing mbedTLS minimum-version deprecation warning and skipped repository Python tests because `pytest` is unavailable.

## Risk and rollout

- The contract intentionally constrains graph/compiler freedom: optimizations must remain observably equivalent to the fixed stage barriers and deterministic merge rules.
- Atomic candidate state and deterministic scratch/output reservation can increase memory requirements for gameplay-visible CPU emitters.
- Bit-identical floating-point behavior is not promised outside a separately qualified deterministic-math and Physics fingerprint; the ADR makes that limitation explicit to avoid an unprovable cross-platform guarantee.
- Runtime/compiler implementation and executable regression fixtures remain follow-up delivery work.

## Issue links

- Closes #1750
- Jira: [HORO-1707](https://horo-engine.atlassian.net/browse/HORO-1707)
- Domain ticket: `[VFX-002.1]`

## Reviewer Notes

- Review the stage ownership table and atomic commit boundary first; these define what may mutate and when state becomes observable.
- Check the RNG tuple, semantic channel stability, and exact-versus-tolerant determinism split against future CPU/GPU equivalence expectations.
- Check that gameplay access remains schema-limited and post-commit, with no path from private SoA state, GPU readback, RenderOnly data, or Null simulation into authoritative gameplay.
- This PR is preserved as an individual merge commit on `develop`; final review and non-squash delivery to `main` occur in PR #2508.


[HORO-1707]: https://horo-engine.atlassian.net/browse/HORO-1707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ