### PR TITLE
docs(vfx): define decal projection policy HORO-1711 #1754 [VFX-006.1]

### DIFF
--- a/docs/adr/127-vfx-decal-projection-lifetime-and-rendering-path-policy.md
+++ b/docs/adr/127-vfx-decal-projection-lifetime-and-rendering-path-policy.md
@@ -1,0 +1,314 @@
+# ADR-127: VFX Decal Projection, Lifetime and Rendering Path Policy
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Decal box/oriented-box placement, scene projection data, permanent/timed/event-driven lifetime, count admission, fade/removal authority, deferred-default and forward fallback policy
+- **Issue**: [VFX-006.1](https://github.com/abdullahbodur/horo-engine/issues/1754)
+- **Jira**: [HORO-1711](https://horo-engine.atlassian.net/browse/HORO-1711)
+- **Related**: [ADR-011](011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md), [ADR-012](012-world-streaming-partition-authority-and-subsystem-boundaries.md), [ADR-026](026-large-world-precision-and-floating-origin-strategy.md), [ADR-034](034-gpu-memory-and-residency-ownership.md), [ADR-036](036-raster-render-path-and-quality-architecture.md), [ADR-126](126-vfx-graph-compilation-and-runtime-representation-convergence.md)
+- **Normative documents**: [VFX and Particles Architecture](../architecture/runtime/vfx-and-particles-architecture.md), [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
+
+## Context
+
+ADR-011 already owns the live boundary: scene-owned `VfxWorld`/`DecalManager` owns
+logical decal instances, fades and atlas requests; Renderer owns physical atlas/image
+storage, graph passes and deferred retirement. ADR-036 maps a deferred decal request to
+an admitted forward-decal substitute when the active raster recipe is not Deferred.
+
+The remaining model is underspecified. The VFX architecture shows one descriptor with
+`BoxProjection`, `OrientedBox`, a lifetime float and a permanent bool, which cannot
+represent event removal, owner scope, clock/fade semantics or invalid combinations.
+It also does not define world-versus-owner-local placement, admission for permanent
+and event-driven instances, or when deferred-to-forward remapping is compatible rather
+than silent visual degradation.
+
+This decision specializes projection and lifetime only. It deliberately does not add
+a scene component owner, renderer-owned logical decal world or independent decal
+scheduler beside ADR-011.
+
+## Decision
+
+### 1. ADR-011 ownership remains unchanged
+
+An authored scene decal component is an inert placement descriptor. Scene conversion
+submits it to the owning scene incarnation's `DecalManager`; the component does not own
+a live renderer object. Effect-spawned decals enter the same logical store and use the
+same identity, placement, lifetime, admission and rendering-path contracts.
+
+`DecalManager` is the only live logical owner. It creates generation-safe `DecalId`,
+advances timed fades, accepts authorized removal commands, closes admission and emits
+immutable `DecalRenderBatch` values. Renderer consumes those values, owns native
+resources/passes and acknowledges retirement. Neither editor components nor render
+backends maintain a second authoritative lifetime/count registry.
+
+### 2. Projection and placement are typed separately
+
+The compiled descriptor uses:
+
+```cpp
+enum class DecalProjectionMode : uint8_t {
+    Box,
+    OrientedBox
+};
+
+enum class DecalPlacementSpace : uint8_t {
+    WorldLocked,
+    OwnerLocal
+};
+
+struct DecalPlacementDescriptor {
+    DecalProjectionMode projection;
+    DecalPlacementSpace space;
+    Transform64 localOrWorldTransform;
+    Vec3 positiveHalfExtents;
+    DecalReceiverMask receivers;
+    float normalFadeCosine;
+    float distanceFadeStart;
+    float distanceFadeEnd;
+};
+```
+
+`Box` is axis-aligned in the declared placement space: its rotation is identity after
+canonicalization. `OrientedBox` admits a normalized orthonormal rotation plus
+translation and positive half extents. Neither mode permits shear, perspective,
+nonfinite values, degenerate extents or an arbitrary mesh/frustum. Scale is folded into
+half extents during cook/conversion.
+
+`WorldLocked` captures canonical ADR-026 world position/orientation and does not follow
+a source entity after spawn. `OwnerLocal` retains a generation-safe scene entity/bone
+owner and local transform; SceneRuntime supplies the resolved immutable world transform
+at extraction. A stale/destroyed owner removes the decal at the owner boundary. Raw ECS
+pointers, renderer transforms and native handles are forbidden.
+
+Spatial-cell decals also carry ADR-012 cell/partition fences. Cell unload closes their
+admission and logical visibility; renderer resources retire asynchronously after all
+snapshots/fences complete. Rebase changes only extracted render-relative transforms,
+not durable decal identity or lifetime.
+
+### 3. Lifetime is one tagged policy, never bool-plus-float combinations
+
+```cpp
+struct PermanentDecalLifetime {};
+
+struct TimedFadeDecalLifetime {
+    VfxClockDomain clock;
+    float visibleSeconds;
+    float fadeSeconds;
+    VfxCurveId fadeCurve;
+};
+
+struct EventDrivenDecalLifetime {
+    DecalRemovalChannelId channel;
+    DecalRemovalKey key;
+};
+
+using DecalLifetimePolicy = std::variant<
+    PermanentDecalLifetime,
+    TimedFadeDecalLifetime,
+    EventDrivenDecalLifetime>;
+```
+
+Exactly one variant is present. Cook rejects negative/nonfinite time, invalid curves,
+unknown clock domains, missing event channel/key and legacy combinations such as
+`isPermanent=true` with a finite expiration.
+
+### 4. Each lifetime mode has one removal authority
+
+| Lifetime | Visibility/fade | Removal authority |
+|---|---|---|
+| `Permanent` | Full authored opacity while its scene/entity/cell owner scope is active; distance/angle rendering fade may cull but does not age it | `DecalManager` removes on explicit authorized scene edit/delete, owning entity/cell/scene retirement or project/runtime teardown |
+| `TimedFade` | Full opacity for `visibleSeconds`, then sampled authored fade curve for `fadeSeconds` on the declared clock; zero-length visible or fade is valid immediate boundary behavior | `DecalManager` advances the logical clock and removes exactly at completed fade or earlier owner-scope retirement |
+| `EventDriven` | Full opacity until one matching admitted removal command; optional rendering distance/angle fade remains visual only | `DecalManager` validates owner/channel/key/generation at its command cutoff and removes once; owner-scope retirement remains unconditional |
+
+Pause and time scale follow the declared VFX clock. Wall time, render cadence, view
+count and GPU completion never advance lifetime. Renderer receives only the current
+immutable fade factor and cannot retain, expire or resurrect a logical decal.
+
+Removal is idempotent for the same current `DecalId`/command identity: the first
+accepted removal closes publication; duplicate/stale generations return typed status
+and do not target a reused slot. Event commands arriving during a cutoff apply at the
+next eligible owner boundary and never mutate an extracted snapshot.
+
+### 5. Permanent and event-driven do not bypass finite capacity
+
+Every compiled effect/scene descriptor declares maximum concurrent decals and per-
+spawn upper bounds. The active `VfxQualityPolicy` supplies finite per-effect, owner/
+cell and aggregate limits; the existing desktop aggregate default remains 256 decals.
+Permanent and event-driven instances consume a slot for their full owner lifetime.
+
+`TrySpawnDecal` admits identity, logical slot, result/retirement record, material/atlas
+reference and renderer cost before publication. Capacity exhaustion rejects the
+incoming decal with `DecalCapacityExceeded`; it does not evict an existing permanent,
+oldest or farthest instance and does not grow a pool in the frame path. Optional effect
+logic may observe rejection and follow a separately authored cosmetic response.
+
+Gameplay-required outcomes cannot depend on decal visibility or successful visual
+admission. Decals remain visual; a bullet-hit/gameplay fact exists independently on
+the CPU authority path. Reserved gameplay VFX work cannot be consumed by permanent
+cosmetic decal growth.
+
+### 6. Deferred projection is the default preference
+
+Compiled decals declare backend-neutral path intent:
+
+```cpp
+enum class DecalPathPreference : uint8_t {
+    PreferDeferred,
+    RequireDeferred,
+    PreferForward,
+    RequireForward
+};
+
+enum class ResolvedDecalPath : uint8_t {
+    DeferredProjection,
+    ForwardProjection
+};
+```
+
+Absent/legacy path intent migrates to `PreferDeferred`. The asset stores semantic
+requirements and compatible material variants, not GBuffer attachments, draw APIs,
+native blend state or backend names.
+
+`DeferredProjection` is eligible only when the resolved ADR-036 recipe is Deferred,
+admits the required deferred-decal capability/GBuffer semantics and has complete
+material/resource/budget variants. It executes in the dedicated deferred-decal pass
+after GBuffer production and before affected lighting; it does not write scene depth.
+
+`ForwardProjection` uses the recipe's dedicated bounded forward-decal path/list and
+compatible material variant. It is available on Forward/Clustered Forward+ tiers and
+may be explicitly selected in a hybrid Deferred frame. Its exact receiver/light/list
+capabilities and limits must be present; "forward" is not permission for an unbounded
+per-object scan or immediate draw.
+
+### 7. Path fallback is explicit, compatible and resolved with the raster recipe
+
+Resolution uses the same immutable recipe/capability/budget snapshot as rendering:
+
+| Preference | Resolution |
+|---|---|
+| `PreferDeferred` | Admitted deferred path; otherwise admitted authored forward variant; otherwise typed unavailability |
+| `RequireDeferred` | Admitted deferred path or typed recipe/capability/variant/budget failure; no forward remap |
+| `PreferForward` | Admitted forward path; otherwise admitted authored deferred variant when the active recipe supports it; otherwise typed unavailability |
+| `RequireForward` | Admitted forward path or typed failure, including on Deferred recipes without the required hybrid path |
+
+An authored compatibility record binds both material variants, receiver semantics,
+normal/distance fade, color/normal/roughness/emissive channel expectations and a finite
+visual-difference envelope. Missing channels/features cannot be silently discarded.
+Optional cosmetic decals may instead declare complete suppression as a fallback;
+required visual content fails/suspends its owning effect.
+
+Resolution records requested/resolved path, raster recipe, capability/policy/material
+generations, failed predicates, fallback rule and reserved cost. It occurs before
+activation or during an explicit separately admitted safe-point replacement. A path
+change does not reinterpret an active native resource or render both paths in one view.
+
+Forward-only tiers therefore use the authored forward projection when admitted;
+Deferred remains the default preference, not an engine-wide requirement. Missing
+deferred capability never switches the selected graphics backend or raster recipe just
+to preserve one decal.
+
+### 8. Logical lifetime is independent of rendering availability
+
+View culling, receiver-mask rejection, distance/angle fade, missing optional path and
+temporary renderer suspension do not advance or remove a logical decal. `DecalManager`
+continues the selected lifetime policy under its owner clock and exposes typed visual
+status. A later compatible render generation may display the still-live instance.
+
+A required-path failure at initial admission creates no logical instance. A runtime
+device/path loss follows the owning effect's authored suspend/stop/substitute policy;
+it cannot silently mark a timed decal expired. Logical removal immediately closes new
+extraction, while old snapshots/native atlas references remain leased and charged
+until renderer acknowledgement.
+
+### 9. Material/atlas and rendering ownership stay below the snapshot seam
+
+The compiled descriptor references Horo `MaterialId`/resource requirements and logical
+atlas content. `DecalManager` emits bounds, resolved immutable transform, fade factor,
+receiver mask and semantic path/material IDs in `DecalRenderBatch`. It never packs a
+native atlas, binds a GBuffer, chooses a pipeline or submits a pass.
+
+RenderFrontend validates the batch against the resolved recipe and admitted resources.
+Renderer owns physical atlas packing/upload, target-specific formats, graph resources,
+native synchronization and deferred destruction under ADR-034. Atlas replacement
+charges old/new overlap; a logical removal is not evidence that GPU readers finished.
+
+### 10. Failures are typed and generation-safe
+
+Cook/conversion failures include `DecalProjectionInvalid`, `DecalLifetimeInvalid`,
+`DecalPathVariantMissing`, `DecalReceiverContractInvalid` and checked size/count/cost
+overflow. Admission/runtime failures include `DecalCapacityExceeded`,
+`DecalPathUnavailable`, `DecalMaterialUnavailable`, `StaleDecalGeneration`,
+`DecalRemovalUnauthorized` and renderer/resource causes.
+
+Results retain decal/effect/owner/cell/material, requested/resolved path, lifetime,
+clock, recipe/capability/policy generations and failed predicate. Required failures do
+not produce partial logical/native state. Optional suppression/rejection is explicit,
+not successful rendering with missing channels or a silently changed path.
+
+### 11. Qualification covers placement, lifetime, capacity and paths
+
+Required implementation evidence includes:
+
+- Box and OrientedBox in WorldLocked/OwnerLocal spaces, nonfinite/zero/negative/sheared
+  transforms, owner/bone destruction, large-world rebase and stale cell fences;
+- each lifetime at zero/exact/one-tick-beyond boundaries, pause/time scale, duplicate/
+  stale/unauthorized event removal and owner/cell/scene teardown;
+- per-effect/owner/cell/aggregate limits at 255/256/257 desktop-default cases, permanent
+  and event-driven saturation, incoming rejection and no implicit eviction/growth;
+- every path-preference row across Forward, Clustered Forward+ and Deferred recipes,
+  missing capability/material/channel/budget and explicit suppression;
+- identical semantic receiver/fade fixtures for qualified deferred/forward variants
+  within their declared visual envelope, with no depth write or double rendering;
+- renderer suspension/device loss independent from timed lifetime, logical removal
+  closing extraction and old snapshot/atlas leases retiring after fences; and
+- backend-neutral public/snapshot data scans plus native image tests per shipped path.
+
+## Consequences
+
+### Positive
+
+- Projection volume and placement semantics are unambiguous and generation-safe.
+- Every lifetime mode has one clock/removal owner and finite admission behavior.
+- Deferred is the clear default while forward-only tiers have an explicit compatible path.
+- Scene and effect decals share one live owner, pool, batch and retirement contract.
+- Renderer-native atlas/pass details remain private.
+
+### Costs
+
+- Legacy bool/float lifetime and path fields require cooked-schema migration.
+- Permanent/event-driven content must reserve finite worst-case concurrent capacity.
+- Deferred and forward variants need authored compatibility data and image qualification.
+- Path replacement/atlas reload may temporarily charge both generations.
+
+## Rejected Alternatives
+
+### Give scene components and effects separate live decal managers
+
+Rejected because ADR-011 already assigns one logical owner; separate stores would
+duplicate identity, limits, fades, extraction and retirement.
+
+### Keep `isPermanent` plus `lifetimeSeconds`
+
+Rejected because contradictory values cannot represent event authority, clock domain
+or fade boundaries. One tagged lifetime policy is exhaustive and validated.
+
+### Evict the oldest or farthest decal when the pool is full
+
+Rejected as an implicit policy that can remove permanent/event-owned content and make
+results view-dependent. Reject incoming work unless a future explicit policy says otherwise.
+
+### Treat deferred decals as mandatory on every renderer tier
+
+Rejected because Forward/Clustered Forward+ recipes may lack a compatible GBuffer.
+Default preference resolves to an authored bounded forward variant or typed failure.
+
+### Silently remap `RequireDeferred` to forward
+
+Rejected because required appearance/capability intent would be lost. Only preference
+edges with declared compatible variants may fall back.
+
+### Let Renderer expire decals or own logical placement
+
+Rejected because render cadence/device lifetime cannot author scene/effect state.
+Renderer consumes immutable batches and owns only physical resources/passes.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -138,6 +138,7 @@ to the replacement.
 | [124](124-vfx-gpu-simulation-readback-and-compute-fallback.md) | VFX GPU Simulation, Readback and Compute Fallback | Proposed | 2026-09-02 |
 | [125](125-vfx-transparency-sorting-and-pass-placement.md) | VFX Transparency, Sorting and Pass Placement | Proposed | 2026-09-02 |
 | [126](126-vfx-graph-compilation-and-runtime-representation-convergence.md) | VFX Graph Compilation and Runtime Representation Convergence | Proposed | 2026-09-02 |
+| [127](127-vfx-decal-projection-lifetime-and-rendering-path-policy.md) | VFX Decal Projection, Lifetime and Rendering Path Policy | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -384,6 +384,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [VFX Graph Compilation and Runtime Representation Convergence](../adr/126-vfx-graph-compilation-and-runtime-representation-convergence.md):
   stack/graph authoring convergence on one compiled descriptor, offline-only
   lowering, deterministic artifacts and explicit payload/kernel compatibility.
+- [VFX Decal Projection, Lifetime and Rendering Path Policy](../adr/127-vfx-decal-projection-lifetime-and-rendering-path-policy.md):
+  typed box placement, tagged lifetime/removal authority, finite count admission
+  and deferred-default with compatible forward-tier fallback.
 - [Post-Processing And Effects Architecture](./runtime/post-processing-and-effects-architecture.md):
   screen-space effects, HDR post chain, tonemapping, color grading, and
   accessibility pass ordering.

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -1166,6 +1166,13 @@ the scene-linear additive band follows it without per-particle distance sorting.
 frontend owns per-view stable CPU/GPU sort plans, aggregate work admission and overrun
 evidence. Assets/backends cannot name/reorder these semantic passes or depth policies.
 
+[ADR-127](../../adr/127-vfx-decal-projection-lifetime-and-rendering-path-policy.md)
+keeps logical decal placement/lifetime in VfxWorld while the frontend resolves a
+deferred-preferred or explicitly compatible forward path with the raster recipe.
+Renderer owns physical atlas storage and native passes only. `RequireDeferred` never
+silently remaps; forward-only tiers need an admitted forward variant, and neither path
+writes scene depth or renders the same decal twice in one view.
+
 ## XR Views And External Presentation Targets
 
 XR supplies a bounded runtime-driven set of view descriptors and

--- a/docs/architecture/runtime/vfx-and-particles-architecture.md
+++ b/docs/architecture/runtime/vfx-and-particles-architecture.md
@@ -28,6 +28,11 @@ makes stack and graph two authoring frontends for one `CompiledVfxEffectDescript
 Only deterministic cooked descriptors/kernel packages reach runtime; authoring graphs,
 arbitrary scripts and compiler IR never become parallel executable representations.
 
+[ADR-127](../../adr/127-vfx-decal-projection-lifetime-and-rendering-path-policy.md)
+specializes decals without changing ADR-011 ownership: typed box placement, exhaustive
+permanent/timed/event lifetime, finite admission and deferred-preferred/forward-
+compatible rendering resolution.
+
 DCC workflows, full fluid solvers, atmospheric scattering and screen-space
 post-processing remain outside this subsystem; see
 [Advanced Rendering Architecture](./advanced-rendering-architecture.md).
@@ -724,25 +729,39 @@ authored safe restart and never reinterpret particle memory under a new layout.
 
 ## Decals
 
-A decal is a projected texture applied to scene geometry within an oriented bounding box.
+A decal is a visual projection volume owned logically by the existing scene
+`DecalManager`. Scene components are inert placement descriptors; scene and effect
+decals enter the same generation-safe store, capacity and extraction path.
 
 ```cpp
 struct DecalDescriptor {
     DecalId id;
     MaterialId material;
-    ProjectionMode mode;      // BoxProjection, OrientedBox
-    Vec3 halfSize;
-    float fadeAngle;
-    float fadeOutDistance;
-    float lifetimeSeconds;
-    bool isPermanent;
+    DecalProjectionMode projection; // Box or OrientedBox
+    DecalPlacementSpace space;       // WorldLocked or OwnerLocal
+    Transform64 localOrWorldTransform;
+    Vec3 positiveHalfExtents;
+    DecalReceiverMask receivers;
+    DecalLifetimePolicy lifetime;    // Permanent, TimedFade or EventDriven
+    DecalPathPreference path;        // defaults to PreferDeferred
 };
 ```
 
-- **Projection Mode**: Default is deferred projection writing to the G-Buffer.
-  Forward decals use clustered/tiled decal lists on forward feature tiers.
-- **Lifetime**: Supports permanent environmental decals, timed fading decals
-  (e.g., bullet holes, blood splatters), and event-driven removal.
+- **Projection and placement**: Box is axis-aligned in its declared space;
+  OrientedBox permits normalized rotation, translation and positive half extents but
+  no shear/perspective. WorldLocked snapshots canonical world placement. OwnerLocal
+  follows one generation-safe entity/bone and is removed when that owner retires.
+- **Lifetime**: Permanent lasts until explicit/owner teardown; TimedFade uses declared
+  VFX clock, visible duration, fade duration and curve; EventDriven accepts one typed
+  owner/channel/key removal. `DecalManager` alone advances/removes logical instances.
+- **Capacity**: Per-effect/owner/cell and aggregate bounds are admitted before spawn;
+  the desktop aggregate default remains 256. Exhaustion rejects the incoming decal
+  with `DecalCapacityExceeded`; permanent/event-driven entries do not trigger hidden
+  oldest/farthest eviction or frame-path pool growth.
+- **Rendering path**: PreferDeferred is default and uses the dedicated deferred-decal
+  pass only on a compatible admitted Deferred recipe. Forward-only tiers require an
+  authored compatible bounded forward variant. RequireDeferred/RequireForward never
+  silently remap; no path writes scene depth or selects another backend/recipe.
 - **Atlas Management**: `DecalManager` groups logical atlas requests; the renderer
   owns texture packing/upload and deferred atlas retirement under the admitted budget.
 
@@ -900,6 +919,12 @@ architecture-only change:
 - Scan packaged/headless runtime reachability for source stack/graph parsers, authoring
   node/plugin dependencies, arbitrary particle script/JIT paths or missing-variant
   source compilation; none may be reachable from VFX execution.
+- Exercise Box/OrientedBox with WorldLocked/OwnerLocal placement, invalid transforms,
+  rebase and stale owner/cell fences. Verify each permanent/timed/event lifetime and
+  exact aggregate 255/256/257 count boundaries with incoming rejection/no eviction.
+- Resolve every decal path preference across Forward, Clustered Forward+ and Deferred,
+  including missing variants/capabilities/budgets and explicit suppression. Verify no
+  depth write, double rendering or renderer-driven lifetime change.
 - Delay workers, GPU fences and snapshot readers across cell eviction and scene
   replacement. No early free/slot reuse, stale publication or lost accounting;
   Retired remains pending and teardown timeout retains dependencies safely.
@@ -918,6 +943,8 @@ architecture-only change:
   Normative particle blend/pass, stable sorting and sort-budget contract.
 - [ADR-126: VFX Graph Compilation and Runtime Representation Convergence](../../adr/126-vfx-graph-compilation-and-runtime-representation-convergence.md):
   Normative authoring convergence, compiled artifact and compatibility contract.
+- [ADR-127: VFX Decal Projection, Lifetime and Rendering Path Policy](../../adr/127-vfx-decal-projection-lifetime-and-rendering-path-policy.md):
+  Normative decal placement, lifetime, admission and rendering-path contract.
 - [Particle Editor UI Reference](./particle-editor.html): Emitter stack, curve editing,
   and live preview panel.
 - [Material And Shader Model](./material-and-shader-model.md): Particle and decal materials.


### PR DESCRIPTION
## Summary

- Adds ADR-127 to define typed Box/OrientedBox decal projection and WorldLocked/OwnerLocal scene placement without changing ADR-011 ownership.
- Replaces ambiguous `isPermanent` plus `lifetimeSeconds` combinations with exhaustive Permanent, TimedFade, and EventDriven policies, each with one clock/removal authority.
- Keeps scene-authored and effect-spawned decals in the same generation-safe `DecalManager` store, finite pools, extraction path, and renderer retirement contract.
- Defines per-effect/owner/cell and aggregate count admission; the existing desktop aggregate default remains 256 and exhaustion rejects the incoming decal without implicit eviction or frame-path growth.
- Makes `PreferDeferred` the default and defines explicit `Require/PreferDeferred/Forward` resolution with authored compatible material variants and typed unavailability.
- Projects the decision into the VFX architecture, Rendering Architecture, and architecture/ADR indexes with placement, lifetime, capacity, path, and lifecycle qualification scenarios.

## Why

The existing VFX model exposed Box/OrientedBox, a lifetime float, a permanent bool, and a broad deferred/forward statement. It did not represent event-removal authority, clock/fade boundaries, owner-local placement, permanent/event-driven capacity, or when deferred-to-forward remapping is an authored compatible fallback instead of silent degradation.

ADR-127 fills those gaps while preserving ADR-011: `VfxWorld`/`DecalManager` remains the sole live logical owner and Renderer remains the physical atlas/pass/resource owner.

## Decision and boundaries

- Scene decal components are inert placement descriptors. Scene conversion and effect spawning both create logical instances in the owning scene incarnation's `DecalManager`.
- `Box` is axis-aligned in its declared placement space; `OrientedBox` supports normalized orthonormal rotation, translation, and positive half extents. Shear, perspective, nonfinite values, and degenerate extents fail validation.
- `WorldLocked` captures canonical world placement. `OwnerLocal` follows one generation-safe entity/bone and is removed when that owner retires; raw ECS pointers and renderer handles are forbidden.
- Permanent decals last until authorized explicit deletion or owner/entity/cell/scene teardown. TimedFade uses the declared VFX clock, visible duration, fade duration, and curve. EventDriven accepts one matching typed owner/channel/key removal.
- Renderer visibility, culling, distance/angle fade, path suspension, or GPU completion never advances logical lifetime. Renderer receives only immutable resolved transform/fade data.
- `TrySpawnDecal` reserves identity, logical/retirement records, material/atlas references, and renderer cost before publication. Permanent and event-driven instances hold capacity for their full owner lifetime.
- Deferred projection is eligible only on an admitted Deferred recipe with matching GBuffer/material/resource semantics. Forward projection uses a bounded dedicated forward-decal path/list and compatible variant.
- `RequireDeferred` and `RequireForward` never remap. Preference fallback records the recipe, capability/policy/material generations, failed predicate, selected rule, and reserved cost.
- Missing deferred support never switches the graphics backend or raster recipe to preserve a decal, and no view renders both paths for the same instance.
- Logical removal closes new extraction immediately, but old snapshots/atlas resources remain leased and charged until renderer fence retirement.
- This is an architecture-only change; it defines implementation and regression obligations without claiming the decal paths already exist.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/127-vfx-decal-projection-lifetime-and-rendering-path-policy.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/vfx-and-particles-architecture.md docs/architecture/runtime/rendering-architecture.md`
- `git diff --check`
- `git diff --cached --check`
- Added-Markdown-link resolution check over the staged diff
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. It reported the existing mbedTLS minimum-version deprecation warning and skipped repository Python tests because `pytest` is unavailable.

## Risk and rollout

- Legacy bool/float lifetime and path fields require cooked-schema migration to exhaustive tagged policies.
- Permanent and event-driven content must reserve finite worst-case capacity and can become explicitly unavailable rather than triggering hidden oldest/farthest eviction.
- Deferred and forward variants need authored semantic compatibility data and native image qualification on each shipped raster path.
- Path/material/atlas replacement may temporarily charge old and new generations until all frame readers and GPU fences retire.

## Issue links

- Closes #1754
- Jira: [HORO-1711](https://horo-engine.atlassian.net/browse/HORO-1711)
- Domain ticket: `[VFX-006.1]`

## Reviewer Notes

- Review that no second ownership story was introduced: DecalManager owns logical identity/lifetime, Renderer owns only native atlas/pass/resource state.
- Check Box/OrientedBox and WorldLocked/OwnerLocal validation, especially stale owner/cell fences and large-world rebase behavior.
- Check every lifetime row for clock, fade visibility, explicit/owner teardown, idempotent event removal, and slot reuse safety.
- Check the 256 aggregate default and incoming-rejection policy for no implicit eviction or frame-path pool growth.
- Review every decal path preference across Forward, Clustered Forward+, and Deferred, including compatible variants, required failures, no depth write, and no double rendering.
- This PR is preserved as an individual merge commit on `develop`; final review and non-squash delivery to `main` occur in PR #2508.


[HORO-1711]: https://horo-engine.atlassian.net/browse/HORO-1711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ