### PR TITLE
docs(platform): define stable ID namespace policy HORO-1844 #1888 [PLS-003.1]

### DIFF
--- a/docs/adr/132-platform-services-project-salt-stable-id-tombstone-and-provider-mapping.md
+++ b/docs/adr/132-platform-services-project-salt-stable-id-tombstone-and-provider-mapping.md
@@ -1,0 +1,395 @@
+# ADR-132: Platform Services Project Salt, Stable ID, Tombstone and Provider Mapping
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Project-scoped Platform Services identity namespace, deterministic numeric ID algorithm and encoding, key aliases, tombstones, collision handling, salt cloning/regeneration, provider mappings and cooked/runtime consumption
+- **Issue**: [PLS-003.1](https://github.com/abdullahbodur/horo-engine/issues/1888)
+- **Jira**: [HORO-1844](https://horo-engine.atlassian.net/browse/HORO-1844)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-009](009-configuration-schema-precedence-and-secret-boundary.md), [ADR-054](054-extension-and-package-authority-boundary.md), [ADR-103](103-network-project-configuration-and-build-profile-ownership.md), [ADR-113](113-local-storage-user-profile-and-slot-ownership.md), [ADR-130](130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md), [ADR-131](131-platform-services-closed-sdk-extension-abi-package-and-composition-boundary.md)
+- **Normative documents**: [Platform Services Architecture](../architecture/runtime/platform-services-architecture.md), [Project Model](../architecture/editor/project-model.md), [Project Versioning and Migration](../architecture/foundation/project-versioning-and-migration.md), [Release Security](../architecture/release/release-security.md)
+
+## Context
+
+Platform Services definitions need durable achievement, leaderboard, stat and
+presence identities before their registries and provider manifests are implemented.
+The architecture currently suggests hashing an authoring name with an unspecified
+project salt. It does not define the hash input bytes, salt encoding, numeric byte
+order, alias behavior or how a project clone decides whether to preserve identity.
+Two clean builds could therefore disagree while still claiming to use the same
+scheme.
+
+A display-name rename must not change gameplay or remote-platform identity. Deleting
+a definition must not make its value available to an unrelated future definition.
+Collision recovery must also be independent of registry insertion order; silently
+probing for the next value would make the same sources cook differently after a
+merge or reorder.
+
+Provider SDKs add another identity domain. Steam API names, trophy IDs and console
+manifest indexes must map to Horo IDs, but cannot become identifiers serialized by
+gameplay. Conversely, a provider manifest generated successfully once cannot become
+a second registry authority or hide that the Horo source has changed.
+
+This ADR fixes the project namespace, deterministic algorithm, canonical storage,
+definition lifecycle and provider-mapping ownership. Later service-specific tickets
+may add fields and limits, but cannot introduce a second ID algorithm or reinterpret
+an existing value.
+
+## Decision
+
+### 1. One project ledger owns Platform Services identity
+
+The Project domain owns one committed, versioned
+`.horo/platform_services.ids.json` ledger. It contains active and tombstoned primary
+definitions plus their key aliases for these disjoint kinds:
+
+```cpp
+enum class PlatformServiceIdKind : std::uint8_t {
+    Achievement = 1,
+    Leaderboard = 2,
+    Stat = 3,
+    PresenceStatus = 4,
+};
+
+struct PlatformServiceStableId {
+    std::uint64_t value;
+};
+
+using AchievementId = StrongId<AchievementTag, PlatformServiceStableId>;
+using LeaderboardId = StrongId<LeaderboardTag, PlatformServiceStableId>;
+using StatId = StrongId<StatTag, PlatformServiceStableId>;
+using PresenceStatusId = StrongId<PresenceStatusTag, PlatformServiceStableId>;
+```
+
+The wrappers are not implicitly interchangeable with each other, a provider-native
+identifier, array index, runtime handle or raw integer. `0` is invalid and reserved.
+Primary numeric values are globally unique across all four kinds so logs, ABI
+envelopes and generic tooling cannot ambiguously identify a record after losing a
+static wrapper.
+
+Service-specific authoring documents own display/localization, behavior, thresholds,
+sort policy and other semantics. They reference a ledger ID; they do not allocate or
+redefine it. Provider mapping documents and generated manifests are consumers. The
+ledger is the only editable Horo identity authority.
+
+The application project service loads and validates the complete ledger as a detached
+candidate. Descriptor construction and parsing are inert. A host-owned composition/
+cook step may publish one immutable snapshot only after project identity, salt,
+bounds, uniqueness, aliases, references and provider mappings validate. No static
+initializer or provider mutates it.
+
+### 2. The project salt is generated once and committed
+
+`PlatformServicesIdSalt` is exactly 128 uniformly random bits obtained from the
+platform cryptographic random source during project creation. The all-zero value and
+short/failed random reads are rejected; Horo never falls back to time, path, project
+name, process ID, `std::random_device` assumptions or a fixed default.
+
+The single authoritative value is the root `platformServicesIdSalt` field in
+`.horo/project.json`, serialized as `psid1:` followed by exactly 32 lowercase
+hexadecimal digits. It is non-secret, portable and source controlled. Environment,
+user settings, CLI flags, provider packages and build profiles cannot override it.
+The ledger records its algorithm version and owning `projectId`, but does not copy the
+salt into a second mutable field.
+
+Project creation commits `projectId`, salt and an empty ledger in one transaction.
+Opening a project fails with a typed actionable diagnostic when a required salt is
+missing, malformed, zero or disagrees with the ledger owner/algorithm. A migration
+from a schema that predates this field generates the salt exactly once in the
+transactional project-migration path; read-only inspection and ordinary cook never
+repair project metadata.
+
+The salt is a namespace seed, not a credential, authenticity proof or privacy
+boundary. Hashing a guessable key with it does not conceal that key.
+
+### 3. Canonical keys are bounded machine identity, not display text
+
+Every primary definition has one immutable `canonicalKey`. Version 1 accepts 1–96
+ASCII bytes matching:
+
+```text
+^[a-z][a-z0-9_.-]{0,95}$
+```
+
+The exact stored bytes are hashed. There is no trimming, case folding, Unicode
+normalization, locale conversion, path normalization or implicit namespace prefix.
+Keys are chosen for durable machine meaning, such as `campaign.first_blood`; localized
+and user-visible names are independent fields in service-specific documents.
+
+Once a definition has been committed, changing its `canonicalKey` is not a rename.
+Presentation can be renamed freely. An author who needs a new accepted textual key
+adds a validated alias to the existing primary entry while retaining the original
+canonical key. An unrelated semantic definition receives a new canonical key and ID.
+
+### 4. Version 1 IDs use one exact SHA-256 derivation
+
+For a validated primary definition, Horo builds this byte sequence:
+
+```text
+ASCII("horo.platform-services.stable-id.v1")
+0x00
+project salt                                      (16 raw bytes)
+kind                                              (one uint8 tag above)
+canonical-key byte count                          (uint16, big-endian)
+canonical-key                                     (exact ASCII bytes)
+```
+
+It computes SHA-256 over exactly that sequence, takes digest bytes 0 through 7 and
+interprets them as one unsigned 64-bit big-endian integer. A zero result is a
+collision with the reserved value and fails exactly like any other collision. The
+algorithm name, domain separator, field order, widths, byte order and truncation are
+part of ledger schema version 1; implementations use a shared golden-vector codec,
+not `std::hash`, a provider hash or a platform-dependent library default.
+
+The ledger stores the derived value beside its canonical key so code review and
+merge diagnostics remain explicit. Validation always recomputes it and rejects a
+mismatch. It never trusts or silently rewrites a stored numeric value.
+
+### 5. Text, JSON, binary and ABI forms are canonical
+
+Authoring JSON serializes every ID as `sid1:` followed by exactly 16 lowercase
+hexadecimal digits, including leading zeroes. JSON numbers, signed decimal values,
+uppercase hex, optional prefixes and shortened forms are non-canonical and rejected.
+The typed in-memory value is `uint64_t`; cooked binary and the ADR-131 C ABI encode its
+eight bytes in big-endian order. Adapters explicitly decode that order and do not pass
+host-endian structs as wire bytes.
+
+Canonical ledger serialization:
+
+- uses schema version `1`, the exact owner `projectId` and algorithm
+  `horo.platform-services.stable-id.v1`;
+- orders primary entries by kind tag and then unsigned numeric ID;
+- orders aliases for one entry by exact unsigned ASCII byte order;
+- emits each schema-defined field once, rejects duplicate JSON object keys and
+  omits no required state; and
+- uses deterministic project JSON formatting and atomic sibling replacement.
+
+The registry fingerprint is a domain-separated SHA-256 over those canonical ledger
+bytes. It is provenance/freshness evidence, not a replacement for an ID or a security
+signature.
+
+### 6. Tombstones permanently reserve deleted identity
+
+A primary entry is exactly `Active` or `Tombstoned`. Removing an active service
+definition transitions its ledger entry to `Tombstoned` and retains kind, canonical
+key, numeric ID, aliases and bounded removal provenance. It does not erase the entry.
+Ordinary authoring, migration cleanup, cook and provider synchronization cannot prune
+tombstones or assign their key, alias or numeric ID to another definition.
+
+Adding a definition whose primary key or alias matches a tombstoned entry reports
+`platform.identity.tombstoned`; it never silently restores the entry. A deliberate
+restore is a separate reviewed operation that keeps the exact original entry and ID,
+checks every affected provider mapping and records the transition. Product policy may
+forbid restore after external publication. If the semantics are not exactly the same,
+the author must choose a new canonical key.
+
+Tombstones participate in every uniqueness and collision check. Cooked runtime
+tables normally omit their service payloads, but carry enough registry revision/
+fingerprint evidence to prove which identity namespace was used. Provider adapters
+retain or retire remote entries according to platform policy; they never offer a
+tombstoned Horo ID to a different definition.
+
+### 7. Aliases resolve only to one existing primary entry
+
+An alias is a version-1 canonical key owned by exactly one primary entry of the same
+kind. It has no independently derived ID. Authoring/import/migration lookup resolves
+the alias directly to its owner's existing numeric ID. Runtime requests and cooked
+gameplay references contain the typed numeric ID, not alias strings.
+
+Primary keys and aliases share one uniqueness namespace per kind across active and
+tombstoned entries. Alias chains, cycles, wildcard/prefix matching, case-insensitive
+lookup and cross-kind aliases are forbidden. Moving an alias between entries is an
+explicit migration conflict, not last-writer-wins behavior. Tombstoning an entry keeps
+its aliases reserved.
+
+Aliases are for Horo authoring compatibility only. A Steam API name, trophy number,
+console resource path or any other provider-native value cannot be registered as a
+Horo alias merely to make provider lookup convenient.
+
+### 8. Collisions fail before publication and never auto-probe
+
+Candidate validation recomputes every primary ID and builds a global numeric index
+covering active and tombstoned entries. Two different primary entries with the same
+numeric value are a hard `platform.identity.hash_collision` failure even if their
+kinds differ. Zero, duplicate keys/aliases, stored/derived mismatches and references
+to unknown or tombstoned entries also fail with separate stable error codes.
+
+Collision diagnostics contain the algorithm version, colliding canonical ID, both
+kind/key pairs and safe source locations. They never report only “duplicate ID” or
+select a winner. For a newly introduced, unpublished entry the remediation is to
+choose another canonical key and review the resulting ID. An existing published
+entry is immutable. If imported histories already contain two published meanings,
+the merge remains blocked until a declared migration/fork maps all durable references;
+Horo cannot guess which meaning wins.
+
+Incrementing the value, adding an insertion-order salt, taking a wider substring on
+one machine or retrying with a counter is forbidden. Such probing would make identity
+depend on document order and hide collision evidence.
+
+### 9. Clone and salt-regeneration intent are explicit
+
+A filesystem copy, VCS clone, branch, checkout, path move, backup/restore or teammate
+checkout preserves `projectId`, salt, ledger and all IDs. These operations represent
+another working copy of the same product identity namespace.
+
+An editor/CLI “Duplicate Project” operation must choose one of two named modes:
+
+- `PreserveIdentity` copies project identity, salt, ledger, provider mappings and
+  references unchanged for a product branch/port; or
+- `ForkIdentity` generates a new `projectId` and cryptographic salt, then performs the
+  namespace migration below for an independent product. It does not copy provider
+  credentials or claim that old remote mappings are valid for the fork.
+
+There is no path/name heuristic and no automatic regeneration after detecting a copy.
+Opening two preserved clones concurrently is a project writer/revision concern, not a
+reason to mutate identity.
+
+Salt regeneration is not an ordinary setting edit. `ForkIdentity` and an explicitly
+authorized `RegeneratePlatformServicesIdentity` command first produce a dry-run plan
+containing every old-to-new active and tombstoned ID, alias, durable source reference,
+provider mapping disposition, cooked/cache invalidation and external-publication
+warning. They derive all candidate IDs with one newly generated salt and validate the
+complete candidate before writing anything.
+
+Commit atomically updates `project.json`, the ledger, all owned durable references and
+eligible provider mapping documents; it invalidates every affected cooked manifest,
+offline operation and cache entry. Failure leaves the old namespace wholly intact.
+Historical tombstoned keys remain tombstoned under newly derived IDs. Unknown/opaque
+references, unowned package payloads, unresolved collisions or incomplete mappings
+block the transaction.
+
+After any ID has shipped, been submitted remotely, entered a save/network protocol or
+been published to another package, regeneration is prohibited by default. It requires
+a separately reviewed product migration with complete external/provider transition
+evidence or an explicit new-product reset that accepts incompatibility. A compatibility
+alias cannot make two numeric namespaces equivalent.
+
+### 10. Provider mappings are private adapter data keyed by Horo ID
+
+Each target/provider mapping table belongs to the corresponding trusted provider
+cook/package adapter and is keyed by `(ProviderId, PlatformServiceIdKind,
+PlatformServiceStableId)`. Its value is bounded provider-specific data such as an API
+name, trophy number or manifest index. The same Horo ID may map differently for each
+provider; one provider value cannot map ambiguously to multiple active Horo entries
+within the provider scope.
+
+The adapter validates the Horo ledger snapshot/fingerprint, target product/profile,
+provider package identity/version, mapping schema and provider constraints. Required
+active definitions need exactly one compatible mapping. Optional omission must be
+declared by typed product capability policy, not inferred from an absent row. Unknown,
+tombstoned, duplicate, wrong-kind or stale-fingerprint mapping rows fail generation.
+
+Provider manifests are deterministic derived artifacts. Provider reverse lookup may
+exist privately for callback correlation and diagnostics, but resolves immediately to
+a typed Horo ID under the captured provider/registry generation. Gameplay, saves,
+offline queues, scripts, telemetry dimensions and public APIs never persist a provider
+value or raw display string as their identity.
+
+Provider packages cannot allocate Horo IDs, add aliases, reactivate tombstones or
+rewrite the ledger. A provider mapping rename changes only adapter data when the
+platform permits it. A provider value retained for a removed entry remains associated
+with that tombstone/history and cannot be reassigned silently.
+
+### 11. Cook and runtime consume immutable validated snapshots
+
+Cook captures exact project identity, salt-algorithm version, ledger fingerprint,
+service-definition revisions, provider mapping revision and target/product profile.
+It resolves authoring keys/aliases once, rejects tombstoned or missing references and
+emits canonical typed IDs in provider-neutral artifacts. Provider adapters then emit
+their private manifests from the same captured snapshot. Any input revision change
+invalidates the candidate rather than mixing generations.
+
+Runtime loads bounded, sorted tables carrying the expected ledger fingerprint and
+product manifest binding. It performs typed numeric lookup only; it never hashes a
+runtime string, registers a definition, consults an editor alias or asks a provider to
+invent identity. An immutable registry generation is retained by admitted ADR-130
+requests and durable offline entries until they terminate/migrate. Hot reload publishes
+a complete compatible generation at a safe point; salt/algorithm changes require the
+explicit migration path and cannot hot reload.
+
+Release/certification evidence freezes the canonical ledger fingerprint and every
+selected provider mapping/manifest digest. Diagnostics use typed Horo IDs, safe
+canonical keys where policy permits, algorithm/revision and source locations. They
+redact provider credentials, restricted native values and account identity under
+ADR-131 and the observability policy.
+
+### 12. Qualification proves identity stability and fail-closed behavior
+
+Required automated evidence includes:
+
+- golden vectors for every kind, leading-zero outputs, canonical salt/ID text and
+  exact SHA-256 input bytes/big-endian decoding on every supported host;
+- identical IDs and canonical ledger bytes across clean builds, developer machines,
+  source order, locale and filesystem location;
+- display rename/reorder stability, alias resolution and cross-kind type rejection;
+- malformed/zero/missing salt, malformed keys/IDs, stored/derived mismatch, duplicate
+  primary/alias, zero result and synthetic hash-collision rejection;
+- active-to-tombstone transition, no silent key/ID reuse, explicit compatible restore
+  and tombstone preservation through clone/fork/migration;
+- `PreserveIdentity` equivalence plus `ForkIdentity` dry-run, complete reference remap,
+  unknown-reference rejection, rollback and cache/offline invalidation;
+- missing/duplicate/stale/wrong-kind provider mappings and proof that provider-native
+  strings never enter Horo runtime/save/offline identity fields; and
+- cook/runtime snapshot fingerprint mismatch, stale generation and mixed-input
+  publication rejection with the prior valid generation preserved.
+
+Private provider repositories add manifest round-trip and certification fixtures, but
+public Mock/Null/golden-vector tests establish the Horo identity contract without a
+closed SDK.
+
+## Consequences
+
+- Every project has one reproducible Platform Services numeric identity namespace
+  with byte-exact derivation and encoding.
+- Display changes, source ordering, clean builds and provider changes cannot rewrite
+  gameplay identity.
+- Tombstones and aliases make deletion/authoring compatibility explicit while keeping
+  old values reserved.
+- Hash collisions and imported-history conflicts block publication with actionable
+  evidence instead of becoming order-dependent IDs.
+- Project forks can deliberately obtain a new namespace, but regeneration is a broad
+  transactional migration with visible compatibility cost.
+- Provider mappings remain replaceable adapter data and cannot become the engine's
+  source of identity truth.
+- The committed ledger and permanent tombstones add source-control/merge overhead,
+  and 64-bit truncation still requires a tested collision path rather than an
+  assumption that collisions cannot occur.
+
+## Rejected Alternatives
+
+### Use display names or provider-native strings as durable IDs
+
+Rejected because localization, branding and provider constraints would rewrite
+gameplay identity and couple portable content to one backend.
+
+### Use `projectId`, project path or a fixed global salt
+
+Rejected because project identity currently serves non-secret observability semantics,
+paths vary per checkout and a global salt would collapse independent product
+namespaces. The dedicated committed salt has explicit clone/fork lifecycle.
+
+### Use UUIDs allocated independently for every definition
+
+Rejected for this registry because the ticket requires deterministic numeric IDs and
+clean-source reproducibility. Randomness enters once at the project namespace; the
+versioned key derivation is then reviewable and reproducible.
+
+### Serialize IDs as JSON numbers or host-endian integers
+
+Rejected because JSON consumers may lose 64-bit precision and host byte order differs.
+Fixed lowercase text and big-endian binary are canonical.
+
+### Resolve collisions by incrementing, rehashing with a counter or insertion order
+
+Rejected because registry ordering and merge history would change assigned values and
+hide a conflict. Collisions must be explicit authoring/migration failures.
+
+### Delete old records and rely on provider manifests as history
+
+Rejected because manifests are target-specific derived artifacts, may be unavailable
+and cannot prevent an unrelated definition from reusing an old Horo value.
+
+### Let each provider allocate or translate public gameplay IDs
+
+Rejected because a provider would become identity authority, cross-provider saves and
+gameplay would diverge, and provider replacement could reinterpret durable state.

--- a/docs/architecture/editor/project-model.md
+++ b/docs/architecture/editor/project-model.md
@@ -79,7 +79,8 @@ Durable portable metadata, machine-local state, and derived output remain
 separate:
 
 - `.horo/project.json`, `.horo/packages.json`, `.horo/packages.lock`,
-  `.horo/input.json`, `.horo/collision.json`, and asset sidecars are portable
+  `.horo/input.json`, `.horo/collision.json`,
+  `.horo/platform_services.ids.json`, and asset sidecars are portable
   source-controlled inputs
 - `.horo/editor_workspace.json`, `.horo/local/`, and `.horo/asset_index.json`
   are local or derived state
@@ -97,6 +98,7 @@ into `.horo/packages.json`; it is not a second package request authority.
   "horoVersion": "0.1.0",
   "persistentContract": "sha256:997e790fc23515b362847c755006156aa35353ce7f2624518acf7ed1214ddb03",
   "projectId": "proj_2a4f...",
+  "platformServicesIdSalt": "psid1:0123456789abcdef0123456789abcdef",
   "name": "MyGame",
   "projectVersion": "0.1.0",
   "createdAt": "2026-01-15T09:30:00Z",
@@ -127,6 +129,15 @@ injected verifier validates an exact compatibility proof.
 `projectId` is generated once at project creation and never changes. It is used
 as a non-secret observability, crash-reporting, and workspace-correlation
 identifier.
+
+`platformServicesIdSalt` is the single non-secret 128-bit namespace seed for
+[ADR-132](../../adr/132-platform-services-project-salt-stable-id-tombstone-and-provider-mapping.md)
+achievement, leaderboard, stat and presence-status IDs. Project creation obtains it
+from the platform cryptographic random source and commits it with the project identity
+and empty `.horo/platform_services.ids.json` ledger. Ordinary VCS/filesystem clones
+preserve it. Only an explicit project-identity fork or reviewed namespace migration
+may replace it; that transaction must remap every durable reference and provider
+mapping rather than editing this field alone.
 
 User activity such as `lastOpenedAt` does not belong in portable
 `project.json`; it is stored in the user-level recent-projects model.

--- a/docs/architecture/foundation/project-versioning-and-migration.md
+++ b/docs/architecture/foundation/project-versioning-and-migration.md
@@ -780,6 +780,14 @@ The following require an explicit engine or trusted package migration recipe:
 - transforming behavior/plugin-owned payload semantics
 - any change requiring domain knowledge not represented by descriptors
 
+[ADR-132](../../adr/132-platform-services-project-salt-stable-id-tombstone-and-provider-mapping.md)
+is one such boundary: replacing `platformServicesIdSalt` changes every Platform
+Services numeric identity. A project fork/regeneration therefore requires a dry-run
+old-to-new map for active and tombstoned entries, complete durable-reference and
+provider-mapping coverage, transactional publication and derived/offline invalidation.
+Editing the salt field, regenerating during cook or treating text aliases as numeric
+namespace compatibility is forbidden.
+
 Example:
 
 ```cpp

--- a/docs/architecture/runtime/platform-services-architecture.md
+++ b/docs/architecture/runtime/platform-services-architecture.md
@@ -24,6 +24,11 @@ load/selection to distinct owners, constrains asynchronous provider exchange to 
 versioned C ABI and freezes explicit composition for development, headless, test,
 unsupported and certification profiles.
 
+[ADR-132](../../adr/132-platform-services-project-salt-stable-id-tombstone-and-provider-mapping.md)
+defines the one committed project identity ledger, byte-exact SHA-256 ID derivation,
+canonical encodings, permanent tombstones, key aliases, clone/fork migration and the
+private provider-mapping boundary used by all service categories.
+
 ## Scope
 
 Platform services covered here:
@@ -567,63 +572,148 @@ Absence of the capability is typed, not a silent empty list.
 
 ## Stable ID Registries
 
-Runtime code never passes strings for achievement, leaderboard, presence, or
-stat IDs. All names are resolved at project cook or package build time into
-stable numeric IDs.
+Runtime and gameplay never pass strings for achievement, leaderboard, stat or
+presence-status identity. All authoring keys resolve before cook publication to
+strong typed 64-bit Horo IDs. The kinds are not interchangeable with each other,
+runtime handles, provider identifiers or raw integers; `0` is invalid.
 
-Stable IDs are produced deterministically from the authoring name using a
-project-scoped hash so that the same name always yields the same numeric ID
-across clean builds and across developer machines:
+### Project identity authority
 
-```cpp
-struct StableId64 { uint64_t value; };
+The Project domain owns one committed `.horo/platform_services.ids.json` ledger. It
+contains all active and tombstoned primary entries and their authoring aliases. A
+service-specific definition document owns display/localization and behavior fields and
+references an ID from this ledger. Provider mapping documents and generated manifests
+consume it; neither can allocate or rewrite a Horo ID.
 
-AchievementId GenerateAchievementId(const std::string& projectSalt,
-                                    const std::string& name);
-LeaderboardId GenerateLeaderboardId(const std::string& projectSalt,
-                                    const std::string& name);
-```
+The ledger header binds schema `1`, the exact owning `projectId` and algorithm
+`horo.platform-services.stable-id.v1`. `.horo/project.json` is the sole authority for
+the 128-bit `platformServicesIdSalt`, serialized as `psid1:` plus 32 lowercase hex
+digits. The ledger does not duplicate the salt. It stores each derived numeric value
+as `sid1:` plus exactly 16 lowercase hex digits, including leading zeroes. JSON numbers
+and alternative spellings are rejected so 64-bit precision and canonical comparison
+do not depend on a parser.
 
-The salt is stored in the project configuration. It must not change after the
-first release that consumes platform IDs, because platform backends map stable
-IDs to platform-specific manifests.
+The salt is generated from the platform cryptographic random source together with a
+new project. Zero, short reads and random-source failure fail project creation. The
+salt is portable non-secret metadata committed with the project; environment, user
+preferences, provider packages and build profiles cannot override it. A project that
+predates the field obtains it once through a transactional migration, never as a
+read-only-open or cook side effect.
 
-The registries enforce uniqueness and traceability:
+### Canonical keys and deterministic derivation
 
-```cpp
-struct AchievementRegistry {
-    enum class RegisterResult { Ok, DuplicateName, DuplicateId };
+Each primary definition has one immutable 1–96 byte ASCII `canonicalKey` matching
+`^[a-z][a-z0-9_.-]{0,95}$`. The exact bytes are machine identity. They are not trimmed,
+case folded, localized or derived from a display name. Presentation renames therefore
+preserve identity.
 
-    Result<AchievementId, RegisterResult>
-    Register(const std::string& name);
-
-    std::optional<AchievementId> Find(const std::string& name) const;
-    std::optional<std::string> FindName(AchievementId id) const;
-};
-```
-
-- Registering the same name twice returns the existing ID and is treated as
-  idempotent during cook, but emits a diagnostic so authors notice accidental
-  reuse.
-- A hash collision between two different names is a cook error. The author must
-  rename one of the definitions.
-- Removed achievements are marked `deprecated` rather than deleted from the
-  registry. Their stable IDs remain reserved so they are never reused by a new
-  definition.
-
-The cook pipeline emits platform-specific manifest files:
+Version 1 hashes exactly:
 
 ```text
-achievements.json          -- Horo authoring source (stable IDs, display text)
-.deprecated_achievements   -- tombstone list for removed IDs
-steam/achievements.vdf     -- Steamworks manifest
-psn/trophy_pack/           -- PSN trophy pack
-xbox/achievements.json     -- Xbox Live manifest
+ASCII("horo.platform-services.stable-id.v1")
+0x00
+project salt                                      (16 raw bytes)
+kind                                              (uint8: achievement=1,
+                                                   leaderboard=2, stat=3,
+                                                   presence-status=4)
+canonical-key byte count                          (uint16, big-endian)
+canonical-key                                     (exact ASCII bytes)
 ```
 
-The same rules apply to leaderboards, stats, and presence status IDs.
+Horo computes SHA-256, takes digest bytes 0–7 and interprets them as an unsigned
+big-endian `uint64`. Cooked binary and the platform provider ABI also encode those
+eight bytes big-endian. Implementations use the shared golden-vector codec; they never
+use `std::hash`, host byte order or a provider hash.
 
-This is the same pattern used by the audio parameter and event registries.
+The ledger retains the derived value beside its key. Validation always recomputes it,
+rejects zero and rejects a stored/derived mismatch. Primary entries are canonically
+ordered by kind tag and then unsigned ID; aliases use exact ASCII byte order. A
+domain-separated SHA-256 of the canonical complete ledger is its snapshot fingerprint.
+
+### Active, tombstoned and aliased identity
+
+A primary entry is exactly `Active` or `Tombstoned`. Removing a definition preserves
+its kind, canonical key, ID, aliases and bounded removal provenance as a tombstone.
+Tombstones participate in key and numeric uniqueness forever under that project
+namespace. Ordinary authoring, cook and cleanup cannot prune them or allocate their
+identity to a new meaning.
+
+Re-adding a tombstoned key fails. A separately reviewed restore operation may reactivate
+the exact same semantics and ID only after provider mappings and product policy accept
+it; it is never implicit. New semantics require a new canonical key.
+
+An alias is another valid canonical-key spelling bound directly to exactly one primary
+entry of the same kind. It has no independently hashed value. Aliases support explicit
+authoring/import migrations while runtime/cooked references retain only the numeric
+ID. Primary keys and aliases are unique per kind across active and tombstoned entries.
+Chains, cycles, wildcard/case-insensitive lookup, cross-kind aliases and provider-native
+values used as Horo aliases are forbidden. Tombstoning retains all aliases.
+
+### Collision and candidate validation
+
+Candidate validation builds one numeric index across every active and tombstoned
+primary entry. Different primaries producing the same 64-bit value fail with
+`platform.identity.hash_collision`, even across kinds. No entry wins. Diagnostics
+name the algorithm, ID, both kind/key pairs and safe source locations.
+
+A new unpublished entry resolves a collision by selecting and reviewing a different
+canonical key. An existing published entry never changes. Incrementing the value,
+rehashing with a counter, insertion-order probing or silently widening one ID is
+forbidden because each would make results depend on authoring/merge order. Conflicting
+published histories require a declared project migration and cannot merge by guess.
+
+The application project service parses a bounded detached candidate and validates
+project/salt ownership, schema/algorithm, canonical encoding/order, key/alias
+uniqueness, stored derivations, global numeric uniqueness, states and all durable
+references before atomically publishing one immutable snapshot. Failure preserves the
+last valid snapshot and never partially mutates a provider registry.
+
+### Clone, fork and regeneration
+
+Filesystem copies, VCS clones/branches/checkouts, path moves and backups preserve
+`projectId`, salt, ledger and IDs because they are working copies of the same product.
+A Duplicate Project workflow must explicitly choose:
+
+- `PreserveIdentity` for a branch/port of the same product; or
+- `ForkIdentity` for an independent product, generating a new `projectId` and
+  cryptographic salt and executing a complete namespace migration.
+
+There is no path heuristic or automatic regeneration when a copy is detected. Salt
+regeneration is not a normal setting. Fork/regeneration first produces a dry-run with
+all active and tombstoned old-to-new IDs, aliases, durable references, provider
+mapping dispositions, offline operations and derived artifacts. It validates the full
+candidate before atomically updating project metadata, ledger and every owned durable
+reference, then invalidates affected manifests/caches/offline entries. Unknown or
+opaque references, incomplete mappings and collisions block with the old namespace
+intact.
+
+After an ID has shipped, entered remote state, saves/network protocols or another
+package, regeneration is prohibited by default. It requires a separately approved
+product migration with complete external transition evidence or an explicit
+incompatible new-product reset. Text aliases cannot bridge two numeric namespaces.
+
+### Provider mapping and cook/runtime projection
+
+A trusted provider adapter owns its mapping keyed by `(ProviderId, kind, Horo ID)`.
+Values such as Steam API names, trophy numbers and console manifest indexes remain
+bounded provider-private data. Required active entries have exactly one mapping for
+the selected target; optional absence is explicit product capability policy. Unknown,
+tombstoned, duplicate, wrong-kind or stale-ledger mapping rows fail provider manifest
+generation. Tombstoned remote values cannot be reassigned to new Horo definitions.
+
+Cook captures the project, algorithm, ledger fingerprint, service definitions,
+provider mapping revision and product/target profile as one generation. It resolves
+keys/aliases once and emits typed IDs into provider-neutral artifacts; provider
+manifests are deterministic derived outputs from that same snapshot. Any revision
+change invalidates the candidate.
+
+Runtime loads bounded sorted tables with the expected fingerprint and performs only
+typed numeric lookup. It never hashes strings, reads editor aliases or asks a provider
+to allocate identity. Registry generations remain pinned by admitted requests and
+durable offline entries until retirement/migration. Provider callback reverse lookup
+is private and immediately converts to the captured Horo ID. Gameplay, saves, scripts,
+offline queues and public telemetry never persist provider IDs or raw display strings
+as identity.
 
 ## Backend Interface
 
@@ -849,15 +939,15 @@ Access: `Edit > Project Settings > Platform Services`
 |   [ Steamworks                                     v ]       |
 |                                                              |
 | Achievements                                                 |
-|   ID      Name                  Hidden  Progress Steps       |
-|   --      ----                  ------  --------------       |
-|   1       first_blood           [ ]     1                     |
-|   2       kill_streak_10        [x]     10                    |
+|   Canonical Key             Display Name      Hidden  Steps |
+|   -------------             ------------      ------  ----- |
+|   campaign.first_blood      First Blood       [ ]     1     |
+|   combat.kill_streak_10     Ten in a Row      [x]     10    |
 |   [+ Add]                                                    |
 |                                                              |
 | Leaderboards                                                 |
-|   ID      Name                  Sort        Friends Only     |
-|   10      high_score            Descending  [x]               |
+|   Canonical Key             Sort        Friends Only        |
+|   score.high                Descending  [x]                  |
 |   [+ Add]                                                    |
 |                                                              |
 | Cloud Save                                                   |
@@ -964,6 +1054,12 @@ Required tests cover:
 - offline queue persists and replays in order
 - request cancellation does not leak state
 - stable ID registries reject unregistered names
+- stable ID golden vectors agree across hosts; malformed salts/encodings, stored/
+  derived mismatches, collisions, duplicate aliases and zero IDs fail closed
+- display rename/reorder and identity-preserving clones retain IDs; tombstones cannot
+  be silently reused and namespace-fork failure rolls back every reference
+- provider mapping generation rejects unknown, tombstoned, duplicate, wrong-kind and
+  stale-fingerprint rows; provider-native values never become gameplay identity
 - typed cloud-object addressing, provider revision propagation and no timestamp-based
   automatic winner selection
 - conditional write/delete and precondition failure; uncoordinated providers never
@@ -1018,6 +1114,11 @@ Platform-specific backend tests live in the private platform repositories.
 
 - [ADR-130](../../adr/130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md):
   frontend request ownership, lifecycle, callback, capability, Null and error baseline.
+- [ADR-131](../../adr/131-platform-services-closed-sdk-extension-abi-package-and-composition-boundary.md):
+  closed SDK packaging, extension ABI, provider lifecycle and product composition.
+- [ADR-132](../../adr/132-platform-services-project-salt-stable-id-tombstone-and-provider-mapping.md):
+  deterministic project IDs, canonical encoding, tombstones, aliases and provider
+  mapping ownership.
 - [Platform Services Config UI Reference](./platform-services-config.html): achievements, leaderboards, cloud saves, presence, and platform adapters panel.
 
 - [Audio Architecture](./audio-architecture.md)


### PR DESCRIPTION
## Summary

- Adds ADR-132 as the normative Platform Services project-salt, stable-ID,
  tombstone, alias, collision, clone/fork and provider-mapping decision.
- Replaces the underspecified “hash an authoring name” guidance with one byte-exact
  SHA-256 derivation and canonical text/binary encodings.
- Projects the decision into Platform Services Architecture, Project Model and the
  project migration contract so every owner follows the same identity lifecycle.

## Why

Platform Services registries and cooked provider manifests need stable identities
before implementation begins. The prior architecture did not fix the hash input,
algorithm version, byte order, salt lifecycle, alias semantics or clone behavior.
That left room for clean builds to disagree, display/provider names to leak into
gameplay identity, and deleted values to be silently reused.

HORO-1844 requires one deterministic identifier model with actionable collision
handling and a clear boundary between Horo identity and provider mappings. This PR
closes those architecture gaps before service-specific registries are built.

## Decision and boundaries

- Defines one committed `.horo/platform_services.ids.json` identity ledger owned by
  the Project domain; service definitions and provider mappings consume it.
- Generates one non-secret 128-bit project salt from the platform cryptographic RNG
  and stores it canonically in `.horo/project.json` as `psid1:<32 lowercase hex>`.
- Derives a typed 64-bit ID from a domain-separated, byte-exact SHA-256 input containing
  the salt, service-kind tag and bounded immutable canonical key. JSON uses
  `sid1:<16 lowercase hex>` and binary/ABI form is big-endian.
- Keeps active and tombstoned primary entries in the same global collision index;
  deletions retain key, aliases and numeric identity instead of freeing them.
- Makes aliases direct same-kind authoring mappings to an existing primary ID; chains,
  cycles, wildcard matching and provider-native aliases are rejected.
- Makes hash collisions hard pre-publication failures with both keys/source locations;
  counter probing, incrementing and insertion-order conflict resolution are forbidden.
- Distinguishes identity-preserving repository copies from explicit independent-product
  forks. Salt regeneration requires a dry-run and atomic remap of all durable references,
  tombstones and eligible provider mappings, with rollback on incomplete coverage.
- Keeps provider IDs and generated manifests private, target-scoped adapter data keyed
  by the Horo ID; they cannot allocate or replace engine identity.
- Adds qualification requirements for golden vectors, canonical encodings, tombstone
  reuse, clone/fork rollback, provider mapping validation and stale snapshot rejection.

Intentionally deferred: registry implementation, service-definition schemas, provider
manifest generators and editor workflows remain in their focused implementation
tickets. They must implement ADR-132 rather than introduce another identity source.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Markdown lint passed for every changed document.
- [x] Added relative Markdown links resolve.
- [x] Git whitespace/error checks passed before and after staging.
- [x] Canonical skeleton CMake configure passed with target header/dependency checks.
- [ ] Runtime/build tests were not run because this PR changes architecture documents
  only and adds no executable code.

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- \
  docs/adr/132-platform-services-project-salt-stable-id-tombstone-and-provider-mapping.md \
  docs/architecture/runtime/platform-services-architecture.md \
  docs/architecture/editor/project-model.md \
  docs/architecture/foundation/project-versioning-and-migration.md
git diff --check
git diff --cached --check
git diff --cached --unified=0 -- '*.md' | ruby -e '<added-link validation>'
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

CMake reported the existing mbedTLS minimum-version deprecation warning and that
pytest is unavailable, so repository Python tests were skipped.

## Risk and rollout

- The fixed 64-bit truncation has a very small but non-zero collision probability;
  the decision deliberately requires a tested hard-failure path instead of assuming
  collisions cannot occur.
- Fork/regeneration touches broad persistent state. Implementation must not expose it
  as a simple settings edit or publish partial remaps.
- Provider repositories must adopt the canonical big-endian ID codec and ledger
  fingerprint together; mixed generations are required to fail closed.
- No runtime behavior exists yet, so conformance depends on later golden-vector,
  migration and provider-adapter test implementation.

## Issue links

- Jira: [HORO-1844](https://horo-engine.atlassian.net/browse/HORO-1844)
- GitHub: Closes #1888

## Reviewer Notes

Suggested review order:

1. Read ADR-132 sections 1–5 for authority, salt, derivation and encoding.
2. Review sections 6–10 for tombstone/alias, collision, fork and provider boundaries.
3. Confirm the condensed Platform Services projection preserves those invariants.
4. Check Project Model and migration wording for single-source and atomicity alignment.

The most consequential choices are the byte-exact SHA-256 input, permanent tombstones,
no collision auto-probing and treating salt replacement as a project-wide namespace
migration rather than configuration.

## Stack

- Base PR: #2466 (`docs/HORO-1838_platform_sdk_abi_composition_boundary`)
- This PR contains only HORO-1844 / #1888 / PLS-003.1.
- Review and merge after #2466 so ADR-132 can reference the provider ABI/composition
  boundary established by ADR-131.


[HORO-1844]: https://horo-engine.atlassian.net/browse/HORO-1844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ