### PR TITLE
docs(platform): define offline queue ownership HORO-1848 #1892 [PLS-007.1]

### DIFF
--- a/docs/adr/136-platform-offline-queue-ownership-replay-and-cloud-intent-boundary.md
+++ b/docs/adr/136-platform-offline-queue-ownership-replay-and-cloud-intent-boundary.md
@@ -1,0 +1,469 @@
+# ADR-136: Platform Offline Queue Ownership, Replay and Cloud Intent Boundary
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Platform offline intent ownership, durable admission, ordering, coalescing, retry/reconciliation, expiry, per-subject partitioning, shutdown, and the caller-owned cloud intent boundary
+- **Issue**: [PLS-007.1](https://github.com/abdullahbodur/horo-engine/issues/1892)
+- **Jira**: [HORO-1848](https://horo-engine.atlassian.net/browse/HORO-1848)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-010](010-job-waiting-and-operation-store-ownership.md), [ADR-113](113-local-storage-user-profile-and-slot-ownership.md), [ADR-115](115-cloud-save-authority-revision-and-conflict-policy.md), [ADR-130](130-platform-services-frontend-request-lifetime-timeout-null-and-error-semantics.md), [ADR-131](131-platform-services-closed-sdk-extension-abi-package-and-composition-boundary.md), [ADR-132](132-platform-services-project-salt-stable-id-tombstone-and-provider-mapping.md), [ADR-133](133-platform-progression-authority-trust-and-idempotency.md), [ADR-134](134-cloud-blob-transport-revision-precondition-and-offline-ownership.md), [ADR-135](135-platform-identity-session-generation-privacy-and-consent.md)
+- **Normative documents**: [Platform Services Architecture](../architecture/runtime/platform-services-architecture.md), [Save Game and Persistence](../architecture/runtime/save-game-and-persistence.md), [Observability Logging](../architecture/observability/observability-logging.md)
+
+## Context
+
+Platform Services needs to preserve selected progression and presence intent while a
+provider is offline, rate limited or temporarily unavailable. The existing architecture
+identifies replay-safe progression algebra and reserves cloud upload/delete durability
+for Save, but does not yet define the generic queue's durable acceptance boundary,
+state machine, ordering, expiry, account partitioning or shutdown behavior.
+
+Without one owner, a progression coordinator, frontend and provider adapter could each
+persist the same mutation and replay it independently. Conversely, accepting an intent
+before its queue record is durable creates an unreported crash-loss window. Removing a
+record immediately after a provider callback creates the opposite ambiguity: the
+remote effect may be committed while local completion was not durable.
+
+Cloud synchronization has a different semantic owner. Save must retain archive bytes,
+slot lineage, expected provider revision, conflict state and local publication leases.
+Putting the same upload/delete in a generic FIFO would lose those invariants and could
+publish an old generation after a newer local save or account switch.
+
+This ADR assigns one durable owner per operation class and defines replay guarantees
+and visible data-loss boundaries. PLS-007.2 will specify the physical queue schema and
+atomic storage implementation; PLS-007.3 will implement mutation-ID allocation and
+in-flight deduplication without changing the ownership decided here.
+
+## Decision
+
+### 1. Every durable intent has exactly one owner
+
+| Operation class | Durable owner | Deliberate non-owner |
+|---|---|---|
+| Eligible achievement/stat/leaderboard logical mutation | Platform Services `PlatformOfflineQueue` | Gameplay, progression coordinator, frontend request store and provider adapter keep no second durable replay record |
+| Opted-in presence desired state | `PlatformOfflineQueue`, as one expiring per-subject desired-state lane | UI, presence frontend and provider adapter do not persist a second copy |
+| Cloud upload/delete and remote ambiguity | Save-owned `CloudSaveCoordinator` journal under ADR-115/134 | `PlatformOfflineQueue` never admits cloud mutation or archive bytes |
+| Reads and queries, including cloud/friends/progression reads | No durable owner | They may receive bounded in-memory retry only |
+| Provider-native request/callback | No Horo durable owner | ADR-130 frontend and provider package retain it only in memory through retirement |
+
+The queue is hosted by Platform Services but stores service-owned logical intent, not
+serialized public API calls or provider requests. The progression coordinator remains
+the semantic authority for mutation algebra and logical outcome; the queue is its only
+durable persistence/scheduling implementation. Presence policy owns desired-state
+meaning; the same queue is its only optional durable store.
+
+A component may retain an in-memory handle, cache or observer projection, but cannot
+also journal a replayable copy. Sharing an atomic-file helper, retry calculator,
+clock abstraction or transport adapter does not transfer ownership. Shared helpers are
+stateless or operate on caller-owned storage and never discover or schedule records.
+
+### 2. Durability is an explicit admission mode and receipt
+
+Producers choose one declared delivery mode before the first provider attempt:
+
+```cpp
+enum class PlatformDeliveryMode : std::uint8_t {
+    VolatileAttempt,
+    DurableUntilTerminal,
+};
+
+enum class OfflineAdmissionState : std::uint8_t {
+    NotQueued,
+    DurableAccepted,
+    JoinedExisting,
+    Rejected,
+};
+```
+
+`VolatileAttempt` uses ADR-130 in-memory request/retry only. Process exit, crash or
+frontend shutdown may lose it, and no API/UI may label it queued or guaranteed.
+
+`DurableUntilTerminal` first validates replay eligibility and atomically publishes the
+queue record through the qualified durable storage adapter. Only after required file/
+directory synchronization succeeds may it return `DurableAccepted` and schedule a
+provider request. Storage failure, capacity exhaustion or unknown publication outcome
+returns a typed admission failure and creates no provider attempt until storage truth
+is reconciled. This write-before-submit rule closes the unreported crash window.
+
+An exact duplicate canonical logical identity returns `JoinedExisting` and observes
+the same durable outcome. A different payload reusing that identity fails conflict.
+Dropping a receipt, closing UI or cancelling an ADR-130 attempt does not erase the
+durable intent.
+
+`DurableAccepted` promises only that Horo will retain and reconsider the exact intent
+until a durable terminal disposition. It is not remote success, infinite retention,
+availability, provider support or guaranteed eventual delivery.
+
+### 3. Queue records contain canonical Horo intent, never live/native identity
+
+The logical record contains a bounded versioned envelope equivalent to:
+
+```cpp
+struct PlatformOfflineIntent {
+    PlatformOfflineIntentId identity;
+    OfflineSubjectPartition partition;
+    PlatformOfflineOperation operation;
+    CanonicalOfflinePayload payload;
+    PlatformStableRegistryFingerprint registry;
+    ProgressionPolicyRevision progressionPolicy;
+    PlatformConsentRequirements accessRequirements;
+    PlatformReplayRequirements replayRequirements;
+    OfflineOrderingKey ordering;
+    OfflineExpiryPolicy expiry;
+    OfflineAttemptPolicy attempts;
+};
+```
+
+For progression, `identity` is the existing ADR-133 `ProgressionMutationId` and the
+payload is the exact accepted mutation envelope. Presence uses a nonzero
+`PresenceIntentId`, exact typed ADR-132 status/art IDs, bounded detail, desired
+`Set`/`Clear` state and consent/retention policy. Queue insertion never allocates a new
+progression mutation ID or changes a value/precondition.
+
+`OfflineSubjectPartition` is a protected pseudonymous same-binding partition from
+ADR-135. It is not a live `PlatformSubjectHandle`, raw provider account ID, display
+name or provider request token. The record carries requirements needed to obtain a new
+current subject capability and reauthorize later; it does not serialize credentials,
+native objects, callbacks, archive bytes or unrestricted errors.
+
+Records are provider-neutral. Provider mapping/capability generations are captured as
+requirements/evidence, not native API payloads. Replay remaps the same Horo stable IDs
+only after the current ADR-132 registry fingerprint and selected provider mapping are
+proved compatible. A stale/unknown/tombstoned mapping blocks rather than rewriting the
+durable envelope.
+
+### 4. Replay eligibility is exhaustive by operation class
+
+| Operation | Durable queue policy |
+|---|---|
+| `UnlockOnce` | Eligible only with qualified intrinsic repeated-unlock semantics |
+| `SetProgressMaximum`, `SetStatMaximum`, `SetStatMinimum` | Eligible only with matching atomic monotonic provider/gateway semantics |
+| `SubmitBestScore` | Eligible only with provider/gateway atomic best-score comparison using the registered ordering |
+| `SetStatSnapshot`, `ReplaceScoreAtRevision` | Eligible with the exact conditional revision; precondition failure enters reconciliation, never unconditional retry |
+| `AddStatOnce` or another non-intrinsic effect | Eligible only with durable provider/gateway deduplication of the original mutation ID |
+| Presence `Set`/`Clear` desired state | Optionally eligible as one coalesced, expiring state lane when product purpose/retention consent and provider support permit |
+| Progression, friends or cloud read/query | Never durable; stale reads are not future write intent |
+| Cloud upload/delete | Never admitted; Save's coordinator journal owns it |
+
+ADR-133 mutation algebra and qualified effective provider/gateway capability are the
+authorities for progression eligibility. This queue cannot make an unsafe operation
+safe, emulate atomicity with read-then-write or treat a locally persisted ID as remote
+deduplication.
+
+Presence durability is disabled by default. Enabling it requires an explicit
+`PresencePublish` purpose, persistence/retention policy and current consent. It stores
+only the latest desired state for that subject/policy lane and has a finite short
+expiry. It is not presence history and cannot republish user text after consent,
+session or product relevance expires.
+
+### 5. One durable state machine survives every crash boundary
+
+Queue state is exhaustive:
+
+```cpp
+enum class OfflineIntentState : std::uint8_t {
+    Pending,
+    Dispatching,
+    Reconciling,
+    Suspended,
+    Succeeded,
+    PermanentlyFailed,
+    Expired,
+    Superseded,
+    Abandoned,
+};
+```
+
+Only the queue storage transaction changes durable state. The ADR-130 request is an
+in-memory attempt projection and cannot delete/change the row directly.
+
+1. Admission durably writes `Pending` before any provider submit.
+2. Scheduling captures a fresh subject/access/provider/policy snapshot and records the
+   attempt generation before creating an ADR-130 request.
+3. Known pre-commit transient failure returns to `Pending` with bounded backoff.
+4. A possibly committed outcome becomes `Reconciling`; it never returns to a naïve
+   “not attempted” state.
+5. Confirmed remote success or a permanent/expired/superseded/abandoned disposition is
+   committed durably before the live receipt reports terminal.
+6. Checkpoint/compaction may later remove terminal rows only after required producer
+   redelivery/deduplication retention and atomic checkpoint publication.
+
+A crash before Step 1 produced no durable acceptance and no provider call. A crash
+after Step 1 but before submit replays the pending record. A crash after remote commit
+but before local terminal commit leaves the record eligible only for its declared
+same-ID retry/reconciliation rule. A crash after durable terminal commit cannot replay
+the effect even if physical compaction did not finish.
+
+Corrupt, truncated, incompatible or publication-unknown queue storage is quarantined
+and fails closed. Horo does not discard it, recreate an empty queue or report pending
+work as success. Recovery exposes a bounded diagnostic and requires schema recovery or
+explicit operator/product disposition.
+
+### 6. Ordering is per subject and semantic lane, never global FIFO
+
+There is no cross-subject or global provider completion order. Each record belongs to
+one partition and `OfflineOrderingKey`:
+
+- progression lanes use `(subject partition, definition ID, policy generation)`;
+- presence uses `(subject partition, presence purpose/policy generation)`; and
+- unrelated lanes may schedule concurrently within provider/service budgets.
+
+Conditional progression operations serialize within their lane and reconcile the
+exact expected revision before a successor can dispatch. Non-commutative operations
+cannot overtake. Intrinsic monotonic/best operations may coalesce according to ADR-133
+only when every individual mutation retains an outcome and the aggregate is
+mathematically result preserving for every arrival order.
+
+Presence is latest desired state, not an event log. A later `Set` replaces an older
+unsent `Set`; `Clear` supersedes prior unsent publication; a later `Set` after `Clear`
+is a new desired state. Coalescing is allowed only inside the exact subject/purpose/
+access-policy lane. Once remote outcome is ambiguous, replacement cannot erase the
+record until reconciliation establishes what was published.
+
+Fair scheduling uses bounded per-partition and per-service concurrency plus a stable
+round-robin/priority policy. One noisy account/definition cannot starve another. Queue
+sequence proves only local lane order; it is not provider time, gameplay authority or
+remote revision.
+
+### 7. Replay always reauthorizes current capability and the same binding
+
+Startup opens and validates queue storage without a provider call. Records remain
+`Suspended` until the matching protected subject binding is active. Replay admission
+then revalidates:
+
+- exact same ADR-135 subject-binding partition and a new live subject handle;
+- current session and `PlatformAccessPolicyRevision` with required purpose granted;
+- product/profile/authority and ADR-132 registry/policy compatibility;
+- selected provider mapping and effective operation capability; and
+- payload lease/bounds, expiry, attempt budget and prior ambiguity state.
+
+Sign-out/account switch first closes scheduling and invalidates the captured session.
+The old partition remains suspended and cannot target the new current account.
+Same-account reauthentication may resume only after binding proof and full
+reauthorization. Consent revocation prevents dispatch/publication and applies the
+service's retention/deletion policy; UI or debug tooling cannot resume it.
+
+An `AuthorityServer` progression record is replayed only by a currently qualified
+server authority/gateway with valid retained authority evidence. An offline client
+cannot queue or later upgrade a locally manufactured server mutation.
+
+### 8. Retry, backoff, expiry and capacity are bounded policy
+
+Retry is driven by normalized provider state and engine scheduling events, not a busy
+poll. Each record has finite attempt/backoff and expiry policy captured at admission.
+Transient offline/network failure and a bounded `RateLimited` delay may reschedule;
+forbidden, authority/access mismatch, invalid/tombstoned definition, unsupported
+semantics, conflicting identity/payload and permanent provider failure do not.
+
+Backoff uses jittered monotonic scheduling within a process. Durable checkpoints store
+bounded next-eligible/attempt evidence; after restart, clock rollback or unavailable
+trusted time never extends retention indefinitely or causes an immediate retry storm.
+Provider retry hints are validated and clamped to product hard limits.
+
+Expiry is an explicit terminal outcome, evaluated before every dispatch and after
+recovery. Progression and presence have separately configured finite maximum ages;
+presence is always shorter-lived. Expired work is durably marked `Expired`, observers
+are notified and the semantic owner decides any user-visible remediation. The queue
+never silently drops oldest records, resets expiry after retry/restart or reports
+expiry as remote success.
+
+Expiry applies only while the queue can prove no unresolved remote effect. A
+`Reconciling` record does not become `Expired` when its ordinary delivery TTL elapses;
+it remains retained until semantic reconciliation or an explicitly authorized,
+audited `Abandoned` disposition. Attempt exhaustion follows the same rule: known
+pre-commit failure may become `PermanentlyFailed`, while remote ambiguity cannot.
+
+Record count, per-record bytes, total bytes, per-partition count, in-flight attempts
+and terminal-retention storage are finite checked limits declared by the product
+profile within engine hard maxima. Capacity may be recovered only by legal semantic
+coalescing or terminal compaction. A full queue rejects new durable admission; it does
+not evict another subject, cloud journal, ambiguous record or oldest mutation.
+
+### 9. Remote ambiguity retains the original identity and strategy
+
+Timeout, cancellation, transport loss or provider shutdown after submission may leave
+remote outcome unknown. The ADR-130 request keeps its terminal state, while the queue
+durably records `Reconciling` for the logical intent.
+
+- intrinsic/deduplicated operations may resubmit the exact same identity/envelope;
+- conditional operations query/reconcile the exact target/revision and retry only the
+  still-valid precondition;
+- unsafe non-deduplicated operations stop automatic dispatch and require explicit
+  semantic reconciliation; and
+- late provider evidence may inform reconciliation but cannot rewrite the original
+  request result or bypass current session/access checks.
+
+The queue never allocates a replacement mutation ID, changes provider target/payload,
+marks ambiguity as failure eligible for a fresh attempt or lets compaction erase it.
+
+### 10. Cloud intent remains fully caller-owned
+
+`CloudSaveCoordinator` alone persists cloud upload/delete. Its ADR-115/134 journal
+retains local slot generation and parent, archive hash/digest/size, immutable payload
+lease, exact object key and provider precondition, `CloudMutationId`, subject binding,
+supersession/conflict/recovery state and outcome ambiguity.
+
+Platform Services receives one caller-owned immutable request/lease and owns only the
+ADR-130 in-memory attempt/native lifetime. It may use the same stateless backoff,
+deadline, jitter, error-normalization and transport helpers as the offline queue, but
+those helpers neither persist nor schedule cloud work. The coordinator decides when
+to reconcile/resubmit after request terminal state.
+
+No API converts cloud intent into `PlatformOfflineIntent`; no queue row references or
+copies an archive; and no Project Settings “persist offline queue” switch controls
+cloud durability. A startup/reconnect service may wake both owners, but each opens and
+reconciles its own state. Cross-owner ordering is expressed by typed coordinator
+dependencies, never by inserting cloud work into a shared FIFO.
+
+### 11. Cancellation, shutdown and deletion preserve truth
+
+Producer cancellation may durably remove/supersede a `Pending` intent only when the
+semantic owner proves no provider attempt crossed its commit boundary. Once dispatch
+or ambiguity exists, cancellation stops new attempts but retains reconciliation; it
+cannot claim remote rollback. Presence desired-state supersession follows Section 6.
+
+Shutdown proceeds in bounded phases:
+
+1. close queue admission and scheduling;
+2. persist current state/attempt evidence and detach deferred observers;
+3. request best-effort cancellation of in-memory provider work;
+4. retain queue storage, provider/module/credential leases and completion sinks until
+   possible callbacks retire under ADR-130/131; and
+5. publish a typed shutdown result without deleting unresolved records.
+
+Failure to durably checkpoint is a visible shutdown/storage failure. Forced process
+termination may interrupt cleanup but the last atomically published state remains the
+recovery authority. Startup never interprets an unclean marker as permission to clear
+the queue.
+
+Explicit user/admin deletion is a separate permissioned semantic operation. It shows
+counts/classes, cannot target another subject through display name, refuses ambiguous
+remote work unless policy records an acknowledged abandonment, and writes an audited
+`Abandoned` terminal disposition before compaction. Ordinary cache cleanup cannot
+erase intent.
+
+### 12. Outcomes, diagnostics and privacy are bounded
+
+Stable results include:
+
+```text
+platform.offline.ineligible
+platform.offline.durable_unavailable
+platform.offline.capacity_exceeded
+platform.offline.storage_unknown
+platform.offline.identity_conflict
+platform.offline.suspended
+platform.offline.expired
+platform.offline.permanently_failed
+platform.offline.reconciliation_required
+platform.offline.abandoned
+platform.offline.corrupt
+```
+
+Snapshots expose aggregate counts/bytes by service and safe state, oldest bounded age,
+next eligible delay, capacity pressure, and normalized last failure. Metrics have no
+subject, mutation, stable-definition, display or provider-native identity dimensions.
+Logs exclude payload/presence text, raw account/handle values, credentials and private
+binding locators. Safe correlation uses short-lived non-account-derived IDs.
+
+Diagnostics distinguish `Pending`, `Suspended`, `Reconciling`, `Expired` and permanent
+failure. “Queued” is never shown as success. Presence content requires the same
+purpose/consent as publication and is redacted from ordinary diagnostics. Cloud queue
+depth is reported from the Save coordinator separately, never added to the Platform
+Offline Queue count.
+
+### 13. Qualification covers storage, replay and owner boundaries
+
+Required Mock/Null, fault-injection and integration evidence includes:
+
+- ownership inventory proving every supported operation has exactly one or no durable
+  owner and cloud upload/delete can never enter the platform queue;
+- crash at every durable admission/attempt/terminal/checkpoint boundary, including
+  remote commit before local completion, with no false success or duplicate unsafe
+  effect;
+- all ADR-133 operation classes against provider variants with intrinsic semantics,
+  conditional revisions, durable dedupe and no safe primitive;
+- exact duplicate join, conflicting identity/payload rejection, mutation identity
+  preservation and individual outcomes after legal coalescing;
+- per-lane ordering, conditional serialization, cross-lane concurrency, partition
+  fairness and presence Set/Clear supersession permutations;
+- offline/reconnect/rate-limit/backoff/clock-skew/expiry/attempt exhaustion without
+  spin, retry storm, TTL reset or silent eviction;
+- queue record/count/partition/byte/in-flight hard limits, disk-full, permission,
+  sync/rename-unknown, corrupt/truncated/version-skewed storage and atomic recovery;
+- Alice-to-Bob switch, sign-out, same-binding reauthentication, consent revocation,
+  provider/mapping/policy replacement and stale callback evidence with no cross-subject
+  dispatch/publication;
+- AuthorityServer records never admitted/replayed by a client or stale world authority;
+- cancellation before submit, during dispatch and after ambiguous commit plus bounded
+  repeated/partial shutdown and late provider callback retirement;
+- privacy/redaction/cardinality checks for records, logs, metrics, crash bundles,
+  diagnostics and admin deletion; and
+- concurrent Save cloud journal and Platform Offline Queue recovery proving shared
+  helpers create no shared storage, scheduler, outcome or cross-owner FIFO.
+
+## Consequences
+
+- Eligible progression and opted-in presence have one durable queue with explicit
+  acceptance, terminal and crash-recovery semantics.
+- No operation can be replayed independently by multiple Horo queues, and cloud
+  lineage/conflict intent remains entirely with Save.
+- Durable acceptance is stronger than an in-memory request but intentionally weaker
+  than remote success or infinite delivery; expiry/capacity/storage failure is visible.
+- Account switch and consent changes suspend or terminate the old partition instead of
+  retargeting whichever user is current.
+- Providers with insufficient idempotency/atomicity expose narrower replay capability;
+  persistence cannot manufacture remote safety.
+- Implementation requires qualified atomic storage, finite scheduling, recovery,
+  compaction, privacy-safe diagnostics and fault-injection coverage.
+
+## Rejected Alternatives
+
+### Persist every failed `PlatformRequest`
+
+Rejected because requests contain attempt/provider/session lifetime and may represent
+reads or unsafe mutations. The queue stores only qualified logical intent.
+
+### Queue only after the first offline failure
+
+Rejected for `DurableUntilTerminal` because a process may crash between remote submit
+and persistence. Durable mode commits the record before the first attempt.
+
+### Let each service keep its own durable retry file
+
+Rejected because duplicate schedulers can replay one mutation more than once and make
+capacity, shutdown, account partitioning and diagnostics inconsistent.
+
+### Put cloud upload/delete into the generic queue
+
+Rejected because a generic row cannot own slot lineage, archive lease, revision CAS,
+conflict preservation or local publication. Save already owns the complete intent.
+
+### Use one global FIFO across all subjects and services
+
+Rejected because independent work would block, a noisy lane could starve others and
+FIFO order is not semantic order for monotonic/coalescible operations.
+
+### Replay against whichever account is currently signed in
+
+Rejected because old-session work would mutate another user. Records are partitioned
+by protected binding and reauthorized only for that same binding.
+
+### Drop the oldest record when capacity is full
+
+Rejected because age is not semantic priority and remote ambiguity or an achievement
+could be silently lost. Admission fails unless legal coalescing frees capacity.
+
+### Treat durable acceptance or queue expiry as remote success
+
+Rejected because local persistence does not prove provider commit, while expiry is an
+explicit delivery failure requiring a terminal outcome.
+
+### Delete a record immediately after a provider callback
+
+Rejected because a crash may lose local completion truth and later re-admit/replay the
+same intent. Terminal disposition is durable before compaction.
+
+### Persist presence by default
+
+Rejected because presence can contain personal/user-authored data and quickly becomes
+stale. Durable presence is explicit, consented, bounded and short-lived.

--- a/docs/architecture/observability/observability-logging.md
+++ b/docs/architecture/observability/observability-logging.md
@@ -285,6 +285,13 @@ duration under one operation context. External process, filesystem, network,
 renderer, and serialization boundaries log enough metadata to identify the
 boundary without dumping sensitive or unbounded payloads.
 
+ADR-136 Platform Offline Queue instrumentation distinguishes durable admission,
+pending/dispatching/suspended/reconciling and explicit terminal disposition. It may
+report aggregate counts/bytes, bounded age/delay, capacity pressure and normalized
+failure by service/state. It never labels queued/expired work successful, combines
+Save cloud-journal depth with the Platform queue, or emits subject partitions,
+mutation/definition IDs, payload/presence text, raw provider identity or credentials.
+
 Empty catch blocks and silent fallback paths are not allowed. A fallback that is
 part of normal expected selection may be `Debug`; a fallback caused by a failed
 preferred path is normally `Warn`.
@@ -1312,6 +1319,10 @@ developer's process-global state.
 | Child process context | test executable that prints its received allowlist |
 | Allocation behavior | allocation probe around disabled and enabled calls |
 
+Platform offline tests additionally exercise crash/recovery and terminal checkpoint
+boundaries, queue-versus-Save owner separation, bounded cardinality and redaction of
+every durable state without exposing personal or provider-native identity.
+
 ### C++ Patterns
 
 Compile-time and runtime-disabled calls verify that expensive arguments are not
@@ -1435,3 +1446,4 @@ Release packages are smoke-tested for:
 - [Quality And CI](../delivery/quality-and-ci.md): gates and retained CI artifacts.
 - [Release Architecture](../release/release.md): job-specific logs.
 - [Release Security](../release/release-security.md): secrets, privacy, and redaction.
+- [ADR-136](../../adr/136-platform-offline-queue-ownership-replay-and-cloud-intent-boundary.md): offline durability states, owner separation and privacy-safe diagnostics.

--- a/docs/architecture/runtime/platform-services-architecture.md
+++ b/docs/architecture/runtime/platform-services-architecture.md
@@ -45,6 +45,11 @@ separates provider account, live subject capability, local profile, gameplay ide
 and presentation data; every user-scoped commit is fenced by session/access generation
 and every consent/restriction decision is enforced by a typed capability snapshot.
 
+[ADR-136](../../adr/136-platform-offline-queue-ownership-replay-and-cloud-intent-boundary.md)
+makes the Platform Offline Queue the single durable owner for eligible progression and
+opted-in expiring presence intent. Durable acceptance precedes provider submission,
+while cloud upload/delete remains exclusively in Save's coordinator journal.
+
 ## Scope
 
 Platform services covered here:
@@ -366,6 +371,13 @@ platform.provider.failed            -- admitted provider operation failed
 platform.progression.authority_denied -- fact lacks the definition's required authority
 platform.progression.idempotency_conflict -- mutation ID reused with another envelope
 platform.progression.unsafe_retry   -- algebra/provider cannot safely retry ambiguity
+platform.offline.ineligible         -- operation/provider semantics prohibit durability
+platform.offline.durable_unavailable -- queue storage cannot provide durable acceptance
+platform.offline.capacity_exceeded  -- finite queue/partition/byte budget exhausted
+platform.offline.storage_unknown    -- queue publication outcome requires recovery
+platform.offline.expired            -- finite replay age ended without remote success
+platform.offline.reconciliation_required -- remote outcome cannot safely auto-retry
+platform.offline.abandoned          -- authorized audited stop with no false rollback
 ```
 
 `platform.provider.failed` carries one normalized category: `Offline`, `NotSignedIn`,
@@ -840,49 +852,69 @@ generation/revision; stale completion evidence cannot publish into the replaceme
 
 ## Offline And Degraded Behavior
 
-PLS-007 owns the generic durable queue mechanics. It may admit only ADR-133 logical
-mutation envelopes whose algebra and effective provider/gateway capability make replay
-safe:
+The ADR-136 `PlatformOfflineQueue` is the only durable owner for replay-eligible
+progression and explicitly opted-in presence desired state. It stores canonical Horo
+logical intent, not ADR-130 requests or provider calls. `DurableUntilTerminal` commits
+the bounded record through qualified atomic storage before the first provider submit;
+only then may the producer observe durable acceptance. `VolatileAttempt` is explicitly
+process-lossy and never presented as queued.
 
-- qualified `UnlockOnce` and atomic `SetProgressMaximum`;
-- atomic `SetStatMaximum` / `SetStatMinimum`;
-- conditional stat/score replacement retaining its exact revision; and
-- `AddStatOnce` or other non-intrinsic effects only with durable provider/gateway
-  mutation-ID deduplication.
+Eligibility remains exhaustive:
 
-The progression coordinator allocates the mutation ID when the correct semantic
-authority accepts the fact, before the first provider attempt. The queue preserves the
-exact ID, payload, subject, authority/policy/registry and provider requirements across
-restart. It never allocates an ID during replay, retargets another account/session or
-turns an ambiguous unsafe attempt into “not attempted.”
+- ADR-133 intrinsic/atomic monotonic/best operations may persist only when the current
+  provider/gateway capability proves their exact semantics;
+- conditional stat/score replacement retains and reconciles its exact revision;
+- `AddStatOnce` or another non-intrinsic effect requires durable provider/gateway
+  mutation-ID deduplication;
+- presence may persist only as one consented, bounded and short-expiry latest desired
+  `Set`/`Clear` state per subject/purpose lane; and
+- reads, queries and cloud mutation are never admitted.
 
-When the backend reports normalized `Offline` or `NotSignedIn`, the frontend:
+The queue preserves the original progression mutation or presence intent identity,
+canonical payload, protected ADR-135 subject-binding partition, registry/policy/access
+requirements, expiry and attempt policy. It never allocates identity on replay,
+contains a live subject handle/raw provider identity or retargets the current account.
+Exact duplicates join one row; different payload reuse is a conflict.
 
-1. returns the ADR-130 typed attempt outcome to the progression coordinator;
-2. lets the single PLS-007 owner validate replay eligibility and persist the existing
-   logical envelope;
-3. joins an exact duplicate mutation ID or rejects a conflicting payload;
-4. keeps subject/session and authority generations partitioned; and
-5. schedules a new bounded request only after recovery/reconciliation and capability
-   revalidation.
+Durable states distinguish Pending, Dispatching, Reconciling, Suspended, Succeeded,
+PermanentlyFailed, Expired, Superseded and Abandoned. Terminal disposition is committed
+before observer success and later atomic compaction. A crash after remote commit but
+before local completion therefore retains the original intent in Reconciling rather
+than creating a fresh unsafe attempt. Corrupt/publication-unknown storage is
+quarantined; startup never silently creates an empty queue.
 
-Operations that cannot be safely replayed, such as cloud save reads or
-leaderboard/stat/achievement queries, are never durable progression intents. An
-AuthorityServer definition does not let an offline client manufacture a queued remote
-mutation; the server must later derive/accept the gameplay fact through its ordinary
-authority path.
+Ordering is per `(subject partition, semantic definition/purpose lane)`, not global
+FIFO. Conditional/non-commutative work serializes; ADR-133 monotonic/best operations
+coalesce only when every receipt/result is preserved. Presence keeps the latest desired
+state, but cannot erase an already ambiguous provider outcome. Unrelated lanes use
+bounded fair concurrency.
 
-Cloud archive writes/deletes are deliberately absent from this generic queue. Their
-immutable payload lease, slot lineage, expected provider revision, retry identity and
-profile-session scope are durably owned by ADR-115's `CloudSaveCoordinator`. After
-offline recovery it reconciles remote state before conditional mutation; it never
-replays a stale FIFO upload under a later local generation or different user.
+Startup validates storage without provider calls. Replay resumes only after proving
+the same subject binding and revalidating current session/access, authority/profile,
+registry/mapping and provider capability. Sign-out/account switch suspends the old
+partition. `AuthorityServer` records require a current server authority path; a client
+cannot manufacture or upgrade them.
 
-Detailed queue ordering, expiry, compaction, retention and shutdown are PLS-007 policy.
-Those mechanics cannot broaden the replay classes above. `Forbidden`, authority/
-subject mismatch, unsupported capability and permanent semantic failure never retry.
-A remote ambiguous outcome remains retained for reconciliation according to its
-algebra; it is not dropped as a generic failure or reported as success.
+Attempt count, jittered backoff, record/byte/partition/in-flight capacity and expiry
+are finite product policy within engine hard maxima. Expiry is a durable explicit
+failure and never resets on retry/restart. Full capacity rejects admission instead of
+dropping oldest or ambiguous work. Provider retry hints are bounded and clock anomalies
+cannot extend retention indefinitely or produce a retry storm.
+
+Expiry/attempt exhaustion applies only when no unresolved remote effect exists.
+Reconciling ambiguity remains retained until semantic resolution or an explicitly
+permissioned, audited Abandoned disposition; neither TTL nor cleanup can erase it.
+
+Cloud archive writes/deletes are deliberately absent. Their immutable payload lease,
+slot lineage, expected provider revision, retry identity and profile binding remain
+durably owned only by ADR-115/134 `CloudSaveCoordinator`. Both owners may use stateless
+deadline/backoff/error/atomic-storage helpers, but share no row, scheduler, outcome or
+FIFO. Reconnect may wake both coordinators independently.
+
+Shutdown closes admission/scheduling, durably checkpoints state, requests bounded
+best-effort cancellation and retains provider/module/credential dependencies until
+callbacks retire. It never deletes unresolved rows. Cancellation may remove a Pending
+intent only before provider commit is possible; ambiguity remains for reconciliation.
 
 The Null backend is a valid explicit headless/test/product composition. It reports all
 remote services unavailable with `NullProviderSelected`. Every read and write fails
@@ -1087,7 +1119,9 @@ platform.request.pending_count           -- in-flight requests
 platform.request.completed_count         -- completed by service and backend
 platform.request.failed_count            -- by error category
 platform.request.latency_ms              -- end-to-end latency
-platform.request.offline_queued_count    -- operations deferred offline
+platform.offline.pending                 -- aggregate pending by service/state
+platform.offline.reconciling             -- aggregate remote-ambiguity count
+platform.offline.storage_bytes           -- bounded queue storage utilization
 platform.session.signed_in               -- 0/1 gauge
 platform.capability.available            -- gauge per service per backend
 ```
@@ -1127,8 +1161,12 @@ Access: `Edit > Project Settings > Platform Services`
 |   [+ Add]                                                    |
 |                                                              |
 | Cloud Save                                                   |
-|   Conflict resolution: [ Most Recent               v ]       |
-|   [x] Persist offline queue across sessions                  |
+|   Conflict policy: [ Defer to Save Coordinator      v ]      |
+|                                                              |
+| Offline Delivery                                             |
+|   [x] Eligible progression durable delivery                  |
+|   [ ] Persist consented presence desired state               |
+|   Progression expiry: [ 7 days ]  Presence: [ 15 minutes ]  |
 |                                                              |
 | Timeouts And Retry                                           |
 |   Default timeout:  [ 30 ] seconds                           |
@@ -1144,8 +1182,8 @@ Access: `Window > Platform Diagnostics`
 +--------------------------------------------------------------+
 | Platform Diagnostics                                   [x]   |
 +--------------------------------------------------------------+
-| Session: Signed In                                           |
-| User:    PlayerOne#1234                                      |
+| Session: Active          Generation: 17                      |
+| Subject: Bound           Presentation: Consent granted       |
 | Backend: SteamBackend                                        |
 +--------------------------------------------------------------+
 | Service        | Available | Pending | Errors | Avg Latency |
@@ -1156,7 +1194,8 @@ Access: `Window > Platform Diagnostics`
 | Presence       |    [ ]    |    0    |   0  |      -      |
 | Friends        |    [x]    |    0    |   0  |    30 ms    |
 +--------------------------------------------------------------+
-| Offline Queue: 2 pending  |  Oldest: 4m 12s                |
+| Platform Queue: 2 pending | Reconciling: 0 | Oldest: 4m 12s |
+| Save Cloud Journal: 1 pending | Conflict: 0                  |
 +--------------------------------------------------------------+
 ```
 
@@ -1237,7 +1276,18 @@ Required tests cover:
   ambiguity reconciles without a second remote effect
 - max/min/best coalescing is result-preserving under every input order and retains an
   outcome for each logical receipt; conditional/additive operations never coalesce
-- offline queue persists and replays only eligible mutation classes
+- durable mode commits one queue row before first provider submit; volatile mode is
+  never reported as queued, and duplicate admission joins only an exact envelope
+- every ADR-133 replay class is accepted/rejected against qualified provider semantics;
+  cloud writes/deletes and all reads/queries can never enter the platform queue
+- crash/fault injection at queue admission, provider submit/commit, terminal commit and
+  compaction preserves the original intent/ambiguity without false success
+- per-subject/semantic-lane ordering, fair cross-lane scheduling and legal coalescing
+  retain every logical receipt; capacity exhaustion never evicts oldest/ambiguous work
+- backoff, rate limit, expiry, clock skew, attempt and storage limits are bounded;
+  expiry is a durable terminal failure and never resets across restart
+- presence persistence is opt-in/consented/short-lived, coalesces Set/Clear desired
+  state only within one exact lane and never becomes history
 - request cancellation does not leak state
 - stable ID registries reject unregistered names
 - stable ID golden vectors agree across hosts; malformed salts/encodings, stored/
@@ -1314,6 +1364,10 @@ Tests use the mock backend to verify:
   committed-after-timeout scripts with exact caller-owned reconciliation evidence
 - authentication-stage failure, account-switch/stale-callback and consent-revocation
   scripts with no cross-subject cache, observer or durable-replay publication
+- queue storage disk-full, permission, truncated/corrupt/version-skewed and publication-
+  unknown scripts plus repeated/partial shutdown and late callback retirement
+- concurrent Platform Offline Queue and Save cloud-journal recovery proves there is no
+  shared durable row, scheduler, outcome or cross-owner FIFO
 
 Platform-specific backend tests live in the private platform repositories.
 
@@ -1335,6 +1389,9 @@ Platform-specific backend tests live in the private platform repositories.
 - [ADR-135](../../adr/135-platform-identity-session-generation-privacy-and-consent.md):
   platform identity-domain separation, generation-fenced subject capabilities,
   consent/restriction authority and personal-data handling.
+- [ADR-136](../../adr/136-platform-offline-queue-ownership-replay-and-cloud-intent-boundary.md):
+  single-owner offline durability, admission/replay/expiry/shutdown semantics and the
+  Save-owned cloud intent boundary.
 - [Platform Services Config UI Reference](./platform-services-config.html): achievements, leaderboards, cloud saves, presence, and platform adapters panel.
 
 - [Audio Architecture](./audio-architecture.md)

--- a/docs/architecture/runtime/save-game-and-persistence.md
+++ b/docs/architecture/runtime/save-game-and-persistence.md
@@ -939,9 +939,23 @@ timeout and short transfer publish no partial bytes.
 
 The coordinator allocates the durable `CloudMutationId` and retains exact payload
 lease/digest, precondition and reconciliation state in its existing journal. Platform
-Services holds only an in-memory request and the generic offline queue holds no cloud
+Services holds only an in-memory request and the Platform Offline Queue holds no cloud
 upload/delete copy. Quota observations are advisory: transport cannot delete,
 truncate, split or select another local generation when provider capacity changes.
+
+[ADR-136](../../adr/136-platform-offline-queue-ownership-replay-and-cloud-intent-boundary.md)
+makes that exclusion structural: no API converts cloud upload/delete into a Platform
+Offline Queue record, and no “persist offline queue” setting controls Save durability.
+The queue and `CloudSaveCoordinator` may share stateless retry/deadline/error and
+caller-owned atomic-storage helpers, but never a row, scheduler, outcome or cross-owner
+FIFO. Reconnect wakes the owners independently.
+
+The Save journal is durable before the coordinator submits its first automatic remote
+mutation. Confirmed remote completion is journalled before cleanup; a crash after
+provider commit but before local completion therefore re-enters exact-key/revision/hash
+reconciliation with the original `CloudMutationId`. It never becomes a fresh generic
+upload. Shutdown closes scheduling, checkpoints journal state and retains archive/
+provider leases through request retirement without deleting unresolved intent.
 
 On startup/reconnect the coordinator opens local state first, then reconciles verified
 local and remote heads. Same generation/hash is InSync. A known remote ancestor of
@@ -1083,6 +1097,7 @@ and regression coverage.
 - [Concurrency And Jobs](../foundation/concurrency-and-jobs.md): Worker/owner completion ownership.
 - [ADR-010](../../adr/010-job-waiting-and-operation-store-ownership.md): OperationStore and non-blocking work.
 - [ADR-012](../../adr/012-world-streaming-partition-authority-and-subsystem-boundaries.md): Cell authority and barriers.
+- [ADR-136](../../adr/136-platform-offline-queue-ownership-replay-and-cloud-intent-boundary.md): Platform offline queue ownership, replay guarantees and Save-owned cloud intent.
 - [ADR-008](../../adr/008-error-model-exception-boundary-and-registry.md): Typed error propagation.
 - [ADR-112](../../adr/112-save-archive-container-and-compatibility-policy.md): Portable container, canonical state, version axes, identities and compatibility horizon.
 - [ADR-113](../../adr/113-local-storage-user-profile-and-slot-ownership.md): Product/user/profile namespaces, logical slot addressing and physical storage ownership.


### PR DESCRIPTION
## Summary

- Adds ADR-136 to assign one durable owner to every Platform Services operation class
  and define the generic offline queue's admission, replay, expiry, ordering,
  reconciliation, capacity, cancellation, and shutdown contract.
- Makes `PlatformOfflineQueue` the sole durable store/scheduler for replay-eligible
  progression and explicitly opted-in, short-lived presence desired state.
- Keeps cloud upload/delete exclusively in Save's `CloudSaveCoordinator` journal while
  allowing both owners to reuse stateless deadline, backoff, error, and atomic-storage
  helpers.
- Projects the decision into Platform Services, Save Game and Persistence, and
  Observability Logging, including diagnostics/settings examples and qualification
  coverage.

## Why

The architecture already defined which progression mutation algebra can survive an
ambiguous retry and established Save as the authority for cloud lineage/conflicts. It
did not define the generic queue's durable acceptance boundary or prevent the same
logical mutation from being persisted by a coordinator, frontend, and provider
adapter at once.

That gap creates two opposite failure modes: reporting work as queued before its local
record is durable can lose it on crash, while deleting a row immediately after a
provider callback can forget that the remote effect committed before local completion
was persisted. A generic cloud FIFO would also be unable to preserve slot generation,
archive lease, revision CAS, conflict, and supersession invariants.

This decision gives each operation exactly one durable owner and makes every crash,
account switch, consent change, TTL, and remote-ambiguity boundary observable rather
than silently converting it into success, loss, or a fresh unsafe attempt.

## Decision and boundaries

- `DurableUntilTerminal` atomically publishes the canonical queue record before the
  first provider submit. Only successful qualified storage publication returns
  `DurableAccepted`; `VolatileAttempt` remains explicitly process-lossy.
- The queue persists logical Horo intent, not ADR-130 requests or provider calls.
  Progression retains its original `ProgressionMutationId`; presence uses one bounded
  desired-state intent. Live subject handles, raw provider IDs, credentials, callbacks,
  and native payloads are prohibited.
- Replay eligibility is exhaustive by ADR-133 algebra and effective provider/gateway
  capability. Reads/queries and cloud mutations can never enter the platform queue;
  `AddStatOnce` requires real durable remote deduplication.
- Durable states distinguish pending, dispatching, reconciling, suspended, succeeded,
  permanent failure, expiry, supersession, and explicit audited abandonment. Terminal
  disposition is durable before observers report it or compaction removes a row.
- Ordering is per protected subject partition and semantic lane, not one global FIFO.
  Conditional work serializes; monotonic/best progression coalesces only when every
  receipt is preserved; presence is the latest consented short-lived Set/Clear state.
- Startup validates storage before provider access. Replay requires the same protected
  ADR-135 binding and fresh session/access, authority/profile, registry/mapping, and
  provider capability validation. A new current account cannot inherit old work.
- Retry, backoff, expiry, record/byte/partition/in-flight capacity, and terminal
  retention are finite. Full capacity rejects admission; it never evicts the oldest or
  an ambiguous record. TTL/attempt exhaustion cannot erase unresolved remote effects.
- Save's cloud journal remains the only owner of archive generation, payload lease,
  revision precondition, `CloudMutationId`, conflict, supersession, and ambiguity.
  Shared helpers create no shared row, scheduler, outcome, or cross-owner ordering.
- Observability exposes aggregate service/state counts, bounded age/delay, and storage
  pressure while separating Save journal depth and redacting subject/payload/native
  identity.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/136-platform-offline-queue-ownership-replay-and-cloud-intent-boundary.md docs/architecture/runtime/platform-services-architecture.md docs/architecture/runtime/save-game-and-persistence.md docs/architecture/observability/observability-logging.md`
- `git diff --check`
- `git diff --cached --check`
- Staged added-Markdown-link resolution check: passed.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. The existing mbedTLS minimum-version
deprecation warning remains, and repository Python tests were skipped because pytest
is unavailable in this environment.

## Risk and rollout

- This PR defines normative behavior; the physical schema, atomic storage, mutation-ID
  generation, and implementation must land under PLS-007.2/PLS-007.3 without weakening
  write-before-submit or durable-terminal-before-compaction guarantees.
- Providers with weak atomicity/deduplication intentionally expose less replay
  capability. Product configuration cannot turn persistence into safe remote semantics.
- Remote ambiguity may outlive ordinary delivery TTL and consume durable capacity until
  reconciliation or explicit audited abandonment. This is intentional to avoid hiding
  a possibly committed effect, but requires operational diagnostics and tooling.
- Optional durable presence can contain user-authored data; it remains disabled by
  default and requires purpose-specific consent, bounded retention, and redaction.
- Queue recovery and Save cloud-journal recovery may run concurrently. Implementations
  must preserve independent scheduling/outcome authority even when sharing utilities.

## Issue links

- Jira: [HORO-1848](https://horo-engine.atlassian.net/browse/HORO-1848)
- GitHub: Closes #1892
- Domain ticket: `[PLS-007.1]`
- Parent capability: `HORO-1829` / `[PLS-007]`

## Reviewer Notes

Please review the ownership table first: every supported operation should resolve to
exactly one durable owner or explicitly none. In particular, verify that no cloud
upload/delete path can be represented as `PlatformOfflineIntent`, and that sharing
retry/storage helpers cannot acquire persistence or scheduling authority.

The second critical area is crash truth. Durable mode writes before submit; remote
success/permanent disposition is written before terminal observation/compaction; and
an uncertain remote effect remains `Reconciling` with the original identity. Please
look for any transition that could reset ambiguity to Pending, expire it silently, or
allocate a replacement mutation ID.

Finally, check account and policy fencing: replay must prove the same protected binding
and reauthorize current session/access/authority/registry/provider state. “Current
user” alone is deliberately never sufficient.

## Stack

- Base branch: `docs/HORO-1847_platform_identity_session_consent`
- Previous PR: #2470 (`HORO-1847`, `[PLS-006.1]`)
- This PR consumes ADR-135's protected subject partition and session/access fences, so
  it must be reviewed and merged after #2470.


[HORO-1848]: https://horo-engine.atlassian.net/browse/HORO-1848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ