### PR TITLE
docs(platform): define frontend request semantics HORO-1830 #1874 [PLS-001.1]

### DIFF
--- a/docs/adr/130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md
+++ b/docs/adr/130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md
@@ -1,0 +1,320 @@
+# ADR-130: Platform Services Frontend, Request Lifetime, Timeout, Null and Error Semantics
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Platform-services frontend request ownership, admission, state machine, dropped handles, cancellation/timeout races, callback dispatch, capability absence, Null behavior and provider-error normalization
+- **Issue**: [PLS-001.1](https://github.com/abdullahbodur/horo-engine/issues/1874)
+- **Jira**: [HORO-1830](https://horo-engine.atlassian.net/browse/HORO-1830)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md), [ADR-056](056-external-editor-ui-boundary.md), [ADR-060](060-release-domain-model-and-state-machine.md), [ADR-113](113-local-storage-user-profile-and-slot-ownership.md), [ADR-115](115-cloud-save-authority-revision-and-conflict-policy.md), [ADR-116](116-save-data-threat-model-and-trust-policy.md)
+- **Normative documents**: [Platform Services Architecture](../architecture/runtime/platform-services-architecture.md), [Error and Diagnostics Architecture](../architecture/foundation/error-and-diagnostics.md), [Internal Module Descriptor](../architecture/foundation/internal-module-descriptor.md)
+
+## Context
+
+The Platform Services architecture intends one backend-neutral asynchronous frontend,
+but its examples define contradictory semantics. `OnComplete` may run synchronously
+for an already-finished request even though provider completions must be dispatched on
+an engine-controlled thread. It does not say whether dropping a returned handle
+cancels, detaches or destroys provider work, nor which owner retains terminal results.
+
+Timeout is described as generic `platform_error` while the error list also exposes a
+distinct `timeout`. Capability availability has two competing sources of truth: bool
+fields and nullable service pointers. The Null backend reports no capabilities and
+returns `not_supported` for reads, yet accepts and silently discards writes. A caller
+therefore cannot distinguish a real accepted mutation from deliberate absence.
+
+Later achievement, stat, leaderboard, cloud, identity and offline-queue decisions need
+one request lifecycle and error rule. This decision establishes that foundation. It
+does not decide durable offline queue ownership, service-specific idempotency, user
+identity or proprietary SDK packaging except where they constrain request semantics.
+
+## Decision
+
+### 1. The frontend owns every admitted request record
+
+`PlatformServicesFrontend` is the sole owner of frontend request identity, mutable
+state, deadline, cancellation source, terminal result, observer list and bounded
+retention. A provider owns only its native operation and returns completion evidence
+through a generation-checked adapter queue. A `PlatformRequestHandle<T>` is a cheap
+typed reference to `PlatformRequestId` plus the frontend/session generation; it never
+owns or exposes a provider object.
+
+Submission has an explicit admission result:
+
+```cpp
+template <typename T>
+using PlatformSubmitResult = Result<PlatformRequestHandle<T>>;
+
+PlatformSubmitResult<AchievementUnlockResult>
+PlatformServicesFrontend::UnlockAchievement(AchievementId id);
+```
+
+Validation, permission, frontend lifecycle, capability, session and bounded-capacity
+checks happen before admission. Failure returns `Result` with no request ID, provider
+call, callback or partial queue record. Success atomically creates the request record,
+captures policy/provider/session generations and deadline, then returns its handle.
+
+Dropping or destroying the last handle does not cancel, detach provider ownership or
+erase an admitted write. The frontend continues the operation to a terminal record and
+normal provider retirement. This prevents UI lifetime and temporary C++ scope from
+changing remote side effects. Cancellation requires an explicit `Cancel(requestId)` or
+owner shutdown policy.
+
+Terminal records are retained under a finite count/time policy so late query or
+subscription can observe the outcome. Expiry removes only a terminal observation
+record after provider/callback retirement; it never rewrites the remote outcome.
+Querying an expired or wrong-generation ID returns `platform.request.expired` or
+`platform.request.stale`, not a fabricated failure result for that old operation.
+
+### 2. One exhaustive state machine governs every service
+
+```cpp
+enum class PlatformRequestState : uint8_t {
+    Queued,
+    Running,
+    Cancelling,
+    Succeeded,
+    Failed,
+    Cancelled,
+    TimedOut
+};
+```
+
+| From | Legal next states |
+|---|---|
+| `Queued` | `Running`, `Cancelling`, `Failed`, `TimedOut` |
+| `Running` | `Cancelling`, `Succeeded`, `Failed`, `TimedOut` |
+| `Cancelling` | `Succeeded`, `Failed`, `Cancelled`, `TimedOut` |
+| terminal states | none |
+
+`Succeeded`, `Failed`, `Cancelled` and `TimedOut` are terminal. A successful terminal
+record contains exactly one immutable `T`; each other terminal record contains exactly
+one typed `Error` whose code agrees with the state. Non-terminal records contain no
+terminal result. State and result publish atomically once.
+
+The frontend serializes state mutations on its declared owner lane. Provider SDK
+threads may only enqueue bounded completion evidence carrying request, provider,
+session and operation generations. They never mutate records, invoke user callbacks or
+hold frontend locks while entering engine code.
+
+Admission failure is not a synthetic `Failed` request because no request was accepted.
+An accepted request may move directly from `Queued` to `Failed` if provider submission
+fails after the record is published. Coalescing or durable replay may have a separate
+operation identity, but each caller-visible request still owns one terminal outcome.
+
+### 3. Cancellation is explicit, best-effort and idempotent
+
+`Cancel()` posts one cancellation intent to the frontend owner and never invokes a
+provider or callback inline. Repeated intents for the same current request are
+idempotent. An accepted intent moves `Queued` or `Running` to `Cancelling`, closes new
+retries and asks the provider adapter to abort when supported.
+
+Cancellation intent is not terminal acknowledgement. From `Cancelling`:
+
+- provider acknowledgement with no committed operation publishes `Cancelled` and
+  `platform.request.cancelled`;
+- an eligible provider success already committed or completing despite best-effort
+  cancellation may publish `Succeeded`;
+- a provider-reported failure may publish `Failed`; and
+- deadline expiry publishes `TimedOut` if no eligible completion won first.
+
+The immutable terminal record includes whether cancellation was requested and the
+provider's bounded cancellation/commit evidence. `Cancelled` never promises that a
+remote mutation was rolled back unless the service-specific contract provides that
+guarantee. Callers determine behavior from terminal state/code, not a separate
+`WasCancelled` boolean that can contradict the result.
+
+### 4. Timeout is a frontend-owned terminal result
+
+Every admitted request captures a finite monotonic deadline from the selected service
+policy. At the owner boundary, valid provider completion evidence observed no later
+than that deadline is processed before deadline evaluation. If no such evidence can
+publish, the frontend atomically commits `TimedOut` with
+`platform.request.timed_out`, requests best-effort provider cancellation and closes
+caller-visible completion.
+
+Timeout is not `platform.provider.failed`, `offline` or `Cancelled`. Later provider
+completion cannot replace the terminal result. It is consumed only for resource/
+idempotency reconciliation and reported as late evidence. Native provider work and
+borrowed buffers remain alive until the adapter acknowledges retirement; terminal
+publication does not prove physical cancellation.
+
+Retry attempts and backoff fit inside the original request deadline unless a later
+service-specific durable operation explicitly creates a new request. A retry does not
+reset the deadline, request ID or exactly-once terminal slot. A zero, infinite,
+overflowing or wall-clock-derived deadline is invalid policy.
+
+### 5. Completion callbacks are deferred observations
+
+The authoritative API is immutable request snapshot query plus optional subscription.
+Registering an observer returns a move-only RAII `PlatformRequestSubscription`. Each
+subscription receives at most one terminal notification for its request. Destroying
+the subscription prevents future invocation but does not cancel the request. Dropping
+the request handle has the same non-cancelling behavior.
+
+Callbacks never run inline from submission, subscription registration, `Cancel`,
+provider callbacks, queue drain, state mutation or while a frontend/provider lock is
+held. Terminal state is committed first; the frontend posts notification to the
+request's declared engine executor for a later dispatch turn. Registering after a
+retained terminal result schedules the same deferred delivery rather than invoking
+synchronously.
+
+A callback receives immutable request ID and terminal snapshot. Re-entering the
+frontend from that later callback may enqueue a new request/cancel/subscription, but it
+cannot mutate the callback's terminal record or recursively drain completion. Callback
+exceptions are caught at the engine executor boundary under ADR-008, converted to the
+subscriber owner's error/diagnostic path and never alter the platform request outcome.
+
+Progress/session events are non-authoritative bounded observations with revision/gap
+semantics. Consumers query the current snapshot after a gap. They cannot stand in for
+the terminal record.
+
+### 6. Capability truth has one typed source
+
+Composition validates one immutable `PlatformServiceCapabilitySnapshot` for the
+selected provider generation. Each service has a typed availability entry containing
+support level, limits, required session/consent conditions and provider binding ID.
+There is no independent bool plus nullable-interface combination.
+
+Provider binding lookup is private to the validated frontend composition. A capability
+marked available must have exactly one compatible bound service; missing, duplicate or
+mismatched binding fails composition. A capability marked unavailable has no callable
+binding and carries one reason such as `NoProviderSelected`, `NullProviderSelected`,
+`ServiceUnsupported`, `HostPolicyDenied` or `ProviderInitializationFailed`.
+
+Dynamic sign-in, connectivity, consent and rate state are operation preconditions or
+session snapshots, not changes that forge installed capability. Provider reload or
+session replacement creates a new generation. Requests retain the generation captured
+at admission; stale completion evidence cannot publish into a replacement frontend.
+
+Public callers see only frontend capabilities and Horo types. They never test provider
+pointers, backend names or SDK flags and never route around the frontend.
+
+### 7. Null is fail-closed and never acknowledges a write
+
+`PlatformServicesNull` is an explicit valid composition for headless, tests and
+products without remote platform services. Its capability snapshot marks every remote
+service unavailable with `NullProviderSelected`. Every read and write fails admission
+with `platform.provider.null`; no request record, offline entry, idempotency record or
+provider mutation is created.
+
+Null never accepts and silently discards achievements, stats, scores, cloud mutations
+or presence. Such behavior would make success mean two incompatible things and could
+hide missing product composition. Tests that require successful or scripted async
+behavior use `PlatformServicesMock`, which advertises exactly the capabilities it
+implements and follows the same state/callback/deadline contract.
+
+An application may explicitly suppress an optional cosmetic presence intent before
+submission. That application policy is not a successful Null write and remains
+observable as suppression at its owner boundary.
+
+### 8. Errors preserve frontend and provider responsibility
+
+All failures use ADR-008 `ErrorCode`/`Result`; message or native SDK text is never the
+branching contract. Stable frontend codes include:
+
+| Code | Owner/meaning |
+|---|---|
+| `platform.frontend.unavailable` | Frontend absent, starting, stopping or generation closed before admission |
+| `platform.capability.unavailable` | Selected real provider/host policy does not expose the required service |
+| `platform.provider.null` | Explicit Null composition; read/write not accepted |
+| `platform.request.capacity_exceeded` | Bounded request/result/subscription capacity unavailable before admission |
+| `platform.request.cancelled` | Accepted request reached acknowledged cancellation terminal state |
+| `platform.request.timed_out` | Frontend deadline reached before eligible completion |
+| `platform.request.expired` | Terminal observation retention ended |
+| `platform.request.stale` | Request/frontend/session/provider generation mismatch |
+| `platform.provider.failed` | Valid provider operation failed after admission; normalized category and safe cause retained |
+
+`platform.provider.failed` carries a typed normalized category: `Offline`,
+`NotSignedIn`, `Forbidden`, `RateLimited`, `PreconditionFailed`, `QuotaExceeded`,
+`InvalidResponse`, `TransientFailure` or `PermanentFailure`. Service-specific decisions
+may refine categories with stable codes, but cannot remap cancellation, timeout, Null
+or capability absence into provider failure.
+
+The provider adapter maps native results once. It retains service/operation, request,
+provider/session generation, retryability, retry-after or revision evidence where
+applicable, plus bounded redacted native code as diagnostics/cause. It never leaks SDK
+types, credentials, raw response bodies or user identifiers. GUI/CLI/MCP/gameplay
+adapters translate the same Horo error rather than inventing local business outcomes.
+
+### 9. Shutdown closes admission before draining requests
+
+Frontend shutdown is explicit and idempotent:
+
+1. close admission and publish a new frontend generation;
+2. reject new submissions with `platform.frontend.unavailable`;
+3. post cancellation for requests whose service policy permits it;
+4. drain owner-queued completions and commit one terminal result per admitted request;
+5. stop/cancel subscriptions and executor deliveries;
+6. wait within the declared bound for provider acknowledgements and callback epochs;
+7. retain dependencies when work cannot retire safely, reporting shutdown failure
+   rather than freeing provider code or borrowed memory early; and
+8. release terminal stores, bindings and provider generation in reverse ownership
+   order after all leases retire.
+
+Dropping application/UI handles during shutdown does not shorten this sequence. A late
+native callback carries the closed generation, is consumed for adapter retirement and
+cannot publish or invoke a user callback.
+
+### 10. Existing examples migrate to this contract
+
+The Platform Services architecture examples change as follows:
+
+- `PlatformServiceRequest<T>` becomes an admitted `PlatformRequestHandle<T>` returned
+  by `Result`; the frontend, not the handle, owns the record.
+- `IsPending`/`IsComplete`/`WasCancelled` are replaced by one snapshot state and
+  terminal variant.
+- `OnComplete` never invokes synchronously; it becomes deferred subscription with a
+  move-only token and immutable terminal snapshot.
+- bool capabilities and nullable service getters become one validated typed capability
+  snapshot plus private binding.
+- frontend timeout maps only to `platform.request.timed_out`.
+- Null rejects both reads and writes with `platform.provider.null`.
+- provider-native failures map to `platform.provider.failed` plus normalized category;
+  cancellation, timeout, capability absence and Null remain separate.
+
+Later platform-service ADRs must reuse this ownership/state/error contract and may only
+specialize payload, authority, trust, retry/idempotency and durable-queue behavior.
+
+## Consequences
+
+- Callers can distinguish admission failure, Null, capability absence, cancellation,
+  timeout and provider failure without inspecting text or contradictory flags.
+- UI/handle lifetime cannot cancel or falsely complete remote side effects.
+- Terminal publication and callback behavior are exactly once, non-reentrant and safe
+  across SDK threads, reload and shutdown.
+- Null/headless builds fail closed, making missing platform-service composition visible.
+- Frontend implementation needs a bounded request/result/subscription store, owner
+  executor, generation fencing and provider-retirement bookkeeping.
+- Dropped handles may leave useful work running; owners that no longer want it must
+  explicitly cancel, and retained result limits must be sized and observed.
+- Existing architecture examples and any prototypes using synchronous `OnComplete`,
+  nullable services or successful Null writes require migration.
+
+## Rejected Alternatives
+
+### Let the request handle own and cancel provider work on destruction
+
+Rejected because temporary UI/C++ lifetime would silently change remote mutations and
+provider callbacks could outlive freed state. The frontend record owns the operation.
+
+### Invoke late-registered completion callbacks synchronously
+
+Rejected because behavior would depend on timing, permit recursion under caller locks
+and violate the engine-controlled dispatch boundary.
+
+### Represent timeout as cancellation or generic provider failure
+
+Rejected because the frontend deadline, caller cancellation and provider failure have
+different owners, retry evidence and diagnostics.
+
+### Keep both capability flags and nullable service pointers
+
+Rejected because disagreement is representable and forces callers to invent routing.
+Composition validates one typed availability snapshot and private binding.
+
+### Treat Null writes as successful no-ops
+
+Rejected because achievements, stats, scores, cloud and presence would appear accepted
+without any provider effect. Optional intent may be suppressed explicitly by its owner;
+the frontend cannot fabricate success.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -141,6 +141,7 @@ to the replacement.
 | [127](127-vfx-decal-projection-lifetime-and-rendering-path-policy.md) | VFX Decal Projection, Lifetime and Rendering Path Policy | Proposed | 2026-09-02 |
 | [128](128-vfx-spawn-event-mapping-pooling-and-budget-enforcement.md) | VFX Spawn Event Mapping, Pooling and Budget Enforcement | Proposed | 2026-09-02 |
 | [129](129-vfx-editor-document-live-preview-and-module-authoring.md) | VFX Editor Document, Live Preview and Module Authoring | Proposed | 2026-09-02 |
+| [130](130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md) | Platform Services Frontend, Request Lifetime, Timeout, Null and Error Semantics | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -393,6 +393,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [VFX Editor Document, Live Preview and Module Authoring](../adr/129-vfx-editor-document-live-preview-and-module-authoring.md):
   persistent effect document tabs, independent stack/graph frontends, ordinary
   runtime-pipeline preview and shared decal document/command ownership.
+- [Platform Services Frontend, Request Lifetime, Timeout, Null and Error Semantics](../adr/130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md):
+  frontend-owned asynchronous requests, exactly-once terminal publication, deferred
+  callbacks, typed capability truth and distinct Null/timeout/provider failures.
 - [Post-Processing And Effects Architecture](./runtime/post-processing-and-effects-architecture.md):
   screen-space effects, HDR post chain, tonemapping, color grading, and
   accessibility pass ordering.

--- a/docs/architecture/foundation/error-and-diagnostics.md
+++ b/docs/architecture/foundation/error-and-diagnostics.md
@@ -207,6 +207,25 @@ Code descriptors are metadata, not a dispatch mechanism. Runtime hot paths may
 store compact interned identifiers after validation, but serialized errors keep
 the stable textual domain and code.
 
+### Platform Services Async Failures
+
+[ADR-130](../../adr/130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md)
+applies this model to frontend-owned asynchronous platform requests. Pre-admission
+failure returns `Result<PlatformRequestHandle<T>>` with no request record. An admitted
+request atomically publishes exactly one `Succeeded`, `Failed`, `Cancelled` or
+`TimedOut` terminal state/result; observers are deferred views of that record and do
+not create another outcome channel.
+
+The following identities are deliberately distinct: `platform.frontend.unavailable`,
+`platform.capability.unavailable`, `platform.provider.null`,
+`platform.request.cancelled`, `platform.request.timed_out`,
+`platform.request.expired`, `platform.request.stale` and
+`platform.provider.failed`. Provider failure additionally carries one typed normalized
+category such as Offline, NotSignedIn, Forbidden, RateLimited, PreconditionFailed,
+QuotaExceeded, InvalidResponse, TransientFailure or PermanentFailure. Native SDK codes
+remain bounded redacted cause/diagnostic evidence and never replace Horo branching
+identity.
+
 ### Serialized Error Shape
 
 Structured host payloads use one canonical safe shape derived from the C++

--- a/docs/architecture/runtime/platform-services-architecture.md
+++ b/docs/architecture/runtime/platform-services-architecture.md
@@ -12,6 +12,12 @@ The goal is a single backend-neutral frontend that gameplay code can use
 without caring which platform the game is running on, while the actual
 platform SDK implementations live in separate, optionally loaded backends.
 
+[ADR-130](../../adr/130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md)
+is the normative baseline for frontend-owned request records, admission, state and
+result publication, deferred callback dispatch, capability truth, Null behavior,
+timeout and provider-error normalization. Later service decisions specialize this
+contract rather than creating another request lifecycle.
+
 ## Scope
 
 Platform services covered here:
@@ -87,61 +93,104 @@ calling thread on network I/O.
 
 ```cpp
 template <typename T>
-class PlatformServiceRequest {
+class PlatformRequestHandle {
 public:
     RequestId Id() const;
-    RequestState State() const;
-    bool IsPending() const;
-    bool IsComplete() const;
-    bool WasCancelled() const;
-
-    void OnComplete(std::function<void(Result<T>)> callback);
-    void Cancel();
+    FrontendGeneration Frontend() const;
 };
 
 class PlatformServicesFrontend {
 public:
-    PlatformServiceRequest<AchievementUnlockResult>
+    Result<PlatformRequestHandle<AchievementUnlockResult>>
     UnlockAchievement(AchievementId id);
 
-    PlatformServiceRequest<LeaderboardEntries>
+    Result<PlatformRequestHandle<LeaderboardEntries>>
     GetLeaderboardEntries(LeaderboardId id, const LeaderboardQuery& query);
 
-    PlatformServiceRequest<CloudReadResult>
+    Result<PlatformRequestHandle<CloudReadResult>>
     ReadCloudSave(CloudSaveObjectKey key);
 
-    PlatformServiceRequest<CloudMutationResult>
+    Result<PlatformRequestHandle<CloudMutationResult>>
     WriteCloudSave(CloudWriteRequest request);
 
-    PlatformServiceRequest<void>
+    Result<PlatformRequestHandle<void>>
     SetPresence(const PresenceState& state);
+
+    template <typename T>
+    Result<PlatformRequestSnapshot<T>> Query(PlatformRequestHandle<T> request) const;
+    template <typename T>
+    Result<PlatformRequestSubscription> Subscribe(
+        PlatformRequestHandle<T> request,
+        PlatformCompletionExecutor executor,
+        PlatformTerminalObserver<T> observer);
+    Result<void> Cancel(PlatformRequestId request);
 };
 ```
 
+Pre-admission validation, permission, lifecycle, capability, session and bounded-
+capacity failure returns `Result` with no request record or provider call. Once admitted,
+the frontend owns the request record independently of every handle and subscription.
+Handles contain only typed request/frontend identity; they never own provider objects.
+
+The authoritative snapshot state is exhaustive:
+
+```cpp
+enum class PlatformRequestState : uint8_t {
+    Queued,
+    Running,
+    Cancelling,
+    Succeeded,
+    Failed,
+    Cancelled,
+    TimedOut
+};
+```
+
+| From | Legal next states |
+|---|---|
+| `Queued` | `Running`, `Cancelling`, `Failed`, `TimedOut` |
+| `Running` | `Cancelling`, `Succeeded`, `Failed`, `TimedOut` |
+| `Cancelling` | `Succeeded`, `Failed`, `Cancelled`, `TimedOut` |
+| `Succeeded`, `Failed`, `Cancelled`, `TimedOut` | none |
+
+Exactly one terminal result publishes atomically with the terminal state. Success owns
+one immutable value; Failed, Cancelled and TimedOut own one typed Error matching the
+state. Non-terminal snapshots contain no terminal result.
+
 ### Request Lifetime
 
-1. Caller invokes a frontend method and receives a `PlatformServiceRequest`.
-2. The frontend assigns a unique `RequestId`, validates inputs, and routes the
-   call to the active backend service.
-3. The backend performs the platform call asynchronously. It may complete
-   immediately, queue work on an SDK thread, or schedule a network operation.
-4. When the backend reports completion, the frontend transitions the request to
-   `Complete` and dispatches the caller's callback on an engine job or main
-   thread.
-5. The request handle remains valid after completion; `OnComplete` may be
-   invoked synchronously if the request has already finished.
+1. The frontend validates and either returns an admission error or atomically creates
+   a `Queued` record with request, provider, session, policy and deadline generations.
+2. Provider submission moves the record to `Running`; failure after admission commits
+   `Failed` without inventing provider progress.
+3. The provider performs asynchronous work and enqueues bounded generation-tagged
+   evidence. SDK threads never mutate frontend state or invoke user code.
+4. The frontend owner lane validates evidence and commits at most one terminal state/
+   result before scheduling observer notification.
+5. The record remains queryable under finite count/time retention after completion and
+   until provider/callback retirement permits reclamation.
+
+Dropping the last handle or subscription does not cancel an admitted request, erase a
+write or free provider work. Explicit `Cancel(requestId)` or owner shutdown policy is
+required. Querying expired or stale identity returns `platform.request.expired` or
+`platform.request.stale`; it does not fabricate a replacement terminal result.
 
 ### Cancellation
 
-`Cancel()` asks the frontend to abort the operation. Cancellation is best-effort:
+`Cancel()` posts cancellation intent to the frontend owner. It never invokes the
+provider or an observer inline. Cancellation is best-effort:
 
-- If the request has not left the frontend queue, it is removed and the caller
-  receives `request_cancelled`.
-- If the backend is already executing, the frontend forwards the cancellation.
-  The backend may ignore it if the SDK does not support cancellation.
-- A completed request cannot be cancelled retroactively.
+- An accepted queued/running request moves to `Cancelling` and closes new retries.
+- Provider acknowledgement with no committed effect publishes `Cancelled` and
+  `platform.request.cancelled`.
+- A provider success already committed or completed despite cancellation may publish
+  `Succeeded`; provider failure may publish `Failed`.
+- Deadline expiry may still publish `TimedOut`. A terminal request cannot be cancelled
+  retroactively.
 
-Multiple `Cancel()` calls are idempotent. Only one final state is published.
+Multiple `Cancel()` calls are idempotent. Cancellation intent is recorded separately
+from the one final state; `Cancelled` does not promise rollback unless a service-
+specific contract provides that guarantee.
 
 ### Threading
 
@@ -150,23 +199,39 @@ SDK thread. Backends must not call frontend completion handlers directly; they
 notify the frontend through an internal completion queue that the frontend
 drains on an appropriate engine thread.
 
-Gameplay code may call frontend methods from any thread, but request handles
-and callbacks should be owned by systems that understand the engine's threading
-rules. The frontend itself is thread-safe.
+The authoritative observation API is snapshot query plus optional subscription.
+Subscription returns a move-only RAII token and each token receives at most one
+terminal notification. Destroying it prevents future delivery without cancelling the
+request. Callbacks never run inline from submit, subscribe, cancel, provider callback,
+queue drain/state mutation or while a frontend/provider lock is held. The frontend
+commits terminal state first, then posts immutable request ID/terminal snapshot to the
+declared engine executor for a later dispatch turn. Subscribing after retained terminal
+completion schedules the same deferred delivery rather than invoking synchronously.
+
+Gameplay code may submit from permitted threads through bounded ingress, but the
+frontend serializes request mutation on its declared owner lane. Re-entering from a
+later completion callback may enqueue new work; it cannot recursively drain completion
+or change the published terminal record. Callback exceptions are caught at the engine
+executor boundary and do not change the platform request result.
 
 ### Timeouts, Retry, And Throttling
 
-The frontend applies a per-service timeout policy. If a backend does not
-complete a request in time, the frontend treats it as `platform_error` and
-cancels the underlying operation.
+The frontend captures one finite monotonic deadline at admission. Valid completion
+evidence observed no later than the deadline is processed before deadline evaluation.
+Otherwise the frontend commits `TimedOut` with `platform.request.timed_out`, requests
+best-effort provider cancellation and closes caller-visible completion. Later native
+completion is retirement/reconciliation evidence only and cannot replace the result.
+Provider resources remain alive until acknowledged safe; timeout is not proof of
+physical cancellation.
 
-Retry is controlled by the frontend, not by gameplay code:
+Retry is controlled by the owning frontend/service policy, not gameplay code, and all
+attempts fit within the original request deadline:
 
 - Idempotent writes such as stat updates may be retried a bounded number of
   times before surfacing an error.
 - Reads and queries are not retried automatically unless the project policy
   explicitly allows it.
-- When the backend reports `offline` or `not_signed_in`, retriable writes move
+- When the backend reports normalized `Offline` or `NotSignedIn`, retriable writes move
   to the offline queue instead of being retried immediately.
 
 High-frequency writes are throttled and coalesced:
@@ -190,21 +255,26 @@ platform.leaderboards.deferred_submits -- submissions delayed by debounce
 
 ### Result And Errors
 
-Requests return typed `Result<T>`. Errors are normalized so gameplay code does
-not need platform-specific error handling:
+Submission and terminal snapshots use typed `Result`/`Error` contracts. Errors are
+normalized so gameplay code does not need platform-specific error handling:
 
 ```text
-offline           -- no network or platform session
-not_signed_in     -- no authenticated user
-forbidden         -- platform policy or user consent blocks the call
-not_supported     -- the active backend does not implement this service
-rate_limited      -- call must be retried later
-precondition_failed -- remote revision changed; caller must refetch/reclassify
-quota_exceeded    -- provider cannot retain the requested object
-platform_error    -- backend-specific error, diagnostic detail available
-request_cancelled -- caller cancelled
-timeout           -- frontend timeout before backend completion
+platform.frontend.unavailable       -- frontend not active for admission
+platform.capability.unavailable     -- selected real provider lacks the service
+platform.provider.null              -- explicit Null composition; no operation accepted
+platform.request.capacity_exceeded  -- bounded admission/observation capacity exhausted
+platform.request.cancelled          -- acknowledged cancellation terminal outcome
+platform.request.timed_out          -- frontend deadline terminal outcome
+platform.request.expired            -- terminal observation retention ended
+platform.request.stale              -- request/frontend/provider/session generation mismatch
+platform.provider.failed            -- admitted provider operation failed
 ```
+
+`platform.provider.failed` carries one normalized category: `Offline`, `NotSignedIn`,
+`Forbidden`, `RateLimited`, `PreconditionFailed`, `QuotaExceeded`, `InvalidResponse`,
+`TransientFailure` or `PermanentFailure`. Bounded redacted native codes may appear as
+diagnostic/cause evidence but never as branching identity. Capability absence, Null,
+cancellation and timeout are never remapped into provider failure.
 
 ### Ordering And Coalescing
 
@@ -236,13 +306,13 @@ struct AchievementDefinition {
 
 class IAchievementService {
 public:
-    virtual PlatformServiceRequest<AchievementUnlockResult>
+    virtual Result<PlatformRequestHandle<AchievementUnlockResult>>
     Unlock(AchievementId id) = 0;
 
-    virtual PlatformServiceRequest<AchievementProgressResult>
+    virtual Result<PlatformRequestHandle<AchievementProgressResult>>
     SetProgress(AchievementId id, uint32_t current, uint32_t total) = 0;
 
-    virtual PlatformServiceRequest<std::vector<AchievementState>>
+    virtual Result<PlatformRequestHandle<std::vector<AchievementState>>>
     QueryState() = 0;
 };
 ```
@@ -274,18 +344,18 @@ class ILeaderboardService {
 public:
     // The backend receives an idempotency key so duplicate submissions from
     // retry or offline replay do not create multiple leaderboard entries.
-    virtual PlatformServiceRequest<void>
+    virtual Result<PlatformRequestHandle<void>>
     SubmitScore(LeaderboardId id,
                 int64_t score,
                 IdempotencyKey key) = 0;
 
-    virtual PlatformServiceRequest<LeaderboardEntries>
+    virtual Result<PlatformRequestHandle<LeaderboardEntries>>
     GetEntries(LeaderboardId id, const LeaderboardQuery& query) = 0;
 
-    virtual PlatformServiceRequest<void>
+    virtual Result<PlatformRequestHandle<void>>
     SetStat(StatName name, int64_t value) = 0;
 
-    virtual PlatformServiceRequest<std::optional<int64_t>>
+    virtual Result<PlatformRequestHandle<std::optional<int64_t>>>
     GetStat(StatName name) = 0;
 };
 ```
@@ -345,16 +415,16 @@ class ICloudSaveService {
 public:
     virtual CloudConcurrencyCapability ConcurrencyCapability() const = 0;
 
-    virtual PlatformServiceRequest<std::vector<CloudSaveMetadata>>
+    virtual Result<PlatformRequestHandle<std::vector<CloudSaveMetadata>>>
     List() = 0;
 
-    virtual PlatformServiceRequest<CloudReadResult>
+    virtual Result<PlatformRequestHandle<CloudReadResult>>
     Read(CloudSaveObjectKey key) = 0;
 
-    virtual PlatformServiceRequest<CloudMutationResult>
+    virtual Result<PlatformRequestHandle<CloudMutationResult>>
     Write(CloudWriteRequest request) = 0;
 
-    virtual PlatformServiceRequest<CloudMutationResult>
+    virtual Result<PlatformRequestHandle<CloudMutationResult>>
     Delete(CloudSaveObjectKey key, ProviderObjectRevision expected) = 0;
 };
 ```
@@ -397,10 +467,10 @@ struct PresenceState {
 
 class IPresenceService {
 public:
-    virtual PlatformServiceRequest<void>
+    virtual Result<PlatformRequestHandle<void>>
     SetPresence(const PresenceState& state) = 0;
 
-    virtual PlatformServiceRequest<void>
+    virtual Result<PlatformRequestHandle<void>>
     ClearPresence() = 0;
 };
 ```
@@ -418,7 +488,7 @@ struct PlatformUserHandle {
 
 class IFriendsService {
 public:
-    virtual PlatformServiceRequest<std::vector<PlatformUserHandle>>
+    virtual Result<PlatformRequestHandle<std::vector<PlatformUserHandle>>>
     GetFriends() = 0;
 };
 ```
@@ -492,33 +562,54 @@ The backend is a capability bundle. A platform may implement all, some, or none
 of the services.
 
 ```cpp
-struct PlatformServiceCapabilities {
-    bool achievements;
-    bool leaderboards;
-    bool cloudSave;
-    bool presence;
-    bool friends;
+enum class PlatformServiceAvailability : uint8_t {
+    Available,
+    Unavailable
+};
+
+enum class PlatformServiceUnavailableReason : uint8_t {
+    NoProviderSelected,
+    NullProviderSelected,
+    ServiceUnsupported,
+    HostPolicyDenied,
+    ProviderInitializationFailed
+};
+
+struct PlatformServiceCapability {
+    PlatformServiceKind service;
+    PlatformServiceAvailability availability;
+    PlatformServiceLimits limits;
+    std::optional<PlatformServiceBindingId> binding;
+    std::optional<PlatformServiceUnavailableReason> unavailableReason;
+};
+
+struct PlatformServiceCapabilitySnapshot {
+    ProviderGeneration providerGeneration;
+    BoundedArray<PlatformServiceCapability> services;
 };
 
 class IPlatformServicesBackend {
 public:
     virtual ~IPlatformServicesBackend() = default;
 
-    virtual PlatformServiceCapabilities Capabilities() const = 0;
-
-    virtual void Initialize(const PlatformServicesConfig& config) = 0;
-    virtual void Shutdown() = 0;
-
-    virtual IAchievementService* Achievements() = 0;
-    virtual ILeaderboardService* Leaderboards() = 0;
-    virtual ICloudSaveService* CloudSave() = 0;
-    virtual IPresenceService* Presence() = 0;
-    virtual IFriendsService* Friends() = 0;
+    virtual Result<PlatformServiceCapabilitySnapshot>
+    Initialize(const PlatformServicesConfig& config) = 0;
+    virtual Result<ProviderOperationId>
+    Submit(const PlatformProviderRequest& request,
+           PlatformProviderCompletionSink& completions) = 0;
+    virtual Result<void> RequestCancel(ProviderOperationId operation) = 0;
+    virtual Result<void> Shutdown() = 0;
 };
 ```
 
-Backends return `nullptr` for services they do not implement. The frontend
-returns `not_supported` for calls to unavailable services.
+The validated capability snapshot is the sole availability truth. `Available` has
+exactly one compatible private binding; `Unavailable` has no binding and exactly one
+reason. Missing, duplicate or mismatched bindings fail composition. Public callers do
+not inspect provider pointers, backend names or SDK flags.
+
+Connectivity, sign-in, consent and rate-limit state are request preconditions/session
+state, not a second installed-capability flag. Provider reload or session replacement
+increments generation; stale completion evidence cannot publish into the replacement.
 
 ## Offline And Degraded Behavior
 
@@ -535,7 +626,7 @@ when the operation enters the frontend and is preserved across persistence,
 retry, and replay. This prevents a retry + queue replay combination from
 producing duplicate backend effects.
 
-When the backend reports `offline` or `not_signed_in`, the frontend:
+When the backend reports normalized `Offline` or `NotSignedIn`, the frontend:
 
 1. assigns an idempotency key if the operation does not already have one
 2. persists the operation to the local queue
@@ -557,17 +648,18 @@ Replay rules:
 
 - Queue order is preserved per user account.
 - If a queued operation fails with a non-retriable error (for example,
-  `forbidden`), it is removed from the queue and the failure is surfaced.
+  normalized `Forbidden`), it is removed from the queue and the failure is surfaced.
 - If the backend accepts an idempotent operation, the queue advances.
 - Duplicate keys are ignored: the frontend checks the queue file and the set of
   in-flight requests before submitting.
 
-The null backend is always available. It:
-
-- reports no capabilities
-- returns `not_supported` for all reads
-- accepts and silently discards all writes after logging a metric
-- never leaves the local queue in an inconsistent state
+The Null backend is a valid explicit headless/test/product composition. It reports all
+remote services unavailable with `NullProviderSelected`. Every read and write fails
+admission with `platform.provider.null`; it creates no request, offline queue entry,
+idempotency record or provider mutation. In particular, it never accepts or silently
+discards achievements, stats, scores, cloud writes or presence. Optional
+application intent may be explicitly suppressed before submission, but that is not a
+successful Null operation. Tests needing success use the capability-accurate mock.
 
 ## Authentication And Session Boundary
 
@@ -578,8 +670,8 @@ ADR-113 requires that mapping to produce a private provider-scoped
 `LocalUserStorageId` and then select a product-owned `GameProfileId`. Raw platform
 handles, gamertags, emails and display names are not save-directory or cloud-slot
 identity. Backends explicitly report single-local-user, current-user-only or
-multi-user capability; unsupported switching returns `not_supported` rather than
-sharing a guessed user namespace.
+multi-user capability; unsupported switching returns
+`platform.capability.unavailable` rather than sharing a guessed user namespace.
 
 ```cpp
 struct PlatformSessionState {
@@ -600,6 +692,22 @@ public:
 The frontend dispatches these changes to gameplay systems that care about sign
 in/out. Cloud save sync and offline queue replay are triggered by sign-in
 events.
+
+## Shutdown And Late Completion
+
+Shutdown closes frontend admission and increments generation before requesting
+policy-permitted cancellation. It then drains accepted owner-lane evidence, commits at
+most one terminal result per admitted request, stops subscriptions/executor delivery
+and waits within the declared bound for provider operation and callback epochs. Safe
+retirement, not terminal publication or dropped handles, permits provider/package and
+borrowed-buffer release.
+
+If native work does not retire within the bound, shutdown reports typed failure and
+retains the required dependencies rather than unloading provider code early. Late
+callbacks carry the closed provider/session/frontend generation, may complete private
+retirement bookkeeping and cannot publish a new terminal result or invoke user code.
+Shutdown is idempotent after partial initialization and repeated calls return the
+recorded outcome without duplicating cancellation or native teardown.
 
 ## Security And Trust
 
@@ -631,7 +739,9 @@ events.
   not been reviewed.
 - Cloud save retention follows platform policy; the engine does not control it.
 - Children's accounts and restricted platforms may disable social features.
-  The frontend surfaces this as `forbidden` or `not_supported`.
+  The frontend surfaces this as normalized `Forbidden` provider failure or
+  `platform.capability.unavailable`, according to whether a supported operation was
+  denied dynamically or the capability was excluded at composition.
 
 ## Observability
 
@@ -769,7 +879,17 @@ by Horo UI. Horo only authors the configuration and observes the state.
 
 Required tests cover:
 
-- null backend accepts writes without crashing
+- admission failure creates no request/provider call/callback, while dropping every
+  handle/subscription leaves an admitted operation owned until terminal retirement
+- every legal and illegal request-state transition, with terminal state/result atomic
+  and exactly once under completion/cancel/timeout/shutdown races
+- callbacks are never inline or under frontend/provider locks; late subscription is
+  deferred, token destruction suppresses delivery and re-entry cannot recursively
+  drain completion
+- timeout uses one monotonic admission deadline across retries, wins only when no
+  eligible pre-deadline completion exists and remains terminal after late provider work
+- Null rejects every read and write with `platform.provider.null` and creates no
+  request, offline entry or idempotency record
 - mock backend replays scripted responses
 - frontend routes calls to the correct backend service
 - offline queue persists and replays in order
@@ -784,7 +904,11 @@ Required tests cover:
   malformed/oversized results cannot publish or replace a local generation
 - cloud credential/provider metadata is redacted from save diagnostics and tools
 - session sign-in/out triggers queue replay and state callbacks
-- unavailable services return `not_supported`
+- typed capability snapshot and private binding agree; missing/duplicate/mismatched
+  bindings fail composition and unavailable services return
+  `platform.capability.unavailable`
+- Null, capability absence, cancellation, timeout and provider failure have distinct
+  stable codes; provider categories/native evidence never replace frontend identity
 - presence updates coalesce to the most recent state
 
 ### Mock Backend
@@ -815,7 +939,7 @@ Tests use the mock backend to verify:
 
 - correct request routing and error translation
 - timeout handling when `delay` exceeds the policy
-- offline queue behavior when the backend returns `offline`
+- offline queue behavior when the backend returns normalized `Offline`
 - idempotency key stability across retries and replay
 - stat coalescing and leaderboard debounce logic
 
@@ -823,6 +947,8 @@ Platform-specific backend tests live in the private platform repositories.
 
 ## Related Documents
 
+- [ADR-130](../../adr/130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md):
+  frontend request ownership, lifecycle, callback, capability, Null and error baseline.
 - [Platform Services Config UI Reference](./platform-services-config.html): achievements, leaderboards, cloud saves, presence, and platform adapters panel.
 
 - [Audio Architecture](./audio-architecture.md)


### PR DESCRIPTION
## Summary

- Records ADR-130 as the single Platform Services frontend request, callback, capability, Null, timeout, and error baseline.
- Replaces the contradictory request examples with frontend-owned records, explicit admission, one exhaustive state machine, exactly-once terminal publication, and deferred observer delivery.
- Removes bool-plus-nullable-pointer capability truth and makes the Null backend reject every read and write instead of silently acknowledging discarded mutations.
- Projects the normalized async error identities into the foundation Error and Diagnostics architecture and updates the architecture/ADR indexes.

## Why

The existing Platform Services text allowed an already-complete callback to run synchronously, left dropped-handle ownership undefined, described timeout as both generic provider failure and a distinct result, exposed capability through two disagreeing mechanisms, and made Null writes appear successful despite no capability. Later achievement, leaderboard, cloud, identity, and offline-queue contracts cannot safely specialize that model until one lifecycle and error authority is fixed.

ADR-130 resolves these contradictions before public request contracts are introduced.

## Decision and boundaries

- `PlatformServicesFrontend` owns every admitted request record independently of handles and subscriptions. Admission failure returns `Result<PlatformRequestHandle<T>>` without creating a request or provider call.
- Defines `Queued`, `Running`, `Cancelling`, `Succeeded`, `Failed`, `Cancelled`, and `TimedOut`, including legal transitions and atomic state/result invariants.
- Dropping handles or subscription tokens never cancels provider work. Cancellation is explicit, idempotent, best-effort intent; a raced committed success may remain success.
- Captures one finite monotonic deadline at admission. Timeout publishes `platform.request.timed_out` once, asks for best-effort provider cancellation, and treats later native completion only as retirement/reconciliation evidence.
- Replaces synchronous `OnComplete` with immutable snapshot query and move-only subscription. Notifications are always posted to a declared engine executor after terminal commit and never run inline or under frontend/provider locks.
- Replaces capability bools plus nullable service getters with one validated typed capability snapshot and private binding. Provider/session reloads are generation-fenced.
- Makes `PlatformServicesNull` fail closed with `platform.provider.null` for both reads and writes; successful scripted behavior belongs to the capability-accurate mock.
- Distinguishes frontend unavailable, capability unavailable, Null, capacity, cancelled, timed out, expired, stale, and provider failed. Provider failures carry normalized categories and bounded redacted native evidence.
- Defines shutdown ordering so provider code and borrowed memory cannot unload before native work and callback epochs retire.
- Migrates all service examples and expands race, callback, capability, Null, timeout, and error qualification requirements.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/platform-services-architecture.md docs/architecture/foundation/error-and-diagnostics.md`
- `git diff --check`
- `git diff --cached --check`
- Added Markdown links resolve with the repository-relative staged-link checker.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. Existing warnings remain: mbedTLS declares an old CMake compatibility floor, and repository Python tests are skipped because `pytest` is unavailable.

## Risk and rollout

- This is an architecture-only change; bounded stores, executors, provider adapters, Null/mock behavior, and concurrency tests remain follow-up implementation.
- Dropped handles no longer imply cancellation. Callers that relied on scope-based abort must issue explicit cancellation and handle a raced successful provider commit.
- Null writes now fail instead of succeeding as no-ops. Products/tests that used Null as silent success must declare application-level suppression or use Mock.
- Existing callback consumers must migrate away from timing-dependent synchronous completion and retain subscription tokens when delivery is required.
- Provider-specific errors must be mapped once into the normalized taxonomy; private SDK packages need adapters that preserve safe evidence without leaking native types or credentials.

## Issue links

- Jira: [HORO-1830](https://horo-engine.atlassian.net/browse/HORO-1830)
- GitHub: Closes #1874
- Domain ticket: `[PLS-001.1]`

## Reviewer Notes

- Review the state table and cancellation/timeout race rules first; confirm each admitted request has exactly one terminal state/result.
- Check that observer registration after completion is still deferred and cannot cause inline reentrancy.
- Confirm capability snapshot and private binding form one validated truth with no public provider-pointer routing.
- Verify Null, capability absence, cancellation, timeout, and provider failure remain independently branchable stable codes.
- Check shutdown retention: terminal publication or dropped handles must not free native provider work early.

## Stack

- Base: `docs/HORO-1713_vfx_editor_document_preview_authoring`
- Head: `docs/HORO-1830_platform_frontend_request_semantics`


[HORO-1830]: https://horo-engine.atlassian.net/browse/HORO-1830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ