### PR TITLE
docs(platform): define progression authority policy HORO-1845 #1889 [PLS-004.1]

### DIFF
--- a/docs/adr/133-platform-progression-authority-trust-and-idempotency.md
+++ b/docs/adr/133-platform-progression-authority-trust-and-idempotency.md
@@ -1,0 +1,406 @@
+# ADR-133: Platform Progression Authority, Trust and Idempotency
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Achievement, stat and leaderboard mutation/query authority; local and server trust boundaries; typed mutation semantics; idempotency, retry, duplicate, replay, ambiguity, unsupported capability and cheating policy
+- **Issue**: [PLS-004.1](https://github.com/abdullahbodur/horo-engine/issues/1889)
+- **Jira**: [HORO-1845](https://horo-engine.atlassian.net/browse/HORO-1845)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-020](020-network-target-ownership-and-dependency-boundary.md), [ADR-098](098-protocol-session-and-trust-policy.md), [ADR-102](102-runtime-network-modes-and-authority-exposure.md), [ADR-113](113-local-storage-user-profile-and-slot-ownership.md), [ADR-130](130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md), [ADR-131](131-platform-services-closed-sdk-extension-abi-package-and-composition-boundary.md), [ADR-132](132-platform-services-project-salt-stable-id-tombstone-and-provider-mapping.md)
+- **Normative documents**: [Platform Services Architecture](../architecture/runtime/platform-services-architecture.md), [Multiplayer Replication Architecture](../architecture/runtime/multiplayer-replication-architecture.md), [Application Security](../architecture/security/application-security.md)
+
+## Context
+
+Achievements, persistent stats and leaderboard scores project gameplay facts into a
+remote platform account. The current architecture exposes simple `Unlock`, `SetStat`
+and `SubmitScore` calls and says writes can be retried with an idempotency key. It does
+not say which owner establishes the fact, whether a client is trusted to submit it,
+what duplicate success means or which stat/score operations are actually idempotent.
+
+This distinction matters after an uncertain provider outcome. A frontend timeout is
+terminal for its ADR-130 request, but the provider may still have committed the remote
+effect. Retrying an unlock or monotonic maximum can be safe; retrying an increment or
+unconditional replacement may double count or reorder state. A key helps only if the
+provider or an authoritative gateway truly enforces deduplication.
+
+Remote platform state is also not automatically authoritative gameplay state. A local
+client can be modified, provider results are account-scoped external observations and
+leaderboard ranking is provider-owned presentation. Competitive progression, rewards
+and shared economy need a server-owned validation path without teaching gameplay code
+which provider SDK or backend is active.
+
+This ADR assigns every progression mutation/query owner, fixes mutation algebra and
+idempotency behavior, and defines the server-authoritative route. PLS-007.1 separately
+owns the generic durable queue file, ordering, expiry and shutdown mechanics; it must
+admit only the replay classes defined here.
+
+## Decision
+
+### 1. Gameplay facts, Horo intent and remote projection are separate authorities
+
+The authority chain is:
+
+| Stage | Authority and responsibility | Deliberate non-authority |
+|---|---|---|
+| Gameplay semantic owner | Decides that a committed game fact occurred, with stable occurrence/evidence identity | Does not select a provider, retry or format native values |
+| Product progression policy/router | Validates the registered definition, subject, authority mode and typed mutation; accepts one logical intent | Does not invent gameplay facts or treat provider state as simulation truth |
+| Authority server, when required | Validates the fact in its authoritative world/epoch and is the only owner allowed to accept server-mode mutation intent | Client prediction, local UI and listen-server client world cannot mint authority |
+| Platform progression coordinator | Owns semantic normalization, duplicate/coalescing rules, reconciliation and one intent outcome | Does not own ADR-130 request state or provider-native operations |
+| `PlatformServicesFrontend` | Owns request admission, attempts, deadline, cancellation, terminal result and provider-generation fencing | Does not decide achievement eligibility, score validity or anti-cheat policy |
+| PLS-007 durable owner | Persists and schedules only eligible logical intents with their original mutation identity/scope | Does not change mutation algebra or create a second cloud/progression authority |
+| Provider adapter/package | Translates one validated Horo operation and declares/enforces native capability/limits | Cannot allocate Horo IDs, authorize gameplay facts or silently weaken semantics |
+| Remote platform service | Owns the external account record, provider revision/deduplication behavior and ranked view | Its record is not authoritative Horo simulation, economy or reward state |
+| UI/telemetry | Observes bounded typed outcomes and safe aggregate state | Cannot submit privileged mutations by changing display state |
+
+The Horo source of identity remains ADR-132. Definitions, mutation values, outcomes
+and authority policy are typed Horo data. Provider API names, trophy numbers, native
+score structs, account IDs and display strings never become gameplay identity or
+branching policy.
+
+### 2. Every definition declares one immutable authority mode
+
+Each achievement, stat and leaderboard definition binds one
+`ProgressionAuthorityMode` in the cooked product profile:
+
+```cpp
+enum class ProgressionAuthorityMode : std::uint8_t {
+    LocalProduct,
+    AuthorityServer,
+};
+```
+
+`LocalProduct` permits the current standalone/local product progression coordinator to
+accept facts. It is appropriate only where the product explicitly accepts that a
+modified client can fabricate progress. Provider APIs, local obfuscation, save
+signatures and idempotency keys do not make this mode cheat resistant.
+
+`AuthorityServer` permits acceptance only through a server-world progression commit
+capability bound to the current host, world and authority generations. Client builds
+receive no such capability. A listen server has separate server and client worlds;
+locality, loopback, headless state, a provider login or a process-global `IsServer`
+boolean cannot grant the client world authority.
+
+Competitive ranks, shared economy/rewards, cross-player records and any mutation whose
+integrity affects another user or trusted service use `AuthorityServer`. A product may
+also choose server authority for ordinary achievements. If its selected deployment has
+no compatible server progression gateway/provider route, the required definition is
+unavailable at composition; it never downgrades to `LocalProduct`.
+
+Authority mode and mutation semantics are release/cook inputs. Runtime flags, gameplay
+code or providers cannot rewrite them. Changing either after publication is a product
+data migration and compatibility review, not a live setting.
+
+### 3. Gameplay submits Horo intent through one policy-routed port
+
+Gameplay produces a typed fact, not a platform call:
+
+```cpp
+struct ProgressionFact {
+    ProgressionDefinitionId definition;
+    GameplayOccurrenceId occurrence;
+    ProgressionValue value;
+    GameplayAuthorityContext authority;
+};
+
+class IProgressionIntentSink {
+public:
+    virtual Result<ProgressionIntentReceipt>
+    Submit(const ProgressionFact& fact) = 0;
+};
+```
+
+The injected application capability routes according to the cooked definition. For a
+local definition it validates/accepts locally. For a server definition a client sends
+ordinary authenticated gameplay input/command to the server-owned gameplay system;
+the client does not forward a “grant achievement” RPC. The authoritative server
+validates its committed fact and submits through its server-only progression commit
+port. Gameplay source is identical with respect to platform providers in either case.
+
+`GameplayOccurrenceId` deduplicates one committed semantic fact and is scoped to its
+owning world/session schema. It is not a provider idempotency token or proof by itself.
+Prediction/rollback never publishes irreversible remote effects: the authority waits
+for committed fact confirmation, and replay of the same occurrence resolves to the
+same accepted logical intent rather than emitting another mutation.
+
+Debug, editor, CLI and MCP adapters require an explicitly registered permission and
+the same authority capability. Shipping clients do not gain server progression
+authority through tooling. Administrative provider corrections are out-of-band
+operator flows and do not share the runtime gameplay API.
+
+### 4. One logical mutation receives one immutable mutation ID
+
+When the correct semantic authority first accepts a valid fact, the progression
+coordinator allocates one nonzero 128-bit `ProgressionMutationId` and records:
+
+```cpp
+struct ProgressionMutationEnvelope {
+    ProgressionMutationId mutation;
+    ProgressionSubjectScope subject;
+    ProgressionDefinitionId definition;
+    ProgressionMutationKind kind;
+    ProgressionValue value;
+    ProgressionPrecondition precondition;
+    ProgressionAuthorityEvidence authority;
+    ProgressionPolicyRevision policy;
+};
+```
+
+The ID identifies this logical mutation from initial submission through bounded
+frontend retry, process restart, durable replay and reconciliation. A new ADR-130
+request/attempt may be created, but it carries the same mutation ID and exact semantic
+payload. Timeout, cancellation or a dropped request handle never authorizes allocating
+a replacement mutation ID for the same logical intent.
+
+The authority evidence is a bounded Horo-owned proof/reference to the accepted local
+or server fact and captured generations. It contains no credential, raw account ID,
+provider request token or unrestricted gameplay payload. The provider sees only the
+minimal translated fields needed by the accepted operation.
+
+An exact duplicate `(mutation ID, canonical envelope)` joins/observes the existing
+logical intent and receives its outcome. Reuse of a mutation ID with any different
+subject, definition, kind, value, precondition, authority or policy revision fails
+`platform.progression.idempotency_conflict`. Last writer never wins.
+
+Idempotency is deduplication, not authentication. Locally supplied IDs do not grant a
+fact, bypass authority validation or prove an unmodified client.
+
+### 5. Mutation algebra determines retry and replay safety
+
+Version 1 admits only declared semantics:
+
+| Operation | Horo semantic effect | Automatic retry/replay eligibility |
+|---|---|---|
+| `UnlockOnce` | Remote unlocked state becomes true; never resets | Intrinsically idempotent when provider conformance proves repeated unlock is the same effect |
+| `SetProgressMaximum` | Progress becomes `max(remote,current)` within the registered total; never decrements | Eligible only when provider/gateway atomically supplies max-or-equal semantics |
+| `SetStatMaximum` / `SetStatMinimum` | Typed stat moves monotonically in the declared direction | Eligible only with matching atomic provider semantics and bounds |
+| `SetStatSnapshot` | Replace exact typed value at an expected provider revision | Eligible with an atomic conditional revision; precondition failure reconciles, never retries unconditionally |
+| `AddStatOnce` | Apply one delta exactly once | Eligible only when provider/gateway durably deduplicates `ProgressionMutationId`; otherwise no automatic retry/replay after submission ambiguity |
+| `SubmitBestScore` | Keep the declared ascending-minimum or descending-maximum best score | Eligible only when provider/gateway atomically implements that comparison |
+| `ReplaceScoreAtRevision` | Replace exact score at an expected revision | Eligible only with atomic conditional revision and the exact captured revision |
+
+An adapter cannot emulate atomic maximum, conditional replacement or durable dedupe
+with a read followed by an unconditional write. A process-local “seen IDs” set cannot
+protect another device, server or a provider commit that outlives the process.
+
+Unconditional `SetStat`, naked increments and “last submitted score wins” are not
+portable v1 semantics. A provider exposing only those primitives may support a
+narrower declared capability or a trusted gateway may implement the required atomic
+operation. It cannot claim the stronger Horo operation and hope retries are rare.
+
+Reset/decrement/delete and moderation corrections are excluded from the runtime
+progression API. They require a separately authorized operator/product migration path
+with provider-specific audit and cannot be disguised as a negative delta.
+
+### 6. Attempts preserve identity, payload, scope and deadline
+
+The coordinator declares retry eligibility before frontend admission using the
+operation algebra, provider capability snapshot and product policy. Each in-memory
+retry uses the same ADR-130 request, original finite monotonic deadline, mutation ID,
+canonical payload, subject, authority/policy/session/provider generations and
+precondition. Backoff, rate-limit delay and attempt count are bounded by policy and
+must fit the original deadline.
+
+Only normalized transient transport/provider failure may retry automatically.
+`Forbidden`, invalid definition/value, authority denial, unsupported capability,
+permanent provider failure and an exhausted/invalid precondition do not. `RateLimited`
+may retry only after a bounded provider-independent normalized delay accepted by
+policy. A session/account or authority-generation change closes attempts rather than
+retargeting the operation.
+
+PLS-007 durable replay may create a new frontend request after restart or offline
+recovery, but it preserves the exact logical envelope and validates current subject,
+authority, registry/policy and provider capability before scheduling. It does not
+reset an unsafe operation to “not attempted.” Reads/queries have no durable replay
+intent.
+
+### 7. Timeout and transport loss can leave remote outcome unknown
+
+ADR-130 remains authoritative for the caller-visible request: a missed deadline
+publishes `TimedOut` exactly once and late provider completion cannot rewrite it.
+That terminal state does not prove the provider failed to commit.
+
+The progression coordinator separately classifies the logical intent as
+`RemoteOutcomeUnknown` when an eligible mutation may have crossed the provider commit
+boundary without conclusive evidence. It then follows the mutation algebra:
+
+- intrinsically idempotent/deduplicated operations may resubmit the same envelope;
+- conditional operations first query the exact remote value/revision and either
+  recognize the intended effect, retry with the still-valid precondition or surface a
+  conflict;
+- non-idempotent operations without durable provider/gateway dedupe stop automatic
+  retry and require reconciliation or explicit operator/user resolution; and
+- a late completion may resolve coordinator reconciliation evidence but never mutate
+  the original request terminal record or invoke its observers twice.
+
+`RemoteOutcomeUnknown` is not reported as success, failure or queued success. UI may
+present a bounded pending/reconciling state. Gameplay cannot assume a reward was
+granted or repeat a side effect merely because remote projection is uncertain.
+
+### 8. Coalescing preserves semantic results and individual receipts
+
+Exact duplicate mutation IDs deduplicate as Section 4. Distinct mutations may
+coalesce only when their declared algebra is associative, commutative and result-
+preserving for every intent:
+
+- maximum/minimum progress or stat mutations for the same subject/definition/policy
+  generation may reduce to the strongest value;
+- `SubmitBestScore` may reduce to the mathematically best score under the definition's
+  declared ordering, never the most recent arrival;
+- unlocks may share one remote operation after every occurrence has its own accepted
+  logical receipt; and
+- conditional snapshots, replacements and `AddStatOnce` never coalesce.
+
+The coordinator retains a bounded mapping from each mutation ID to the aggregate
+operation and publishes an outcome for each receipt. Coalescing cannot erase a higher
+score, acknowledge a mutation that failed authority validation, merge subjects or
+cross policy/session/provider generations.
+
+Independent targets may complete out of order. Mutations for one
+`(subject, definition)` are serialized or combined by the declared algebra; provider
+completion order never becomes last-writer policy.
+
+### 9. Query results have explicit source and trust
+
+Achievement-state and stat queries return the remote platform's account projection at
+a captured provider/session generation and optional opaque revision. Leaderboard
+queries return a bounded ranked view according to provider/product definition. They
+are authoritative only for “what this provider currently reports,” not for the
+underlying Horo gameplay fact.
+
+Queries validate registered typed ADR-132 IDs, pagination/range/count limits, typed
+values, provider response bounds and current generation before publication. Provider
+display names, avatars or other personal data are separate consent-scoped presentation
+fields; they are not identity or values accepted back into mutations.
+
+Gameplay may use results for UI, local hints or explicitly non-authoritative product
+features. It cannot derive server rewards, shared economy, simulation state or access
+control from a client/provider query. A server that needs external state fetches it
+through its trusted integration and applies product-owned validation.
+
+Reads may receive a bounded transient in-memory retry under explicit policy, but are
+never written to the progression offline queue. Cache entries include provider,
+subject, registry and session generations plus freshness; stale cache is labeled and
+cannot masquerade as a successful current query.
+
+### 10. Unsupported semantics fail without policy downgrade
+
+The provider capability snapshot declares each supported mutation kind, typed value
+domain/range, atomic comparison/precondition support, durable mutation-ID dedupe,
+query/revision features, limits and server/client availability. The product profile
+intersects this with every required definition before admission opens.
+
+Missing required semantics fails composition/certification or the required feature
+with a typed reason. Optional definitions become explicitly unavailable. Horo never:
+
+- maps `AddStatOnce` to an unconditional increment without dedupe;
+- maps maximum/best semantics to read-then-write;
+- changes `AuthorityServer` to local authority;
+- accepts writes through Null or treats an absent mapping as success; or
+- changes score ordering/value type to fit a provider.
+
+Gameplay may suppress optional unavailable presentation intent before submission, but
+that is not a remote success. Every admitted mutation still receives one explicit
+logical/request outcome.
+
+### 11. Security and privacy constraints are independent of idempotency
+
+Client-authoritative progression is tamperable by definition. Horo does not market
+provider unlock APIs, signed local saves, obfuscated values, SDK callbacks or
+idempotency keys as anti-cheat. Secure competitive products validate facts on an
+authority server and keep server credentials/privileged provider routes out of client
+artifacts. Provider anti-cheat products, when used, are additional product policy and
+do not replace server authority.
+
+Mutation persistence and diagnostics store typed Horo IDs, mutation IDs, normalized
+values, safe authority/policy/session generations and stable outcomes. They exclude
+credentials, raw platform account IDs, native request tokens, unrestricted provider
+errors and personal/display data. Subject scopes are opaque and partitioned; work
+accepted for one subject/session cannot replay for another.
+
+Repeated invalid authority, replay/conflicting mutation IDs, impossible value changes
+and provider rejection may emit bounded security audit events. Logging a suspicion
+does not silently reject a valid committed server fact or grant the frontend authority
+to decide cheating.
+
+### 12. Qualification covers authority, ambiguity and provider diversity
+
+Required public Mock/Null and product integration evidence includes:
+
+- every operation/query owner and local/server route, including client/listen-server/
+  dedicated-server capability exposure and no local downgrade;
+- rollback/replay of one gameplay occurrence producing one accepted logical mutation;
+- exact duplicate join, conflicting ID/payload rejection and independent mutation IDs;
+- each mutation algebra at lower/equal/higher values, score sort directions, bounds
+  and typed value mismatch;
+- retry attempt/deadline bounds and identical envelope across transient failure,
+  process replay, rate limit, cancellation and timeout;
+- completion-before/after timeout, provider-commit ambiguity, late evidence,
+  reconciliation and no double observer/remote effect;
+- providers with full dedupe, only intrinsic monotonic operations, conditional
+  revisions and no safe mutation primitive, proving exact capability projection;
+- coalescing permutations that retain the mathematical best/max/min and an outcome for
+  every logical receipt;
+- offline admission/replay eligibility, subject/session partitioning, stale authority
+  and provider/policy generation rejection; and
+- bounded/malformed query results, stale cache labeling, privacy redaction and proof
+  that provider/native identifiers never enter gameplay persistence.
+
+Private providers add SDK/gateway deduplication and atomic-operation qualification.
+Certification freezes definition authority/algebra, mapping, provider capability and
+gateway versions so a shipping update cannot silently weaken semantics.
+
+## Consequences
+
+- Gameplay owns facts while one progression coordinator owns remote intent semantics;
+  provider and frontend layers cannot invent authorization.
+- Competitive/server-owned paths are explicit and do not require gameplay to branch on
+  Steam, console or other backend policy.
+- Retry and replay safety follows the mutation algebra and real provider capability,
+  not a blanket assumption that every stat write is idempotent.
+- Every logical mutation has a durable identity across attempts, and a timeout can be
+  reconciled without rewriting ADR-130 terminal state.
+- Provider queries remain useful for UI while being unable to become trusted gameplay
+  or economy state accidentally.
+- Providers lacking atomic/dedupe primitives expose narrower capabilities; some
+  operations intentionally remain unavailable rather than becoming lossy emulations.
+- Server-authoritative products require a separately composed trusted progression
+  gateway and operational reconciliation/deduplication storage.
+
+## Rejected Alternatives
+
+### Let gameplay call achievement/stat/leaderboard backends directly
+
+Rejected because gameplay would own provider selection, retry and native semantics,
+bypass authority policy and make server validation inconsistent.
+
+### Treat every write carrying an idempotency key as safe to retry
+
+Rejected because a token has no effect unless a provider/gateway durably enforces it;
+increments and unconditional replacements can duplicate or reorder after ambiguity.
+
+### Retry timeout as a new logical mutation
+
+Rejected because timeout does not prove the remote effect was absent. A new ID can
+double apply; the same intent must reconcile or retry under its declared algebra.
+
+### Trust platform state as authoritative gameplay or anti-cheat truth
+
+Rejected because local clients and account projections have different trust domains.
+Server rewards and shared state require product-owned server validation.
+
+### Send a client `GrantAchievement` or `SubmitScore` RPC to the server
+
+Rejected because it asks the client to state the privileged conclusion. Clients send
+ordinary gameplay input/commands; the server's gameplay owner derives and commits the
+fact.
+
+### Coalesce stat/score writes by keeping the most recent call
+
+Rejected because arrival order can discard a better score, change monotonic progress
+or hide an increment. Coalescing is permitted only under a declared result-preserving
+algebra with individual receipts.
+
+### Emulate atomic operations with read-then-unconditional-write
+
+Rejected because another device/server can commit between calls. Missing atomic
+provider semantics is capability absence unless a trusted gateway implements it.

--- a/docs/architecture/runtime/multiplayer-replication-architecture.md
+++ b/docs/architecture/runtime/multiplayer-replication-architecture.md
@@ -284,6 +284,14 @@ and client-majority correction are unsupported. Speculative side effects require
 stable occurrence IDs and bounded confirm/cancel/deduplication; irreversible
 external effects are server-authoritative only.
 
+Platform achievement, stat and leaderboard projection follows
+[ADR-133](../../adr/133-platform-progression-authority-trust-and-idempotency.md).
+A client sends ordinary gameplay input/commands, never a privileged “grant progression”
+conclusion. The server gameplay owner derives a committed fact after authoritative
+validation and uses an injected server-only progression commit capability. Prediction
+and rollback of the same stable occurrence cannot emit a second logical mutation, and
+the listen-server client world gains no authority from process locality.
+
 ## Interest Management
 
 `ReplicationScheduler` is the sole interest/priority/budget authority for an

--- a/docs/architecture/runtime/platform-services-architecture.md
+++ b/docs/architecture/runtime/platform-services-architecture.md
@@ -29,6 +29,11 @@ defines the one committed project identity ledger, byte-exact SHA-256 ID derivat
 canonical encodings, permanent tombstones, key aliases, clone/fork migration and the
 private provider-mapping boundary used by all service categories.
 
+[ADR-133](../../adr/133-platform-progression-authority-trust-and-idempotency.md)
+separates gameplay facts from remote projection, selects local or server authority per
+definition and makes retry/replay depend on typed mutation algebra plus qualified
+provider deduplication/atomicity rather than a blanket “idempotent write” assumption.
+
 ## Scope
 
 Platform services covered here:
@@ -301,24 +306,29 @@ physical cancellation.
 Retry is controlled by the owning frontend/service policy, not gameplay code, and all
 attempts fit within the original request deadline:
 
-- Idempotent writes such as stat updates may be retried a bounded number of
-  times before surfacing an error.
-- Reads and queries are not retried automatically unless the project policy
-  explicitly allows it.
+- Only ADR-133 operations whose declared algebra and effective provider/gateway
+  capability prove retry safety may be retried.
+- Every attempt preserves the exact progression mutation ID, payload, subject,
+  authority/policy/session/provider generations and precondition. Timeout never
+  allocates a replacement logical mutation.
+- Reads and queries receive a bounded in-memory retry only when project policy allows;
+  they never become durable progression replay intents.
 - When the backend reports normalized `Offline` or `NotSignedIn`, retriable writes move
-  to the offline queue instead of being retried immediately.
+  to the PLS-007 durable owner only when their ADR-133 replay class and captured
+  subject/session are eligible.
 
 High-frequency writes are throttled and coalesced:
 
-- `SetStat` calls for the same stat are coalesced to the most recent value
-  within a configured debounce window. The frontend emits one backend write per
-  window, not one per gameplay call.
-- `SubmitScore` calls are debounced, not coalesced: only the most recent score
-  for a leaderboard is submitted after the debounce interval, but scores are
-  not merged.
-- Achievement unlock and progress updates are not throttled because they are
-  infrequent, but duplicate unlocks for the same achievement are suppressed in
-  memory before entering the queue.
+- maximum/minimum progress or stat intents may reduce to the strongest value only
+  within one subject/policy generation;
+- `SubmitBestScore` may reduce to the mathematical best under the definition's
+  declared ordering, never the most recent arrival;
+- exact duplicate progression mutation IDs join one logical intent; and
+- conditional snapshots/replacements and `AddStatOnce` are never coalesced.
+
+Every accepted logical mutation retains an individual receipt/outcome even when a
+result-preserving aggregate uses one provider operation. Arrival or provider completion
+order never becomes stat/score conflict policy.
 
 Throttling metrics:
 
@@ -342,6 +352,9 @@ platform.request.timed_out          -- frontend deadline terminal outcome
 platform.request.expired            -- terminal observation retention ended
 platform.request.stale              -- request/frontend/provider/session generation mismatch
 platform.provider.failed            -- admitted provider operation failed
+platform.progression.authority_denied -- fact lacks the definition's required authority
+platform.progression.idempotency_conflict -- mutation ID reused with another envelope
+platform.progression.unsafe_retry   -- algebra/provider cannot safely retry ambiguity
 ```
 
 `platform.provider.failed` carries one normalized category: `Offline`, `NotSignedIn`,
@@ -365,83 +378,86 @@ the backend finishes the previous update, only the most recent state is sent.
 ### Achievements
 
 Achievements are authored once in project configuration and cooked into
-platform-specific manifests.
+platform-specific manifests. Each definition uses an ADR-132 `AchievementId`, typed
+progress schema and immutable `LocalProduct` or `AuthorityServer` policy. Display text
+is presentation and provider names remain mapping data.
 
 ```cpp
-struct AchievementId { uint64_t value; };  // stable, numeric
-
 struct AchievementDefinition {
     AchievementId id;
-    std::string displayName;
-    std::string description;
-    bool hidden;
-    uint32_t progressSteps;  // 0 or 1 for binary, >1 for progress
+    ProgressionAuthorityMode authority;
+    AchievementProgressSchema progress;
+    LocalizedAchievementPresentation presentation;
 };
 
-class IAchievementService {
-public:
-    virtual Result<PlatformRequestHandle<AchievementUnlockResult>>
-    Unlock(AchievementId id) = 0;
-
-    virtual Result<PlatformRequestHandle<AchievementProgressResult>>
-    SetProgress(AchievementId id, uint32_t current, uint32_t total) = 0;
-
-    virtual Result<PlatformRequestHandle<std::vector<AchievementState>>>
-    QueryState() = 0;
-};
+using AchievementMutation =
+    std::variant<UnlockOnce, SetProgressMaximum>;
 ```
 
-The frontend validates that `current <= total` and that the achievement ID is
-registered. Runtime code never passes raw strings or platform-specific IDs.
+Gameplay submits a committed typed fact through `IProgressionIntentSink`; it never
+calls a provider service. The product progression router validates the definition,
+value and authority. Server-mode clients send ordinary gameplay input/commands; the
+server gameplay owner derives the achievement fact and its server-only progression
+commit capability submits it. A client cannot send a privileged “unlock” conclusion.
+
+`UnlockOnce` makes unlocked true and is intrinsically idempotent only after provider
+qualification proves repeated unlock has the same effect. `SetProgressMaximum` is
+monotonic and retryable only when the provider/gateway atomically implements maximum-
+or-equal. Reset/decrement is not a runtime operation. The remote platform owns its
+account projection; querying that projection does not make it trusted gameplay state.
 
 ### Leaderboards And Stats
 
 Leaderboards are also authored once and mapped to platform backends at cook
-time.
+time. Definitions fix typed numeric domain/range, score ordering, mutation algebra and
+local/server authority before runtime composition.
 
 ```cpp
-struct LeaderboardId { uint64_t value; };
-struct StatName { StableString name; };
-
-enum class LeaderboardSort {
-    Ascending,
-    Descending
+enum class ProgressionMutationKind : std::uint8_t {
+    SetStatMaximum,
+    SetStatMinimum,
+    SetStatSnapshot,
+    AddStatOnce,
+    SubmitBestScore,
+    ReplaceScoreAtRevision,
 };
 
-struct LeaderboardQuery {
-    uint32_t rangeStart;
-    uint32_t rangeCount;
-    bool friendsOnly;
-};
-
-class ILeaderboardService {
-public:
-    // The backend receives an idempotency key so duplicate submissions from
-    // retry or offline replay do not create multiple leaderboard entries.
-    virtual Result<PlatformRequestHandle<void>>
-    SubmitScore(LeaderboardId id,
-                int64_t score,
-                IdempotencyKey key) = 0;
-
-    virtual Result<PlatformRequestHandle<LeaderboardEntries>>
-    GetEntries(LeaderboardId id, const LeaderboardQuery& query) = 0;
-
-    virtual Result<PlatformRequestHandle<void>>
-    SetStat(StatName name, int64_t value) = 0;
-
-    virtual Result<PlatformRequestHandle<std::optional<int64_t>>>
-    GetStat(StatName name) = 0;
+struct ProgressionMutationEnvelope {
+    ProgressionMutationId mutation;
+    ProgressionSubjectScope subject;
+    ProgressionDefinitionId definition;
+    ProgressionMutationKind kind;
+    ProgressionValue value;
+    ProgressionPrecondition precondition;
+    ProgressionAuthorityEvidence authority;
+    ProgressionPolicyRevision policy;
 };
 ```
 
-`IdempotencyKey` is generated by the frontend from a monotonic write sequence
-and the stable operation identity. The same key is reused across frontend
-retries and offline queue replay. The backend must treat the second call with
-an identical key as a no-op and return the same result.
+The correct semantic authority allocates one nonzero 128-bit
+`ProgressionMutationId` when it first accepts a logical fact. The exact canonical
+envelope follows that intent through retries, durable replay and reconciliation. An
+exact duplicate joins the existing intent; reuse of the ID with different fields is
+`platform.progression.idempotency_conflict`. A key is deduplication identity, not
+authentication.
 
-Stats are server-authoritative where the platform allows. The frontend keeps a
-read-through local cache for stats that gameplay reads frequently, but writes
-always go to the backend.
+Maximum/minimum stats and best-score submissions retry only with matching atomic
+provider semantics. Snapshot/score replacement requires an exact opaque revision and
+atomic precondition. `AddStatOnce` requires durable mutation-ID dedupe in the provider
+or trusted gateway. Horo never emulates these with read-then-unconditional-write. A
+provider without the required primitive reports the operation unavailable rather than
+silently weakening it.
+
+Timeout or transport loss after submission can leave `RemoteOutcomeUnknown`. The
+original ADR-130 request remains `TimedOut`; safe algebra may resubmit the same
+envelope, conditional operations query/reconcile revision, and an unsafe non-deduped
+operation stops automatic retry. Late provider evidence may resolve coordinator
+reconciliation but never rewrites the terminal request or invokes observers twice.
+
+Stat and leaderboard queries return bounded provider/account projections at a captured
+generation/revision. Leaderboard order is provider-owned under the cooked definition.
+These values support UI and local hints; clients cannot use them as authority for
+shared economy, rewards, simulation or access control.
 
 ### Cloud Save
 
@@ -772,30 +788,37 @@ increments generation; stale completion evidence cannot publish into the replace
 
 ## Offline And Degraded Behavior
 
-The frontend maintains a persistent local queue for operations that can be
-safely retried:
+PLS-007 owns the generic durable queue mechanics. It may admit only ADR-133 logical
+mutation envelopes whose algebra and effective provider/gateway capability make replay
+safe:
 
-- achievement unlocks
-- achievement progress updates
-- leaderboard score submissions
-- stat writes
+- qualified `UnlockOnce` and atomic `SetProgressMaximum`;
+- atomic `SetStatMaximum` / `SetStatMinimum`;
+- conditional stat/score replacement retaining its exact revision; and
+- `AddStatOnce` or other non-intrinsic effects only with durable provider/gateway
+  mutation-ID deduplication.
 
-Each queued operation carries an `IdempotencyKey`. The key is generated once
-when the operation enters the frontend and is preserved across persistence,
-retry, and replay. This prevents a retry + queue replay combination from
-producing duplicate backend effects.
+The progression coordinator allocates the mutation ID when the correct semantic
+authority accepts the fact, before the first provider attempt. The queue preserves the
+exact ID, payload, subject, authority/policy/registry and provider requirements across
+restart. It never allocates an ID during replay, retargets another account/session or
+turns an ambiguous unsafe attempt into “not attempted.”
 
 When the backend reports normalized `Offline` or `NotSignedIn`, the frontend:
 
-1. assigns an idempotency key if the operation does not already have one
-2. persists the operation to the local queue
-3. deduplicates against the queue using the operation type, target ID, and key
-4. emits an `offline_queued` metric
-5. returns a result indicating queued state
-6. replays the queue in order when the platform session becomes active
+1. returns the ADR-130 typed attempt outcome to the progression coordinator;
+2. lets the single PLS-007 owner validate replay eligibility and persist the existing
+   logical envelope;
+3. joins an exact duplicate mutation ID or rejects a conflicting payload;
+4. keeps subject/session and authority generations partitioned; and
+5. schedules a new bounded request only after recovery/reconciliation and capability
+   revalidation.
 
 Operations that cannot be safely replayed, such as cloud save reads or
-leaderboard queries, fail immediately with the appropriate error.
+leaderboard/stat/achievement queries, are never durable progression intents. An
+AuthorityServer definition does not let an offline client manufacture a queued remote
+mutation; the server must later derive/accept the gameplay fact through its ordinary
+authority path.
 
 Cloud archive writes/deletes are deliberately absent from this generic queue. Their
 immutable payload lease, slot lineage, expected provider revision, retry identity and
@@ -803,14 +826,11 @@ profile-session scope are durably owned by ADR-115's `CloudSaveCoordinator`. Aft
 offline recovery it reconciles remote state before conditional mutation; it never
 replays a stale FIFO upload under a later local generation or different user.
 
-Replay rules:
-
-- Queue order is preserved per user account.
-- If a queued operation fails with a non-retriable error (for example,
-  normalized `Forbidden`), it is removed from the queue and the failure is surfaced.
-- If the backend accepts an idempotent operation, the queue advances.
-- Duplicate keys are ignored: the frontend checks the queue file and the set of
-  in-flight requests before submitting.
+Detailed queue ordering, expiry, compaction, retention and shutdown are PLS-007 policy.
+Those mechanics cannot broaden the replay classes above. `Forbidden`, authority/
+subject mismatch, unsupported capability and permanent semantic failure never retry.
+A remote ambiguous outcome remains retained for reconciliation according to its
+algebra; it is not dropped as a generic failure or reported as success.
 
 The Null backend is a valid explicit headless/test/product composition. It reports all
 remote services unavailable with `NullProviderSelected`. Every read and write fails
@@ -1051,7 +1071,17 @@ Required tests cover:
   request, offline entry or idempotency record
 - mock backend replays scripted responses
 - frontend routes calls to the correct backend service
-- offline queue persists and replays in order
+- local/server authority routing exposes no server commit capability to clients or the
+  listen-server client world; prediction replay emits one logical mutation
+- every achievement/stat/leaderboard operation exercises its exact algebra and
+  capability requirement, including provider variants without safe primitives
+- exact mutation duplicates join, conflicting payload reuse fails and every retry/
+  durable replay preserves envelope identity and scope
+- timeout/late completion races preserve ADR-130 terminal state while progression
+  ambiguity reconciles without a second remote effect
+- max/min/best coalescing is result-preserving under every input order and retains an
+  outcome for each logical receipt; conditional/additive operations never coalesce
+- offline queue persists and replays only eligible mutation classes
 - request cancellation does not leak state
 - stable ID registries reject unregistered names
 - stable ID golden vectors agree across hosts; malformed salts/encodings, stored/
@@ -1104,9 +1134,11 @@ Tests use the mock backend to verify:
 
 - correct request routing and error translation
 - timeout handling when `delay` exceeds the policy
-- offline queue behavior when the backend returns normalized `Offline`
-- idempotency key stability across retries and replay
-- stat coalescing and leaderboard debounce logic
+- offline eligibility when the backend returns normalized `Offline`
+- progression mutation ID/envelope stability across retry, replay and reconciliation
+- stat max/min and leaderboard best-score coalescing under reordered inputs
+- conditional revision, durable dedupe, unsupported operation and ambiguous-outcome
+  provider capability variants
 
 Platform-specific backend tests live in the private platform repositories.
 
@@ -1119,6 +1151,9 @@ Platform-specific backend tests live in the private platform repositories.
 - [ADR-132](../../adr/132-platform-services-project-salt-stable-id-tombstone-and-provider-mapping.md):
   deterministic project IDs, canonical encoding, tombstones, aliases and provider
   mapping ownership.
+- [ADR-133](../../adr/133-platform-progression-authority-trust-and-idempotency.md):
+  achievement/stat/leaderboard authority, trust, typed mutation algebra, retry and
+  ambiguity policy.
 - [Platform Services Config UI Reference](./platform-services-config.html): achievements, leaderboards, cloud saves, presence, and platform adapters panel.
 
 - [Audio Architecture](./audio-architecture.md)

--- a/docs/architecture/security/application-security.md
+++ b/docs/architecture/security/application-security.md
@@ -128,6 +128,28 @@ path containment, transactional publication or credential isolation. Shipping an
 secure server namespaces reject policy downgrade. A valid signature is not anti-replay
 state, encryption, semantic validity, anti-cheat or a native-code sandbox.
 
+## Platform Progression Trust
+
+[ADR-133](../../adr/133-platform-progression-authority-trust-and-idempotency.md)
+separates a committed gameplay fact, Horo progression intent, frontend request and
+remote provider projection. Local-client achievement/stat/score submissions are
+tamperable and cannot authorize shared economy, competitive rewards, simulation or
+access control. Idempotency keys, provider callbacks, SDK anti-tamper features and
+signed local saves do not turn them into server evidence.
+
+Definitions with integrity impact require `AuthorityServer`. Clients send ordinary
+authenticated gameplay input/commands; the authoritative server gameplay owner derives
+the fact and uses a server-only progression commit capability. Client, listen-server
+client world, debug UI and provider login cannot mint that capability or downgrade the
+cooked policy. Server credentials and privileged provider/gateway routes stay out of
+client artifacts.
+
+Repeated conflicting mutation IDs, stale authority/session generations and impossible
+value transitions may emit bounded audit events. Mutation/diagnostic state stores typed
+Horo IDs and normalized values/outcomes, not credentials, raw provider account IDs,
+native tokens or personal display data. Idempotency deduplicates an already-authorized
+intent; it never authenticates one.
+
 ## Process Execution
 
 Process policy validates:


### PR DESCRIPTION
## Summary

- Adds ADR-133 as the authority, trust, idempotency and ambiguity contract for
  achievements, persistent stats and leaderboards.
- Replaces blanket retry/coalescing assumptions with an explicit mutation-algebra and
  provider-capability matrix.
- Projects the decision into Platform Services, multiplayer authority and application
  security documentation.

## Why

The existing Platform Services text exposed direct unlock/stat/score calls and treated
stat writes plus idempotency keys as generally safe to retry. That is unsafe for
increments, unconditional replacements and uncertain provider commits, and it did not
identify who is trusted to establish a progression fact.

HORO-1845 requires named authority and trust boundaries for every mutation/query, safe
deterministic duplicate/retry behavior, and a server-authoritative path that does not
embed provider policy in gameplay. ADR-133 establishes that baseline before the
registries, queue and provider adapters are implemented.

## Decision and boundaries

- Separates the gameplay fact, product progression policy/router, authority server,
  progression coordinator, ADR-130 frontend request, PLS-007 durable owner, provider
  adapter and remote platform projection into distinct authorities.
- Makes every definition choose immutable `LocalProduct` or `AuthorityServer` policy;
  missing server integration fails capability resolution instead of downgrading locally.
- Routes gameplay through one Horo `IProgressionIntentSink`. Clients send ordinary
  gameplay input/commands; the server derives the privileged progression conclusion.
- Allocates one 128-bit logical `ProgressionMutationId` at semantic acceptance and
  preserves the exact envelope across retry, restart, replay and reconciliation.
- Treats an exact duplicate as an observer/join of the existing intent and rejects the
  same mutation ID with a different payload as an idempotency conflict.
- Defines safe semantics for unlock-once, monotonic progress/stat values, conditional
  snapshots, add-once, best-score and revision-guarded score replacement.
- Requires real atomic provider/gateway maximum, comparison, revision or durable-dedupe
  support; read-then-unconditional-write and process-local dedupe cannot emulate it.
- Preserves ADR-130's terminal timeout while separately tracking an unknown remote
  progression outcome and reconciling according to the exact mutation algebra.
- Permits coalescing only for result-preserving max/min/best operations and retains an
  individual receipt/outcome for every logical intent.
- Classifies provider query results as bounded account projections for UI/local hints,
  not authoritative simulation, economy, rewards or access-control state.
- Constrains future PLS-007 offline replay to the safe operation classes defined here
  and prevents offline clients from manufacturing server-authoritative mutations.
- Records that client progression and idempotency are not anti-cheat; integrity-impacting
  paths require a server-only commit capability and protected server credentials.

Intentionally deferred: PLS-007.1 owns durable queue storage, order, expiry, compaction
and shutdown. Provider-specific SDK/gateway implementation remains private, but must
qualify the atomic/deduplication capabilities it advertises.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- [x] Markdown lint passed for every changed document.
- [x] Added relative Markdown links resolve.
- [x] Git whitespace/error checks passed before and after staging.
- [x] Canonical skeleton CMake configure passed with target header/dependency checks.
- [ ] Runtime/build tests were not run because this PR changes architecture documents
  only and adds no executable code.

Commands run:

```bash
npx --yes markdownlint-cli --disable MD013 MD060 -- \
  docs/adr/133-platform-progression-authority-trust-and-idempotency.md \
  docs/architecture/runtime/platform-services-architecture.md \
  docs/architecture/runtime/multiplayer-replication-architecture.md \
  docs/architecture/security/application-security.md
git diff --check
git diff --cached --check
git diff --cached --unified=0 -- '*.md' | ruby -e '<added-link validation>'
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
```

CMake reported the existing mbedTLS minimum-version deprecation warning and that
pytest is unavailable, so repository Python tests were skipped.

## Risk and rollout

- Providers with only native increment or unconditional-set APIs expose narrower Horo
  capability; products may need a trusted gateway for exact-once/conditional semantics.
- `AuthorityServer` requires correct host/world/authority generation scoping. A future
  implementation must not reduce this to process-local `IsServer` state.
- Timeout reconciliation adds a second semantic lifecycle above the immutable request
  result; observers must not confuse `TimedOut` with proof that no remote commit exists.
- Coalescing must retain every logical receipt and use mathematical best/max/min, not
  arrival order; tests are required before enabling it.
- Durable queue details are deliberately deferred, so this PR proves eligibility and
  ownership constraints rather than queue persistence behavior.

## Issue links

- Jira: [HORO-1845](https://horo-engine.atlassian.net/browse/HORO-1845)
- GitHub: Closes #1889

## Reviewer Notes

Suggested review order:

1. ADR-133 sections 1–4 for ownership, local/server routing and mutation identity.
2. Sections 5–8 for the retry matrix, ambiguity and coalescing invariants.
3. Sections 9–12 for query trust, unsupported behavior, security and qualification.
4. Platform Services projection, then the multiplayer and security cross-boundaries.

The key invariant is that retry safety comes from the declared semantic operation plus
qualified atomic/dedupe capability—not from merely attaching an idempotency string.

## Stack

- Base PR: #2467 (`docs/HORO-1844_platform_stable_id_tombstone_mapping`)
- This PR contains only HORO-1845 / #1889 / PLS-004.1.
- Review and merge after #2467 so ADR-133 can consume the stable ID/provider mapping
  model established by ADR-132.


[HORO-1845]: https://horo-engine.atlassian.net/browse/HORO-1845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ