### PR TITLE
docs(vfx): define spawn pool budget policy HORO-1712 #1755 [VFX-007.1]

### DIFF
--- a/docs/adr/128-vfx-spawn-event-mapping-pooling-and-budget-enforcement.md
+++ b/docs/adr/128-vfx-spawn-event-mapping-pooling-and-budget-enforcement.md
@@ -1,0 +1,275 @@
+# ADR-128: VFX Spawn Event Mapping, Pooling and Budget Enforcement
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Gameplay-event binding ownership, allocation-free playback pools, aggregate VFX budget accounting, explicit overload selection, and inactive-system sleep/wake admission
+- **Issue**: [VFX-007.1](https://github.com/abdullahbodur/horo-engine/issues/1755)
+- **Jira**: [HORO-1712](https://horo-engine.atlassian.net/browse/HORO-1712)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-011](011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md), [ADR-012](012-world-streaming-partition-authority-and-subsystem-boundaries.md), [ADR-034](034-gpu-memory-and-residency-ownership.md), [ADR-091](091-footstep-and-locomotion-event-ownership.md), [ADR-123](123-vfx-cpu-stage-order-determinism-and-gameplay-coupling.md), [ADR-124](124-vfx-gpu-simulation-readback-and-compute-fallback.md), [ADR-125](125-vfx-transparency-sorting-and-pass-placement.md), [ADR-126](126-vfx-graph-compilation-and-runtime-representation-convergence.md), [ADR-127](127-vfx-decal-projection-lifetime-and-rendering-path-policy.md)
+- **Normative documents**: [VFX and Particles Architecture](../architecture/runtime/vfx-and-particles-architecture.md), [Gameplay Module Boundary](../architecture/extensions/gameplay-module-boundary.md)
+
+## Context
+
+ADR-011 gives one scene incarnation's `VfxWorld` ownership of effect instances,
+preallocated storage, bounded requests and deterministic queue admission. It rejects
+the incoming request when a queue or pool is full and prohibits implicit eviction of
+an existing effect. ADR-123 through ADR-127 specialize simulation, GPU work, sorting,
+compiled representation and decals without changing that ownership.
+
+Two boundaries remain underspecified. First, gameplay code needs semantic events such
+as a landed impact or weapon hit, while VFX assets are presentation choices. If the VFX
+subsystem hardcodes gameplay meanings or gameplay code selects internal emitters, both
+sides become a second owner of presentation policy. Second, count ceilings alone do
+not define how CPU work, GPU work, draw calls, delayed timing evidence and retained
+memory share one finite product budget.
+
+Pooling and inactivity also need one lifecycle contract. A system that stops visible
+work may still retain slots and GPU resources. Conversely, waking a dormant system
+must not allocate or perform unbounded catch-up. Treating sleep as an unrelated
+visibility optimization would bypass the same admission rules that protect overload,
+streaming and teardown.
+
+This decision preserves rejection of the incoming request as the baseline. It permits
+oldest/farthest eviction or bounded delay only when an immutable binding explicitly
+selects that policy and every affected instance is eligible cosmetic work.
+
+## Decision
+
+### 1. The application owns semantic event-to-effect bindings
+
+Gameplay and application composition own a cooked, immutable
+`GameplayVfxBindingTable`. A binding maps a typed semantic event identity or declared
+effect tag to one or more effect assets and fixed spawn policy. `VfxWorld` validates
+and executes the resolved request; it never hardcodes meanings such as Footstep,
+Explosion, Hit or Weather and never queries gameplay state to infer them.
+
+```cpp
+struct GameplayVfxEvent {
+    GameplayVfxEventId event;
+    GameplayEventOccurrenceId occurrence;
+    SceneRuntimeId scene;
+    SimulationTick tick;
+    ProducerId producer;
+    uint32_t producerSequence;
+    Transform worldTransform;
+    VfxEventPayload payload;
+};
+
+struct GameplayVfxBinding {
+    GameplayVfxEventId event;
+    VfxEffectAssetId effect;
+    VfxPayloadSchemaId payloadSchema;
+    VfxSpawnPolicyId spawnPolicy;
+    VfxOwnershipPolicy ownership;
+};
+```
+
+The application adapter that owns a semantic event occurrence resolves it against one
+captured binding-table generation and submits a bounded `VfxSpawnRequest`. A binding
+may fan one occurrence out to an authored finite set of layered effects, but each
+request retains the original occurrence ID and a stable layer index for deduplication.
+Tags are stable typed IDs from a cooked registry, not runtime strings or substring
+matching.
+
+Bindings declare payload schema, allowed producer/principal, ownership scope, request
+class, quality variants and overload policy. Load/cook rejects duplicate semantic
+ownership, missing assets, invalid schemas, unbounded fan-out and a policy incompatible
+with required gameplay behavior. Hot reload prepares and validates a new immutable
+generation, then swaps at an owner safe point; already accepted requests retain the
+generation used to resolve them.
+
+Direct effect-asset requests remain available only to explicitly granted low-level
+application/tooling capabilities. Ordinary gameplay modules receive a semantic spawn
+capability scoped to their permitted event/tag set. Knowing an asset or tag ID is not
+authority to spawn it.
+
+### 2. Acceptance order and results are deterministic and bounded
+
+The scene/application owner orders authoritative inputs by scene, tick, producer and
+producer sequence before binding resolution. Fan-out layer order is cooked. Each clock
+domain freezes its accepted queue prefix and drains within the existing per-tick limit;
+worker arrival order, hash-map iteration, render visibility and GPU completion never
+choose winners.
+
+Binding miss, stale generation, unauthorized event, payload mismatch and duplicate
+occurrence return typed results without consuming a pool slot. Queue, pool or resource
+failure returns the existing `EventQueueFull`, `EffectCapacityExceeded` or
+`ResourceBudgetExceeded` class with event, occurrence, binding generation, effect,
+request class and failed budget dimension. No completion is delivered inline.
+
+### 3. Playback performs zero heap allocation
+
+Before activation, explicit load/preload or streaming preparation admits and
+materializes every runtime resource needed by the selected binding generation:
+
+- effect-instance, emitter, CPU particle and decal slots;
+- GPU particle/resource slices, indirect work and frames-in-flight overlap;
+- spawn, delayed-request, result, cancellation and retirement records;
+- simulation scratch, parameter blocks, extraction, upload and per-view sort storage;
+- diagnostics records and bounded Audio/VFX follow-up event storage.
+
+`TryEnqueueSpawn`, queue drain, spawn, simulation, extraction, render scheduling,
+sleep and wake do not allocate, grow a container, compile a graph or cook an asset.
+Allocation is allowed only inside an explicit non-playing preparation transaction:
+initial scene/project load, admitted cell preparation, or a policy/hot-reload resize.
+Such a transaction reserves peak old-plus-new memory and publishes atomically after
+validation. It is not an on-demand escape hatch from a gameplay frame.
+
+Pool slots carry scene/owner generation and are returned only after logical readers,
+jobs, snapshots and GPU fences retire. Sleeping retains its slots and memory charges;
+only complete retirement can return those credits. Pools may be partitioned into
+required and cosmetic reserves. Cosmetic work cannot borrow required capacity in a
+way that makes a previously admitted required bound unavailable.
+
+### 4. One VFX budget plan covers all work and retained resources
+
+Host composition owns the finite product envelope. `VfxWorld` owns the scene VFX
+ledger and produces one `VfxBudgetPlan`; Renderer validates and charges the GPU and
+per-view portions against the same host envelope rather than creating a second VFX
+allowance. Streaming-cell reservations are slices of this ledger.
+
+Every quality profile defines finite hard limits for at least:
+
+- live CPU and GPU particles, effect/emitter instances and decals;
+- admitted and delayed spawn/result records;
+- CPU simulation work, jobs, scratch, upload/readback bytes and pending readbacks;
+- per-view packed particles, sort keys, draw batches/calls and shadow/decal/volume work;
+- GPU compute, sort and render work plus qualified delayed GPU-time evidence;
+- live, replacement-overlap and retirement-pending CPU/GPU memory.
+
+The baseline configurable ceilings remain 16,384 aggregate CPU particles, 1,000,000
+GPU particles and 256 decals. They are ceilings, not promises. Per-domain, per-asset,
+per-owner and per-cell limits subdivide the aggregate and cannot create additional
+capacity. Every count/stride/frames-in-flight product is overflow checked.
+
+Hard work and memory counters decide current admission before work starts. CPU/GPU
+time targets use measurements qualified by workload, device/profile, backend,
+resolution/view count, build and policy revision. Delayed or unavailable GPU timing
+is never interpreted as zero. Timing evidence may tighten a later deterministic policy
+revision; it does not retroactively preempt submitted native work.
+
+Required gameplay work has reserved count, work, output and result capacity. Failure
+to admit its declared worst case is a typed owner-visible failure, never cosmetic
+quality reduction. Null follows the same logical count, queue and lifecycle accounting
+while recording visual GPU work as unsupported/suppressed, not completed for free.
+
+### 5. Over-budget behavior is explicit, finite and observable
+
+Each binding selects one cooked `VfxOverBudgetPolicy`:
+
+```cpp
+enum class VfxOverBudgetPolicy : uint8_t {
+    RejectNewest,
+    DelayBounded,
+    EvictOldestCosmetic,
+    EvictFarthestCosmetic,
+    UseAuthoredReduction
+};
+```
+
+`RejectNewest` is the default and preserves ADR-011: accepted work is not overwritten,
+the incoming request fails, and an emitter at its particle cap drops new cosmetic
+births. `UseAuthoredReduction` may select only a precompiled compatible variant whose
+full costs are admitted before activation.
+
+`DelayBounded` applies only to cosmetic requests. The binding defines maximum queued
+requests, maximum ticks/age and fixed FIFO priority. Delayed requests retain their
+original order and reserved result record, are retried only at declared tick boundaries
+and expire with `VfxSpawnDelayExpired`. Delay never blocks a producer, spins, grows a
+queue or crosses a scene/cell/owner generation.
+
+`EvictOldestCosmetic` and `EvictFarthestCosmetic` are opt-in replacement policies, not
+implicit pool behavior. Eligible victims must be cosmetic, explicitly replaceable,
+inside the same declared budget partition and free enough reusable logical capacity
+without waiting for GPU retirement. Required/gameplay-coupled instances, permanent or
+event-driven decals, protected owner/cell effects and work with pending outputs are
+never eligible.
+
+Oldest uses admitted spawn tick, producer sequence and instance ID as stable ties.
+Farthest uses a binding-declared canonical distance reference frozen for the admission
+boundary; multi-view policy names the authoritative view set and aggregation rule.
+Nonfinite/missing references make the candidate ineligible. Distance does not depend
+on unordered view traversal or a backend visibility result. Equal candidates use the
+same stable oldest/instance ties.
+
+Eviction is a normal typed stop transition and records victim/replacement correlation.
+If retirement cannot provide immediately reusable capacity, the new request is
+rejected or bounded-delayed according to its single cooked fallback; it cannot cascade
+through arbitrary victims. No policy changes gameplay output, collision, timing or
+required capacity to preserve a visual effect.
+
+### 6. Sleep and wake are budget-controlled lifecycle states
+
+`VfxWorld` owns `Active`, `Sleeping`, `WakePending` and `Retiring` state transitions.
+A system is sleep-eligible only when its compiled policy marks it cosmetic and
+sleepable and it has no required gameplay output, pending sub-emitter/Audio event,
+readback consumer, owner callback or retirement dependency. Render invisibility alone
+does not make required or gameplay-coupled work sleepable.
+
+The sleep policy declares one clock behavior: freeze logical age, advance a bounded
+analytic age without simulation, or restart on wake. Entry occurs at the owner safe
+point after current jobs/extraction complete. Sleeping schedules no simulation,
+packing, sort or draw work, but retains and charges all occupied slots and physical
+resources. It is not eviction and does not satisfy a memory/slot shortage.
+
+Wake is a fresh work admission using already prepared storage. If count/work/draw/GPU
+budget is unavailable, the system remains sleeping or follows its single declared
+cosmetic fallback and reports `VfxWakeBudgetExceeded`. Analytic advance is bounded;
+there is no per-missed-tick replay or unbounded catch-up. A stale scene/cell/owner
+generation retires instead of waking.
+
+### 7. Diagnostics expose decisions without becoming authority
+
+Structured metrics report capacity and high-water marks by budget dimension, binding
+generation, request class, effect and owner partition. Outcomes distinguish binding
+miss, queue rejection, pool rejection, each delay/expiry, authored reduction, selected
+victim, sleep reason, wake denial and physical retirement lag. Required failures carry
+correlation identities and are never reduced to a rate-limited log.
+
+Observability may recommend another authored profile but cannot mutate budgets,
+bindings, priority, victim eligibility or sleep state from a telemetry callback. Policy
+changes are explicit revisioned transactions at the application/host owner boundary.
+
+## Consequences
+
+- Gameplay semantics and presentation asset choice have one explicit owner each.
+- Normal playback has a finite memory/work proof and no frame-path allocation escape.
+- Default overload behavior remains compatible with ADR-011 while opt-in cosmetic
+  delay or replacement has deterministic selection and bounded failure.
+- Sleeping reduces active work but honestly retains memory and slot accounting.
+- Budgets and diagnostics span CPU, GPU and Renderer work without duplicate ledgers.
+- Content authors must provide policies, variants and bounds; load/cook may reject
+  effects that previously depended on runtime growth or ambiguous dropping.
+- Farthest replacement requires a declared canonical reference and may be unavailable
+  for a multi-view composition that cannot define one.
+
+## Rejected Alternatives
+
+### Let VFX interpret gameplay events and choose effects internally
+
+Rejected because semantic authority, asset policy and gameplay state queries would be
+hidden inside a presentation subsystem and impossible to capability-scope cleanly.
+
+### Allocate or grow a pool when a spawn arrives
+
+Rejected because allocator latency, fragmentation and failure would enter frame-hot
+paths, and a successful local allocation could bypass aggregate host/GPU admission.
+
+### Always drop the oldest or farthest instance
+
+Rejected because permanent, gameplay-required or still-referenced work may be chosen;
+distance can also vary by view. Replacement is allowed only as an explicit cosmetic
+policy with stable eligible candidates and ties.
+
+### Use visibility as an independent automatic sleep mechanism
+
+Rejected because visibility is view-dependent, sleeping retains resources and some
+invisible effects still produce required logical outputs. Sleep/wake belongs to the
+same lifecycle and budget owner as spawn admission.
+
+### Enforce budgets from measured frame time alone
+
+Rejected because CPU/GPU timing is noisy and GPU evidence is delayed or unavailable.
+Finite work/count/memory bounds provide current safety; qualified timing guides later
+policy selection and diagnostics.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -139,6 +139,7 @@ to the replacement.
 | [125](125-vfx-transparency-sorting-and-pass-placement.md) | VFX Transparency, Sorting and Pass Placement | Proposed | 2026-09-02 |
 | [126](126-vfx-graph-compilation-and-runtime-representation-convergence.md) | VFX Graph Compilation and Runtime Representation Convergence | Proposed | 2026-09-02 |
 | [127](127-vfx-decal-projection-lifetime-and-rendering-path-policy.md) | VFX Decal Projection, Lifetime and Rendering Path Policy | Proposed | 2026-09-02 |
+| [128](128-vfx-spawn-event-mapping-pooling-and-budget-enforcement.md) | VFX Spawn Event Mapping, Pooling and Budget Enforcement | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -387,6 +387,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [VFX Decal Projection, Lifetime and Rendering Path Policy](../adr/127-vfx-decal-projection-lifetime-and-rendering-path-policy.md):
   typed box placement, tagged lifetime/removal authority, finite count admission
   and deferred-default with compatible forward-tier fallback.
+- [VFX Spawn Event Mapping, Pooling and Budget Enforcement](../adr/128-vfx-spawn-event-mapping-pooling-and-budget-enforcement.md):
+  application-owned semantic bindings, allocation-free playback pools, one finite
+  CPU/GPU budget ledger and deterministic cosmetic overload/sleep policy.
 - [Post-Processing And Effects Architecture](./runtime/post-processing-and-effects-architecture.md):
   screen-space effects, HDR post chain, tonemapping, color grading, and
   accessibility pass ordering.

--- a/docs/architecture/extensions/gameplay-module-boundary.md
+++ b/docs/architecture/extensions/gameplay-module-boundary.md
@@ -324,6 +324,20 @@ GPU readback and Null/visual output cannot drive authoritative gameplay. A behav
 needing particle-derived gameplay declares a CPU-mandatory compiled unit and admits
 its worst-case work/output capacity.
 
+[ADR-128](../../adr/128-vfx-spawn-event-mapping-pooling-and-budget-enforcement.md)
+places event-to-effect choice in an application-owned cooked
+`GameplayVfxBindingTable`. Ordinary modules/scripts receive a capability scoped to
+declared semantic event IDs or typed effect tags; they do not discover internal
+emitters, inspect the binding table or gain spawn authority merely by knowing an asset
+or tag ID. The application adapter resolves one immutable binding generation and
+submits bounded requests carrying stable occurrence/layer identity.
+
+The binding fixes payload schema, ownership/request class, finite fan-out, compatible
+quality variants and overload policy. Load rejects duplicate semantic ownership,
+unbounded mappings or required behavior paired with cosmetic delay/eviction. Queue,
+pool and budget denials return typed correlated results; gameplay cannot block, grow a
+pool or bypass the reserved required capacity.
+
 ## Services
 
 A game module may create project- or runtime-scoped services through explicit

--- a/docs/architecture/runtime/vfx-and-particles-architecture.md
+++ b/docs/architecture/runtime/vfx-and-particles-architecture.md
@@ -33,6 +33,11 @@ specializes decals without changing ADR-011 ownership: typed box placement, exha
 permanent/timed/event lifetime, finite admission and deferred-preferred/forward-
 compatible rendering resolution.
 
+[ADR-128](../../adr/128-vfx-spawn-event-mapping-pooling-and-budget-enforcement.md)
+places semantic event-to-effect bindings at the application boundary, requires
+allocation-free playback from prepared pools, unifies count/work/time/memory budgets
+and makes cosmetic overload plus sleep/wake explicit and deterministic.
+
 DCC workflows, full fluid solvers, atmospheric scattering and screen-space
 post-processing remain outside this subsystem; see
 [Advanced Rendering Architecture](./advanced-rendering-architecture.md).
@@ -360,6 +365,17 @@ entries retain FIFO order for later ticks. Results, cancellation and retirement 
 reserved capacity so overload cannot prevent cleanup. Configuration validates queue,
 result and gameplay-reserve limits together. Null follows the same capacity policy;
 a separate reduced visual resource budget cannot consume the gameplay reserve.
+
+ADR-128 permits `DelayBounded`, `EvictOldestCosmetic`,
+`EvictFarthestCosmetic` or `UseAuthoredReduction` only when an immutable binding
+explicitly selects it. `RejectNewest` remains the default. Delay has fixed count/age
+bounds and FIFO ties. Replacement considers only explicitly replaceable cosmetic work
+inside the same partition; required/gameplay work, permanent or event-driven decals,
+pending outputs and protected owner/cell effects are ineligible. Oldest uses admitted
+tick/sequence/instance identity. Farthest uses a declared reference frozen for that
+admission boundary and stable ties, never renderer traversal order. If retirement does
+not yield immediately reusable logical capacity, the incoming request is rejected or
+uses its one bounded declared fallback.
 
 ## Scene And Cell Teardown
 
@@ -767,8 +783,23 @@ struct DecalDescriptor {
 
 ## Event-Driven Spawning & Audio Coupling
 
-Gameplay requests effects through fallible bounded admission to VfxEventQueue;
-this schematic payload is copied into queue-owned storage:
+Gameplay/application composition owns an immutable cooked
+`GameplayVfxBindingTable`. It maps typed semantic event IDs or registry-backed effect
+tags to effect assets, payload schemas, owner/request class, quality variants and one
+overload policy. `VfxWorld` validates and executes resolved requests; it never
+hardcodes gameplay meanings or queries gameplay state to infer a Footstep, Explosion,
+Hit or Weather effect. Ordinary gameplay receives a capability scoped to permitted
+events/tags; direct asset requests require an explicit low-level application/tooling
+grant.
+
+The semantic event retains scene/tick/producer/sequence and occurrence identity. The
+owning application adapter resolves one captured binding generation, applies cooked
+finite fan-out order and submits each deduplicated layer through fallible bounded
+admission. Binding hot reload publishes atomically at an owner safe point; accepted
+requests retain their original binding generation. Missing/duplicate/unauthorized
+bindings and payload mismatch are typed zero-mutation failures.
+
+The resolved schematic payload is copied into queue-owned storage:
 
 ```cpp
 struct VfxSpawnRequest {
@@ -838,12 +869,28 @@ budget. Fallback requires a complete new plan, and replacement overlap remains c
 until retirement. GPU/readback pressure cannot consume reserved gameplay CPU work or
 output capacity.
 
-The single overflow policy above rejects incoming requests/new cosmetic births.
-There is no separate implicit oldest/farthest eviction policy. Authored quality
-reductions are selected during admission/restart and reported with the resolved
-cap, capability/policy revision, emitter identity and reason. Diagnostics expose
-queue/pool use, rejected requests, deferred steps, gameplay failures, sort omissions,
-retired bytes and timeout causes through the observability system.
+The default overflow policy above rejects incoming requests/new cosmetic births.
+There is no implicit oldest/farthest eviction policy. ADR-128's opt-in cosmetic delay,
+replacement and authored-reduction modes use the same ledger and stable owner ordering;
+they never evict or degrade required work. Authored quality reductions are selected
+during admission/restart and reported with the resolved cap, capability/policy
+revision, emitter identity and reason. Diagnostics expose queue/pool use, rejected and
+delayed requests, selected victims, sleep/wake outcomes, gameplay failures, sort
+omissions, retired bytes and timeout causes through the observability system.
+
+### Sleep And Wake Admission
+
+`VfxWorld` alone transitions `Active`, `Sleeping`, `WakePending` and `Retiring`.
+Only compiled cosmetic sleepable systems with no required gameplay output, pending
+sub-emitter/Audio event, readback consumer, owner callback or retirement dependency
+are eligible. Visibility alone cannot sleep gameplay-coupled work. The authored policy
+freezes age, advances bounded analytic age or restarts on wake.
+
+Sleeping schedules no simulation, extraction, sort or draw work, but its occupied
+slots and physical resources remain charged. Wake re-admits work against prepared
+storage and never allocates or replays every missed tick. On denial the system remains
+sleeping or follows its one declared cosmetic fallback with a typed diagnostic. A stale
+scene/cell/owner generation retires rather than waking.
 
 ## Typed Failure Contract
 
@@ -925,6 +972,18 @@ architecture-only change:
 - Resolve every decal path preference across Forward, Clustered Forward+ and Deferred,
   including missing variants/capabilities/budgets and explicit suppression. Verify no
   depth write, double rendering or renderer-driven lifetime change.
+- Resolve semantic events/tags through versioned binding fixtures. Reject duplicate
+  ownership, invalid schema/capability, unbounded fan-out and stale generations; prove
+  stable occurrence/layer deduplication and no hardcoded gameplay-to-asset mapping.
+- Instrument enqueue, drain, spawn, simulation, extraction, sleep and wake under mixed
+  load and require zero heap allocations. Exercise prepared resize with admitted
+  old/new overlap and retain slot/memory charges through final reader/GPU retirement.
+- Saturate every count/work/draw/time/memory dimension and each ADR-128 overload mode.
+  Verify RejectNewest default, bounded FIFO delay/expiry, stable oldest/farthest ties,
+  protected required/permanent/event-driven work and no cascading or hidden eviction.
+- Exercise Active/Sleeping/WakePending/Retiring across visibility, multi-view, owner
+  and cell generation changes. Verify sleeping retains memory charges, wake performs
+  no allocation or unbounded catch-up and denied wake remains bounded and observable.
 - Delay workers, GPU fences and snapshot readers across cell eviction and scene
   replacement. No early free/slot reuse, stale publication or lost accounting;
   Retired remains pending and teardown timeout retains dependencies safely.
@@ -945,6 +1004,8 @@ architecture-only change:
   Normative authoring convergence, compiled artifact and compatibility contract.
 - [ADR-127: VFX Decal Projection, Lifetime and Rendering Path Policy](../../adr/127-vfx-decal-projection-lifetime-and-rendering-path-policy.md):
   Normative decal placement, lifetime, admission and rendering-path contract.
+- [ADR-128: VFX Spawn Event Mapping, Pooling and Budget Enforcement](../../adr/128-vfx-spawn-event-mapping-pooling-and-budget-enforcement.md):
+  Normative semantic binding, allocation-free playback, budget, overload and sleep/wake contract.
 - [Particle Editor UI Reference](./particle-editor.html): Emitter stack, curve editing,
   and live preview panel.
 - [Material And Shader Model](./material-and-shader-model.md): Particle and decal materials.


### PR DESCRIPTION
## Summary

- Records ADR-128 for gameplay-event-to-effect mapping, allocation-free VFX playback pools, aggregate budget enforcement, and sleep/wake admission.
- Makes the application-owned `GameplayVfxBindingTable` the single semantic mapping authority while keeping `VfxWorld` responsible for validation, admission, execution, and lifecycle.
- Preserves `RejectNewest` as the baseline overload behavior and limits delay/oldest/farthest/reduction policies to explicitly authored, finite cosmetic cases.
- Projects the decision into the VFX runtime architecture, gameplay module capability boundary, architecture index, and ADR index.

## Why

The existing VFX contracts define bounded queues and preallocated storage, but they do not identify one owner for mapping gameplay semantics to presentation assets or fully specify how count, CPU/GPU work, draw, time, memory, and inactive-system behavior share one product budget. Without that boundary, gameplay can become coupled to emitter internals, VFX can acquire hidden gameplay semantics, and overload handling can vary with worker arrival, visibility, or renderer traversal.

ADR-128 closes those gaps while retaining the safety properties of ADR-011 and the specialized simulation/rendering decisions in ADR-123 through ADR-127.

## Decision and boundaries

- Defines typed, cooked semantic events/tags and immutable binding generations with bounded fan-out, payload schema, ownership, request class, variants, and overload policy.
- Requires every frame-hot playback resource to be admitted and materialized during explicit load/preload/streaming preparation; enqueue, spawn, simulation, extraction, render scheduling, sleep, and wake perform no heap allocation.
- Uses one `VfxBudgetPlan` across `VfxWorld`, Renderer, and streaming slices for live/retiring memory, particles, instances, decals, queues, CPU/GPU work, per-view sort/draw work, upload/readback, and qualified timing evidence.
- Defines deterministic `RejectNewest`, bounded FIFO delay, eligible-cosmetic oldest/farthest replacement, and precompiled authored reduction. Required/gameplay work, permanent/event-driven decals, pending outputs, and protected owner/cell work cannot be evicted or degraded.
- Makes sleep/wake explicit `VfxWorld` lifecycle states. Sleeping saves active work but retains slot/memory charges; wake is allocation-free fresh admission with no unbounded catch-up.
- Adds qualification scenarios covering mapping ownership, hot-path allocation, every budget dimension and overload mode, deterministic ties, protected work, and sleep/wake transitions.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/128-vfx-spawn-event-mapping-pooling-and-budget-enforcement.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/vfx-and-particles-architecture.md docs/architecture/extensions/gameplay-module-boundary.md`
- `git diff --check`
- `git diff --cached --check`
- Added Markdown links resolve with the repository-relative staged-link checker.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. Existing warnings remain: mbedTLS declares an old CMake compatibility floor, and repository Python tests are skipped because `pytest` is unavailable.

## Risk and rollout

- This is an architecture-only change; implementation and executable qualification coverage remain follow-up work.
- Opt-in oldest/farthest replacement is intentionally narrower than a generic eviction mechanism. Content that cannot provide a stable reference or immediately reusable eligible capacity falls back to bounded delay or rejection.
- Sleeping intentionally does not reclaim memory or slots. Profiles must size retained inactive effects separately from active work savings.
- Existing content that relies on runtime pool growth, unbounded event fan-out, or implicit gameplay-to-asset lookup will require migration to cooked bindings and admitted pools.

## Issue links

- Jira: [HORO-1712](https://horo-engine.atlassian.net/browse/HORO-1712)
- GitHub: Closes #1755
- Domain ticket: `[VFX-007.1]`

## Reviewer Notes

- Confirm that application ownership of semantic bindings is narrow enough for native/script gameplay without moving effect lifecycle ownership out of `VfxWorld`.
- Check that `RejectNewest` remains the default and that opt-in replacement cannot select required/gameplay-coupled, permanent/event-driven, pending-output, or protected owner/cell work.
- Review the deterministic ordering and farthest-reference rules, especially for multi-view compositions.
- Confirm that sleeping retains all slot/memory charges and wake cannot allocate or replay missed ticks without bound.

## Stack

- Base: `docs/HORO-1711_vfx_decal_projection_lifetime`
- Head: `docs/HORO-1712_vfx_spawn_pool_budget_policy`


[HORO-1712]: https://horo-engine.atlassian.net/browse/HORO-1712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ