### PR TITLE
docs(vfx): unify graph runtime compilation HORO-1710 #1753 [VFX-005.1]

### DIFF
--- a/docs/adr/126-vfx-graph-compilation-and-runtime-representation-convergence.md
+++ b/docs/adr/126-vfx-graph-compilation-and-runtime-representation-convergence.md
@@ -1,0 +1,338 @@
+# ADR-126: VFX Graph Compilation and Runtime Representation Convergence
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Stack/graph authoring convergence, canonical VFX compilation target, offline lowering, CPU/GPU kernel packages, cook validation, artifact identity/versioning, runtime loading and migration
+- **Issue**: [VFX-005.1](https://github.com/abdullahbodur/horo-engine/issues/1753)
+- **Jira**: [HORO-1710](https://horo-engine.atlassian.net/browse/HORO-1710)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-011](011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md), [ADR-028](028-renderer-capability-limits-and-product-profiles.md), [ADR-035](035-shader-source-and-intermediate-representation.md), [ADR-123](123-vfx-cpu-stage-order-determinism-and-gameplay-coupling.md), [ADR-124](124-vfx-gpu-simulation-readback-and-compute-fallback.md), [ADR-125](125-vfx-transparency-sorting-and-pass-placement.md)
+- **Normative documents**: [VFX and Particles Architecture](../architecture/runtime/vfx-and-particles-architecture.md), [Asset Pipeline](../architecture/runtime/asset-pipeline.md)
+
+## Context
+
+Horo's VFX design describes both a stack-oriented particle authoring surface and a
+future node graph. It also sketches `ParticleSystemDescriptor`, CPU SoA execution,
+GPU kernels and render batches, but does not name the one immutable cooked root that
+all runtime instances consume. Without that convergence, stack and graph tooling could
+create separate loaders, parameter schemas, simulation semantics or renderer seams.
+
+The current text says graphs compile ahead of time and runtime does not interpret
+arbitrary scripts per particle. That constraint needs an implementable boundary:
+which compiler stages are editor/cook-only, which typed descriptor is the single
+target, how CPU/GPU work is represented without shipping the authoring graph, and how
+version/capability changes invalidate or migrate artifacts.
+
+The generic Asset Pipeline already owns source snapshots, cook orchestration, cache
+identity, target selection, immutable envelopes and atomic generation publication.
+VFX must specialize its semantic payload without building a second cache/publisher or
+letting editor/runtime code execute source graphs directly.
+
+## Decision
+
+### 1. `CompiledVfxEffectDescriptor` is the single runtime model
+
+Both authoring paths compile to exactly one root runtime representation:
+
+```cpp
+struct CompiledVfxEffectDescriptor {
+    VfxEffectAssetId asset;
+    VfxArtifactSchemaVersion schemaVersion;
+    VfxSemanticModelVersion semanticVersion;
+    VfxParameterSchema parameterSchema;
+    BoundedArray<ParticleSystemDescriptor> emitterUnits;
+    BoundedArray<VfxCompiledEdge> asynchronousEdges;
+    BoundedArray<VfxResourceRequirement> resources;
+    VfxCapabilityRequirements capabilities;
+    VfxFallbackSet fallbacks;
+    VfxPeakCostEnvelope peakCosts;
+    VfxCookFingerprint fingerprint;
+};
+```
+
+`ParticleSystemDescriptor` remains the typed emitter-unit foundation nested in that
+root. It contains normalized spawn/simulation/render intent and references immutable
+compiled plans/kernels; it is not a second top-level asset or a graph-specific runtime.
+Implementation may rename it to `CompiledVfxEmitterUnitDescriptor` during migration,
+but only one of those names may remain in the installed/runtime schema.
+
+`EffectSystem`, `SimulationDomainResolver`, CPU/GPU simulators, extraction and Renderer
+consume views derived from `CompiledVfxEffectDescriptor`. No caller loads a parallel
+`CompiledGraphEffect`, `StackParticleRuntime`, source-node tree or property bag.
+
+### 2. Stack and graph are authoring frontends, not runtime types
+
+The editor may persist two source document kinds:
+
+- a stack document with ordered emitter modules and fixed connection points; and
+- a graph document with typed nodes/ports and explicit supported dependency edges.
+
+Their editors, layout, comments, selection and presentation metadata may differ.
+They need not round-trip into one another. Each frontend validates its source schema,
+resolves defaults and emits the same compiler-owned semantic input. `sourceKind` may
+be retained as diagnostics/provenance but cannot change runtime loading, scheduling,
+parameter binding, simulation, fallback, extraction or rendering behavior.
+
+Semantically equivalent stack/graph sources under identical locked inputs must produce
+the same canonical descriptor and kernel fingerprints. A frontend cannot add a private
+runtime module, hidden default or special renderer callback to preserve authoring
+convenience.
+
+### 3. The compiler has one deterministic lowering pipeline
+
+The VFX cooker executes these bounded phases against the generic cook operation's
+immutable source/dependency/target snapshot:
+
+```text
+Parse and migrate authoring schema
+    -> canonicalize typed modules/nodes, IDs, defaults and parameters
+    -> validate types, topology, stages, authority and boundedness
+    -> partition connected emitter simulation units and asynchronous edges
+    -> lower ADR-123 CPU stage plans and semantic RNG/payload schemas
+    -> lower GPU work/kernel requirements and ADR-124 readback/fallback envelopes
+    -> lower ADR-125 render classes, sort requirements and resource layouts
+    -> compute dependencies, capability requirements and peak costs
+    -> emit one CompiledVfxEffectDescriptor plus target kernel packages/source map
+    -> validate complete payload and return it to Asset Pipeline publication
+```
+
+A compiler-internal IR may exist only inside the bounded cook invocation. It is not an
+asset, public API, cache authority or runtime representation. It cannot be retained by
+a plugin after invocation or serialized as an alternate executable payload.
+
+Canonical ordering uses stable semantic IDs, not editor node position, insertion
+history, pointer order, unordered-container iteration, worker completion or module
+registration order. Given the same complete cache inputs, output descriptor, kernel
+packages, dependency list and diagnostics are byte-identical.
+
+### 4. Runtime never interprets authoring graphs or arbitrary particle scripts
+
+Packaged/runtime compositions load only a validated cooked artifact. They do not parse
+stack/graph source, visit authoring nodes per particle, evaluate editor expressions,
+JIT user source, execute arbitrary bytecode, invoke an authoring plugin or search for a
+missing compiler. Cooked source text and editor metadata are not executable fallback.
+
+CPU execution uses an immutable ADR-123 stage plan whose prevalidated typed kernel IDs
+bind to installed runtime kernel implementations. Iterating that bounded plan is not
+permission for an untyped script VM: kernels have declared stage reads/writes, schemas,
+costs and versions, and cannot allocate or discover functions during a particle step.
+
+GPU execution uses target kernel artifacts produced through ADR-035's shader/compiler
+routes and referenced by logical `VfxKernelId`. Runtime/native realization permitted by
+the selected cook target does not reconstruct the VFX graph or change semantic plans.
+Missing CPU/GPU variants follow typed admission/fallback, never source compilation.
+
+### 5. Node/module extension points terminate at cook and typed kernels
+
+A VFX module/node provider contributes stable provider, node-type, schema and kernel
+IDs through the host's validated catalog. The cook snapshot pins the provider version
+and validates parameter/port schemas, allowed ADR-123 stages, domain support, resource
+requirements, deterministic behavior class and finite cost bounds.
+
+Trusted extension code may run as a bounded cooker contribution under the Asset
+Pipeline contract. Runtime support is a separately installed typed kernel provider;
+the cooked artifact references its stable ABI/schema identity. Neither contribution
+may retain borrowed cook input, publish files, expose native renderer types, register
+ambient callbacks or smuggle executable source/script into the descriptor.
+
+An unavailable/mismatched provider fails cook or runtime admission with its exact
+identity. Registration order cannot select a competing implementation. Packaged assets
+include only dependencies reachable from the accepted compiled descriptor and target
+kernel packages.
+
+### 6. Cook validation is complete and rejects partial semantics
+
+Before payload emission, the compiler validates at least:
+
+- stable unique effect/emitter/module/node/port/channel/parameter identities;
+- source schema migration, typed defaults/ranges, finite numeric values and bounded
+  strings/arrays/maps;
+- graph/stack topology, allowed cycles/delays, reachable outputs and deterministic
+  canonical ordering;
+- ADR-123 stage reads/writes, initialization, RNG channel stability, payload authority,
+  occurrence bounds and CPU-mandatory behavior;
+- unit partitioning, cross-domain asynchronous edges and rejection of synchronous
+  authoritative GPU-to-CPU dependencies;
+- required CPU/GPU kernels, target variants, capabilities and provider versions;
+- ADR-124 readback schema, fallback compatibility and complete CPU/GPU/shared peak
+  costs, including replacement/frames-in-flight overlap;
+- ADR-125 material/blend/topology/shadow/sort compatibility and layout bounds;
+- referenced materials, meshes, textures, fields, audio/event assets and package
+  dependencies with their exact generations/digests; and
+- checked count/stride/offset/byte/work products and artifact size limits.
+
+Unknown nodes/fields, implicit lossy conversion, unbounded loops/recursion/events,
+missing variants, conflicting writers and unsupported target requirements are errors.
+The cooker never drops a required node, substitutes a default graph, clamps gameplay
+semantics or emits a partially runnable descriptor to make the cook succeed.
+
+Diagnostics retain source document kind, stable source node/module/port and property
+identity through a bounded source map. Human-readable editor position is presentation
+evidence only and never changes artifact semantics.
+
+### 7. `VfxCookedArtifact` separates common semantics from target kernels
+
+The VFX payload inside the generic Asset Pipeline envelope is:
+
+```cpp
+struct VfxCookedArtifactHeader {
+    VfxArtifactSchemaVersion schemaVersion;
+    VfxSemanticModelVersion semanticVersion;
+    VfxCpuKernelAbiVersion cpuKernelAbi;
+    VfxGpuKernelPackageVersion gpuKernelPackage;
+    CookTargetId target;
+    CapabilityFingerprint capabilityFingerprint;
+    Digest descriptorDigest;
+    Digest dependencyDigest;
+};
+
+struct VfxCookedArtifact {
+    VfxCookedArtifactHeader header;
+    CompiledVfxEffectDescriptor descriptor;
+    VfxCpuKernelPackage cpuKernels;
+    VfxGpuKernelPackage gpuKernels;
+    OptionalVfxSourceMap sourceMap;
+};
+```
+
+The descriptor is backend-neutral common semantic data. Target packages may contain
+different qualified native/intermediate shader bytes, but they implement the same
+logical kernel IDs, parameter/resource layouts, stage order and render outputs. A
+backend-specific package cannot replace the common descriptor or select a different
+fallback/pass policy.
+
+The CPU package contains bounded stage plans, immutable parameter/layout data and
+stable references to installed typed kernels; it is not arbitrary loadable machine
+code or script bytecode. The GPU package follows ADR-035's admitted target artifact
+rules and remains renderer-private at realization.
+
+Headless target artifacts retain enough descriptor/CPU information to validate and run
+required gameplay VFX without GPU dependencies; permitted visual-only units resolve to
+Null according to ADR-011/124. They do not pretend to contain interactive GPU kernels.
+
+### 8. Artifact identity includes every semantic input
+
+The VFX cook/cache fingerprint extends the Asset Pipeline's complete `CacheKeyV1` with:
+
+- authoring schema and canonical source digest;
+- VFX compiler/lowering and semantic-model versions;
+- provider/node/module schemas and runtime kernel ABI versions;
+- ADR-owned stage/RNG/payload/readback/fallback/sort/layout schema versions;
+- selected cook target and effective target capability/limit fingerprint;
+- all referenced asset IDs, accepted revisions and content digests;
+- project VFX policy/default inputs that are explicitly cooker-visible; and
+- descriptor/kernel encoding and diagnostic source-map format versions.
+
+Editor layout, selection, timestamps, absolute source paths, machine identity,
+diagnostic wording and worker scheduling are excluded. A relevant input change creates
+a new cache key/generation; the cooker never patches an existing immutable artifact.
+
+### 9. Compatibility is explicit at envelope, payload and kernel layers
+
+Asset Pipeline envelope compatibility remains authoritative. Within an accepted
+envelope, VFX validates schema, semantic-model, CPU ABI, GPU package, target,
+capability fingerprint, dependency and payload digests before decoding any array or
+binding a kernel.
+
+The runtime supports the current VFX payload schema and at least the two prior schemas
+only through explicit tested readers/migrations that produce the current immutable
+model without semantic loss. Older artifacts require recook; newer artifacts,
+unsupported semantic changes, provider ABI mismatches or incompatible target packages
+return `VfxArtifactVersionUnsupported`/typed dependency failure. Packaged runtime never
+attempts repair from authoring source.
+
+Schema evolution uses tagged/versioned fields with fixed-width encodings and checked
+lengths. Removing/retyping a field, changing a default, RNG channel, stage meaning,
+fallback envelope, layout or kernel ABI is a compatibility change and updates the
+appropriate version/fingerprint. Unknown required fields are errors; unknown optional
+fields may be ignored only when the schema explicitly declares forward-safe behavior.
+
+### 10. Publication and hot reload remain atomic and lease-safe
+
+VFX cooker output returns through host-owned bounded writers. Asset Pipeline verifies
+the generic envelope plus VFX payload/digests and atomically publishes the complete
+generation; VFX code cannot choose output paths, publish a cache entry or replace
+`current.json`.
+
+Runtime resolves one immutable artifact lease, validates it fully, builds an admission
+plan and only then creates an effect instance. Failure creates no half-bound kernels,
+resource reservation or active emitter. Active instances pin their artifact/provider/
+resource generations through stop and retirement.
+
+Hot reload prepares and validates a new artifact/admission generation separately.
+Existing instances either finish on the old lease or restart at an authored safe point;
+their live particle buffers are never reinterpreted under a new descriptor/layout.
+Failed reload retains the last good generation and reports the exact validation/cook/
+admission cause. Old and new peak overlap remains charged until final retirement.
+
+### 11. Qualification proves convergence and runtime isolation
+
+Required implementation evidence includes:
+
+- equivalent stack/graph fixtures producing byte-identical canonical descriptor and
+  kernel fingerprints while authoring-only layout/comments do not change output;
+- proof that all runtime entry points accept only `CompiledVfxEffectDescriptor` views
+  and no source kind selects a loader, executor, parameter or renderer path;
+- packaged/headless scans with no source graph/stack parser, authoring node classes,
+  script/JIT compiler or editor plugin dependency reachable from VFX execution;
+- deterministic fresh/cached/multi-worker cook output and diagnostics under randomized
+  registration/insertion/completion order;
+- every validation category at exact bounds and one beyond, with source-mapped errors
+  and zero partial artifact publication;
+- current, two previous, too-old, newer, corrupted, truncated, oversized, wrong-target,
+  wrong-capability, provider/kernel ABI and dependency-digest cases;
+- missing CPU/GPU variants using ADR-011/124 fallback rather than authoring-source
+  compilation or required-node deletion;
+- atomic generation publication, failed cook/reload last-good retention, active old
+  leases, new admission and final retirement accounting; and
+- common semantic fixtures across every shipped target/backend while target packages
+  remain private implementations of the same logical IDs/layouts.
+
+## Consequences
+
+### Positive
+
+- Stack and graph authoring share one loader, runtime, parameter model and renderer seam.
+- Runtime cost is bounded compiled kernel execution, not per-particle graph/script interpretation.
+- Cook validation and fingerprints expose semantic/version drift before activation.
+- Target-specific kernels remain compatible implementations of one common descriptor.
+- Atomic publication/hot reload preserves last-good state and live-instance lifetimes.
+
+### Costs
+
+- The VFX compiler needs canonical IDs/order, a semantic lowering pipeline and source maps.
+- Descriptor, kernel and provider schemas require deliberate version/compatibility tests.
+- Semantically equivalent authoring paths must maintain shared golden fixtures.
+- Unsupported/old artifacts may require recook instead of runtime best-effort repair.
+
+## Rejected Alternatives
+
+### Maintain separate stack and graph runtime descriptors
+
+Rejected because loaders, defaults, simulation/fallback and rendering semantics would
+drift. Both frontends terminate at `CompiledVfxEffectDescriptor`.
+
+### Ship the authoring graph and interpret it per particle
+
+Rejected because traversal, dynamic typing, allocation and arbitrary scripts violate
+bounded frame execution, packaged isolation and deterministic stage authority.
+
+### Treat compiler IR as a stable public/runtime asset
+
+Rejected because it creates a second executable representation and freezes compiler
+internals. IR remains invocation-local; only the compiled descriptor/packages persist.
+
+### Compile missing source variants on packaged runtime startup
+
+Rejected because packaged runtime lacks authoring trust/tools and would produce
+machine-dependent latency/behavior. Missing variants return typed fallback/failure.
+
+### Let target GPU packages carry their own fallback or pass policy
+
+Rejected because native target artifacts implement kernels; common Horo descriptor and
+frontend contracts own domain, fallback, material, sort and pass semantics.
+
+### Mutate active particle storage in place during hot reload
+
+Rejected because layout/kernel/schema changes would reinterpret live memory. New
+artifacts are separately admitted and instances finish old or restart safely.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -137,6 +137,7 @@ to the replacement.
 | [123](123-vfx-cpu-stage-order-determinism-and-gameplay-coupling.md) | VFX CPU Stage Order, Determinism and Gameplay Coupling | Proposed | 2026-09-02 |
 | [124](124-vfx-gpu-simulation-readback-and-compute-fallback.md) | VFX GPU Simulation, Readback and Compute Fallback | Proposed | 2026-09-02 |
 | [125](125-vfx-transparency-sorting-and-pass-placement.md) | VFX Transparency, Sorting and Pass Placement | Proposed | 2026-09-02 |
+| [126](126-vfx-graph-compilation-and-runtime-representation-convergence.md) | VFX Graph Compilation and Runtime Representation Convergence | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -381,6 +381,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [VFX Transparency, Sorting and Pass Placement](../adr/125-vfx-transparency-sorting-and-pass-placement.md):
   semantic particle pass/depth mapping, stable per-view CPU/GPU sorting, additive
   exemption, finite sort ceilings and measured frame-time targets.
+- [VFX Graph Compilation and Runtime Representation Convergence](../adr/126-vfx-graph-compilation-and-runtime-representation-convergence.md):
+  stack/graph authoring convergence on one compiled descriptor, offline-only
+  lowering, deterministic artifacts and explicit payload/kernel compatibility.
 - [Post-Processing And Effects Architecture](./runtime/post-processing-and-effects-architecture.md):
   screen-space effects, HDR post chain, tonemapping, color grading, and
   accessibility pass ordering.

--- a/docs/architecture/runtime/asset-pipeline.md
+++ b/docs/architecture/runtime/asset-pipeline.md
@@ -647,6 +647,38 @@ ownership, and C++ object ownership do not cross that ABI. The adapter must
 validate all output before it can enter the cache or a candidate cooked
 generation, so external and built-in contributions cannot bypass host invariants.
 
+### VFX Domain Import And Cook Boundary
+
+[ADR-126](../../adr/126-vfx-graph-compilation-and-runtime-representation-convergence.md)
+applies the same generic-Assets/domain-semantics split to stack and graph VFX assets.
+Assets owns stable `AssetId`, immutable source/metadata snapshots, generic cooker
+catalog/scheduling, `CacheKeyV1`, target selection, output bounds, staging, atomic
+generation publication, rollback and immutable runtime byte delivery. It does not
+interpret particle modules/nodes, select simulation domains, compile VFX kernels or
+define runtime parameter/render behavior.
+
+VFX Model/Cook owns both authoring schemas and one deterministic lowering pipeline to
+the backend-neutral `CompiledVfxEffectDescriptor` plus target CPU/GPU kernel packages.
+`ParticleSystemDescriptor` is the nested compiled emitter-unit foundation, not a
+parallel stack/graph runtime. VFX validation owns semantic IDs/order, stages, payloads,
+domain edges, readback/fallback, render/sort compatibility, resource dependencies,
+provider/kernel versions and peak costs. A compiler IR is invocation-local and never
+becomes a published executable representation.
+
+The VFX cache extension includes source/semantic/compiler/provider/kernel/plan schema
+versions, the effective target capability fingerprint and every accepted dependency
+digest. Stack/graph sources with equivalent semantics and identical locked inputs emit
+identical descriptor/kernel fingerprints. Editor layout, comments, timestamps, paths
+and worker completion are not semantic inputs.
+
+Runtime receives the published immutable envelope through the Assets provider, then
+VFX validates payload/kernel/target/provider versions and digests before admission.
+It never parses authoring nodes, invokes cookers/plugins, runs arbitrary particle
+scripts or compiles missing variants. Too-old artifacts recook in authoring hosts;
+newer/incompatible packaged artifacts fail typed loading. Hot reload publishes a new
+generation atomically while active instances retain old artifact/provider/resource
+leases until safe finish/restart and final retirement.
+
 ### Audio Domain Import And Cook Boundary
 
 [ADR-064](../../adr/064-audio-asset-and-cook-boundary.md) is the single

--- a/docs/architecture/runtime/vfx-and-particles-architecture.md
+++ b/docs/architecture/runtime/vfx-and-particles-architecture.md
@@ -23,6 +23,11 @@ specializes render output: every baseline blend class has one semantic pass/dept
 contract, translucent ordering uses stable per-view CPU/GPU plans, additive skips
 strict sorting and finite work/time budgets govern admission and diagnostics.
 
+[ADR-126](../../adr/126-vfx-graph-compilation-and-runtime-representation-convergence.md)
+makes stack and graph two authoring frontends for one `CompiledVfxEffectDescriptor`.
+Only deterministic cooked descriptors/kernel packages reach runtime; authoring graphs,
+arbitrary scripts and compiler IR never become parallel executable representations.
+
 DCC workflows, full fluid solvers, atmospheric scattering and screen-space
 post-processing remain outside this subsystem; see
 [Advanced Rendering Architecture](./advanced-rendering-architecture.md).
@@ -580,8 +585,10 @@ is not zero; repeated overruns can only inform an explicitly re-admitted later p
 
 ## Particle System Data Model
 
-A particle system is a template that describes how particles are spawned,
-simulated, rendered, and destroyed. The sortMode is validated against its output
+`ParticleSystemDescriptor` is the compiled emitter-unit foundation nested only in
+`CompiledVfxEffectDescriptor`; it is not a second top-level stack/graph runtime asset.
+It describes how particles are spawned, simulated, rendered and destroyed. The
+sortMode is validated against its output
 material: None/OldestFirst cannot override required back-to-front alpha ordering.
 Authored age order is allowed only for an output whose blend contract permits it.
 
@@ -681,12 +688,39 @@ Graph nodes:
 | `Light` | Spawns a temporary point light (bounded, tier-aware). |
 | `Audio` | Triggers an audio event on spawn or collision. |
 
-Graphs compile ahead-of-time (or at asset cook time) into runtime descriptors and
-optimized compute/CPU kernels. Compilation validates emitter dependency closure,
-CPU-mandatory conflicts, fallback compatibility, bounded parameters and peak cost.
-Asset versions migrate the previous domain field explicitly; cook diagnoses required
-unsupported nodes rather than silently dropping gameplay behavior. The graph runtime
-never interprets arbitrary scripts per particle.
+Stack documents and graph documents are authoring frontends for one deterministic
+cook pipeline. Both lower to exactly one root `CompiledVfxEffectDescriptor` containing
+the same bounded `ParticleSystemDescriptor` emitter units, typed parameters/edges,
+resources, capabilities, fallbacks, peak costs and fingerprint. Source kind may appear
+in diagnostics, but runtime loading, binding, simulation and rendering never branch on
+it. Compiler IR is invocation-local and is not serialized as another executable asset.
+
+Cook validates/migrates the source schema, canonicalizes stable semantic IDs/order,
+partitions emitter units, enforces ADR-123 stages/payloads, ADR-124 domain/readback/
+fallback contracts and ADR-125 render/sort rules, then emits prevalidated CPU stage
+plans and target GPU kernel packages. It also validates dependency closure, target/
+provider/kernel versions, bounded parameters/resources, checked layout/cost products
+and complete peak overlap. Unknown nodes, required unsupported features and unbounded
+behavior fail the candidate rather than being removed or defaulted.
+
+The generic Asset Pipeline owns source snapshots, cache keys, target selection,
+staging and atomic generation publication. The VFX fingerprint includes authoring and
+semantic schemas, compiler/lowering/provider/kernel versions, target capability
+fingerprint, ADR-owned plan schemas and all accepted dependency digests. Equivalent
+stack/graph semantics under identical inputs produce identical descriptor/kernel
+fingerprints; editor layout/comments/timestamps and worker order are excluded.
+
+Packaged runtime accepts only the validated cooked descriptor/kernel packages. It
+never parses source stack/graph nodes per particle, runs arbitrary script/bytecode,
+JITs missing variants or invokes an authoring plugin/compiler. CPU uses installed typed
+kernel IDs in bounded stage plans; GPU uses logical kernel IDs backed by the selected
+cook target. Missing variants follow typed fallback/failure, not source compilation.
+
+VFX validates current and explicitly supported prior payload/kernel schemas inside the
+generic envelope. Too-old artifacts require recook; newer, wrong-target, incompatible
+provider/kernel ABI or digest failures are rejected. Hot reload separately validates
+and admits a complete new generation; live instances pin the old lease until finish or
+authored safe restart and never reinterpret particle memory under a new layout.
 
 ## Decals
 
@@ -857,6 +891,15 @@ architecture-only change:
   backend switch, hidden node deletion or change to paired CPU gameplay outputs.
 - Saturate mixed CPU/GPU/shared/readback charges and replacement overlap. Preserve
   gameplay reserves and return readback/GPU credits only after final fence retirement.
+- Compile equivalent stack/graph fixtures and require identical canonical descriptor/
+  kernel fingerprints; layout/comments/selection and randomized cook scheduling must
+  not alter output. Both runtime routes consume only `CompiledVfxEffectDescriptor`.
+- Reject every stage/domain/provider/resource/layout/cost/version violation before
+  atomic publication. Exercise current/two-prior/too-old/newer/corrupt/wrong-target
+  artifacts, failed reload last-good retention and active old artifact leases.
+- Scan packaged/headless runtime reachability for source stack/graph parsers, authoring
+  node/plugin dependencies, arbitrary particle script/JIT paths or missing-variant
+  source compilation; none may be reachable from VFX execution.
 - Delay workers, GPU fences and snapshot readers across cell eviction and scene
   replacement. No early free/slot reuse, stale publication or lost accounting;
   Retired remains pending and teardown timeout retains dependencies safely.
@@ -873,6 +916,8 @@ architecture-only change:
   Normative GPU authority, observation, fallback and shared-admission contract.
 - [ADR-125: VFX Transparency, Sorting and Pass Placement](../../adr/125-vfx-transparency-sorting-and-pass-placement.md):
   Normative particle blend/pass, stable sorting and sort-budget contract.
+- [ADR-126: VFX Graph Compilation and Runtime Representation Convergence](../../adr/126-vfx-graph-compilation-and-runtime-representation-convergence.md):
+  Normative authoring convergence, compiled artifact and compatibility contract.
 - [Particle Editor UI Reference](./particle-editor.html): Emitter stack, curve editing,
   and live preview panel.
 - [Material And Shader Model](./material-and-shader-model.md): Particle and decal materials.


### PR DESCRIPTION
## Summary

- Adds ADR-126 to make stack-based and graph-based VFX authoring two frontends for one `CompiledVfxEffectDescriptor` runtime model.
- Keeps `ParticleSystemDescriptor` as the single nested compiled emitter-unit foundation instead of creating separate stack and graph runtime assets.
- Defines one deterministic offline lowering pipeline covering canonical IDs/order, unit partitioning, CPU stage plans, GPU kernel requirements, readback/fallback, render/sort rules, dependencies, capability requirements, and peak costs.
- Forbids runtime graph traversal, arbitrary particle script/bytecode/JIT execution, authoring-plugin invocation, or source compilation of missing variants.
- Defines the VFX cooked payload/header, complete semantic cache inputs, current/two-prior compatibility rules, target/provider/kernel validation, and lease-safe atomic hot reload.
- Projects the decision into the VFX architecture, generic Asset Pipeline ownership boundary, and architecture/ADR indexes with explicit qualification scenarios.

## Why

The existing VFX architecture described both stack and graph authoring and stated that graphs compile ahead of time, but it did not name the single immutable root consumed by runtime. That ambiguity could produce separate loaders, defaults, parameter schemas, simulation paths, fallback behavior, or renderer seams for the two editors. It also left compiler IR, provider kernels, artifact versions, and hot-reload compatibility underspecified.

ADR-126 closes the boundary: editor representations stop at cook, generic Assets retains cache/publication authority, and runtime behavior depends only on one validated descriptor plus typed CPU/GPU kernel packages.

## Decision and boundaries

- `CompiledVfxEffectDescriptor` contains the common parameter schema, bounded emitter units, asynchronous edges, resources, capability requirements, fallbacks, peak cost envelope, and semantic fingerprint.
- Stack and graph source documents may differ in UI/layout and need not round-trip, but equivalent semantics under identical locked inputs must produce identical canonical descriptor and kernel fingerprints.
- Compiler-internal IR is invocation-local; it is neither serialized nor exposed as a public/cache/runtime representation.
- Cook migration/canonicalization precedes validation and lowering. Stable semantic IDs—not node position, insertion order, pointers, unordered containers, registration order, or worker completion—determine output order.
- CPU packages contain bounded stage plans, immutable layout/parameter data, and stable references to installed typed kernels; they do not contain arbitrary executable code or script bytecode.
- GPU packages follow ADR-035 target artifact rules and implement the common logical kernel/layout/stage contract without owning fallback, pass, or domain policy.
- Cook rejects unknown nodes, stage/payload violations, synchronous authoritative GPU-to-CPU edges, missing variants/providers, unbounded behavior, layout/cost overflow, and incomplete dependencies before any artifact publication.
- The VFX cache fingerprint includes source/semantic/compiler/provider/kernel/plan schemas, effective target capability fingerprint, cooker-visible policy inputs, and all dependency generations/digests; editor-only state is excluded.
- Runtime validates envelope, payload, semantic model, target, capability, provider/kernel ABI, and dependency digests before admission. Packaged runtime never repairs from source.
- Hot reload validates and admits a complete new generation separately. Active instances retain their old artifact/provider/resource leases until finish or authored safe restart; live particle memory is never reinterpreted under a new layout.
- This is an architecture-only change; it defines implementation and regression obligations without claiming the compiler/runtime support already exists.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/126-vfx-graph-compilation-and-runtime-representation-convergence.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/vfx-and-particles-architecture.md docs/architecture/runtime/asset-pipeline.md`
- `git diff --check`
- `git diff --cached --check`
- Added-Markdown-link resolution check over the staged diff
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. It reported the existing mbedTLS minimum-version deprecation warning and skipped repository Python tests because `pytest` is unavailable.

## Risk and rollout

- Both authoring frontends must maintain common semantic golden fixtures and deterministic canonicalization, increasing compiler/test obligations.
- Descriptor, provider, CPU-kernel, GPU-package, and plan schemas need explicit compatibility readers or recook paths; best-effort runtime interpretation is intentionally unavailable.
- Some authoring extensions must ship a separately validated runtime typed-kernel provider; cooker availability alone does not make an artifact runnable.
- Target-specific GPU bytes may differ, so cross-target qualification must prove they implement the same common logical IDs/layouts rather than compare packages byte-for-byte.

## Issue links

- Closes #1753
- Jira: [HORO-1710](https://horo-engine.atlassian.net/browse/HORO-1710)
- Domain ticket: `[VFX-005.1]`

## Reviewer Notes

- Review the single-root rule first: every runtime entry point must consume `CompiledVfxEffectDescriptor`, with no source-kind-selected loader or executor.
- Check the offline lowering boundary for any path that could serialize compiler IR, execute authoring graphs/scripts, invoke an editor plugin, or source-compile a missing packaged variant.
- Check that generic Asset Pipeline owns snapshots/cache/target/staging/publication while VFX Model/Cook owns only semantic lowering, validation, payload, and fingerprints.
- Review version identity at all layers—generic envelope, VFX schema/semantic model, CPU ABI, GPU package, target capability, providers, and dependencies—and the current/two-prior/recook/reject outcomes.
- Check hot reload for atomic last-good retention, separate admission, active old leases, peak overlap, and no live storage reinterpretation.
- This PR is preserved as an individual merge commit on `develop`; final review and non-squash delivery to `main` occur in PR #2508.


[HORO-1710]: https://horo-engine.atlassian.net/browse/HORO-1710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ