### PR TITLE
docs(platform): define identity and consent boundary HORO-1847 #1891 [PLS-006.1]

### DIFF
--- a/docs/adr/135-platform-identity-session-generation-privacy-and-consent.md
+++ b/docs/adr/135-platform-identity-session-generation-privacy-and-consent.md
@@ -1,0 +1,438 @@
+# ADR-135: Platform Identity, Session Generation, Privacy and Consent
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Platform account/handle/presentation separation, session and access-policy generations, sign-in/out/account switching, opaque subject handles, stale callbacks, service-purpose consent, restricted accounts, privacy, retention and observability
+- **Issue**: [PLS-006.1](https://github.com/abdullahbodur/horo-engine/issues/1891)
+- **Jira**: [HORO-1847](https://horo-engine.atlassian.net/browse/HORO-1847)
+- **Related**: [ADR-002](002-credential-handling.md), [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-056](056-external-editor-ui-boundary.md), [ADR-098](098-protocol-session-and-trust-policy.md), [ADR-113](113-local-storage-user-profile-and-slot-ownership.md), [ADR-115](115-cloud-save-authority-revision-and-conflict-policy.md), [ADR-130](130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md), [ADR-131](131-platform-services-closed-sdk-extension-abi-package-and-composition-boundary.md), [ADR-133](133-platform-progression-authority-trust-and-idempotency.md), [ADR-134](134-cloud-blob-transport-revision-precondition-and-offline-ownership.md)
+- **Normative documents**: [Platform Services Architecture](../architecture/runtime/platform-services-architecture.md), [Save Game and Persistence](../architecture/runtime/save-game-and-persistence.md), [Application Security](../architecture/security/application-security.md), [Observability Logging](../architecture/observability/observability-logging.md)
+
+## Context
+
+Platform Services operations are scoped to a signed-in platform user, but “user” is
+currently represented by a string-bearing handle and a `signedIn` boolean. That model
+can conflate a provider's native account locator, a live authentication session, local
+save/profile identity, network gameplay identity and user-visible display data.
+
+It also does not define account-switch fencing. A provider callback for Alice may
+arrive after Bob becomes current, a queued achievement may replay after sign-out, or a
+friends response may publish after consent is revoked. Checking whichever account is
+current when the callback arrives would route old work into a new subject.
+
+Privacy and restricted-account rules are currently described as UI/platform concerns.
+An operation needs a capability-level purpose/consent decision before admission and a
+generation check before every user-scoped commit. UI can present a platform or product
+prompt, but hiding a panel is not enforcement.
+
+This ADR defines the identities, session state, access snapshot, consent/restriction
+gates, switching transaction and data-minimization rules. It does not create Horo game
+accounts, define platform login UI, retain friends history or bypass platform-holder
+identity policy.
+
+## Decision
+
+### 1. Five identity domains remain non-interchangeable
+
+| Domain | Owner | Lifetime/use | Forbidden substitution |
+|---|---|---|---|
+| Provider account subject/locator | Private provider/identity adapter | Provider-specific authentication and durable private binding only | Never gameplay, public API, log, save path or display identity |
+| `PlatformSubjectHandle` | Platform frontend identity broker | Non-guessable live capability for one provider/session subject | Never persistent account key, display value or provider-native handle |
+| `LocalUserStorageId` + `GameProfileId` | ADR-113 game identity/profile service | Durable product-local storage/profile namespace | Never raw provider account or live authentication proof |
+| Gameplay/network player/principal | Product gameplay/network authority | World/session authority and replication | Never inferred from provider login or display name |
+| `PlatformUserPresentation` | Consent-scoped presentation projection | Bounded short-lived name/avatar/status fields | Never equality, routing, storage or authorization |
+
+No implicit conversions exist. Linking two domains is an explicit service operation
+with captured source/destination identity, consent/product policy, expected revisions
+and transactional result. Sign-in does not automatically select/merge a game profile;
+loading a save cannot switch platform account; a provider display-name match cannot
+link identities.
+
+### 2. Public subject handles are random generation-scoped capabilities
+
+```cpp
+struct PlatformSubjectHandle {
+    UInt128 nonce;
+    ProviderGeneration provider;
+    PlatformSessionGeneration session;
+};
+```
+
+The frontend identity broker allocates `nonce` from the platform cryptographic random
+source after successful authenticated subject binding. Zero, reuse and RNG failure
+fail binding. The value is equality-only and non-guessable within the threat model; it
+is not a UUID supplied by the provider, a hash of account ID/gamertag/email or an
+authorization secret.
+
+The handle is valid only while its exact provider and session generations are active.
+It is passed as a typed capability to permitted Horo services and cannot be serialized
+to project files, saves, offline records, scripts, console history, analytics or logs.
+Diagnostic correlation uses a separately generated ephemeral safe correlation ID when
+policy allows, never the handle bytes.
+
+Gameplay and ordinary UI cannot enumerate handles or construct them from bytes. A
+multi-user host obtains handles only from an immutable active-session projection and
+selects one explicitly. A handle grants no service by itself; every operation also
+passes the effective service access/consent gate.
+
+### 3. Durable provider-to-local mapping stays private and pseudonymous
+
+The private provider adapter may expose a stable authenticated account subject only to
+the identity/profile mapping service through a narrow credential-protected operation.
+That service resolves a product/provider-scoped `ProviderAccountBindingId` and maps it
+to ADR-113 `LocalUserStorageId` plus explicitly selected `GameProfileId`.
+
+Portable project files, save archives/catalogs, cloud blobs, progression/offline
+records and general settings contain no raw provider account ID, gamertag, email,
+native handle or credential. The minimal durable mapping store is owned by the identity
+service, scoped to product/environment/provider, access controlled and encrypted or
+protected by the platform credential/storage facility where available. It stores a
+pseudonymous binding ID and protected locator/reference sufficient to re-resolve the
+provider subject, not display metadata.
+
+If the provider cannot supply a stable cross-launch subject, it advertises the ADR-113
+single-installation/local-user capability and cloud persistence/account linking is
+unavailable. Horo never hashes mutable personal/display data as a fallback. Cross-
+provider account linking requires a separate product account authority and explicit
+verified transaction; equal names prove nothing.
+
+### 4. Every active binding has an immutable session snapshot
+
+```cpp
+enum class PlatformSessionPhase : std::uint8_t {
+    NoSubject,
+    Authenticating,
+    Active,
+    Closing,
+    Failed,
+};
+
+struct PlatformSessionSnapshot {
+    PlatformSessionPhase phase;
+    PlatformSessionGeneration generation;
+    std::optional<PlatformSubjectHandle> subject;
+    PlatformAccessPolicyRevision accessRevision;
+    PlatformSessionCapabilities capabilities;
+    NormalizedSessionReason reason;
+};
+```
+
+There is no independent `signedIn` boolean or nullable user object that can contradict
+phase/capability. `Active` has exactly one valid subject and immutable effective access
+snapshot. `NoSubject`, `Authenticating`, `Closing` and `Failed` expose no subject for
+new admission. A restricted account may still be `Active` while individual service/
+operation capabilities are unavailable with typed reasons.
+
+`PlatformSessionGeneration` is nonzero and increases whenever a provider subject is
+first published, signed out, switched, invalidated, rebound or provider generation is
+replaced. It never wraps/reuses within a process; exhaustion fails closed. Account
+refresh that preserves the exact authenticated subject may publish a new access
+revision without changing session generation. Any uncertainty that the subject is the
+same closes and rebinds with a new session generation.
+
+Snapshots publish on the frontend owner lane. Provider SDK callbacks enqueue bounded
+evidence; they never mutate session state or invoke gameplay/UI directly. Observers
+receive immutable deferred projections after commit and cannot veto or extend the old
+session lifetime.
+
+### 5. Every user-scoped operation captures and revalidates generations
+
+Admission captures at least:
+
+- `PlatformSubjectHandle` and `PlatformSessionGeneration`;
+- provider/frontend generation;
+- effective `PlatformAccessPolicyRevision` and operation access decision;
+- product/profile/authority generation required by its semantic owner; and
+- request/durable-intent identity under ADR-130, ADR-133 or ADR-134.
+
+The frontend validates them before provider submit and again before every user-scoped
+state/result/cache/event/offline/journal commit. The consuming coordinator revalidates
+its own profile/authority generation at its commit boundary. Checking only “currently
+signed in” or comparing display/native IDs is forbidden.
+
+A mismatch is `platform.session.stale`. Provider work may finish privately for safe
+retirement, but cannot publish into the active subject, update a new user's cache,
+replay durable intent, mark a cloud generation synced or dispatch a user observer.
+Late evidence retains the old request's terminal/retirement rules and never targets the
+new generation.
+
+Durable intent carries a pseudonymous subject-binding partition and captured policy/
+session requirements, not a live handle or raw provider ID. Replay first establishes a
+new active session for the same protected binding, then obtains a new handle and
+explicitly reauthorizes the intent. It cannot reuse old handle bytes or retarget a new
+account merely because that account is current.
+
+### 6. Sign-in and account switch publish transactionally
+
+Sign-in/authentication prepares a detached candidate:
+
+```text
+provider authentication evidence
+  -> private stable-subject resolution
+  -> product/provider binding lookup
+  -> platform restrictions and product-purpose consent resolution
+  -> capability/limit/access snapshot validation
+  -> subject handle allocation
+  -> atomic Active session publication
+```
+
+Failure destroys candidate credentials/handles and publishes no partial subject or
+capability. Authentication UI completion is evidence, not publication authority.
+
+Account switch is close-then-bind:
+
+1. close old admission and atomically publish `Closing` with old generation invalid;
+2. stop callbacks/observers, cache publication and durable replay for the old subject;
+3. request bounded cancellation and retire/preserve request/coordinator state under
+   each service's policy;
+4. revoke subject handle and short-lived credentials after native callback safety;
+5. prepare and validate the new subject/access/profile binding independently; and
+6. publish a new `Active` snapshot/generation or explicit `NoSubject`/`Failed`.
+
+There is never an active snapshot containing old profile state and new provider
+identity. If new binding fails, Horo does not silently reopen or merge the old account;
+rebind is a fresh explicit transaction. Multiple platform users, when supported, have
+separate sessions/handles and request partitions rather than a mutable global current-
+user pointer.
+
+### 7. Sign-out closes authority before native teardown
+
+Sign-out, provider-forced logout, credential revocation and account removal first close
+frontend admission and advance/invalidate session generation. Service coordinators
+stop scheduling/replay and snapshot which durable intents remain partitioned for a
+future verified same binding. Only then does the provider receive cancellation/logout
+and release native identity/credential state after callback epochs retire.
+
+Already committed provider effects remain actual effects; sign-out does not promise
+rollback. Admitted requests follow ADR-130 terminal rules but stale results cannot
+publish user data into a later session. Cloud/progression ambiguity remains owned by
+its old partition and may reconcile only after verified same-binding reauthorization.
+
+A shutdown deadline does not authorize force-freeing provider code, identity cookies,
+sinks or credentials still referenced by possible callbacks. The module/credential
+lease is retained and a typed shutdown failure is reported under ADR-131.
+
+### 8. Consent and restrictions are typed capability policy
+
+Every operation descriptor declares a finite Horo purpose and data-class set, for
+example `CloudSaveSync`, `AchievementProjection`, `LeaderboardRead`, `FriendsRead` or
+`PresencePublish`. Product policy declares whether each purpose is included/required,
+its minimum age/region/parental requirements, retention class and whether product
+consent is needed in addition to provider/OS authorization.
+
+The effective access decision is the intersection of:
+
+- provider/platform capability and authenticated subject state;
+- platform/parental/child/restricted-account policy;
+- region/legal/product-profile availability;
+- current provider/OS permission where applicable; and
+- a purpose/version/data-class-specific product consent receipt when required.
+
+```cpp
+enum class PlatformAccessState : std::uint8_t {
+    Granted,
+    ConsentRequired,
+    Denied,
+    Restricted,
+    Revoked,
+    Unavailable,
+};
+
+struct PlatformServiceAccess {
+    PlatformServiceOperation operation;
+    PlatformAccessState state;
+    PlatformAccessReason reason;
+    PlatformPurposeId purpose;
+    PlatformDataClassMask dataClasses;
+    ConsentPolicyVersion consentVersion;
+};
+```
+
+Only `Granted` permits admission. All other states have one typed reason and no usable
+provider binding for that operation. The access snapshot is the sole truth; UI
+visibility, a remembered checkbox, nullable service pointer, provider overlay success
+or generic `signedIn` state cannot bypass it.
+
+### 9. Consent UI records evidence but cannot grant itself
+
+Consent is informed, purpose-specific, versioned and revocable. The product consent
+authority owns receipts containing subject-binding partition, purpose/data classes,
+policy/text version, decision, source, time/expiry where required and revision—never a
+credential or unrestricted personal data. A broad “online features” acceptance cannot
+silently authorize friends, presence publication and analytics as one unrelated grant.
+
+UI/overlay presents localized disclosure and submits a typed consent decision with an
+expected access revision. The authority validates the exact policy/purpose and commits
+the receipt; UI then observes a new access snapshot. Closing/dismissing a prompt is not
+grant. Repeated denial cannot trigger an unbounded prompt loop; product/platform policy
+controls when another request may be offered.
+
+Provider/OS consent remains provider-owned evidence translated by the adapter. Horo
+does not fake it with a product checkbox. Conversely, provider permission does not
+replace separately required product consent. A restricted/parental account cannot be
+overridden by local UI, config, debug command or a stale prior receipt.
+
+Consent or restriction change increments `PlatformAccessPolicyRevision`, closes new
+admission immediately and invalidates in-flight publication for affected operations.
+Unrelated service operations may remain active only if their captured decision and
+data classes are unchanged under the new snapshot. Revocation triggers bounded service-
+owned cache/retention cleanup and observer withdrawal; it does not claim a provider
+already committed effect was rolled back.
+
+### 10. Personal/display data is bounded, untrusted presentation
+
+`PlatformUserPresentation` is a separate opt-in projection with bounded UTF-8 display
+name, optional provider-approved avatar/art token and presence fields plus source/
+freshness/access revision. It is untrusted text/data: rendering escapes markup,
+validates UTF-8/length/image source and never executes links/content.
+
+Friends/social results expose ephemeral `PlatformSocialSubjectHandle` values scoped to
+the requesting session/access revision, not raw account IDs. They cannot be used as
+the local player's `PlatformSubjectHandle`, stored as gameplay identity or compared
+across provider/session generations. A product account service may perform explicit
+linking through its own trusted flow; visual name equality is irrelevant.
+
+By default friends lists, presence, avatars and display strings are held only in
+bounded memory until response/session/consent retention expires. Durable caching,
+analytics/export or user-generated presence text requires a separately declared
+purpose, schema, retention/deletion policy and consent. “The provider returned it” is
+not blanket permission to persist or log it.
+
+### 11. Logs, persistence and tools expose safe projections only
+
+General logs, metrics, crash bundles, traces, save/cloud/progression journals, project
+files, scripts, CLI/MCP history and ordinary tool results exclude:
+
+- raw/native platform account/user/session/request identifiers;
+- `PlatformSubjectHandle` and social subject handle bytes;
+- gamertag/display name, email, avatar payload/URL, friends graph and presence free
+  text;
+- credentials, consent-provider tokens or private binding-store locators; and
+- unrestricted native restriction/error payloads.
+
+Allowed evidence is bounded service/operation, state/reason, provider capability ID,
+provider/session/access generations, counts/latency buckets and ephemeral random
+correlation IDs not usable to recover/link an account. Metrics never use per-user,
+handle, display-name or mutation IDs as dimensions.
+
+Explicit privacy/admin tools use separate authenticated capabilities, return minimum
+allowlisted fields, audit access and obey purpose/retention/deletion policy. Developer
+build does not imply consent or allow raw IDs in ordinary logs. Support export previews
+which categories will be included and defaults to redaction.
+
+### 12. Errors preserve absence, restriction and stale identity
+
+Stable outcomes include:
+
+```text
+platform.session.no_subject
+platform.session.authenticating
+platform.session.closing
+platform.session.stale
+platform.session.switch_failed
+platform.identity.binding_failed
+platform.identity.mapping_unavailable
+platform.access.consent_required
+platform.access.denied
+platform.access.restricted
+platform.access.revoked
+platform.access.policy_stale
+```
+
+Composition-time service absence remains `platform.capability.unavailable`; explicit
+Null remains `platform.provider.null`; an operation dynamically denied for the current
+subject uses the specific access result above rather than generic provider failure.
+Provider-native codes may appear only as bounded redacted cause evidence.
+
+A denied/restricted/consent-required operation fails before ADR-130 request creation or
+provider call. Revocation/staleness after admission follows request retirement but
+blocks affected user-data commit. No path converts denial to empty friends, successful
+presence clear, accepted progression or cloud absence.
+
+### 13. Qualification exercises identity and policy races
+
+Required evidence includes:
+
+- type/compile-time separation of provider locator, local profile/storage, gameplay
+  identity, live subject handle and presentation/social handles;
+- handle RNG failure/zero/reuse/guess rejection, generation expiration and proof that
+  handle/native bytes never enter durable or observable broad surfaces;
+- sign-in candidate failure at each stage with no partial subject/capability/credential
+  publication;
+- sign-out/account switch/provider replacement before submit, in flight, after native
+  commit and before callback, proving every user-scoped commit checks session generation;
+- Alice-to-Bob switch with stale provider callbacks, queued progression, cloud journal,
+  friends cache and observers never publishing/replaying into Bob;
+- single/current/multiple-user providers, guest partition, same-account reauth and
+  ambiguous identity refresh forcing new generation;
+- consent required/granted/denied/revoked/expired/version-changed and OS/provider versus
+  product-consent intersections at admission and commit;
+- child/parental/region/restricted-account policy that cannot be bypassed by UI,
+  config, debug tooling or stale receipts;
+- bounded/malformed personal presentation and friends data, retention expiry,
+  revocation cleanup and no raw-ID/PII log/metric/crash/tool leakage; and
+- shutdown/cancellation timeout retaining provider/credential dependencies until late
+  callback retirement without user publication.
+
+Private provider tests qualify native account-change callbacks, stable-subject mapping,
+restriction/consent projection and credential revocation. Public Mock/Null fixtures
+cover the full Horo state/access model without real personal data.
+
+## Consequences
+
+- A live platform subject is a non-guessable generation-scoped capability, not a
+  display/native/persistent identity.
+- Every user-scoped commit is fenced against account switch, sign-out, provider reload
+  and applicable consent/restriction changes.
+- Local profiles, cloud/progression partitions and gameplay identities link only through
+  explicit owners and cannot be inferred from a platform login.
+- Consent and restricted-account behavior is enforced at capability admission/commit,
+  while UI remains a presenter of authority-owned decisions.
+- Personal/social data has bounded purpose, exposure and retention instead of becoming
+  general gameplay/log/cache state.
+- Hosts and providers must implement transactional switching, protected binding stores,
+  policy revisions, cleanup and race qualification; a global “current user” is simpler
+  but unsafe.
+
+## Rejected Alternatives
+
+### Expose a provider user ID string as `PlatformUserHandle`
+
+Rejected because it is guessable/persistable, provider-specific and likely to leak
+through gameplay, saves, logs or UI while lacking explicit session lifetime.
+
+### Use display name, email or gamertag to map local profiles
+
+Rejected because these are personal, mutable, non-unique and untrusted presentation
+data. A provider must supply a private stable subject or advertise narrower capability.
+
+### Keep one mutable process-global current user
+
+Rejected because callbacks, requests and durable replay can cross account switches and
+multi-user hosts cannot express separate subjects safely.
+
+### Check the current user only when a callback arrives
+
+Rejected because old work could be attributed to the new current account. Admission
+captures and commit revalidates the exact session generation and subject partition.
+
+### Treat UI visibility or a checkbox as the consent gate
+
+Rejected because hidden/debug/headless/API paths could bypass it and stale UI state can
+outlive policy. One versioned access snapshot controls all adapters.
+
+### Treat provider/OS permission as blanket product consent
+
+Rejected because platform authorization and product purpose/data-use disclosure are
+separate requirements; effective access is their intersection.
+
+### Return empty data for restricted/denied social access
+
+Rejected because empty success is indistinguishable from “no friends/data,” encourages
+retry/prompt loops and hides a policy boundary. Denial is typed before admission.
+
+### Log hashed platform account IDs for correlation
+
+Rejected because stable hashes remain linkable/potentially enumerable personal
+identifiers. Use ephemeral non-account-derived correlation IDs and bounded aggregates.

--- a/docs/architecture/observability/observability-logging.md
+++ b/docs/architecture/observability/observability-logging.md
@@ -424,6 +424,8 @@ The startup snapshot must not contain:
 - passwords, tokens, credentials, authorization headers, or private keys
 - a full environment-variable dump
 - username, email address, machine hostname, or hardware serial number
+- raw provider/platform account identifiers, generation-scoped subject/social handle
+  bytes, gamertags, friends graphs, avatar locators, or presence free text
 - full home-directory paths when a normalized or project-relative path suffices
 - project assets, source contents, or arbitrary command arguments
 

--- a/docs/architecture/runtime/platform-services-architecture.md
+++ b/docs/architecture/runtime/platform-services-architecture.md
@@ -40,6 +40,11 @@ revision-consistent reads, conditional atomic mutations, finite quota/transfer l
 whole-blob integrity and partial/ambiguous outcomes while the ADR-115 coordinator stays
 the only durable cloud-intent owner.
 
+[ADR-135](../../adr/135-platform-identity-session-generation-privacy-and-consent.md)
+separates provider account, live subject capability, local profile, gameplay identity
+and presentation data; every user-scoped commit is fenced by session/access generation
+and every consent/restriction decision is enforced by a typed capability snapshot.
+
 ## Scope
 
 Platform services covered here:
@@ -578,21 +583,27 @@ updates and coalesces them into the most recent state.
 
 ```cpp
 struct PresenceState {
-    std::string statusId;          // stable ID, mapped at cook time
-    std::string detail;            // optional free text
-    std::string largeImageKey;     // stable art key
-    std::string smallImageKey;     // stable art key
+    PresenceStatusId status;
+    std::optional<BoundedUtf8> detail;
+    std::optional<PlatformPresenceArtId> largeImage;
+    std::optional<PlatformPresenceArtId> smallImage;
 };
 
 class IPresenceService {
 public:
     virtual Result<PlatformRequestHandle<void>>
-    SetPresence(const PresenceState& state) = 0;
+    SetPresence(PlatformSubjectHandle subject, const PresenceState& state) = 0;
 
     virtual Result<PlatformRequestHandle<void>>
-    ClearPresence() = 0;
+    ClearPresence(PlatformSubjectHandle subject) = 0;
 };
 ```
+
+`PresenceStatusId` and art IDs are project-owned typed identities resolved through the
+ADR-132 registry/mapping pipeline. Optional detail is bounded untrusted presentation
+data. Publication requires a current subject plus `PresencePublish` access, and the
+captured session/access generations are revalidated before provider submission and
+observable completion.
 
 ### Friends
 
@@ -600,20 +611,30 @@ Friends access is read-only in core. Invites and friend management UI are
 platform-owned.
 
 ```cpp
-struct PlatformUserHandle {
-    std::string platformUserId;
-    std::string displayName;
+struct PlatformSocialSubjectHandle {
+    UInt128 nonce;
+    PlatformSessionGeneration session;
+    PlatformAccessPolicyRevision access;
+};
+
+struct PlatformUserPresentation {
+    PlatformSocialSubjectHandle subject;
+    BoundedUtf8 displayName;
+    std::optional<ProviderApprovedAvatarToken> avatar;
 };
 
 class IFriendsService {
 public:
-    virtual Result<PlatformRequestHandle<std::vector<PlatformUserHandle>>>
-    GetFriends() = 0;
+    virtual Result<PlatformRequestHandle<BoundedArray<PlatformUserPresentation>>>
+    GetFriends(PlatformSubjectHandle subject) = 0;
 };
 ```
 
 Friends access requires explicit user consent and platform policy support.
-Absence of the capability is typed, not a silent empty list.
+Absence of the capability is typed, not a silent empty list. Social handles are
+ephemeral, scoped to the requesting session/access revision and distinct from the
+local subject capability. Display/avatar fields are bounded consent-scoped
+presentation, never account, gameplay or durable storage identity.
 
 ## Stable ID Registries
 
@@ -811,9 +832,11 @@ exactly one compatible private binding; `Unavailable` has no binding and exactly
 reason. Missing, duplicate or mismatched bindings fail composition. Public callers do
 not inspect provider pointers, backend names or SDK flags.
 
-Connectivity, sign-in, consent and rate-limit state are request preconditions/session
-state, not a second installed-capability flag. Provider reload or session replacement
-increments generation; stale completion evidence cannot publish into the replacement.
+Installed/provider capability and effective subject access are distinct immutable
+snapshots; admission intersects them instead of collapsing them into a boolean.
+Connectivity and rate-limit state remain dynamic request preconditions. Provider
+reload, session replacement or access-policy change increments the applicable
+generation/revision; stale completion evidence cannot publish into the replacement.
 
 ## Offline And Degraded Behavior
 
@@ -871,35 +894,141 @@ successful Null operation. Tests needing success use the capability-accurate moc
 
 ## Authentication And Session Boundary
 
-Platform services do not own the game user account. They expose a platform user
-handle that the game identity layer can map to its own player profile.
-
-ADR-113 requires that mapping to produce a private provider-scoped
-`LocalUserStorageId` and then select a product-owned `GameProfileId`. Raw platform
-handles, gamertags, emails and display names are not save-directory or cloud-slot
-identity. Backends explicitly report single-local-user, current-user-only or
-multi-user capability; unsupported switching returns
-`platform.capability.unavailable` rather than sharing a guessed user namespace.
+Platform account locator, live platform subject, ADR-113 local storage/profile,
+gameplay/network player and user presentation are distinct identity domains. Equal
+display text never links them. Provider account/native identity stays inside the
+private provider/identity adapter; gameplay and broad services receive only a typed
+live capability:
 
 ```cpp
-struct PlatformSessionState {
-    bool signedIn;
-    PlatformUserHandle currentUser;
+struct PlatformSubjectHandle {
+    UInt128 nonce;
+    ProviderGeneration provider;
+    PlatformSessionGeneration session;
+};
+
+enum class PlatformSessionPhase : std::uint8_t {
+    NoSubject,
+    Authenticating,
+    Active,
+    Closing,
+    Failed,
+};
+
+struct PlatformSessionSnapshot {
+    PlatformSessionPhase phase;
+    PlatformSessionGeneration generation;
+    std::optional<PlatformSubjectHandle> subject;
+    PlatformAccessPolicyRevision accessRevision;
+    PlatformSessionCapabilities capabilities;
+    NormalizedSessionReason reason;
 };
 ```
 
-The backend reports session changes through an observer interface:
+The subject nonce is nonzero/non-reused 128-bit cryptographic randomness allocated by
+the frontend identity broker after authenticated binding. It is equality-only,
+non-guessable and valid only for its exact provider/session generations. It is not a
+provider ID, persistent account key, authorization secret or display value and is never
+serialized/logged. Gameplay cannot construct or enumerate handles.
+
+`Active` has exactly one subject and immutable effective access snapshot. Other phases
+have none for admission; there is no second `signedIn` bool or nullable provider object.
+A restricted account may be Active while individual operations are unavailable. The
+session generation increases on bind, sign-out, account switch/invalidation and
+provider replacement. Subject-preserving access changes increment the access revision;
+identity uncertainty closes/rebinds a new generation.
+
+The private identity/profile service maps a provider stable authenticated subject to a
+pseudonymous product/provider-scoped binding, ADR-113 `LocalUserStorageId` and explicit
+`GameProfileId`. Raw account ID, gamertag, email, native handle or credentials do not
+enter portable project/save/cloud/progression/offline state. If no stable provider
+subject exists, the provider advertises installation-local/single-user capability and
+cloud/linking remains unavailable; mutable personal text is never hashed as fallback.
+
+Every user-scoped admission captures subject, session, provider/frontend and access-
+policy generations plus its semantic profile/authority generation. Every result,
+cache, event, observer, journal/offline or synced-state commit revalidates the captured
+session and applicable access revision. Mismatch is `platform.session.stale`; old
+provider work may retire privately but cannot publish into a new account.
+
+Durable intent stores a protected pseudonymous subject-binding partition and policy
+requirements, never a live handle. Replay first verifies the same binding under a new
+active session and reauthorizes the operation. “Current account” cannot retarget it.
+
+### Sign-in, sign-out and account switch
+
+Sign-in prepares provider authentication, stable-subject/private profile mapping,
+restrictions/consent, capability limits and a fresh handle as a detached candidate,
+then atomically publishes Active. Authentication UI completion is evidence, not
+publication authority. Failure destroys candidate handles/credentials with no partial
+capability.
+
+Sign-out/account switch closes old admission and invalidates its generation before
+cancelling/retiring native work, stopping cache/observer publication and suspending old
+durable partitions. Credentials/handles release only after callback safety. A switch
+then prepares a wholly new binding; it never mutates a global user pointer in place or
+publishes old profile state with a new account. Failure leaves explicit NoSubject/
+Failed; reopening old state is a fresh transaction.
+
+Single/current/multiple-user support remains explicit. Multiple users have separate
+sessions, handles and request partitions. Listen-server locality, UI selection or
+provider login never changes gameplay/server authority.
+
+### Consent and restricted access
+
+Each operation declares a finite Horo purpose/data-class set such as cloud sync,
+achievement projection, leaderboard read, friends read or presence publish. Effective
+access is the intersection of provider capability/session, platform/parental/child
+restriction, region/legal/product policy, OS/provider permission and versioned product
+consent where required:
 
 ```cpp
-class IPlatformSessionObserver {
-public:
-    virtual void OnSessionStateChanged(const PlatformSessionState& state) = 0;
+enum class PlatformAccessState : std::uint8_t {
+    Granted,
+    ConsentRequired,
+    Denied,
+    Restricted,
+    Revoked,
+    Unavailable,
+};
+
+struct PlatformServiceAccess {
+    PlatformServiceOperation operation;
+    PlatformAccessState state;
+    PlatformAccessReason reason;
+    PlatformPurposeId purpose;
+    PlatformDataClassMask dataClasses;
+    ConsentPolicyVersion consentVersion;
 };
 ```
 
-The frontend dispatches these changes to gameplay systems that care about sign
-in/out. Cloud save sync and offline queue replay are triggered by sign-in
-events.
+Only Granted admits work; every other state has one typed reason and no usable binding
+for that operation. UI/overlay presents localized disclosure and submits an expected-
+revision decision to the consent authority. UI cannot grant itself; closing a prompt
+is not consent, provider permission does not replace required product consent and a
+checkbox cannot override parental/restricted policy.
+
+Consent is purpose/data-class/version specific, revocable and finitely retained. A
+policy/restriction change closes affected admission, advances access revision, blocks
+stale in-flight publication and triggers bounded service cache/observer cleanup.
+Unrelated operations continue only when their captured decision/data classes remain
+valid. Revocation does not claim already committed provider effects were rolled back.
+
+### Personal and display data
+
+`PlatformUserPresentation` and social-subject handles are bounded, untrusted,
+consent-scoped projections separate from identity. Display names, avatars, presence
+and friend data never authorize, route, identify storage or compare accounts. Text/
+images are validated/escaped before rendering. By default they remain only in bounded
+memory until request/session/consent retention expires.
+
+Durable cache, analytics/export or user-generated presence requires a separate
+declared purpose, schema, retention/deletion policy and consent. General logs, metrics,
+crash bundles, project/save files, journals, scripts and ordinary CLI/MCP results
+contain no raw account/native IDs, live/social handle bytes, personal display data,
+friends graph, presence free text, credentials or private binding locators. Safe
+observability uses aggregate counts, typed state/reason/generations and ephemeral
+non-account-derived correlation IDs.
 
 ## Shutdown And Late Completion
 
@@ -922,12 +1051,9 @@ recorded outcome without duplicating cancellation or native teardown.
 - Closed platform SDK implementations live in private repositories. The public
   engine repository contains only interfaces, registries, the null backend, and
   the mock backend.
-- Achievements and stats are unlocked/submitted through gameplay systems. For
-  competitive or online games, critical stats should be validated by the game
-  server before the client calls the platform backend, or the backend should be
-  invoked from a trusted server path. See
-  [Release Security](../release/release-security.md) for the broader trust and
-  signing model that governs backend packages.
+- ADR-133 progression definitions select local or server authority; competitive
+  clients never submit privileged conclusions and idempotency does not provide
+  authentication/anti-cheat.
 - Cloud save data is opaque untrusted input to the platform service layer. Transport
   authentication does not establish archive trust. Integrity, signature/scope,
   compatibility and optional confidentiality policy belong to Runtime Save and the
@@ -935,21 +1061,22 @@ recorded outcome without duplicating cancellation or native teardown.
 - Provider tokens and account credentials remain inside the backend's short-lived
   credential lease. They never enter archive bytes, coordinator journals, tool
   results, logs or conflict metadata.
-- Friends and presence data are subject to platform privacy policies and user
-  consent. The frontend does not cache or expose this data beyond what the
-  backend provides.
+- ADR-135 live subject handles are non-persistent generation capabilities; personal/
+  social presentation is separate bounded data and every operation passes typed
+  purpose, consent and restriction policy before admission/commit.
 
 ## Privacy And Compliance
 
-- Friends and presence require explicit user consent where the platform
-  requires it.
-- Presence free text must not include PII or user-generated content that has
-  not been reviewed.
-- Cloud save retention follows platform policy; the engine does not control it.
-- Children's accounts and restricted platforms may disable social features.
-  The frontend surfaces this as normalized `Forbidden` provider failure or
-  `platform.capability.unavailable`, according to whether a supported operation was
-  denied dynamically or the capability was excluded at composition.
+- Friends, presence and any other personal-data operation declare purpose/data class,
+  product retention and required provider/OS/product consent explicitly.
+- Child, parental, region and platform restriction is an operation capability state,
+  not UI-only visibility or a generic successful empty result.
+- Presence free text and display/social data are untrusted user/provider content;
+  retention/export/analytics requires separate consent and policy.
+- Cloud provider retention/backup is external evidence; Horo's local journal/recovery
+  retention and deletion intent remain product/coordinator policy.
+- Consent denial/revocation is typed, closes affected publication and cannot be
+  bypassed by debug tooling, configuration or development builds.
 
 ## Observability
 
@@ -1073,7 +1200,7 @@ Configuration authority lives in Project Settings:
 
 The Platform Diagnostics panel shows runtime state:
 
-- signed-in user and session state
+- session phase/generations and consent-safe presentation availability
 - backend capability availability (per service)
 - pending request count and recent errors by category
 - offline queue depth and oldest pending operation
@@ -1135,7 +1262,14 @@ Required tests cover:
 - authenticated-provider downloads remain untrusted until local bounded admission;
   malformed/oversized results cannot publish or replace a local generation
 - cloud credential/provider metadata is redacted from save diagnostics and tools
-- session sign-in/out triggers queue replay and state callbacks
+- sign-in candidate failure, sign-out/account-switch/provider-reload races and stale
+  callbacks never publish across subject/session generations
+- same-binding reauthorization may resume an eligible durable partition; a newly
+  current account never retargets old progression or cloud intent
+- every consent/restriction state and access-revision change is enforced at admission
+  and commit, including child/parental/region policy and UI/debug bypass attempts
+- social handles and bounded presentation expire with session/access scope; malformed
+  personal data and raw-ID/PII leakage into logs, metrics, crashes or tools fail closed
 - typed capability snapshot and private binding agree; missing/duplicate/mismatched
   bindings fail composition and unavailable services return
   `platform.capability.unavailable`
@@ -1178,6 +1312,8 @@ Tests use the mock backend to verify:
   provider capability variants
 - cloud list/read consistency, partial transfer, atomic revision CAS, quota and
   committed-after-timeout scripts with exact caller-owned reconciliation evidence
+- authentication-stage failure, account-switch/stale-callback and consent-revocation
+  scripts with no cross-subject cache, observer or durable-replay publication
 
 Platform-specific backend tests live in the private platform repositories.
 
@@ -1196,6 +1332,9 @@ Platform-specific backend tests live in the private platform repositories.
 - [ADR-134](../../adr/134-cloud-blob-transport-revision-precondition-and-offline-ownership.md):
   authenticated opaque blobs, revision CAS, quota/integrity/partial transfer and
   caller-owned durable cloud intent.
+- [ADR-135](../../adr/135-platform-identity-session-generation-privacy-and-consent.md):
+  platform identity-domain separation, generation-fenced subject capabilities,
+  consent/restriction authority and personal-data handling.
 - [Platform Services Config UI Reference](./platform-services-config.html): achievements, leaderboards, cloud saves, presence, and platform adapters panel.
 
 - [Audio Architecture](./audio-architecture.md)

--- a/docs/architecture/runtime/save-game-and-persistence.md
+++ b/docs/architecture/runtime/save-game-and-persistence.md
@@ -795,6 +795,15 @@ the per-user profile catalog, active `GameProfileId`, account association and pr
 display metadata. Runtime Save owns slot operations, not user sign-in, profile
 creation/linking or profile-store state.
 
+[ADR-135](../../adr/135-platform-identity-session-generation-privacy-and-consent.md)
+requires that live handle to be a non-guessable, non-persistent capability scoped to
+one provider/session generation, distinct from the private durable provider binding.
+Every cloud/profile user-scoped commit revalidates the captured session and applicable
+access-policy revision. Account switch/sign-out invalidates old admission before native
+teardown; stale callbacks and journal work cannot publish/replay into the next user.
+Raw provider identity and personal presentation never enter save catalogs, archives,
+paths or broad diagnostics.
+
 When multi-device/cloud persistence is advertised, the backend must provide a stable
 opaque authenticated-user scope so the same platform account maps consistently on
 each device. If it cannot, cloud persistence is unavailable and local fallback uses

--- a/docs/architecture/security/application-security.md
+++ b/docs/architecture/security/application-security.md
@@ -159,6 +159,24 @@ Horo IDs and normalized values/outcomes, not credentials, raw provider account I
 native tokens or personal display data. Idempotency deduplicates an already-authorized
 intent; it never authenticates one.
 
+## Platform Identity And Consent
+
+[ADR-135](../../adr/135-platform-identity-session-generation-privacy-and-consent.md)
+keeps provider account locators private and exposes only non-guessable, generation-
+scoped live subject capabilities. Local storage/profile and gameplay identities remain
+separate explicit mappings; display name, email, gamertag or provider login cannot
+authorize/link them. Every user-scoped commit revalidates session generation and the
+applicable access-policy revision so stale callbacks, caches and durable work cannot
+cross sign-out/account switch.
+
+Consent/restriction is the intersection of operation purpose/data classes, provider/
+OS permission, product consent, region/legal and child/parental policy. Only a typed
+Granted capability admits work. UI presents/submits a decision but cannot grant itself,
+and development/debug paths cannot bypass or convert denial into empty success.
+Personal/social presentation is bounded, untrusted and ephemeral by default. General
+logs, metrics, crash bundles, saves/journals and ordinary tools exclude raw account/
+handle values, friends graphs, display data, presence free text and credentials.
+
 ## Process Execution
 
 Process policy validates:


### PR DESCRIPTION
## Summary

- Adds ADR-135 to define a provider-neutral platform identity, session-generation,
  privacy, consent, and restricted-account contract.
- Separates provider account locators, live platform subject capabilities, durable
  local profile/storage identity, gameplay/network identity, and consent-scoped user
  presentation.
- Projects the decision into Platform Services, Save Game and Persistence,
  Application Security, and Observability Logging.
- Replaces the architecture's raw string-bearing friends/presence examples with
  typed, bounded, generation-scoped contracts.

## Why

The previous architecture represented the signed-in platform user with a string-
bearing handle and an independent boolean. That leaves account-switch and consent
races underspecified: an old provider callback, cache publication, cloud journal, or
queued progression mutation could otherwise be attributed to whichever account is
current when completion arrives. Raw provider IDs and display data could also escape
into portable state, logs, or gameplay identity.

This change establishes one explicit authority model before provider adapters and
offline replay are implemented. A user-scoped operation now has an immutable subject
and access snapshot at admission, and every observable commit must prove that the
captured session and policy revisions are still current.

## Decision and boundaries

- `PlatformSubjectHandle` is a nonzero, non-reused random 128-bit equality capability
  scoped to exact provider and session generations. It is neither a provider ID nor a
  durable account key and cannot be serialized or logged.
- Durable provider-to-local mapping remains private and pseudonymous, resolving into
  ADR-113 `LocalUserStorageId` and explicit `GameProfileId` ownership. Display names,
  emails, gamertags, and provider handles cannot be used as fallback identity.
- Session state is an exhaustive immutable phase/snapshot model. Sign-in publishes a
  fully validated detached candidate; sign-out and account switch close old admission
  and invalidate its generation before native cancellation and teardown.
- Every user-scoped request, callback, cache, observer, durable intent, and synced-
  state commit captures and revalidates subject/session/provider/frontend/access and
  semantic profile or authority generations. Stale evidence retires privately and
  cannot publish into a replacement account.
- Effective access is a typed intersection of provider capability, authenticated
  session, platform/OS permission, child/parental restrictions, region/legal/product
  policy, and purpose/version/data-class-specific consent. Only `Granted` admits work;
  UI records evidence but cannot grant authority itself.
- Friends and presence now expose bounded consent-scoped presentation with ephemeral
  social handles. They no longer expose raw platform IDs or unconstrained identity
  strings.
- Broad logs, metrics, crash bundles, saves, journals, scripts, and ordinary tooling
  exclude raw account/handle values and personal/social presentation data.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/135-platform-identity-session-generation-privacy-and-consent.md docs/architecture/runtime/platform-services-architecture.md docs/architecture/runtime/save-game-and-persistence.md docs/architecture/security/application-security.md docs/architecture/observability/observability-logging.md`
- `git diff --check`
- `git diff --cached --check`
- Staged added-Markdown-link resolution check: passed.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. The existing mbedTLS minimum-version
deprecation warning remains, and repository Python tests were skipped because pytest
is unavailable in this environment.

## Risk and rollout

- This is a normative contract change rather than runtime implementation, so future
  frontend, provider, coordinator, persistence, and UI work must preserve the new
  generation and access-revision fences.
- Provider SDKs differ in account stability, multi-user support, restriction evidence,
  and consent flows. Adapters that cannot prove a stable subject must advertise a
  narrower capability instead of synthesizing identity.
- Revocation and account-switch cleanup cross asynchronous callback and durable-intent
  boundaries. The ADR intentionally keeps old provider/module/credential leases alive
  until callback retirement while prohibiting user-data publication.
- Consent receipts and privacy/admin tooling will require later implementation-specific
  retention, audit, and storage hardening under this contract.

## Issue links

- Jira: [HORO-1847](https://horo-engine.atlassian.net/browse/HORO-1847)
- GitHub: Closes #1891
- Domain ticket: `[PLS-006.1]`

## Reviewer Notes

Please focus on the identity-domain boundaries, the exact point at which session and
access generations are invalidated, and whether any user-scoped commit path could
still publish after account switch or consent revocation. The most consequential
choice is that live subject handles never become durable identity: offline/cloud/
progression intent retains only a protected binding partition and must reauthorize
against the same binding before replay.

Also review the Friends and Presence projections for accidental provider-specific or
unbounded personal-data exposure, and the distinction between installed provider
capability and effective per-subject access.

## Stack

- Base branch: `docs/HORO-1846_cloud_blob_transport_revision_contract`
- Previous PR: #2469 (`HORO-1846`, `[PLS-005.1]`)
- This PR must be reviewed and merged after #2469 so the ADR numbering and Platform
  Services architecture projection remain linear.


[HORO-1847]: https://horo-engine.atlassian.net/browse/HORO-1847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ