### PR TITLE
docs(vfx): define editor preview authoring HORO-1713 #1756 [VFX-008.1]

### DIFF
--- a/docs/adr/129-vfx-editor-document-live-preview-and-module-authoring.md
+++ b/docs/adr/129-vfx-editor-document-live-preview-and-module-authoring.md
@@ -1,0 +1,291 @@
+# ADR-129: VFX Editor Document, Live Preview and Module Authoring
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Persistent VFX effect document ownership, transient creation workflows, stack/graph authoring scope, runtime-pipeline preview parity, preview lifecycle and decal projection manipulation
+- **Issue**: [VFX-008.1](https://github.com/abdullahbodur/horo-engine/issues/1756)
+- **Jira**: [HORO-1713](https://horo-engine.atlassian.net/browse/HORO-1713)
+- **Related**: [ADR-011](011-vfx-effect-ownership-simulation-domain-and-renderer-boundary.md), [ADR-056](056-external-editor-ui-boundary.md), [ADR-121](121-cinematic-editor-document-and-authoring-context.md), [ADR-123](123-vfx-cpu-stage-order-determinism-and-gameplay-coupling.md), [ADR-124](124-vfx-gpu-simulation-readback-and-compute-fallback.md), [ADR-125](125-vfx-transparency-sorting-and-pass-placement.md), [ADR-126](126-vfx-graph-compilation-and-runtime-representation-convergence.md), [ADR-127](127-vfx-decal-projection-lifetime-and-rendering-path-policy.md), [ADR-128](128-vfx-spawn-event-mapping-pooling-and-budget-enforcement.md)
+- **Normative documents**: [Editor Document Model](../architecture/editor/editor-document-model.md), [Editor Panel Host](../architecture/editor/editor-panel-host.md), [VFX and Particles Architecture](../architecture/runtime/vfx-and-particles-architecture.md), [Asset Pipeline](../architecture/runtime/asset-pipeline.md)
+
+## Context
+
+The VFX architecture shows a particle editor with emitter modules, curves, preview,
+budget inspection and a module graph. ADR-126 already decides that stack and graph
+sources are authoring frontends for one compiled runtime representation. It does not
+decide whether an effect is a persistent document or modal, which owner holds dirty
+state/history/save, or whether preview may interpret unsaved source directly.
+
+The generic Editor Document Model and Panel Host already separate authoritative
+document sessions from tab presentation lifetime. VFX must specialize that contract,
+not create a particle-editor undo array, autosave file or direct serializer. The same
+applies to decals: effect-spawned decal modules and scene-placed projection volumes
+need editor tooling, but neither justifies a second persistence mechanism.
+
+Preview fidelity is an architectural concern. An editor-only simulator, graph
+interpreter, immediate renderer or special particle kernel could look plausible while
+disagreeing with runtime stage order, budgets, fallbacks and pass placement. Preview
+must differ only in its isolated host inputs and controls, not in compilation or VFX
+execution semantics.
+
+Finally, the baseline stack editor can ship before a production graph UI. The absence
+of graph widgets must not create a second runtime format, force stack/graph round-trip,
+or leave module ownership undecided.
+
+## Decision
+
+### 1. Each effect asset opens as one persistent document
+
+Every editable VFX effect asset opens as one `VfxEffectDocument` rooted at stable
+`VfxEffectAssetId`/`AssetId`, canonical source identity and accepted source revision.
+Existing top-level particle-system assets migrate through the VFX source schema into
+this document identity; they do not remain a second live document class.
+
+`EditorWorkspaceController` and its document services own `DocumentSessionId`,
+committed state/revision, typed command execution, semantic history, dirty/saved
+revision, validation, save/autosave/recovery/external-conflict state and derived
+compile/preview revisions. `EditorPanelHost` owns the persistent tab route, placement,
+focus and presentation lifecycle. The tab owns only selection, filters, expansion,
+scroll/zoom, viewport camera and other bounded presentation state.
+
+Only one writable session for the same canonical effect asset/revision is admitted in
+a workspace. Reopening focuses the existing tab. Read-only compare, recovery and
+historical views carry separate typed identities and cannot submit canonical commands
+or save over the source.
+
+The document stores stable emitter/module/node/port/output IDs, typed parameters and
+curves, logical asset references, authoring source kind, decal descriptors and other
+source required by ADR-126 compilation. It never stores ImGui state, open popups,
+preview clocks/particles, runtime handles, native renderer objects, compiled-kernel
+leases or transient diagnostics.
+
+### 2. Creation and transient choices remain modal workflows
+
+Create, duplicate, import, template selection, Save As, destructive confirmation and
+conflict resolution use transient routes/modals owned by the editor workflow host.
+Create validates name/location, project boundary, permissions, source control,
+template/source schema and registry collision, then atomically publishes and registers
+one valid asset before opening its document tab.
+
+Cancel or failure leaves no asset, registry record, document, tab, recovery file or
+hidden history. A modal does not become a document owner. Rename, move and delete are
+application asset operations coordinated with the open document, never raw tab or
+filesystem mutations.
+
+### 3. The document has one command, history and persistence path
+
+Emitter/module/node edits, parameter and curve changes, material/output settings,
+fallback/budget policy and decal projection/lifetime edits use typed
+`VfxEditorCommand` values. Continuous drags use a transient preview overlay or one
+reversible transaction and create exactly one semantic history entry on commit.
+Cancel restores the prior state.
+
+UI widgets, module providers, file watchers, cook workers and preview runtime never
+mutate document storage. Undo/redo, dirty state, save, autosave, recovery, Save As/Copy
+As and external conflicts use the shared Editor Document Model unchanged. Compilation
+and preview are derived work: success neither clears dirty state nor advances the
+saved revision.
+
+Save captures an immutable document revision, validates/canonicalizes the VFX source
+schema and atomically publishes the canonical source through the Asset/Project owners.
+Edits committed during save leave the document dirty. Autosave writes recovery state,
+not a competing VFX source or cooked artifact.
+
+### 4. Stack and graph authoring are independent frontends with one target
+
+`VfxAuthoringSourceKind` is an exhaustive source-document discriminator:
+
+```cpp
+enum class VfxAuthoringSourceKind : uint8_t {
+    EmitterStack,
+    NodeGraph
+};
+```
+
+The baseline `EmitterStack` surface authors ordered emitters and stage-valid modules,
+fixed connection points, parameters/curves, typed event edges, materials, outputs,
+fallbacks and finite cost declarations. It cannot express arbitrary graph topology or
+store hidden graph nodes to emulate it.
+
+The `NodeGraph` surface authors typed nodes/ports and supported explicit dependency
+edges. Its production UI may ship later. Until available, the editor reports the graph
+authoring surface as unavailable or opens an explicitly read-only inspection route; it
+does not reinterpret, flatten, auto-convert or save the graph as a stack.
+
+Both frontends use the same catalog identities, semantic validators, compiler-owned
+lowering and `CompiledVfxEffectDescriptor` target defined by ADR-126. They may share
+Horo-owned property, curve, module-catalog, diagnostic and preview controls, but their
+source command schemas and layout metadata remain distinct. Equivalent semantics under
+identical inputs must still produce identical descriptor/kernel fingerprints.
+
+Deferring graph UI therefore does not defer or fork runtime loading, simulation,
+fallback, extraction or rendering. Stack-to-graph or graph-to-stack conversion is a
+future explicit migration tool with preview and loss reporting, not an invariant of
+this decision.
+
+### 5. Module providers contribute schemas, not editor/runtime ownership
+
+The editor resolves a captured module catalog generation containing stable provider,
+module/node, schema, stage, port, parameter, capability and kernel identities. Catalog
+entries are inert metadata plus bounded editor presentation descriptors. They do not
+draw arbitrary UI, retain document references, mutate a source during validation or
+register runtime callbacks from a tab.
+
+Adding a module executes a typed document command against the captured catalog and
+document revision. Missing/unloaded providers preserve unknown source records for
+inspection/recovery where safe and block validation/cook when required; they are not
+silently deleted. The cook/runtime provider boundary remains ADR-126 authority.
+
+### 6. Decal authoring uses the same document infrastructure
+
+An effect-spawned or reusable decal output is authored as a typed module/output inside
+`VfxEffectDocument`, including ADR-127 projection, placement-space, lifetime, material,
+receiver and rendering-path intent. There is no separate `DecalDocument`, decal undo
+stack, sidecar save file or preview simulator. A decal-only reusable effect is still a
+valid effect document with a decal output.
+
+A scene-placed decal component remains authored state of `SceneDocument`, because the
+scene owns its durable object placement and component identity. Its projection-volume
+manipulator uses the same Horo viewport/gizmo controllers: drag writes only a transient
+preview overlay, commit sends one typed command to the owning document, and cancel or
+invalid geometry restores the exact prior value. It supports ADR-127 Box/OrientedBox,
+WorldLocked/OwnerLocal, positive extents and owner/cell identity without exposing
+renderer handles.
+
+Editing a referenced reusable effect opens/focuses `VfxEffectDocument`; moving its
+scene instance remains a Scene command. An intentional action changing both sources
+uses the staged multi-document application transaction. The viewport cannot simulate
+atomicity through two UI callbacks or create a third cross-document history.
+
+### 7. Live preview compiles and runs the ordinary runtime pipeline
+
+Preview captures an immutable `VfxEffectDocument` revision and submits it to the same
+VFX parse/migrate/canonicalize/validate/lower compiler used by Asset Pipeline. Unsaved
+source may use an editor-owned transient cook envelope, but the compiler phases,
+semantic inputs, target capability fingerprint and `CompiledVfxEffectDescriptor`/
+kernel encoding are identical. Preview never interprets stack modules or graph nodes
+as executable behavior.
+
+After successful compile, an isolated `VfxPreviewSession` activates the descriptor
+through the ordinary runtime chain:
+
+```text
+CompiledVfxEffectDescriptor
+  -> VfxWorld admission and EffectSystem lifecycle
+  -> SimulationDomainResolver and CPU/GPU/Null simulators
+  -> immutable RenderWorldSnapshot extraction
+  -> RenderFrontend graph scheduling and selected backend
+```
+
+There is no editor particle simulator, direct immediate draw, preview-only stage
+order, permissive budget bypass, special fallback or private module kernel. ADR-123
+through ADR-128 stage, RNG, payload, compute/readback, sorting/pass, decal, pooling and
+budget rules apply unchanged.
+
+The preview host may supply isolated inputs that runtime normally receives from a
+scene/application: preview transform, bounded parameter fixture, deterministic seed,
+clock controls, camera, background and explicitly selected quality/capability profile.
+Those inputs and their revisions are shown in diagnostics. They cannot mutate a live
+scene, publish authoritative gameplay output, use production event bindings or make a
+missing capability appear present.
+
+### 8. Preview state is isolated, cancellable and generation-fenced
+
+The preview session owns play/pause, fixed-step, restart, seed, fixture, clock,
+diagnostic capture and runtime/resource leases. It is disposable derived state, never
+document/history content. Scrubbing/restart begins from an admitted prepared initial
+state or bounded checkpoint policy; it does not reverse GPU work or replay an unbounded
+number of missed ticks in one frame.
+
+Document commit, source/provider/dependency change or quality/capability change
+invalidates the matching derived preview generation. Work may be debounced, but every
+compile, activation, frame and diagnostic result must match document session/revision,
+source revision, dependency/catalog generation, preview session/generation, cook
+target and host policy/capability revision before publication. Stale work is cancelled
+or discarded and its leases retire normally.
+
+Closing/hiding the tab stops visible preview updates according to host policy; closing
+the document, switching project or destroying the editor closes admission, cancels
+jobs and generation-fences callbacks before CPU/GPU retirement. No raw document/tab
+pointer survives in jobs, renderer snapshots or completion callbacks. A hidden tab
+does not silently consume continuous preview budget unless an explicit bounded
+background-capture operation owns it.
+
+Preview Audio, sub-events and gameplay outputs are disabled or routed to bounded
+preview-only inspection sinks. They cannot reach live `AudioWorld`, gameplay services
+or the application event binding table. Importing a preview observation requires an
+explicit reviewed document command.
+
+### 9. Preview parity has executable evidence
+
+Parity means that the same accepted source/dependencies/target inputs produce the same
+compiled descriptor and kernel fingerprints and are executed by the same runtime
+services and scheduling contracts. It does not claim bitwise-identical GPU pixels
+across devices or profiles.
+
+Qualification must cover:
+
+- create/cancel/failure and repeat-open behavior, one writable session, tab focus,
+  dirty close save/discard/cancel and project teardown with compile/preview in flight;
+- typed command symmetry, grouped module/curve/decal-gizmo drags, dirty state through
+  undo/redo, concurrent save edits, recovery and clean/dirty external conflicts;
+- stack and graph fixtures with equivalent semantics producing identical compiled
+  descriptor/kernel fingerprints, plus no stack/graph source interpretation reachable
+  from preview or packaged runtime;
+- editor preview and runtime harness activation from the same artifact with matching
+  resolver choices, tick/seed inputs, CPU committed state, logical lifecycle, budget/
+  fallback outcomes, extracted batch semantics and typed diagnostics;
+- every supported CPU/GPU/Null and raster/profile combination, with image/performance
+  comparison only under qualified device/backend/resolution/build conditions;
+- unavailable graph UI preserving source without conversion, mutation or alternate
+  persistence and stack authoring remaining fully usable;
+- effect-spawned, decal-only and scene-placed Box/OrientedBox manipulation with preview,
+  commit/cancel, invalid extents, owner/scene staleness and atomic cross-document failure;
+- stale compiler/preview/GPU completion across every document, dependency, catalog,
+  preview, project, scene, policy and capability generation; and
+- allocation/budget instrumentation proving preview uses the same prepared-pool and
+  retirement rules rather than hidden editor-only growth.
+
+## Consequences
+
+- Effect assets gain the same predictable tab, history, save and recovery behavior as
+  other persistent editor documents.
+- Runtime preview is trustworthy because it consumes the same compiled artifact and
+  execution pipeline, with differences recorded as host inputs.
+- The stack editor can ship independently without making graph UI a runtime dependency
+  or forcing lossy source conversion.
+- Decal modules and scene projection tools reuse document/command infrastructure and
+  do not introduce a second persistence mechanism.
+- Preview host composition, transient cooking and qualification fixtures require
+  explicit generation, cancellation, budget and retirement plumbing.
+- A graph asset may be temporarily uneditable when its authoring UI/provider is absent;
+  preserving source is preferred to silent flattening or mutation.
+
+## Rejected Alternatives
+
+### Use a modal particle editor
+
+Rejected because effect editing is persistent, dirty, undoable project work. Modal
+ownership would conflict with tab lifecycle, recovery and multi-document coordination.
+
+### Interpret source modules or nodes directly for preview
+
+Rejected because the editor would acquire a second execution model that could diverge
+from cook validation, runtime kernels, budgets, fallbacks and render scheduling.
+
+### Make graph UI a prerequisite for the stack editor
+
+Rejected because ADR-126 already converges both sources below the UI. Shipping order
+does not require a shared canvas or source round-trip.
+
+### Store decals in an independent editor document and sidecar
+
+Rejected because effect decal outputs belong to the effect source and scene placement
+belongs to SceneDocument. A third owner would split identity, history and save policy.
+
+### Keep preview running whenever its tab is hidden
+
+Rejected as an implicit CPU/GPU budget consumer with unclear lifetime. Background work
+requires an explicit bounded operation; otherwise visibility change suspends/stops it
+under the preview host policy.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -140,6 +140,7 @@ to the replacement.
 | [126](126-vfx-graph-compilation-and-runtime-representation-convergence.md) | VFX Graph Compilation and Runtime Representation Convergence | Proposed | 2026-09-02 |
 | [127](127-vfx-decal-projection-lifetime-and-rendering-path-policy.md) | VFX Decal Projection, Lifetime and Rendering Path Policy | Proposed | 2026-09-02 |
 | [128](128-vfx-spawn-event-mapping-pooling-and-budget-enforcement.md) | VFX Spawn Event Mapping, Pooling and Budget Enforcement | Proposed | 2026-09-02 |
+| [129](129-vfx-editor-document-live-preview-and-module-authoring.md) | VFX Editor Document, Live Preview and Module Authoring | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -390,6 +390,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [VFX Spawn Event Mapping, Pooling and Budget Enforcement](../adr/128-vfx-spawn-event-mapping-pooling-and-budget-enforcement.md):
   application-owned semantic bindings, allocation-free playback pools, one finite
   CPU/GPU budget ledger and deterministic cosmetic overload/sleep policy.
+- [VFX Editor Document, Live Preview and Module Authoring](../adr/129-vfx-editor-document-live-preview-and-module-authoring.md):
+  persistent effect document tabs, independent stack/graph frontends, ordinary
+  runtime-pipeline preview and shared decal document/command ownership.
 - [Post-Processing And Effects Architecture](./runtime/post-processing-and-effects-architecture.md):
   screen-space effects, HDR post chain, tonemapping, color grading, and
   accessibility pass ordering.

--- a/docs/architecture/editor/editor-document-model.md
+++ b/docs/architecture/editor/editor-document-model.md
@@ -407,6 +407,33 @@ and never enter document storage. Save, autosave, recovery, external conflict, S
 As/Copy As, close guards and stale worker-result rejection use the shared policies
 above unchanged.
 
+## VFX Effect Asset Documents
+
+[ADR-129](../../adr/129-vfx-editor-document-live-preview-and-module-authoring.md)
+defines each effect asset as a persistent `VfxEffectDocument` rooted at stable asset
+and source revision. Document services own session/revision, typed commands/history,
+dirty/save/autosave/recovery/conflict and derived compile/preview state; the panel host
+owns the tab route and presentation lifecycle. Existing particle-system assets migrate
+through the effect source schema rather than remaining a second document class.
+
+Stack and graph are independent source kinds with distinct command/layout models but
+one catalog, semantic compiler and ADR-126 `CompiledVfxEffectDescriptor` target. A
+deferred/unavailable graph UI preserves source or exposes read-only inspection; it
+does not flatten or save the graph as a stack. Compiler and preview success never
+advance saved revision or clear dirty state.
+
+Effect-spawned/reusable decals are authored within the effect document. Scene-placed
+decal components remain SceneDocument state. Projection manipulation uses transient
+preview overlays and one typed command to the owning document; intentional cross-
+document edits use the staged multi-document transaction and never a third history.
+
+Live preview compiles one immutable document snapshot with the ordinary VFX cooker and
+activates the resulting descriptor through normal `VfxWorld`, CPU/GPU/Null, extraction
+and Renderer services in an isolated preview host. Preview controls, particles, leases,
+diagnostics and fixture inputs are disposable generation-fenced state. They do not
+mutate documents or publish into live gameplay/Audio/event authorities. Close/project
+teardown cancels derived work and retires resources through normal runtime boundaries.
+
 ## Runtime Conversion
 
 The document converts to `RuntimeSceneDefinition` through an editor service.
@@ -499,6 +526,14 @@ Required tests cover:
 - sequence authoring context covers no/wrong/replaced scene, stable rename/reorder,
   missing object/component, schema mismatch, explicit repair and stale preview/
   binding/compile results without mutating authored identity
+- VFX effect create/open/close uses one persistent document tab and shared command,
+  dirty, save, autosave, recovery and external-conflict ownership without a particle-
+  or decal-specific undo/serializer path
+- stack/graph source kinds preserve independent commands/layout while compiling through
+  one semantic target; unavailable graph UI never converts or mutates its source
+- VFX preview compiles an immutable document revision and executes normal runtime
+  services; stale derived work, tab/project teardown and decal-gizmo cancel/commit
+  cannot mutate either VfxEffectDocument or SceneDocument unexpectedly
 
 ## Related Documents
 
@@ -512,3 +547,4 @@ Required tests cover:
 - [Prefab Architecture](../runtime/prefab-architecture.md)
 - [Save Game And Persistence](../runtime/save-game-and-persistence.md)
 - [Cinematic Sequencer](../runtime/cinematic-sequencer-architecture.md)
+- [VFX And Particles](../runtime/vfx-and-particles-architecture.md)

--- a/docs/architecture/editor/editor-panel-host.md
+++ b/docs/architecture/editor/editor-panel-host.md
@@ -667,6 +667,36 @@ and preview controls; AudioModel owns schema/edit validation and AudioCook owns 
 compiled generator. Preview uses the ordinary AudioFrontend/voice/mixer path, and
 stale compile or diagnostic results are rejected by document revision.
 
+## VFX Effect Document Surface
+
+[ADR-129](../../adr/129-vfx-editor-document-live-preview-and-module-authoring.md)
+places every editable effect asset in a persistent `VfxEffectDocument` tab. The panel
+host owns route, placement, focus, visibility and surface lifecycle; document services
+own source revision, commands/history, dirty/save/recovery/conflict and derived compile
+or preview state. Opening the same asset focuses its existing writable tab. Create,
+import, templates, Save As and confirmation remain transient modal routes that open no
+tab until their application transaction succeeds.
+
+The baseline stack surface composes Horo module/property/curve/output controls. A
+future graph surface uses the shared node-editor adapter but keeps graph source commands
+and layout distinct. Both emit typed commands and display compiler diagnostics; neither
+validates or executes particle semantics during draw. If graph UI is unavailable, the
+host preserves the source or offers explicit read-only inspection rather than silently
+flattening it into the stack.
+
+The effect viewport is an isolated preview surface. It compiles an immutable document
+revision and consumes normal `VfxWorld`/Renderer output through a generation-fenced
+preview capability. Its camera, grid, seed, clock, fixture, selected module and runtime
+handles are presentation/preview state. Closing the document cancels derived work and
+retires resources; a hidden tab does not continue preview work without a separately
+admitted bounded background operation.
+
+Effect decal outputs use the same document tab. Scene-placed decal projection remains
+owned by SceneDocument. Box/OrientedBox manipulation shares viewport/gizmo capture,
+updates a transient overlay during drag and sends exactly one typed command to the
+owning document on commit. It never writes renderer state or maintains decal-specific
+history/persistence.
+
 ## Viewport Panel
 
 The viewport panel owns rendering of the active scene camera or game camera in
@@ -1045,6 +1075,13 @@ agnostic to editor UI structure so that:
 - editor layout changes do not require `Application` recompilation
 - a tab in any panel can communicate with a tab in any other panel without the
   host layer knowing either tab exists
+- VFX effect repeat-open focuses one writable persistent document tab; create failure
+  opens none, dirty close uses the common leave guard, and close/project teardown
+  cancels generation-fenced preview before resource retirement
+- stack authoring remains usable without graph UI; unavailable graphs preserve source
+  or open read-only and never flatten into stack state
+- VFX/decal gizmo drag, cancel and commit preserve pointer capture, transient preview
+  and exactly-one-command history across normal, modal interruption and stale revision
 
 The editor workspace is a higher-level concern composed on top of
 `Application`. Cross-panel notification flow lives entirely below

--- a/docs/architecture/runtime/vfx-and-particles-architecture.md
+++ b/docs/architecture/runtime/vfx-and-particles-architecture.md
@@ -38,6 +38,11 @@ places semantic event-to-effect bindings at the application boundary, requires
 allocation-free playback from prepared pools, unifies count/work/time/memory budgets
 and makes cosmetic overload plus sleep/wake explicit and deterministic.
 
+[ADR-129](../../adr/129-vfx-editor-document-live-preview-and-module-authoring.md)
+makes each effect asset a persistent document tab, keeps stack and graph as independent
+frontends, runs live preview through the ordinary cooked runtime pipeline and routes
+decal manipulation through the owning document command model.
+
 DCC workflows, full fluid solvers, atmospheric scattering and screen-space
 post-processing remain outside this subsystem; see
 [Advanced Rendering Architecture](./advanced-rendering-architecture.md).
@@ -682,6 +687,49 @@ StructuredBuffer<GpuParticleData>   CurrentParticles : register(t0);
 RWStructuredBuffer<GpuParticleData> NextParticles    : register(u0);
 ```
 
+## Editor Document And Runtime Preview
+
+Each editable effect asset opens as one persistent `VfxEffectDocument` rooted at its
+stable asset/source revision. `EditorWorkspaceController` and document services own
+revision, commands/history, dirty/save/autosave/recovery/conflict and derived compile/
+preview state; `EditorPanelHost` owns the tab route, placement, focus and presentation
+lifecycle. Reopening an asset focuses its one writable session. Creation, import,
+templates, Save As, destructive confirmation and conflict resolution are transient
+workflows that open a tab only after successful atomic publication.
+
+All source edits use typed `VfxEditorCommand` transactions. Widgets, providers,
+watchers, cook workers and preview runtime never mutate source directly or keep a
+second undo/save path. Existing particle-system assets migrate into this effect
+document schema. Effect-spawned and reusable decal outputs live in the effect document;
+scene-placed decal components remain `SceneDocument` state. Projection gizmo drags use
+transient overlays and commit one command to the owning document. A deliberate edit
+across both documents uses the staged multi-document transaction contract.
+
+The stack editor is the baseline authoring surface for ordered stage-valid modules,
+parameters/curves, typed edges, materials, outputs, fallbacks and finite costs. The
+graph editor owns typed nodes/ports and supported explicit edges and may ship later.
+Unavailable graph UI preserves source or offers read-only inspection; it never flattens
+or saves a graph as a stack. Both frontends use one captured catalog, the same semantic
+validator/lowering and ADR-126 compiled target. Shared controls do not make their source
+commands or layout metadata interchangeable.
+
+Live preview captures an immutable document revision and runs the ordinary VFX compiler
+into `CompiledVfxEffectDescriptor`. Unsaved source may use a transient cook envelope,
+but no stack/graph interpreter, preview-only kernel or permissive budget path exists.
+An isolated preview host then uses `VfxWorld`, normal domain resolution and CPU/GPU/Null
+simulators, immutable extraction, RenderFrontend and the selected backend. Preview-only
+transform/fixture/seed/clock/camera/profile inputs are explicit revisioned evidence;
+they cannot publish to live gameplay, Audio or event-binding authorities.
+
+Preview state and leases are disposable and generation-fenced by document/dependency/
+catalog/session/target/policy/capability revisions. Document edits cancel or supersede
+stale work. Close/project teardown cancels jobs before normal CPU/GPU retirement. A
+hidden tab performs no continuing preview work unless a separately admitted bounded
+background operation owns it. Preview parity requires matching compiled fingerprints,
+resolver/tick/seed/lifecycle/budget outcomes and extracted semantics against a runtime
+harness; GPU image/performance comparisons remain qualified, not cross-device bitwise
+claims.
+
 ## VFX Graph Asset & Compilation
 
 A VFX graph is an authored node graph that defines a complex effect composed of
@@ -960,6 +1008,16 @@ architecture-only change:
 - Compile equivalent stack/graph fixtures and require identical canonical descriptor/
   kernel fingerprints; layout/comments/selection and randomized cook scheduling must
   not alter output. Both runtime routes consume only `CompiledVfxEffectDescriptor`.
+- Exercise effect create/cancel/failure, repeat-open, one writable tab, typed command
+  symmetry, dirty close guard, recovery/external conflict and close/project teardown
+  while compile and preview work are in flight.
+- Run editor preview and a runtime harness from the same artifact; require matching
+  descriptor/kernel fingerprints, resolver choice, tick/seed inputs, CPU commits,
+  lifecycle/budget/fallback results, extracted semantics and typed diagnostics. Scan
+  preview/runtime reachability for source interpreters or editor-only VFX kernels.
+- Keep stack editing operational with graph UI absent; open graph source read-only or
+  unavailable without flattening/mutation. Verify effect/decal-only/scene decal
+  documents and projection-gizmo preview/commit/cancel with no second persistence path.
 - Reject every stage/domain/provider/resource/layout/cost/version violation before
   atomic publication. Exercise current/two-prior/too-old/newer/corrupt/wrong-target
   artifacts, failed reload last-good retention and active old artifact leases.
@@ -1006,6 +1064,8 @@ architecture-only change:
   Normative decal placement, lifetime, admission and rendering-path contract.
 - [ADR-128: VFX Spawn Event Mapping, Pooling and Budget Enforcement](../../adr/128-vfx-spawn-event-mapping-pooling-and-budget-enforcement.md):
   Normative semantic binding, allocation-free playback, budget, overload and sleep/wake contract.
+- [ADR-129: VFX Editor Document, Live Preview and Module Authoring](../../adr/129-vfx-editor-document-live-preview-and-module-authoring.md):
+  Normative effect document, stack/graph authoring, preview parity and decal editor contract.
 - [Particle Editor UI Reference](./particle-editor.html): Emitter stack, curve editing,
   and live preview panel.
 - [Material And Shader Model](./material-and-shader-model.md): Particle and decal materials.


### PR DESCRIPTION
## Summary

- Records ADR-129 for persistent VFX effect documents, stack/graph module authoring boundaries, runtime-pipeline live preview, and decal projection editing.
- Applies the shared editor document/tab lifecycle instead of introducing particle- or decal-specific history, dirty state, autosave, recovery, or persistence.
- Guarantees preview parity by compiling an immutable document revision through the ordinary VFX cooker and activating the result through normal `VfxWorld`, simulation, extraction, and Renderer services.
- Projects the decision into the Editor Document Model, Editor Panel Host, VFX runtime architecture, architecture index, and ADR index.

## Why

ADR-126 converges stack and graph sources on one compiled runtime representation, but the editor ownership and preview execution boundaries were still open. Without a written document contract, effect authoring could acquire a modal-local undo/save path, graph availability could become a runtime dependency, and preview could interpret source through an editor-only simulator that diverges from runtime stage, budget, fallback, decal, and render behavior.

ADR-129 makes those boundaries explicit while preserving the existing generic editor document, tab host, asset pipeline, and VFX runtime owners.

## Decision and boundaries

- Defines one writable `VfxEffectDocument` session per canonical effect asset/revision. Document services own commands/history, dirty/saved revisions, save/autosave/recovery/conflict, and derived compile/preview state; `EditorPanelHost` owns only the persistent tab route and presentation lifecycle.
- Keeps create/import/template/Save As/destructive/conflict flows transient and opens the persistent tab only after a successful atomic asset transaction.
- Makes `EmitterStack` the baseline ordered module authoring surface and `NodeGraph` an independent, deferrable frontend. Missing graph UI preserves source or offers read-only inspection; it never flattens or saves a graph as a stack.
- Constrains module providers to captured typed schemas/catalog identities. Widgets and providers do not mutate source, validate runtime semantics during draw, or install preview/runtime callbacks.
- Keeps reusable/effect-spawned decals inside `VfxEffectDocument` and scene-placed decal components inside `SceneDocument`. Projection gizmos use transient overlays and one typed commit to the owning document, with staged coordination for deliberate cross-document changes.
- Defines preview as a transient cook of an immutable document revision followed by the ordinary compiled runtime pipeline. Preview-only fixture, seed, clock, camera, profile, and capability inputs are revisioned evidence, not alternate semantics.
- Generation-fences asynchronous compile/preview/GPU results and requires normal cancellation and retirement during document/project teardown.
- Adds qualification scenarios for document lifecycle, stack/graph fingerprint convergence, preview/runtime parity, graph-UI absence, decal manipulation, stale completions, and allocation/budget behavior.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/129-vfx-editor-document-live-preview-and-module-authoring.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/vfx-and-particles-architecture.md docs/architecture/editor/editor-document-model.md docs/architecture/editor/editor-panel-host.md`
- `git diff --check`
- `git diff --cached --check`
- Added Markdown links resolve with the repository-relative staged-link checker.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. Existing warnings remain: mbedTLS declares an old CMake compatibility floor, and repository Python tests are skipped because `pytest` is unavailable.

## Risk and rollout

- This is an architecture-only change; the document controller, preview host, editor commands, transient cook path, and executable parity tests remain follow-up implementation.
- Graph sources may be temporarily read-only or unavailable when graph UI/provider support is absent. This is deliberate source preservation, not a promise of stack conversion.
- Preview shares runtime behavior but still runs in an isolated host with explicit fixtures and capabilities; GPU pixel/performance parity remains qualified by device/backend/profile rather than asserted bitwise across configurations.
- Scene-placed decal edits and reusable effect edits intentionally retain separate document owners; cross-document authoring needs a real staged transaction.

## Issue links

- Jira: [HORO-1713](https://horo-engine.atlassian.net/browse/HORO-1713)
- GitHub: Closes #1756
- Domain ticket: `[VFX-008.1]`

## Reviewer Notes

- Confirm the ownership split: panel host owns the persistent tab route, while editor document services own authoritative VFX source state and persistence.
- Check that graph UI deferral cannot fork runtime representation or trigger implicit stack/graph conversion.
- Review preview parity: unsaved source still uses the same compiler and the resulting descriptor uses the ordinary runtime services, budgets, fallbacks, and Renderer path.
- Confirm decal-only/reusable outputs do not create a `DecalDocument`, while scene placement remains correctly owned by `SceneDocument`.
- Verify stale compile/preview/GPU work cannot publish after document, dependency, catalog, project, policy, or capability generation changes.

## Stack

- Base: `docs/HORO-1712_vfx_spawn_pool_budget_policy`
- Head: `docs/HORO-1713_vfx_editor_document_preview_authoring`


[HORO-1713]: https://horo-engine.atlassian.net/browse/HORO-1713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ