### PR TITLE
docs(platform): define SDK ABI composition boundary HORO-1838 #1882 [PLS-002.1]

### DIFF
--- a/docs/adr/131-platform-services-closed-sdk-extension-abi-package-and-composition-boundary.md
+++ b/docs/adr/131-platform-services-closed-sdk-extension-abi-package-and-composition-boundary.md
@@ -1,0 +1,267 @@
+# ADR-131: Platform Services Closed SDK, Extension ABI, Package and Composition Boundary
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Public/private target boundary, provider discovery and trust, platform-services extension ABI values, candidate activation/rollback, provider selection and headless/test/unsupported/certification composition
+- **Issue**: [PLS-002.1](https://github.com/abdullahbodur/horo-engine/issues/1882)
+- **Jira**: [HORO-1838](https://horo-engine.atlassian.net/browse/HORO-1838)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md), [ADR-054](054-extension-and-package-authority-boundary.md), [ADR-055](055-extension-manifest-v1-typed-model.md), [ADR-056](056-external-editor-ui-boundary.md), [ADR-116](116-save-data-threat-model-and-trust-policy.md), [ADR-130](130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md)
+- **Normative documents**: [Platform Services Architecture](../architecture/runtime/platform-services-architecture.md), [Extension System](../architecture/extensions/plugin-system.md), [Internal Module Descriptor](../architecture/foundation/internal-module-descriptor.md), [Release Security](../architecture/release/release-security.md)
+
+## Context
+
+Platform Services must integrate Steamworks and certification-controlled console SDKs
+without placing proprietary headers, libraries or policy inside the public engine.
+The architecture currently says providers are extension packages, but it does not
+assign discovery, package trust, ABI adaptation, capability registration and final
+selection to distinct owners or define their rollback boundaries.
+
+The generic extension ABI forbids C++ ownership across external module boundaries.
+Platform providers add asynchronous operations, session callbacks, credentials and
+SDK-native objects that can outlive an entry call. Without a platform-specific ABI
+profile, an implementation could leak a provider user/native request handle into the
+frontend, return SDK-allocated memory, throw through the host or unload code while a
+callback is still pending.
+
+Composition also differs by product. Headless servers, unit tests, unsupported targets
+and certification builds cannot use the same discovery/fallback assumptions as an
+editor development host. The selection must remain explicit while ADR-130 continues
+to own public request state and error semantics.
+
+## Decision
+
+### 1. Public Horo targets contain no closed SDK dependency
+
+The public repository owns only backend-neutral Horo contracts, manifests/schema,
+extension ABI definitions/adapters, `PlatformServicesFrontend`, Null, public ABI
+conformance fixtures and Mock test support. No public or core target may include,
+forward-declare, link, delay-load, fetch or generate from proprietary platform SDK
+headers/libraries. Their paths and license-controlled identifiers do not appear in
+installed public headers or public/interace CMake usage requirements.
+
+Closed SDK integration lives in a separately built private provider package, for
+example `horo-platform-steam` or a certification-controlled console package. That
+package owns SDK includes/libraries, SDK initialization, native callbacks, credential
+leases, error translation and platform-holder compliance. It exposes only the Horo
+platform-services extension ABI.
+
+The public engine builds, tests and packages with Null/Mock and ABI fixtures when no
+private SDK is installed. A private package can update its SDK and internal C++ without
+changing gameplay-facing contracts while it still implements an accepted ABI and
+Horo semantic version.
+
+### 2. Provider lifecycle stages have separate owners
+
+| Stage | Owner | Output / rollback boundary |
+|---|---|---|
+| Package discovery | `PackageService` over verified install records | Inert package candidates only; never `dlopen` directory scans |
+| Integrity, signature, license/trust and enablement | `PackageLifecycleService` / `TrustService` | Accepted immutable package graph or fail closed; no module code run |
+| Descriptor and binary resolution | `ExtensionHost` | Exact target/architecture entry from verified manifest; normalized contained path |
+| Dynamic load and ABI negotiation | `ExtensionHost` platform-services adapter | Loaded candidate generation or unload candidate; no live capability registration |
+| SDK/provider candidate initialization | Private package behind ABI | Opaque candidate state; failure destroys partial native resources through its ABI destroy path |
+| Capability/limit enumeration and validation | Platform Services composition adapter | Copied Horo-only candidate snapshot; invalid/duplicate claims destroy candidate |
+| Product-policy selection | Application/process composition root | Exactly one selected provider generation or explicit Null; required absence fails startup |
+| Frontend activation and request ownership | `PlatformServicesFrontend` | ADR-130 immutable capability binding and request store |
+| Native operation execution/retirement | Private package | SDK objects never leave package; completion copied through generation-checked sink |
+| Shutdown/unload | Frontend, then adapter, then `ExtensionHost` | Close/drain/retire callbacks and operations before module unload/package release |
+
+Package discovery does not imply trust; trust does not imply activation; capability
+registration does not select a provider. No stage consults a global service locator or
+mutates a live registry from descriptor construction/static initialization.
+
+### 3. Provider packages are manifest-selected, not probed by loading
+
+The `.horopkg` manifest and verified file record declare package/module identity,
+version, target OS/architecture/product profile, extension ABI range, platform-services
+provider contribution, SDK/runtime dependencies, permissions, certification class and
+content digests. Discovery reads this inert metadata only.
+
+The host loads only the exact binary named by the resolved verified install record.
+It never scans PATH/system library folders, tries backend names in order, loads every
+candidate to ask what it supports or follows symlinks/undeclared dependencies. A
+repository clone cannot grant local native trust or auto-load a project-declared
+provider.
+
+Selection inputs are frozen product/release manifest, host target, approved package
+graph, trust decision, requested service policy and explicit user/developer selection
+where permitted. Native SDK availability or initialization evidence is candidate
+validation, not an authority to rewrite product selection.
+
+### 4. Platform Services uses a versioned C ABI profile
+
+The extension point is a versioned `platform.services.provider` contribution layered
+on `HoroExtensionAbi`. Every exported struct starts with `structSize` and the ABI/
+semantic version is negotiated before any provider function is invoked. New optional
+tail fields are append-only; incompatible required semantics use a new ABI version.
+
+Values permitted across the boundary are:
+
+- fixed-width integers, C enums and explicitly sized flags;
+- stable Horo IDs represented by fixed canonical bytes/integers;
+- byte-counted UTF-8/string and byte spans borrowed for the documented call only;
+- host-owned bounded output/completion sinks whose data is copied during the call;
+- opaque ABI adapter context cookies and provider-operation tokens scoped to one
+  provider generation, never SDK-native handles; and
+- versioned Horo request/result/error structs containing bounded tagged fields.
+
+Forbidden across the ABI are:
+
+- STL/C++ classes, templates, RTTI, exceptions, virtual objects or compiler-owned ABI;
+- ownership of memory allocated by the other side, allocator/deleter transfer, raw
+  owning pointers or retained borrowed spans;
+- Steam/PSN/Xbox/Nintendo/native OS types, SDK request/user/session handles, vtables or
+  error objects;
+- credentials/tokens, raw account IDs, unrestricted provider response bodies or
+  provider-owned display strings as durable Horo identity; and
+- callbacks into arbitrary engine services or a host service locator.
+
+An adapter context cookie is only dispatch identity for the ABI function table. The
+host never dereferences or exposes it beyond the private adapter; the package owns and
+destroys it after callback quiescence. A provider-operation token is a bounded opaque
+ABI token mapped privately to native work. It cannot become `PlatformRequestId`, user
+identity or gameplay-visible data.
+
+### 5. Async completion is host-sink based and generation fenced
+
+The host supplies a narrow completion/event sink table with context and generation.
+Provider SDK callbacks translate native state inside the private package, then submit
+one bounded Horo result to that sink. The sink copies accepted data immediately into
+host-owned storage and returns an ABI status; the provider retains no sink output
+pointer and the host retains no borrowed provider buffer.
+
+Provider code never calls gameplay/frontend observers directly. It does not publish
+after its sink generation is revoked. Every completion carries provider generation,
+operation token, service/operation kind and terminal evidence; ADR-130 frontend owner
+maps it to the one request record. Duplicate, late, malformed, oversized and stale
+completion is rejected for publication while still permitting private retirement.
+
+Exceptions are caught inside the package at every exported function/callback and
+inside the host at every module call. None crosses the C ABI. ABI status reports call/
+transport validity; a valid provider operation failure is returned as the versioned
+Horo result envelope, not conflated with an ABI crash/version error.
+
+### 6. Candidate activation is transactional
+
+The composition transaction executes in this order:
+
+```text
+resolve verified package graph
+  -> resolve exact module binary and entry symbol
+  -> load candidate library and negotiate ABI
+  -> create provider candidate and initialize closed SDK
+  -> copy and validate capability/limit/error descriptors
+  -> select against frozen product policy and reserve frontend capacity
+  -> atomically publish one provider generation and activate frontend admission
+```
+
+Failure before publication destroys provider candidate/native state, revokes sinks,
+unloads the candidate library and releases package leases in reverse order. It leaves
+the old active provider/frontend untouched and publishes no partial capability.
+
+Replacement prepares and validates the full candidate while the old generation stays
+active and charged. At the safe point, the frontend closes old admission, drains or
+cancels according to ADR-130, generation-fences late callbacks, publishes the new
+binding only after old live semantic authority is closed, and retires old code after
+all operations/callback epochs release it. There is never routing by whichever of two
+providers answers first.
+
+An unload timeout or unknown native tail retains the module/package lease and reports
+typed shutdown failure. It does not force-unload code that may receive a callback.
+
+### 7. Composition is explicit per host and release profile
+
+- **Interactive development/editor:** may select one locally trusted compatible
+  private provider or explicit Null. Project requirement prompts for trust but cannot
+  auto-load code. Provider diagnostics are available under redaction policy.
+- **Unit/contract tests:** use built-in Mock/Null and public ABI conformance fixtures.
+  Private packages run SDK integration/certification tests in their controlled repos.
+- **Headless/server:** defaults to Null with all remote client-platform capabilities
+  unavailable. A trusted server-capable provider requires an explicit product manifest
+  and cannot reuse client credentials/session assumptions.
+- **Unsupported OS/architecture:** an absent exact binary/provider capability yields
+  typed unavailable for optional services or startup failure for required services.
+  The host never loads a closest platform variant or silently selects another provider.
+- **Certification/shipping:** freezes exact package/module hashes, ABI, SDK runtime,
+  entitlements, capabilities and provider selection in the signed product manifest.
+  Marketplace/install/update, arbitrary local extensions, Mock and development fallback
+  are excluded. Required initialization/certification preflight failure blocks startup
+  or the certified feature according to explicit product policy; it never falls back
+  to an uncertified provider.
+
+Null remains ADR-130 fail-closed: it does not acknowledge writes. Required product
+services cannot resolve to Null. Optional application intent may be explicitly
+suppressed by its semantic owner before submission.
+
+### 8. Gameplay depends only on Horo frontend capabilities
+
+Gameplay receives narrow Horo application capabilities backed by
+`PlatformServicesFrontend`. It cannot discover provider packages, select a backend,
+call the extension ABI, inspect provider tokens or include SDK headers. Requests,
+stable IDs, values and errors remain Horo-owned and preserve ADR-130 semantics.
+
+Provider-specific mapping, manifests, entitlements and SDK conversions remain inside
+the private package/cook adapter. A provider upgrade may add internal features, but a
+new gameplay-visible semantic requires a versioned Horo contract and public review; it
+cannot escape as a native property map or handle.
+
+### 9. Distribution and dependency checks enforce the boundary
+
+Public CI configures and builds core, Null, Mock and ABI tests with no SDK environment.
+Dependency policy rejects proprietary include roots, link libraries, runtime loader
+names and package binaries from public/core target closures. Installed public headers
+are scanned for native SDK names/types and ABI-unsafe C++ ownership.
+
+Shipping assembly verifies the selected private package outside the public source tree,
+records its manifest/hash/license/provenance and includes it only in authorized target
+products. Symbols, credentials, SDK logs and restricted headers never enter public
+artifacts or ordinary diagnostic bundles.
+
+Qualification covers wrong ABI/size/version, missing entry, tampered package, wrong
+target, denied trust, initialization/capability failure, partial rollback, replacement
+with requests in flight, duplicate/late callback, retained borrowed-buffer attempts,
+throwing exports, unload timeout and certification manifest mismatch. Each failure must
+leave either the prior generation intact or the frontend explicitly unavailable with
+no partial registry mutation.
+
+## Consequences
+
+- The public repository and all core consumers build without proprietary SDK access.
+- Each discovery, trust, load, validation, selection, request and unload stage has one
+  owner and a reversible pre-publication boundary.
+- Provider-native types and memory cannot leak into frontend/gameplay or lock the public
+  API to a private SDK version.
+- Private package and SDK evolution is isolated behind a versioned Horo C ABI/semantic
+  contract.
+- Certification builds gain a frozen auditable composition and cannot silently fall
+  back to a development provider.
+- The ABI adapter requires careful copied envelopes, callback epochs, generation
+  fencing and conformance tests; direct C++ interfaces would be simpler locally but
+  would not preserve binary or ownership boundaries.
+
+## Rejected Alternatives
+
+### Link closed SDKs into the public Platform Services target conditionally
+
+Rejected because configuration flags do not prevent proprietary headers/libraries
+from entering dependency closures, installed interfaces, CI or redistribution.
+
+### Let providers self-register or select themselves during static initialization
+
+Rejected because trust, target/product policy, rollback and deterministic selection
+must precede activation; inert descriptors cannot mutate ambient registries.
+
+### Expose a C++ provider interface across package binaries
+
+Rejected because STL, exceptions, allocator ownership, RTTI and compiler ABI differ and
+would bind public contracts to private toolchains/SDK lifetimes.
+
+### Pass native provider handles through opaque `void*` gameplay values
+
+Rejected because opacity does not define ownership, generation, privacy or unload
+safety. Only adapter-scoped cookies/tokens may cross the C ABI and never reach gameplay.
+
+### Auto-fallback to another installed provider after initialization failure
+
+Rejected because provider choice is product/certification policy. Optional services
+may be explicitly unavailable or Null; required services fail composition visibly.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -142,6 +142,7 @@ to the replacement.
 | [128](128-vfx-spawn-event-mapping-pooling-and-budget-enforcement.md) | VFX Spawn Event Mapping, Pooling and Budget Enforcement | Proposed | 2026-09-02 |
 | [129](129-vfx-editor-document-live-preview-and-module-authoring.md) | VFX Editor Document, Live Preview and Module Authoring | Proposed | 2026-09-02 |
 | [130](130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md) | Platform Services Frontend, Request Lifetime, Timeout, Null and Error Semantics | Proposed | 2026-09-02 |
+| [131](131-platform-services-closed-sdk-extension-abi-package-and-composition-boundary.md) | Platform Services Closed SDK, Extension ABI, Package and Composition Boundary | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -396,6 +396,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Platform Services Frontend, Request Lifetime, Timeout, Null and Error Semantics](../adr/130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md):
   frontend-owned asynchronous requests, exactly-once terminal publication, deferred
   callbacks, typed capability truth and distinct Null/timeout/provider failures.
+- [Platform Services Closed SDK, Extension ABI, Package and Composition Boundary](../adr/131-platform-services-closed-sdk-extension-abi-package-and-composition-boundary.md):
+  SDK-free public targets, manifest/trust-selected private providers, C ABI value and
+  callback rules, transactional activation and profile-specific composition.
 - [Post-Processing And Effects Architecture](./runtime/post-processing-and-effects-architecture.md):
   screen-space effects, HDR post chain, tonemapping, color grading, and
   accessibility pass ordering.

--- a/docs/architecture/extensions/plugin-system.md
+++ b/docs/architecture/extensions/plugin-system.md
@@ -315,6 +315,7 @@ runtime lifecycle contracts:
 | `behavior.provider` | Deferred runtime-facing point for script or graph runtime adapters and generated descriptor providers. It is disabled in the initial contract unless the provider also satisfies gameplay module validation, trust, `runtime.participate` permission, module fingerprint, lifetime, and safe-reload rules. | [Gameplay Behavior Authoring](./gameplay-behavior-authoring.md) |
 | `asset.runtime_loader` | Load game-owned asset types at runtime. | [Gameplay Runtime Integration](./gameplay-runtime-integration.md) |
 | `network.transport` | Provide approved network transport implementations. | [Runtime Lifecycle](../runtime/runtime-lifecycle.md) |
+| `platform.services.provider` | Provide a trusted private adapter for closed platform-service SDKs through the versioned Horo C ABI. Discovery/trust/load remain package/ExtensionHost concerns; application composition selects one provider generation. | [Platform Services Architecture](../runtime/platform-services-architecture.md) |
 
 The catalog is intentionally typed. A package cannot draw arbitrary UI, mutate
 scene state, or open sockets merely because it is installed. It must contribute
@@ -1119,6 +1120,9 @@ Required tests cover:
 - restart-required update, disable, and removal
 - shutdown ordering and no host callbacks after module teardown
 - no STL, exceptions, or cross-allocator ownership in ABI fixtures
+- platform-services provider fixtures reject SDK/native handles, retained borrowed
+  spans, callbacks after sink revocation and partial capability registration; failed
+  candidate activation rolls back without changing the active provider generation
 - marketplace registry schema, SHA-256, signature, and release URL validation
 - extension-only and hybrid `.horopkg` authority fixtures
 - raw directory and undeclared descriptor/binary activation rejection
@@ -1144,5 +1148,7 @@ snapshot-pinned importer again, and performs an identity-preserving reimport.
 - [Editor Panel Host](../editor/editor-panel-host.md)
 - [Editor Modal Host](../editor/editor-modal-host.md)
 - [Asset Pipeline](../runtime/asset-pipeline.md)
+- [Platform Services Architecture](../runtime/platform-services-architecture.md)
+- [ADR-131: Platform Services Closed SDK, Extension ABI, Package and Composition Boundary](../../adr/131-platform-services-closed-sdk-extension-abi-package-and-composition-boundary.md)
 - [MCP Architecture](../interfaces/mcp-architecture.md)
 - [Horo Package System](../packages/package-system.md): game and hybrid packages that may declare editor extensions

--- a/docs/architecture/release/release-security.md
+++ b/docs/architecture/release/release-security.md
@@ -191,6 +191,15 @@ Signing keys are stored outside the repository and build output. Signing
 identity and verification metadata are recorded without embedding private
 material.
 
+Under [ADR-131](../../adr/131-platform-services-closed-sdk-extension-abi-package-and-composition-boundary.md),
+a certification/shipping profile freezes each private Platform Services provider's
+package/module hash, extension ABI, SDK runtime dependency, entitlement/capability
+declaration and selected-provider identity in the signed product manifest. Public/core
+targets retain no closed SDK dependency. Marketplace/update, arbitrary local provider,
+Mock and development fallback paths are excluded from that composition; failure of a
+required certified provider blocks the declared product capability rather than
+silently selecting an uncertified alternative.
+
 The publication process verifies signatures and hashes after upload. An
 artifact is not considered published until post-upload verification succeeds.
 

--- a/docs/architecture/runtime/platform-services-architecture.md
+++ b/docs/architecture/runtime/platform-services-architecture.md
@@ -18,6 +18,12 @@ result publication, deferred callback dispatch, capability truth, Null behavior,
 timeout and provider-error normalization. Later service decisions specialize this
 contract rather than creating another request lifecycle.
 
+[ADR-131](../../adr/131-platform-services-closed-sdk-extension-abi-package-and-composition-boundary.md)
+keeps proprietary SDKs in separately built private packages, assigns discovery/trust/
+load/selection to distinct owners, constrains asynchronous provider exchange to a
+versioned C ABI and freezes explicit composition for development, headless, test,
+unsupported and certification profiles.
+
 ## Scope
 
 Platform services covered here:
@@ -61,6 +67,69 @@ What the core provides:
 Concrete backends live in separate platform packages such as
 `horo-platform-steam`, `horo-platform-ps5`, `horo-platform-xbox`, and are
 loaded by the runtime like any other extension package.
+
+No public/core target includes, links, delay-loads, fetches or generates from a closed
+SDK. Public CI builds the frontend, Null, Mock and ABI conformance fixtures without SDK
+paths. A private provider package owns SDK initialization, native objects/callbacks,
+credentials, error translation and certification policy and exposes only the Horo
+`platform.services.provider` C ABI profile.
+
+## Provider Package And Composition Boundary
+
+Provider discovery reads only verified `.horopkg` install records and inert manifests;
+it never probes PATH or loads candidates to discover capabilities. Package/Trust
+services resolve integrity, signature, permissions, license and enablement. ExtensionHost
+then loads the exact target binary, negotiates ABI and creates a candidate without
+mutating live capability state. The application composition root validates the copied
+Horo capability/limit snapshot and selects exactly one provider generation or explicit
+Null before frontend admission opens.
+
+The transaction is:
+
+```text
+verified package graph
+  -> exact module/entry and ABI negotiation
+  -> private SDK candidate initialization
+  -> copied capability/limit/error descriptor validation
+  -> product-policy selection and frontend reservation
+  -> atomic provider generation publication
+```
+
+Failure before publication revokes candidate sinks, destroys partial SDK state,
+unloads the candidate and releases package leases in reverse order while preserving an
+old active generation. Replacement prepares the new candidate at full overlap, closes
+and drains the old ADR-130 frontend generation at a safe point, then unloads old code
+only after native operations and callback epochs retire. Timeout retains the module
+lease rather than force-unloading code with possible callbacks.
+
+The versioned C ABI carries fixed-width values/enums, sized structs, canonical Horo
+IDs, call-borrowed byte/string spans, host-owned bounded sinks, adapter-scoped context/
+operation tokens and Horo request/result/error envelopes. It carries no STL/C++ object,
+exception, allocator ownership, retained borrowed span, SDK/native handle, credential,
+raw account identity or unrestricted provider payload. Context/operation tokens remain
+inside the private host adapter and never become frontend/gameplay identity.
+
+Provider callbacks translate native state inside the package and copy bounded Horo
+completion into a host sink tagged with provider generation. They never call gameplay
+or observers, retain sink buffers or publish after sink revocation. Both sides catch
+exceptions at the ABI edge; ABI status represents call validity, while valid operation
+failure uses the ADR-130 typed result envelope.
+
+Composition policy is explicit:
+
+- development/editor may use one locally trusted exact provider or Null;
+- tests use Mock/Null and public ABI fixtures;
+- headless defaults to Null unless a server-capable provider is explicitly manifested;
+- unsupported targets report typed optional unavailability or fail required startup,
+  never load a closest variant; and
+- certification builds freeze package/module hashes, ABI, SDK runtime, entitlement,
+  capability and selection in the signed product manifest, with marketplace/update,
+  arbitrary local providers, Mock and development fallback excluded.
+
+Gameplay uses only narrow Horo frontend capabilities. It cannot discover/select a
+provider, invoke the extension ABI or observe SDK types/tokens. Provider mapping and
+SDK evolution remain private; new gameplay semantics require a versioned public Horo
+contract rather than a native property escape.
 
 ## High-Level Architecture
 


### PR DESCRIPTION
## Summary

- Records ADR-131 for the boundary between public Horo Platform Services contracts, private closed-SDK provider packages, the extension C ABI, and process composition.
- Assigns package discovery, trust, binary/ABI resolution, SDK candidate initialization, capability validation, provider selection, frontend activation, native operation retirement, and unload to explicit owners with rollback boundaries.
- Defines the only value/lifetime forms permitted across the asynchronous provider ABI and prohibits SDK-native handles, STL/C++ ownership, exceptions, retained borrowed spans, credentials, and cross-allocator memory.
- Adds explicit development, test, headless, unsupported-target, and certification/shipping composition policy.
- Projects the decision into Platform Services, Extension System, Release Security, the architecture index, and the ADR index.

## Why

Platform Services must integrate proprietary and certification-controlled SDKs without making the public engine depend on their headers, libraries, toolchains, credentials, or native lifetimes. The existing architecture named extension packages but did not separate discovery from trust and selection, did not define asynchronous ABI ownership, and did not specify transactional activation or product-profile fallback policy.

ADR-131 freezes those boundaries while preserving ADR-130 as the sole gameplay-facing request lifecycle and error contract.

## Decision and boundaries

- Public/core targets own only Horo frontend contracts, schemas, C ABI/adapters, Null, Mock, and conformance fixtures. They must configure/build with no closed SDK present and expose no proprietary transitive include/link dependency.
- Private `.horopkg` providers own SDK headers/libraries, initialization, native objects/callbacks, credential leases, error translation, and platform-holder compliance.
- Discovery reads verified inert install records; Package/Trust services approve integrity/signature/license/permissions; `ExtensionHost` loads the exact manifested target binary and negotiates ABI; application composition selects exactly one validated generation or explicit Null.
- Defines a candidate transaction from verified package graph through ABI negotiation, SDK init, copied capability validation, policy selection, reservation, and atomic publication. Pre-publication failure unwinds in reverse without touching the active generation.
- Replacement keeps the old provider active while the full candidate is prepared, then closes/drains the old ADR-130 generation before publishing and eventually unloading it. Unretired callbacks keep the package lease alive.
- The C ABI admits fixed-width values/enums, sized structs, canonical Horo IDs, call-borrowed spans, host-owned sinks, adapter-scoped tokens, and bounded Horo result envelopes. Provider SDK types and ownership never cross.
- Provider callbacks translate privately and copy generation-tagged Horo completion into the host sink; they never call gameplay/observers or retain host buffers. Both sides catch exceptions at the ABI edge.
- Headless defaults to fail-closed Null unless a server-capable provider is explicitly manifested; tests use Mock/Null; unsupported targets do not load nearest variants; certified products freeze exact package/hash/ABI/SDK/entitlement/capability/selection and exclude development fallbacks.
- Adds extension-point, ABI conformance, rollback, and release-manifest requirements.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/131-platform-services-closed-sdk-extension-abi-package-and-composition-boundary.md docs/adr/README.md docs/architecture/README.md docs/architecture/runtime/platform-services-architecture.md docs/architecture/extensions/plugin-system.md docs/architecture/release/release-security.md`
- `git diff --check`
- `git diff --cached --check`
- Added Markdown links resolve with the repository-relative staged-link checker.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. Existing warnings remain: mbedTLS declares an old CMake compatibility floor, and repository Python tests are skipped because `pytest` is unavailable.

## Risk and rollout

- This is an architecture-only change; the `platform.services.provider` ABI structs, adapter, candidate transaction, dependency gates, and conformance fixtures remain follow-up implementation.
- Async C ABI integration requires explicit callback epochs and copied envelopes; private providers that currently return SDK-owned memory or invoke engine callbacks directly need migration.
- Provider replacement may temporarily charge old and candidate package/SDK resources together. Capacity and certification policy must account for that overlap.
- Fail-closed required-service composition can block product startup when the exact trusted provider is missing or invalid; this is intentional and must be surfaced clearly by product diagnostics.
- Certification profiles cannot use arbitrary installed providers or development fallback, so release manifests and private package provenance become hard release inputs.

## Issue links

- Jira: [HORO-1838](https://horo-engine.atlassian.net/browse/HORO-1838)
- GitHub: Closes #1882
- Domain ticket: `[PLS-002.1]`

## Reviewer Notes

- Review the lifecycle owner table and activation transaction first; confirm no stage conflates discovery, trust, registration, or selection.
- Check that the public target closure has no route to proprietary headers/libraries and that private SDK evolution remains behind the versioned Horo ABI/semantics.
- Review async ABI ownership: borrowed spans end with the call, completion is copied into host sinks, adapter tokens never reach gameplay, and callback epochs prevent early unload.
- Confirm headless/test/unsupported/certification policies never silently select an incompatible or uncertified provider.
- Verify this ADR specializes package/composition only and leaves public request state/error ownership with ADR-130.

## Stack

- Base: `docs/HORO-1830_platform_frontend_request_semantics`
- Head: `docs/HORO-1838_platform_sdk_abi_composition_boundary`


[HORO-1838]: https://horo-engine.atlassian.net/browse/HORO-1838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ