### PR TITLE
docs(vfx): define transparency sorting contract HORO-1709 #1752 [VFX-004.1]

### DIFF
--- a/docs/adr/125-vfx-transparency-sorting-and-pass-placement.md
+++ b/docs/adr/125-vfx-transparency-sorting-and-pass-placement.md
@@ -1,0 +1,313 @@
+# ADR-125: VFX Transparency, Sorting and Pass Placement
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Particle blend-class pass placement, semantic depth policy, CPU/GPU per-view sort ownership and algorithms, stable ordering, sort budgets, overload reporting and backend-neutral graph integration
+- **Issue**: [VFX-004.1](https://github.com/abdullahbodur/horo-engine/issues/1752)
+- **Jira**: [HORO-1709](https://horo-engine.atlassian.net/browse/HORO-1709)
+- **Related**: [ADR-011](011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md), [ADR-028](028-renderer-capability-limits-and-product-profiles.md), [ADR-036](036-raster-render-path-and-quality-architecture.md), [ADR-037](037-scene-color-and-hdr-architecture.md), [ADR-038](038-gpu-scene-and-instance-data-model.md), [ADR-124](124-vfx-gpu-simulation-readback-and-compute-fallback.md)
+- **Normative documents**: [VFX and Particles Architecture](../architecture/runtime/vfx-and-particles-architecture.md), [Rendering Architecture](../architecture/runtime/rendering-architecture.md), [Render Backend Parity Contract](../architecture/runtime/render-backend-parity-contract.md)
+
+## Context
+
+ADR-011 establishes immutable VFX extraction, renderer-owned graph construction and
+per-view sorting, while ADR-036 defines the production raster recipes and keeps
+baseline transparency forward shaded. The VFX architecture already names opaque,
+masked, translucent and additive particle classes, but several choices remain implicit:
+
+- whether every raster recipe maps a class to the same semantic pass/depth behavior;
+- where sorted translucent and additive VFX sit relative to one another;
+- which owner builds view keys and selects CPU radix versus GPU radix/bitonic work;
+- how CPU and GPU sorts produce stable equivalent ordering without mutating simulation;
+- what finite work/time budget applies across multiple views; and
+- what the renderer does when a sort cannot be admitted or misses its frame boundary.
+
+Leaving these choices to an effect, sequencer, shader or native backend would make
+visual ordering and performance profile-dependent in unreviewable ways. This ADR
+fixes semantic placement and a measurable initial budget while preserving the
+frontend/backend boundary. It is an architecture contract, not a performance claim
+that an implementation already meets the targets.
+
+## Decision
+
+### 1. The cooked output has one semantic particle class
+
+Each `VfxRenderBatch` declares exactly one `VfxParticlePass`: `Opaque`, `Masked`,
+`Translucent` or `Additive`. The class must agree with the cooked material blend
+contract and primitive topology. Combined alpha-test plus alpha/additive blending is
+not a fifth class; it requires a separately approved raster recipe or fails cook.
+
+The asset declares semantic shading, blend class, soft-particle need and shadow
+intent. It never stores a graph pass ID/name, attachment format, queue family, native
+blend/depth state, pipeline object, backend/API enum or sort-dispatch dimensions.
+Sequencer/gameplay may start or parameterize an effect but cannot rewrite its class,
+pass placement or sort policy per frame.
+
+### 2. Every class has one baseline pass and depth contract
+
+The frontend maps VFX semantics onto the active ADR-036 raster recipe:
+
+| VFX class | Semantic graph placement | Depth test | Depth write | Ordering |
+|---|---|---|---|---|
+| `Opaque` mesh | Recipe depth prepass when present, then GBuffer for compatible Deferred material or standard opaque forward pass | Enabled against the recipe's current depth convention | Enabled in the owning depth/color contract | Renderer opaque front-to-back batch policy; no VFX per-particle alpha sort |
+| `Masked` mesh | Matching alpha-test depth prepass when present, then compatible GBuffer or masked forward pass | Enabled using identical cooked coverage in depth/shadow/color | Enabled for passing samples | Renderer opaque front-to-back batch policy; no translucent sort |
+| `Translucent` billboard/ribbon/mesh | `VfxTranslucentForward` after opaque lighting and before baseline additive VFX | Enabled read-only; soft particles may sample the completed opaque depth | Disabled | Required stable back-to-front per view |
+| `Additive` billboard/ribbon/mesh | `VfxAdditiveForward` after baseline sorted translucent VFX in scene-linear color | Enabled read-only | Disabled | No distance sort; commutative within the additive band |
+
+Opaque/masked shadow casting uses the standard shadow pass and the same masked
+coverage where applicable. Translucent/additive particles and ribbons do not cast
+baseline raster shadows. Unsupported topology/material/shadow combinations require
+an authored substitute or typed failure, never a silently ignored flag.
+
+All VFX color work consumes and writes ADR-037 unexposed scene-linear ACEScg before
+the output transform. `Translucent` uses coverage/opacity alpha; `Additive` adds RGB
+with no coverage alpha. Neither class enters a Deferred GBuffer. Refraction, weighted
+blended/OIT, distortion and other non-baseline transparency are separate capability-
+validated recipes with explicit fallback; they are not aliases for these four rows.
+
+### 3. Pass dependencies are semantic and cycle-free
+
+The graph order relevant to particle batches is:
+
+```text
+VFX Compute once per logical GPU step
+    -> per-view VFX Cull/Key Build
+    -> required per-view VFX Sort
+    -> standard Shadow/Depth/Opaque work for opaque/masked VFX
+    -> opaque lighting / completed scene depth
+    -> VfxTranslucentForward
+    -> VfxAdditiveForward
+    -> later scene-color consumers and output transform
+```
+
+The actual recipe may interleave compatible opaque/masked VFX with ordinary scene
+work, but it preserves the semantic resources and dependencies above. A soft-particle
+draw reads completed opaque depth and never creates a dependency on depth written by
+that same translucent/additive pass. A previous-depth simulation collision input
+remains separate from current-frame draw depth.
+
+The frontend owns graph nodes, resources, pass merging and synchronization. Backends
+translate the compiled graph and cannot reorder translucent/additive bands, choose a
+different depth policy or silently fold a required sort away.
+
+### 4. Sorting is render-view work, never simulation state
+
+Simulation remains camera-independent except for separately declared cosmetic inputs.
+For each admitted `RenderViewId`, RenderFrontend culls and builds immutable render keys
+from the retained particle source, captured render origin and frozen view snapshot.
+No sort writes the CPU SoA, GPU simulation state, durable particle attributes or an
+effect's next-step input. Multiple views reuse the same simulation generation but own
+separate index/key outputs.
+
+The canonical back-to-front key is the tuple:
+
+```text
+finite canonical view-depth descending
++ stable VfxBatchId
++ stable ParticleSimulationId (or cooked stable GPU particle identity)
+```
+
+Depth encoding and comparison are versioned and shared by CPU/GPU fixtures. Nonfinite
+depth and stale view/source generations fail the batch. Equal depths use stable IDs,
+never source slot, atomic append order, worker completion or native subgroup order.
+Culling and clipping cannot change the relative order of surviving equal-key items.
+
+### 5. CPU particle sources use stable CPU radix sorting
+
+For a CPU `ParticleDataSource`, the frontend's CPU sort preparation owns key/index
+storage and schedules a stable radix sort over immutable packed frame data. VFX
+simulation and `VfxRenderExtractor` provide retained particle identity/position data;
+they do not receive a camera or reorder the SoA.
+
+Ranges, scratch and result slots are admitted before the frame. Jobs operate on
+disjoint ranges and publish only a complete generation at the frontend owner boundary.
+A worker does not mutate graph state or block on nested work. If the complete result
+is not ready by the consuming boundary, the affected translucent batch is omitted and
+reported; the frame does not wait and never submits the batch unsorted as success.
+
+Opaque/masked batches use the renderer's ordinary coarse front-to-back batch ordering.
+Additive VFX bypasses per-particle distance key generation and sort entirely. It does
+not consume a translucent sort-key reservation merely to preserve simulation order.
+
+### 6. GPU particle sources use an explicit stable compute sort plan
+
+For a GPU source, RenderFrontend emits backend-neutral `VfxGpuSortPlan` work after the
+producing simulation generation and key-build/cull work, before the translucent draw.
+The plan records stable key layout, item count/capacity, scratch, algorithm, view,
+source/result generations and graph resource usages.
+
+The baseline qualified algorithms are:
+
+- stable bitonic sort for admitted visible counts up to and including 2,048, padding
+  with explicit non-draw sentinel keys; and
+- stable radix sort above 2,048, using a versioned digit width/pass order and stable
+  scatter/reduction contract.
+
+The frontend selects from the effective capability/profile and admitted plan. The
+effect does not choose a backend kernel, and the backend does not substitute another
+algorithm after admission. If only one algorithm is implemented/qualified, its exact
+count/scratch limits are effective capabilities; unsupported required work follows
+the declared batch fallback instead of silently changing semantics.
+
+GPU completion order, subgroup width and queue assignment cannot affect the canonical
+tuple. Backends own native pipelines/dispatch/barriers, but equivalent plans produce
+the same ordered stable IDs under the declared numeric key contract.
+
+### 7. Additive is exempt; translucent is never knowingly unsorted
+
+`Additive` is commutative within its dedicated scene-linear band, so baseline skips
+strict per-particle sorting. Stable batch submission identity remains for diagnostics,
+captures and reproducible graph construction, but it is not a visual depth order.
+
+`Translucent` and ribbons require a complete back-to-front index generation per view.
+`None`, age order, source order or approximate native order cannot override that
+requirement. If a different transparency technique is desired, the asset selects a
+separately cooked and capability-admitted OIT/stochastic recipe; it does not weaken
+the sorted-alpha contract.
+
+An unadmitted, failed or late translucent sort results in deterministic omission of
+the whole affected batch (lowest declared cosmetic priority first when resolving
+capacity). Partial prefixes and unsorted fallback are forbidden because they make the
+same asset blend differently according to timing. Required visual content may instead
+fail/suspend the owning effect according to its authored policy.
+
+### 8. Sort work has hard ceilings and a measured frame target
+
+`VfxQualityPolicy` contains an immutable `VfxSortBudget` captured by the frame plan.
+Initial defaults aggregate all VFX views in one rendered frame:
+
+| VFX profile | CPU sorted keys hard ceiling | GPU sorted keys hard ceiling | CPU/GPU time targets | Aggregate target |
+|---|---:|---:|---:|---:|
+| Headless/test | 0 | 0 | 0.00 ms / 0.00 ms | 0.00 ms |
+| Low visual budget | 8,192 | 65,536 | 0.25 ms / 0.35 ms | 0.60 ms |
+| Desktop baseline | 16,384 | 262,144 | 0.35 ms / 0.65 ms | 1.00 ms |
+| High visual budget | 32,768 | 524,288 | 0.50 ms / 1.00 ms | 1.50 ms |
+
+These are finite product defaults and qualification targets, not measured claims or
+permission to schedule until wall-clock expiry. Project/host profiles may select other
+positive finite values through the normal validated policy path. Hard key, scratch,
+dispatch and byte ceilings are admission limits. Time targets are measured outcomes;
+GPU timestamps are delayed and optional only where the active profile has not claimed
+native time qualification.
+
+CPU duration is the sum of VFX key-build/sort job execution spans; GPU duration is the
+timestamp interval covering only VFX key-build/sort compute passes, excluding unrelated
+queue wait. Aggregate duration is their conservative sum, so overlap does not hide
+cost. Measurements retain build mode, platform, backend/device/driver, profile, view
+set, key counts and algorithm; a target is not reported as qualified without that
+evidence.
+
+View groups consume the aggregate ceiling in frozen `RenderViewPlan` priority followed
+by stable batch priority/ID. Correlated required views such as an XR stereo set admit
+or omit a batch as one group; budget pressure never renders sorted alpha in only one
+required eye. The resolver admits only complete batches and records any omitted
+candidate. It never drains the full ceiling independently for each eye, reflection,
+editor viewport or snapshot reuse.
+
+### 9. Over-budget behavior is bounded and observable
+
+Predicted hard-ceiling overflow is handled before scheduling: omit the lowest-priority
+cosmetic translucent batch, select its authored non-sorted substitute/OIT recipe if
+already admitted, or fail/suspend required visual content. The active frame never
+allocates extra scratch, truncates a batch, changes profile or stalls for capacity.
+
+Measured CPU, GPU or aggregate target overrun does not attempt to preempt submitted
+native work. It emits `VfxSortBudgetExceeded` evidence containing frame/view IDs,
+profile/policy/capability generations, domain, algorithm, key count, scratch/copy
+bytes, measured CPU/GPU duration and target/overage when available. Counters are
+complete; detailed diagnostics are rate-limited through the observability contract.
+Unavailable GPU timing is explicitly unavailable, never recorded as zero.
+
+Repeated overruns may inform an explicit later quality-policy request, but cannot
+silently change sort algorithm, particle domain, view coverage or active batch order.
+Any new policy is re-admitted and published at a safe point with its own generation.
+
+### 10. Failures identify the batch, view and owner boundary
+
+Cook rejects `VfxBlendClassMismatch`, `VfxSortPolicyInvalid`, unsupported shadow/
+topology combinations and backend/pass declarations in effect data. Frontend
+validation returns `VfxSortCapacityExceeded`, `VfxSortKeyInvalid`,
+`VfxSortCapabilityUnavailable`, `StaleVfxGeneration` or `VfxSortResultLate` without
+publishing a partial index generation.
+
+Every failure/omission carries effect/emitter/batch, source/view/frame generations,
+requested blend/sort semantics, algorithm/capability/policy revisions and the failed
+limit. Native backend text may be attached as bounded private evidence, but callers do
+not parse it or branch on API enums. Device loss and cancellation preserve retained
+resource lifetime and return credits only after the renderer's normal retirement.
+
+### 11. Qualification covers classes, views, algorithms and budgets
+
+Required implementation evidence includes:
+
+- every class across Forward, Clustered Forward+ and Deferred recipes, verifying
+  semantic pass placement, depth test/write and matching masked coverage;
+- scene-linear alpha/additive composition, soft-particle completed-depth reads and no
+  GBuffer or current-depth dependency cycle for baseline transparency;
+- CPU stable-radix fixtures proving no SoA mutation, equal-key identity ties and full
+  omission on worker failure/late completion;
+- GPU bitonic fixtures at 0, 1, 2,047, 2,048 and its first unsupported/next path count,
+  plus radix boundaries, sentinel padding, randomized completion and subgroup widths;
+- matching CPU/GPU ordered stable IDs for canonical key fixtures on each shipped
+  backend, with nonfinite/stale inputs rejected;
+- additive scheduling zero per-particle sort work and translucent refusing None/age/
+  source/native ordering;
+- multi-view aggregate admission in frozen priority order, snapshot reuse without
+  duplicate sort, atomic required-view groups, exact hard ceilings and one-key/one-
+  byte/one-dispatch overflow;
+- delayed GPU timestamps, unavailable timing, CPU/GPU/aggregate target overrun and
+  complete/rate-limited `VfxSortBudgetExceeded` evidence, including workload, build,
+  platform, backend/device/driver and algorithm identity; and
+- native GPU smoke evidence per shipped backend. Null/fakes validate plan, ordering,
+  limits and delayed results but cannot prove native time or driver behavior.
+
+## Consequences
+
+### Positive
+
+- Every baseline particle blend class has one reviewable pass and depth contract.
+- CPU/GPU sorting produces stable per-view indices without contaminating simulation.
+- Additive effects avoid unnecessary strict sort work.
+- Hard work ceilings and explicit millisecond targets make overload testable/reportable.
+- Effect and sequencer data remain free of graph/backend implementation details.
+
+### Costs
+
+- Frontend needs versioned key layouts, stable CPU/GPU algorithms and admitted scratch.
+- Multiple views consume separate index/key storage under one aggregate frame budget.
+- Whole-batch omission is visually noticeable but avoids incorrect partial/unsorted alpha.
+- Shipped profiles require per-backend timing and ordering qualification.
+
+## Rejected Alternatives
+
+### Let effect assets name render passes or native blend/depth state
+
+Rejected because recipe and backend details would leak into content and become stale
+when the active raster family changes. Assets declare semantic output requirements.
+
+### Sort particle simulation storage in place
+
+Rejected because view-dependent ordering would corrupt camera-independent CPU/GPU
+state, conflict across views and change deterministic simulation identity.
+
+### Submit translucent particles unsorted when sort work is late
+
+Rejected because blend output would depend on worker/device timing. The complete batch
+is omitted or follows an already admitted authored transparency substitute.
+
+### Sort additive particles back-to-front by default
+
+Rejected because the baseline additive band is commutative and strict sorting consumes
+per-view work without changing its defined composition.
+
+### Let each backend choose bitonic, radix or native ordering
+
+Rejected because algorithm/scratch/capability resolution belongs to the frontend plan
+and native ordering is not a stable cross-backend semantic.
+
+### Use elapsed time as the only hard limiter
+
+Rejected because CPU clocks and delayed GPU timestamps cannot safely preempt bounded
+frame work. Counts/bytes/dispatches are hard admission ceilings; time is a measured
+qualification target with explicit overrun evidence.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -136,6 +136,7 @@ to the replacement.
 | [122](122-cinematic-trigger-sources-and-capability-policy.md) | Cinematic Trigger Sources and Capability Policy | Proposed | 2026-09-02 |
 | [123](123-vfx-cpu-stage-order-determinism-and-gameplay-coupling.md) | VFX CPU Stage Order, Determinism and Gameplay Coupling | Proposed | 2026-09-02 |
 | [124](124-vfx-gpu-simulation-readback-and-compute-fallback.md) | VFX GPU Simulation, Readback and Compute Fallback | Proposed | 2026-09-02 |
+| [125](125-vfx-transparency-sorting-and-pass-placement.md) | VFX Transparency, Sorting and Pass Placement | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -378,6 +378,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [VFX GPU Simulation, Readback and Compute Fallback](../adr/124-vfx-gpu-simulation-readback-and-compute-fallback.md):
   visual-only GPU authority, cooked opt-in asynchronous readback, explicit
   compute-less fallback and unified CPU/GPU/readback admission accounting.
+- [VFX Transparency, Sorting and Pass Placement](../adr/125-vfx-transparency-sorting-and-pass-placement.md):
+  semantic particle pass/depth mapping, stable per-view CPU/GPU sorting, additive
+  exemption, finite sort ceilings and measured frame-time targets.
 - [Post-Processing And Effects Architecture](./runtime/post-processing-and-effects-architecture.md):
   screen-space effects, HDR post chain, tonemapping, color grading, and
   accessibility pass ordering.

--- a/docs/architecture/runtime/render-backend-parity-contract.md
+++ b/docs/architecture/runtime/render-backend-parity-contract.md
@@ -293,6 +293,14 @@ retain logical source-step/schema/generation identity and typed unavailable, deg
 lost or stale outcomes. Null/fakes validate bounds and delayed publication but cannot
 qualify native copy, mapping, synchronization or driver behavior.
 
+[ADR-125 VFX sorting parity](../../adr/125-vfx-transparency-sorting-and-pass-placement.md)
+requires the same semantic pass/depth mapping and canonical view-depth/batch/particle
+ordering. Backends execute frontend-selected stable bitonic/radix plans with declared
+count, scratch, key-layout and synchronization limits; they do not replace the
+algorithm, accept native order or submit unsorted alpha. Null/fakes validate plans,
+ties, ceilings and delayed timing records, while native ordering/time qualification
+still requires each shipped backend.
+
 All backends additionally obey
 [ADR-041's renderer diagnostics model](../../adr/041-backend-neutral-renderer-diagnostics-model.md).
 Equivalent unsupported, invalid, degraded, lost and recovered conditions use the

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -1159,6 +1159,13 @@ generation-tagged delayed observation. The backend privately owns staging, mappi
 cache maintenance and fences. No renderer path waits for same-frame VFX data, grants
 it gameplay authority, chooses an effect fallback or changes the selected backend.
 
+[ADR-125](../../adr/125-vfx-transparency-sorting-and-pass-placement.md) fixes the
+VFX mapping inside every raster recipe: opaque/masked outputs join standard depth and
+opaque work; sorted translucent forward reads but does not write completed depth; and
+the scene-linear additive band follows it without per-particle distance sorting. The
+frontend owns per-view stable CPU/GPU sort plans, aggregate work admission and overrun
+evidence. Assets/backends cannot name/reorder these semantic passes or depth policies.
+
 ## XR Views And External Presentation Targets
 
 XR supplies a bounded runtime-driven set of view descriptors and

--- a/docs/architecture/runtime/vfx-and-particles-architecture.md
+++ b/docs/architecture/runtime/vfx-and-particles-architecture.md
@@ -18,6 +18,11 @@ specializes GPU units: they remain visual-only; cooked readback is bounded,
 asynchronous and observational; compute-less fallback is authored and admitted; and
 CPU, GPU, shared and readback costs remain one auditable plan.
 
+[ADR-125](../../adr/125-vfx-transparency-sorting-and-pass-placement.md)
+specializes render output: every baseline blend class has one semantic pass/depth
+contract, translucent ordering uses stable per-view CPU/GPU plans, additive skips
+strict sorting and finite work/time budgets govern admission and diagnostics.
+
 DCC workflows, full fluid solvers, atmospheric scattering and screen-space
 post-processing remain outside this subsystem; see
 [Advanced Rendering Architecture](./advanced-rendering-architecture.md).
@@ -509,24 +514,69 @@ particle age. Soft-particle fading samples declared scene depth in the draw pass
 | Translucent/ribbons | Per-view sort then translucent forward; depth test, no depth write |
 | Additive | Additive forward; depth test, no depth write, no distance sort |
 
+The baseline scene-linear order is completed opaque lighting/depth, stable sorted
+`VfxTranslucentForward`, then the commutative `VfxAdditiveForward` band. Translucent
+and additive never enter a Deferred GBuffer. Soft-particle draw fading reads completed
+opaque depth; it cannot introduce a current-pass write/read cycle. Effects declare
+semantic class only, never graph pass names, attachments, queues or native state.
+
 Shadow casting is supported here only for opaque/masked mesh particles. Requesting
 OpaqueMaskedCaster on ribbons, translucent/additive particles, decals or volumes is
 an unsupported combination requiring authored substitute or typed rejection. It is
 not a bool that silently inserts arbitrary shadow passes.
 
 Each RenderViewId (game, editor, split screen, XR or reflection) gets its own sort/cull
-indices and keys over compatible immutable data. CPU radix sorting operates on packed
-frame data or an index copy in extraction/render preparation, never reorders the
-simulation SoA or writes particle distance fields. sortDistance lives only in
-VfxViewSortKey. Equal distances use stable batch/particle identity; reject nonfinite
-keys. GPU sort likewise writes separate per-view index buffers after simulation.
-Sorting one view cannot change another view or advance the emitter again.
+indices and keys over compatible immutable data. The canonical back-to-front tuple is
+finite view depth descending, stable VfxBatchId, then stable particle identity. Depth
+encoding/comparison is versioned; reject nonfinite/stale inputs. Source slots, atomic
+append order, worker completion and native subgroup order never break ties. Sorting
+one view cannot change another view, mutate simulation state or advance the emitter.
 
-CPU sorting may use JobSystem staging with completion published before consuming the
-view. It cannot block extraction/render on a pending worker. If its bounded work is
-not ready, the declared cosmetic view fallback omits that batch and reports it; it
-does not submit unsorted alpha as though sorting succeeded. The frontend sorts opaque
-batches front-to-back alongside ordinary meshes. Additive sorting is skipped.
+For CPU sources, frontend CPU preparation uses admitted immutable key/index scratch
+and stable radix sorting; it never reorders the simulation SoA. JobSystem ranges
+publish only one complete result at the frontend owner boundary. A pending/failed
+result cannot block the frame: omit and report the whole translucent batch rather
+than submitting unsorted or partial alpha.
+
+For GPU sources, the frontend emits a backend-neutral stable compute-sort plan after
+simulation/key-build and before the translucent draw. The baseline selects bitonic at
+admitted visible counts up to 2,048 (with explicit non-draw sentinels) and stable radix
+above 2,048 using versioned digit/pass/scatter rules. Actual qualified algorithms and
+limits are effective capabilities; the asset/backend cannot substitute native order.
+
+Opaque/masked batches use the renderer's normal coarse front-to-back ordering.
+Additive emits no per-particle distance keys and consumes no translucent sort budget.
+`None`, age or source order cannot weaken required translucent back-to-front order;
+other techniques require a separately cooked/admitted transparency recipe.
+
+### Sort Work And Time Budget
+
+`VfxSortBudget` aggregates every VFX view in one rendered frame. Initial defaults are:
+
+| VFX profile | CPU keys hard ceiling | GPU keys hard ceiling | CPU/GPU time targets | Aggregate target |
+|---|---:|---:|---:|---:|
+| Headless/test | 0 | 0 | 0.00 ms / 0.00 ms | 0.00 ms |
+| Low visual budget | 8,192 | 65,536 | 0.25 ms / 0.35 ms | 0.60 ms |
+| Desktop baseline | 16,384 | 262,144 | 0.35 ms / 0.65 ms | 1.00 ms |
+| High visual budget | 32,768 | 524,288 | 0.50 ms / 1.00 ms | 1.50 ms |
+
+These are validated finite product defaults/qualification targets, not measured
+performance claims or permission to work until a clock expires. Count, scratch, byte
+and dispatch ceilings are hard admission limits. CPU time sums VFX key/sort job spans;
+GPU time brackets only VFX key/sort passes and excludes unrelated queue wait; aggregate
+is their conservative sum. Evidence retains build, platform, backend/device/driver,
+view/key workload and algorithm. Frozen view-group priority then stable batch priority/
+ID consumes the ceiling, admitting complete batches only. Required XR view groups are
+atomic; pressure never sorts one required eye alone. Snapshot reuse and each eye/view
+do not receive an independent full budget.
+
+Predicted overflow omits the lowest-priority cosmetic translucent batch, uses an
+already admitted authored transparency substitute, or fails/suspends required visual
+content. There is no frame allocation, partial sort, unsorted alpha or implicit
+profile/domain change. Measured target overrun reports `VfxSortBudgetExceeded` with
+frame/view, profile/policy/capability generation, domain/algorithm, key/scratch/copy
+counts and available CPU/GPU target/duration evidence. Unavailable delayed GPU timing
+is not zero; repeated overruns can only inform an explicitly re-admitted later policy.
 
 ## Particle System Data Model
 
@@ -753,6 +803,11 @@ handling. Cancelled/StaleGeneration suppress publication but still route matchin
 retirement acknowledgements. RetirementIncomplete keeps resources/dependencies
 charged and alive; it is never translated into successful shutdown.
 
+Sort-specific failures preserve batch/view/source/frame generation, blend semantics,
+algorithm and the failed count/scratch/time predicate. `VfxSortCapacityExceeded`,
+`VfxSortKeyInvalid`, `VfxSortCapabilityUnavailable` and `VfxSortResultLate` never
+publish a partial index generation. Native text is bounded evidence, not policy input.
+
 ## Testing And Verification Requirements
 
 These are qualification scenarios for implementation, not tests delivered by this
@@ -782,6 +837,16 @@ architecture-only change:
 - Render one snapshot in multiple views/frames: submit each GPU step once; sort each
   view independently; preserve SoA and stable ties; reject nonfinite keys and invalid
   shadow/volume/decal combinations. Exercise a missing previous-depth snapshot.
+- Exercise every ADR-125 blend row across Forward, Clustered Forward+ and Deferred:
+  matching masked coverage, exact depth read/write, scene-linear translucent/additive
+  order, no GBuffer transparency and no soft-particle current-depth dependency cycle.
+- Verify stable CPU radix and GPU bitonic/radix boundaries, sentinel padding, equal-key
+  identity ties and matching canonical fixture order. Additive must schedule zero
+  per-particle sort work; late/failed translucent work omits the complete batch.
+- Exercise each aggregate sort profile at its exact CPU/GPU key/time target and one
+  beyond across multiple views. Verify frozen priority, atomic required-view groups,
+  no duplicated snapshot budget, qualified measurement identity, typed overrun
+  evidence and explicitly unavailable delayed GPU timing.
 - Verify graph compute/read/write/sort/draw dependencies and native affinity on each
   supported backend/capability profile, including an explicit no-compute composition.
 - Verify no-readback emitters schedule no copies; exercise every cooked schema/cadence/
@@ -806,6 +871,8 @@ architecture-only change:
   Normative CPU stage, RNG, payload and gameplay publication contract.
 - [ADR-124: VFX GPU Simulation, Readback and Compute Fallback](../../adr/124-vfx-gpu-simulation-readback-and-compute-fallback.md):
   Normative GPU authority, observation, fallback and shared-admission contract.
+- [ADR-125: VFX Transparency, Sorting and Pass Placement](../../adr/125-vfx-transparency-sorting-and-pass-placement.md):
+  Normative particle blend/pass, stable sorting and sort-budget contract.
 - [Particle Editor UI Reference](./particle-editor.html): Emitter stack, curve editing,
   and live preview panel.
 - [Material And Shader Model](./material-and-shader-model.md): Particle and decal materials.


### PR DESCRIPTION
## Summary

- Adds ADR-125 to give `Opaque`, `Masked`, `Translucent`, and `Additive` VFX outputs one semantic render-pass and depth contract across Forward, Clustered Forward+, and Deferred recipes.
- Defines the baseline scene-linear order as completed opaque lighting/depth, stable sorted `VfxTranslucentForward`, then commutative `VfxAdditiveForward`; baseline transparency never enters a Deferred GBuffer.
- Assigns per-view CPU particle sorting to frontend stable radix preparation and GPU particle sorting to frontend-planned stable bitonic/radix compute work, without mutating simulation storage.
- Defines a canonical finite view-depth/batch/particle key with stable ties and makes additive exempt from per-particle distance sorting.
- Adds profile-specific aggregate hard key ceilings and CPU/GPU millisecond targets, including atomic XR view-group admission and typed over-budget evidence.
- Projects the decision into the VFX architecture, Rendering Architecture, Render Backend Parity Contract, and architecture/ADR indexes with explicit qualification scenarios.

## Why

ADR-011 and the existing VFX architecture named particle pass classes and per-view sorting, but did not fully fix pass order, sort algorithm ownership, numeric budgets, or the outcome when sort work is late or over capacity. That left room for effect assets or native backends to choose pass/depth state, for multi-view sorting to consume an unbounded budget per eye, and for timing pressure to produce partial or unsorted alpha.

ADR-125 turns those choices into one backend-neutral frontend contract. It keeps simulation camera-independent, prevents renderer details from entering effect/sequencer data, and makes sorting workload and overrun reporting directly testable.

## Decision and boundaries

- Opaque/masked mesh particles join the active recipe's normal depth and opaque/GBuffer-or-forward paths with depth writes enabled; masked coverage is identical in depth, shadow, and color.
- Translucent billboard/ribbon/mesh outputs use stable back-to-front forward rendering with depth read/test and no depth write. Soft particles read completed opaque depth and cannot create a current-pass dependency cycle.
- Additive output follows the sorted-translucent band in scene-linear ACEScg, depth-tests without writing depth, and schedules zero per-particle distance-sort work.
- Assets declare only semantic blend/shading/shadow intent. Pass names, attachments, queues, native blend/depth state, pipeline objects, and backend dispatch dimensions remain frontend/backend concerns.
- The canonical sort tuple is finite view depth descending, stable `VfxBatchId`, then stable particle identity. Slot order, atomic append order, worker completion, and GPU subgroup order never break ties.
- CPU sources use admitted immutable key/index scratch and stable radix work. GPU plans use stable bitonic through 2,048 visible entries with explicit sentinels, then stable radix with versioned digit/pass/scatter rules.
- A late/failed/unadmitted translucent sort omits the complete batch or uses an already admitted authored transparency substitute; partial prefixes and knowingly unsorted alpha are forbidden.
- Initial aggregate frame defaults range from 8,192/65,536 CPU/GPU keys and 0.60 ms on Low to 32,768/524,288 keys and 1.50 ms on High; Desktop baseline is 16,384/262,144 and 1.00 ms.
- Required correlated views such as an XR stereo set admit or omit a batch atomically, and reused snapshots or individual eyes do not receive independent full budgets.
- CPU time sums VFX key/sort job spans; GPU time brackets only VFX key/sort passes. Qualification evidence identifies build, platform, backend/device/driver, profile, view/key workload, and algorithm.
- This is an architecture-only change; it defines implementation and regression obligations without claiming the targets are already achieved.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/125-vfx-transparency-sorting-and-pass-placement.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/vfx-and-particles-architecture.md docs/architecture/runtime/rendering-architecture.md docs/architecture/runtime/render-backend-parity-contract.md`
- `git diff --check`
- `git diff --cached --check`
- Added-Markdown-link resolution check over the staged diff
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. It reported the existing mbedTLS minimum-version deprecation warning and skipped repository Python tests because `pytest` is unavailable.

## Risk and rollout

- The initial key/time values are product defaults and qualification targets, not measured performance claims; shipped profiles still need native evidence on their supported backend/device matrix.
- Whole-batch omission under pressure is visually noticeable, but it avoids silently incorrect partial or unsorted alpha.
- Per-view stable key/index storage and deterministic CPU/GPU scratch increase admitted frame memory, especially for XR and multiple editor/reflection views.
- Backends implementing only one qualified GPU sort algorithm expose narrower effective limits; required translucent work outside those limits becomes explicitly unavailable unless an authored substitute is admitted.

## Issue links

- Closes #1752
- Jira: [HORO-1709](https://horo-engine.atlassian.net/browse/HORO-1709)
- Domain ticket: `[VFX-004.1]`

## Reviewer Notes

- Review the four-row class/pass/depth table and baseline translucent-before-additive scene-linear order first.
- Check that sort ownership stays in frontend preparation/planning and never mutates CPU SoA or GPU simulation state.
- Check the stable key/tie contract and the 2,048 bitonic-to-radix boundary for CPU/GPU fixture equivalence.
- Review the hard ceilings separately from measured time targets: counts/bytes/dispatches bound admission, while CPU/GPU timings produce qualified delayed evidence and cannot preempt native work.
- Check multi-view behavior for one aggregate budget and atomic required XR view groups.
- This PR is preserved as an individual merge commit on `develop`; final review and non-squash delivery to `main` occur in PR #2508.


[HORO-1709]: https://horo-engine.atlassian.net/browse/HORO-1709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ