### PR TITLE
docs(terrain): define ownership and lifecycle HORO-1891 #1935 [TRF-001.1]

### DIFF
--- a/docs/adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md
+++ b/docs/adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md
@@ -1,0 +1,539 @@
+# ADR-137: Terrain and Foliage Ownership, Data, Tier and Lifecycle
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Terrain/foliage public and runtime module ownership, data strata, typed identity and revisions, capability tiers, scene/streaming/render/physics/navigation boundaries, mutable state, threading, replacement, cancellation and shutdown
+- **Issue**: [TRF-001.1](https://github.com/abdullahbodur/horo-engine/issues/1935)
+- **Jira**: [HORO-1891](https://horo-engine.atlassian.net/browse/HORO-1891)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-010](010-job-waiting-and-operation-store-ownership.md), [ADR-012](012-world-streaming-partition-authority-and-subsystem-boundaries.md), [ADR-027](027-renderer-resource-identity-and-descriptors.md), [ADR-028](028-renderer-capability-limits-and-product-profiles.md), [ADR-034](034-gpu-memory-and-residency-ownership.md), [ADR-085](085-physics-shape-authoring-cook-and-runtime-boundary.md), [ADR-105](105-navigation-asset-and-scene-ownership-boundary.md), [ADR-108](108-dynamic-overlay-carving-and-tile-rebuild-policy.md)
+- **Normative documents**: [System Design](../architecture/foundation/system-design.md), [Terrain and Foliage Architecture](../architecture/runtime/terrain-and-foliage-architecture.md), [World Streaming Architecture](../architecture/runtime/world-streaming-architecture.md), [Rendering Architecture](../architecture/runtime/rendering-architecture.md), [Physics Architecture](../architecture/runtime/physics-architecture.md), [Navigation and AI Architecture](../architecture/runtime/navigation-and-ai-architecture.md)
+
+## Context
+
+The current Terrain and Foliage architecture describes heightfield vectors, fixed
+component arrays, backend-named tiers, streaming, GPU buffers, collision, navigation,
+runtime spawning and editor tools in one document. It does not establish which target
+owns the public contract or runtime state, which data is authored versus cooked versus
+live, or how a dataset becomes active and retires across dependent subsystems.
+
+That ambiguity invites several unsafe implementations: Scene or gameplay could mutate
+cooked tile memory directly; Terrain could retain native GPU/physics/navigation
+handles; the renderer could become terrain identity authority; workers could publish
+partially prepared tiles; or an API-specific tier name could silently select a lower
+content path. Automatic “furthest” or “oldest” instance deletion on a cap breach would
+also convert capacity pressure into unreported gameplay/editor data loss.
+
+Terrain and foliage span several existing authorities. World Streaming owns cell
+admission and aggregate reservations. Assets/Pipeline own import and cook publication.
+Scene owns scene binding and lifecycle. Render, Physics and Navigation own their
+realized resources. Editor documents own authored mutations. A foundation decision is
+needed so those integrations exchange typed immutable data without making the generic
+Foundation target depend on any of them.
+
+This ADR establishes the module/data/lifecycle baseline. TRF-001.2 will finalize stable
+dataset/tile/type/instance identity derivation. TRF-001.3 will ratify exact v1 numeric
+bounds, tier tables and shared descriptor validation. Later TRF decisions own cooked
+tile/cache/streaming representation, render extraction, foliage state/eviction,
+cross-system readiness and editor tooling without changing the authorities below.
+
+## Decision
+
+### 1. Terrain is a runtime vertical slice, not generic Foundation or a renderer feature
+
+Horo introduces two primary targets:
+
+```text
+HoroEngine::TerrainApi
+HoroEngine::TerrainRuntime
+```
+
+`TerrainApi` owns backend-neutral public values, typed IDs/revisions/handles, immutable
+descriptors and narrow command/query/snapshot interfaces. It depends only on Foundation
+and the narrow Assets identity/contracts its public declarations use. It contains no
+editor, Scene implementation, renderer, physics, navigation, world-streaming, platform
+or native provider type.
+
+`TerrainRuntime` owns live terrain/foliage dataset generations, logical tile/cluster
+state, runtime mutation admission, snapshot publication, internal reservation use and
+coordinated preparation/retirement. It depends on `TerrainApi`, Assets and explicit
+backend-neutral ports needed for host-composed integration. It never selects or creates
+a concrete renderer, physics/navigation provider, filesystem adapter or editor service.
+
+The application/host composition root constructs the runtime with narrow capabilities
+and registers inert metadata before activation. Module descriptors do not scan assets,
+register globals, create jobs/resources or inspect a service locator. Dedicated/headless
+hosts may compose TerrainRuntime without a render integration.
+
+Feature-specific cook, render, physics, navigation, world-streaming and editor adapters
+depend toward the owning public contracts and are composed explicitly. Exact adapter
+target splits may be introduced with the implementation tickets, but cannot reverse a
+dependency into Foundation, Assets, Render, Physics, Navigation or Scene.
+
+### 2. Each lifecycle/data responsibility has one authority
+
+| Responsibility | Authority | Explicit non-authority |
+|---|---|---|
+| Authored terrain source, foliage definitions, paint/sculpt commands and undo | Editor document/application operation | TerrainRuntime and UI never edit document bytes directly |
+| Import, deterministic cook, derived artifacts and atomic publication | Asset Pipeline plus Terrain cooker | Runtime, renderer and editor viewport cannot cook on demand |
+| Stable asset identity and immutable byte leases | Assets | Terrain does not discover files or own package/cache paths |
+| Scene binding, entity lifetime and aggregate scene activation | RuntimeScene | Terrain does not own entity hierarchy or scene transition authority |
+| Live dataset/tile/cluster generations, logical runtime overlays and snapshots | TerrainRuntime | Gameplay, renderer and World Streaming cannot mutate them directly |
+| Cell demand, priority, aggregate CPU/GPU/staging reservation and cell commit barrier | ADR-012 World Streaming authority | Terrain cannot run a second global streaming scheduler or oversubscribe its slice |
+| Terrain/foliage GPU resources, GPU culling, draw execution and deferred GPU retirement | Render frontend/backend under ADR-027/034 | Terrain never exposes or retains native GPU handles/fences |
+| Installed terrain/foliage collision shapes/bodies and physics-thread lifetime | Physics | Terrain supplies typed cooked descriptors and observes readiness only |
+| Installed navigation topology/tiles and query consistency | Navigation | Terrain/hole tools cannot mutate live NavMesh memory directly |
+| Gameplay meaning such as harvest/destruction/placement authorization | Product gameplay authority | Terrain owns spatial instance state but cannot invent gameplay facts |
+| UI, overlays, diagnostics and tools | Presentation adapters over application/Terrain capabilities | Widgets and MCP/CLI handlers own no domain state |
+
+Each cross-system operation has an owning result and generation. Notifications publish
+only after the authority commits. A bus message, worker callback, render draw or
+physics contact cannot become a terrain command or lifetime owner by itself.
+
+### 3. Authored, cooked, scene, runtime and extraction data are distinct strata
+
+The data flow is one-way unless an explicit authoring command starts a new cook:
+
+```text
+authoring source documents/assets
+  -> validated deterministic Terrain cook
+  -> immutable target/tier-keyed cooked dataset and feature payloads
+  -> typed Scene binding
+  -> TerrainRuntime generation and immutable snapshots
+  -> render/physics/navigation/streaming integration packets
+```
+
+Authoring data may contain editable height samples, layer weights, masks, splines,
+foliage rules and manually placed instances. It is not a runtime buffer and remains
+owned by the document/asset operation transaction.
+
+Cooked data is immutable, versioned, bounded and keyed by source revisions, target,
+selected Terrain feature tier, cooker/toolchain identity and all semantic inputs. A
+dataset manifest references independent terrain-tile, foliage-cluster, collision,
+navigation-source and rendering payloads with exact sizes/hashes and compatibility.
+World Streaming may package these as Terrain/Foliage feature blocks but does not
+reinterpret their private schemas.
+
+The Scene stores a typed binding to a cooked dataset plus authored transform/scope and
+required feature policy. It does not embed decoded tile arrays, GPU buffers, physics
+bodies or a mutable pointer to TerrainRuntime.
+
+Runtime owns immutable published dataset/tile/cluster snapshots and separately
+versioned overlays for admitted live changes. Cross-system integrations receive
+bounded descriptors/views plus leases valid for one captured generation. No public
+contract returns an owning `std::vector` of a whole heightfield or exposes mutable
+storage shared across worker, renderer, physics, navigation and editor threads.
+
+Render packets, physics shape-install descriptors, navigation build/source snapshots
+and streaming cost/readiness reports are ephemeral projections. They cannot be written
+back as authored/cooked truth or used as stable identity.
+
+### 4. Identity, revision, handle and lease types are non-interchangeable
+
+The contract reserves distinct strong types:
+
+```cpp
+struct TerrainDatasetId;
+struct TerrainTileId;
+struct FoliageTypeId;
+struct FoliageClusterId;
+struct FoliageInstanceId;
+
+struct TerrainRuntimeHandle {
+    TerrainRuntimeSlot slot;
+    TerrainRuntimeGeneration generation;
+};
+
+struct TerrainSnapshotRevision {
+    TerrainContentRevision content;
+    TerrainResidencyRevision residency;
+    TerrainMutationRevision mutation;
+    TerrainCapabilityRevision capability;
+};
+```
+
+Stable IDs identify durable authored/cooked meaning; runtime handles identify one live
+incarnation; revisions identify immutable state snapshots; leases retain memory/native
+dependencies. An `AssetId`, entity ID, streaming cell ID, native resource, array index,
+world coordinate or display name cannot substitute for one of these types.
+
+TRF-001.2 owns exact stable-ID namespaces, derivation, serialization and tombstone/
+reuse policy. Until ratified, implementations may not publish an ad hoc hash/index or
+persist runtime slot/generation values. Zero/unknown/stale/wrong-owner/wrong-generation
+values fail with typed errors.
+
+Content revision changes when immutable semantic dataset content is replaced. Residency
+revision changes when published tile/cluster availability changes. Mutation revision
+changes when an admitted runtime overlay commits. Capability revision changes when the
+effective plan changes. Consumers compare the applicable fields rather than one vague
+“terrain dirty” flag.
+
+### 5. Feature tiers are provider-neutral product policy
+
+Terrain uses four ordered preference profiles:
+
+```cpp
+enum class TerrainFeatureTier : std::uint8_t {
+    Baseline,
+    Standard,
+    High,
+    Ultra,
+};
+```
+
+The names do not encode OpenGL, Metal, Vulkan, D3D12, console generations or shader
+models. A renderer backend, device class or build configuration cannot select a Terrain
+tier by string comparison. The product profile requests an allowed ordered tier set
+and declares required versus optional terrain/foliage features.
+
+`TerrainEffectiveCapabilities` intersects:
+
+- cooked variants available for the exact dataset/target;
+- TerrainRuntime implementation support;
+- World Streaming CPU/GPU/staging/count reservations;
+- effective Render operations/formats/limits for visual paths;
+- Physics and Navigation provider capability for required grounded data; and
+- host mode, product policy and runtime-mutation/editor permissions.
+
+The resolved immutable plan records selected tier, exact finite numeric limits,
+enabled algorithms, cooked variant identities, provider capability revisions, required
+feature outcomes and every permitted fallback. Profiles express quality/scale policy;
+they do not grant capability.
+
+Baseline guarantees only the product-declared minimal cooked terrain/foliage behavior
+that the current host requires. Standard, High and Ultra may request successively more
+layers/LOD/instances, GPU culling, impostors, wind or mutation features, but no name
+implies a concrete number or algorithm until TRF-001.3's versioned table is ratified.
+Every resolved numeric field is explicit and finite; values such as “10M+”, zero-as-
+unlimited and compile-time API labels are invalid.
+
+A required feature with no compatible implementation/cooked variant fails plan or
+scene activation. Optional fallback occurs only through the product's declared ordered
+alternatives and records a typed reason. Horo never silently clamps layer/instance
+count, drops authored instances, switches GPU work to CPU, removes collision or chooses
+a different renderer/provider merely to make a tier appear successful.
+
+### 6. Dataset activation is detached preparation plus atomic publication
+
+Aggregate lifecycle is exhaustive:
+
+```cpp
+enum class TerrainRuntimeState : std::uint8_t {
+    Absent,
+    Preparing,
+    Prepared,
+    Active,
+    Replacing,
+    Suspended,
+    Retiring,
+    Failed,
+};
+```
+
+The Terrain owner lane validates a Scene binding and effective plan, reserves bounded
+work/resources and creates one operation-owned task group. Workers decode/validate
+immutable candidates using captured asset/registry/capability revisions. They perform
+no live-world mutation and call no renderer/physics/navigation object directly.
+
+Prepared candidates contain owned/leased Horo data and integration descriptors. The
+application/runtime coordinator arranges dependent prepare operations and publishes
+the aggregate generation at the declared Scene safe point only after every required
+participant is Prepared. Publication is a no-fail pointer/handle swap over already
+validated state. Optional unavailable participants are explicit in readiness; they are
+never missing by accident.
+
+Failure or cancellation before publication retires the candidate and preserves the
+old Active generation. Cancellation after publication is an explicit unload/replacement,
+not rollback. A replacement keeps the old generation readable until all Scene,
+streaming, render, physics, navigation, job and snapshot leases retire. Slot numbers,
+cell coordinates or equal assets cannot make stale work valid for the new generation.
+
+Suspension stops new mutation/streaming admission and captures policy-owned residency;
+it does not destroy state or imply device resources survive. Resume revalidates
+capabilities and may prepare a replacement plan/generation. Fatal owner failure closes
+admission and remains observable; it cannot silently publish an empty flat terrain.
+
+### 7. Readiness is multi-dimensional and generation checked
+
+A single `loaded`/`ready` boolean cannot represent cross-system state:
+
+```cpp
+struct TerrainReadinessSnapshot {
+    TerrainRuntimeHandle terrain;
+    TerrainSnapshotRevision revision;
+    TerrainReadinessState logical;
+    TerrainReadinessState streaming;
+    TerrainReadinessState visual;
+    TerrainReadinessState collision;
+    TerrainReadinessState navigation;
+    TerrainReadinessState mutation;
+};
+```
+
+Each dimension is `NotRequested`, `Preparing`, `Ready`, `Unavailable`, `Failed`,
+`Suspended` or `Retiring` with a typed reason and captured provider revision. Required
+dimensions gate aggregate publication or cell activation according to product/scene
+policy. Optional visual absence is legal for headless hosts; required collision or
+navigation cannot be treated as ready because terrain pixels exist.
+
+World Streaming commits cell residency only after required Terrain/Foliage provider
+payloads and their required integration participants are prepared under the same cell/
+terrain generations. Renderer, Physics and Navigation publish their own readiness to
+the coordinator; Terrain records the immutable projection but cannot forge it.
+
+TRF-005 will refine cross-system barriers and partial-cell readiness. That follow-up
+cannot replace typed dimensions with one boolean or let a dependent subsystem publish
+against a stale terrain generation.
+
+### 8. Mutable state uses commands and separate overlays
+
+Authored sculpt/paint/hole/spline and baked foliage changes go through application-
+owned document commands/transactions, update source revisions and trigger an explicit
+recook/publication flow. Runtime does not write back to source files or mutate an
+immutable cooked artifact.
+
+Runtime deformation and dynamic foliage are independent optional capabilities. A
+typed command captures terrain generation, expected mutation revision, bounded region/
+instance count, gameplay authority, lifetime and overflow policy. The owner validates,
+prepares a copy-on-write/overlay candidate and atomically advances mutation revision at
+a safe point. Stale expected revision, unsupported mutation, over-budget work or lost
+authority fails without partial change.
+
+TerrainRuntime owns dynamic foliage spatial/instance state after command commit;
+gameplay owns why a spawn/destruction is authorized and any persistent gameplay fact.
+An instance lifetime uses a typed finite/explicit-persistent policy, never `float 0`
+as a sentinel. Capacity exhaustion returns a typed result. Automatic oldest-first or
+furthest-first deletion is forbidden unless TRF-004 defines and the product explicitly
+selects a deterministic policy with outcome/replication/persistence semantics.
+
+A terrain hole/deformation does not directly modify Physics or Navigation. It publishes
+new typed source/overlay evidence; ADR-108 conservative exclusion and explicit rebuild/
+recook capabilities govern grounded collision/navigation replacement. Visual success
+alone cannot make gameplay ground authoritative.
+
+### 9. Threading follows owner lanes and immutable handoff
+
+TerrainRuntime has one declared mutable owner lane aligned with runtime/Scene safe
+points. Command admission may enter through bounded MPSC ingress; only the owner changes
+lifecycle, revisions, handle tables, resident logical state and published snapshots.
+
+Workers perform bounded decode, validation, placement, CPU culling preparation and
+candidate building inside owned task groups with cancellation. They capture values and
+leases, never references to shorter-lived Scene/components/containers. Worker completion
+enqueues generation-tagged evidence; callbacks never mutate live Terrain state.
+
+Render extraction reads an immutable Terrain snapshot/lease and emits Horo RenderApi
+data. Native GPU creation/draw/retirement stays on renderer-owned threads. Physics and
+Navigation consume prepared descriptors through their own owner queues/safe points.
+Editor UI, CLI and MCP call shared application capabilities and observe snapshots; no
+transport or ImGui thread writes terrain arrays.
+
+Frame-hot extraction/culling iteration uses preallocated/contiguous bounded data. It
+performs no asset I/O, cook, arbitrary allocation, global service lookup, blocking wait
+or cross-thread native call. Slow consumers observe revision notifications and query
+the owning bounded store rather than receiving complete tile/instance payloads on a bus.
+
+### 10. World Streaming and Terrain account every resource once
+
+ADR-012 World Streaming owns aggregate cell admission, priority, linger, queue slots
+and CPU/GPU/staging/retired-resource reservation. Terrain/Foliage budgets are slices,
+not additional allowances. Terrain estimates each feature payload before load and must
+obtain a reservation before allocation/decode/provider preparation.
+
+TerrainRuntime owns allocation/eviction policy only inside its granted slice and for
+disposable non-activation-critical local detail. It cannot run an independent camera
+priority queue for cell residency, evict a pinned/required Active cell, borrow another
+feature's reservation or allocate first and report growth later. It requests additional
+reservation or a typed fallback/eviction decision from the authority.
+
+Renderer GPU backing follows ADR-034: World Streaming/Terrain and Renderer project one
+shared charge identity instead of counting the same physical allocation twice or not
+at all. GPU/native retirement, upload/staging overlap, shared resources and frames in
+flight remain charged until the owning renderer confirms release. Physics/navigation
+resources follow equivalent lease/retirement accounting in their owners.
+
+TRF-001.3 owns exact default/hard per-tier counts and bytes. Unknown estimates are never
+zero/unlimited. Overflow-safe arithmetic, simultaneous old/new replacement generations,
+staging copies and delayed retirement all participate in admission.
+
+### 11. Failure, cancellation, replacement and shutdown preserve the last valid state
+
+Stable error categories include:
+
+```text
+terrain.unavailable
+terrain.capability.unsupported
+terrain.tier.unsatisfied
+terrain.descriptor.invalid
+terrain.identity.invalid
+terrain.generation.stale
+terrain.revision.stale
+terrain.capacity.exceeded
+terrain.budget.denied
+terrain.prepare.failed
+terrain.integration.failed
+terrain.cancelled
+terrain.retirement.stalled
+terrain.shutdown.incomplete
+```
+
+Errors preserve operation, terrain generation/revision, tile/cluster/instance identity
+when safe, required capability/tier and nested provider cause. They do not expose native
+handles, pointers, unbounded asset paths/data or provider-specific control codes.
+
+Partial initialization rolls back only candidate-owned state in reverse dependency
+order. The previous Active generation remains published. A failed optional participant
+is `Unavailable`/`Failed` according to the resolved plan; it does not disappear from the
+snapshot. Retry is a new bounded preparation against newly captured revisions and
+never mutates the failed candidate in place.
+
+Shutdown is idempotent and reverse ordered:
+
+1. close commands, new loads and snapshot subscriptions;
+2. cancel/yield owned task groups and invalidate candidate generations;
+3. detach Scene/world-streaming admissions and request render/physics/navigation
+   retirement for exact installed generations;
+4. retain datasets, payloads, provider/module dependencies and snapshots until worker/
+   native/consumer leases acknowledge release; and
+5. release Assets/reservations and publish Absent only after all required retirement.
+
+A deadline can report `terrain.shutdown.incomplete` but cannot force-free memory or
+native dependencies still referenced by possible work. Renderer device loss, world
+unload and process shutdown use the same generation/retirement rules; none may clear a
+global terrain singleton because no such singleton exists.
+
+### 12. Headless, Null and provider diversity do not change ownership
+
+Terrain's logical/cooked/streaming state is renderer independent. A dedicated server
+may require collision/navigation and no visual readiness. A cook/validation host may
+load descriptors with no live Scene. An editor preview may require visual extraction
+but use isolated preview/world generations.
+
+Null Render means visual capability absence or a deterministic Horo-only extraction
+fixture according to the host plan; it does not claim GPU culling/draw success. Missing
+Physics/Navigation capability is explicit and fails when the scene marks it required.
+No Terrain “Null” backend invents flat ground, empty foliage, collision or successful
+streaming to satisfy callers.
+
+OpenGL, Metal, Vulkan and D3D12 consume the same RenderApi terrain/foliage projection.
+Native resource/command formats stay private, and different capabilities resolve via
+the immutable product plan rather than backend-name branches in Terrain. CPU/GPU
+algorithm alternatives must have equivalent declared semantic outcomes where required;
+quality/performance differences are explicit.
+
+### 13. Migration and qualification precede implementation claims
+
+The current documentation-only structs and backend-named tier table are not a stable
+runtime ABI or serialized format. They migrate to the typed source/cooked/scene/runtime
+strata and provider-neutral plan. No compatibility shim preserves both a mutable whole-
+heightfield public struct and the new leased tile model.
+
+Before implementation/publication, TRF-001.2/001.3 must freeze ID encoding, descriptor
+schemas, exact limits and validation. TRF-002 through TRF-006 must define artifacts,
+render/foliage/cross-system/editor details consistently. Any later public header is
+assigned to exactly one target and receives public-header consumer coverage.
+
+Required evidence includes:
+
+- target/dependency tests proving TerrainApi/Runtime and integration adapters expose no
+  native backend, editor, ImGui, provider or global-service dependency;
+- compile-time/type tests separating stable IDs, runtime handles, revisions and leases,
+  with zero/stale/wrong-owner/wrong-generation failures;
+- malformed/oversized/version-skewed authored/cooked/scene descriptors and no mutable
+  whole-dataset buffer escaping the owning boundary;
+- every requested tier against cooked/runtime/render/physics/navigation capability
+  matrices, required failure and each explicitly permitted fallback reason;
+- candidate failure/cancellation at every prepare participant and safe-point boundary,
+  proving the old Active generation remains intact and no partial readiness publishes;
+- replacement under worker, snapshot, cell, GPU, physics and navigation leases with no
+  early reuse/free or stale publication;
+- runtime deformation/dynamic foliage stale revision, capacity, authority and overflow
+  cases with no implicit instance deletion or cooked/source mutation;
+- world-streaming reserve/growth/pressure/eviction and simultaneous old/new/staging/
+  retirement accounting with no double charge or oversubscription;
+- headless, editor preview, dedicated server, Null Render and every interactive renderer
+  consuming the same Horo contracts without silent capability substitution;
+- owner-thread/worker/native-thread affinity, bounded ingress/backpressure, no frame-hot
+  allocation/I/O/blocking and deterministic snapshot publication; and
+- partial activation, suspension/resume, device loss, world unload, repeated shutdown
+  and retirement timeout with all dependencies retained until safe release.
+
+## Consequences
+
+- Terrain/Foliage becomes an explicit backend-neutral runtime vertical slice with one
+  public API owner and one live-state owner instead of leaking across Scene/Render.
+- Authored, cooked, scene, runtime and extraction data cannot be mistaken for mutable
+  aliases of the same heightfield/instance storage.
+- Provider-neutral feature tiers resolve from real cooked/provider/budget capability;
+  required content fails visibly and optional fallback is reviewable.
+- Generation/revision/readiness snapshots prevent stale worker or dependent-system work
+  from publishing into a replacement terrain.
+- World Streaming, Render, Physics and Navigation keep their existing authority while
+  Terrain coordinates through typed descriptors, leases and commit evidence.
+- Runtime mutation, replacement and shutdown require more explicit state and tests, but
+  preserve the last valid generation and prevent silent data loss/early native free.
+
+## Rejected Alternatives
+
+### Put Terrain/Foliage in `HoroEngine::Foundation`
+
+Rejected because Foundation cannot depend on Assets, Scene, World Streaming, Render,
+Physics or Navigation. Terrain is a vertical runtime feature built on foundational
+types, not a universally lower-layer primitive.
+
+### Implement Terrain inside each renderer backend
+
+Rejected because authored/cooked identity, streaming, collision, navigation, gameplay
+mutation and headless behavior are not GPU-backend concerns. Backends only realize
+Horo RenderApi work.
+
+### Expose a mutable `std::vector<float>` heightfield as the public runtime model
+
+Rejected because ownership, bounds, revision, tiling and cross-thread lifetime are
+undefined, and consumers could mutate data behind active GPU/physics/navigation state.
+
+### Use `es3`, `dx11`, `dx12_vulkan` and `high_end` as Terrain tiers
+
+Rejected because API names mix providers with product quality, group unequal backends,
+do not describe actual device/implementation/cooked capability and encourage branching
+or silent fallback by string.
+
+### Clamp layer/instance/LOD counts silently to the selected tier
+
+Rejected because authored meaning/data can disappear without a result. Required limits
+fail; optional reduction needs an explicit cooked/product fallback with diagnostics.
+
+### Let Terrain own native GPU, physics and navigation resources
+
+Rejected because those systems own native thread affinity, device/provider generation,
+deferred retirement and recovery. Terrain holds Horo leases/readiness projections only.
+
+### Let World Streaming own Terrain tile semantics and internal cache policy
+
+Rejected because it owns cell admission/global budget, not provider payload schema,
+terrain LOD meaning or mutations. Terrain operates within its granted slice.
+
+### Publish each dependent participant as soon as it prepares
+
+Rejected because observers could see visual terrain without required collision or a
+new tile with old navigation. Aggregate required readiness publishes atomically.
+
+### Mutate cooked terrain in place for sculpting or runtime deformation
+
+Rejected because it breaks deterministic assets, cache identity and active-reader
+lifetime. Authoring recooks; runtime changes use separate revisioned overlays.
+
+### Evict oldest or furthest foliage automatically on capacity overflow
+
+Rejected because presentation order is not necessarily gameplay/persistence priority.
+Admission fails unless an explicit deterministic TRF-004 policy owns the disposition.
+
+### Use one global current Terrain singleton
+
+Rejected because editor preview, PIE, scene replacement, streaming generations and
+multi-world/server hosts need scoped owners and stale-handle rejection.
+
+### Force-free terrain dependencies at a shutdown deadline
+
+Rejected because worker/native callbacks and frames in flight may still reference them.
+A typed incomplete result preserves lifetime truth instead of causing use-after-free.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -299,6 +299,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Terrain And Foliage Architecture](./runtime/terrain-and-foliage-architecture.md):
   heightfields, terrain layers, instanced foliage, wind, LOD, collision,
   streaming, and editor tools.
+- [Terrain and Foliage Ownership, Data, Tier and Lifecycle](../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md):
+  public/runtime module boundaries, authored/cooked/live data strata, typed identity
+  and revisions, provider-neutral tier resolution, aggregate lifecycle and retirement.
 - [World Streaming Architecture](./runtime/world-streaming-architecture.md):
   streaming cells, volumes, priority, budgets, server authority, and editor
   world-composition tools.

--- a/docs/architecture/desired-project-tree.md
+++ b/docs/architecture/desired-project-tree.md
@@ -246,6 +246,11 @@ horo-engine/
 │       │   │   ├── NetworkSession.h
 │       │   │   ├── ReplicationManager.h
 │       │   │   └── ReplicationTraits.h
+│       │   ├── Terrain/
+│       │   │   ├── TerrainTypes.h
+│       │   │   ├── TerrainDescriptors.h
+│       │   │   ├── TerrainRuntime.h
+│       │   │   └── TerrainSnapshots.h
 │       │   ├── GameUI.h
 │       │   ├── DebugConsole.h
 │       │   ├── PlatformServices.h
@@ -403,6 +408,13 @@ horo-engine/
 │   │   │   ├── constraints/
 │   │   │   ├── integration/
 │   │   │   └── queries/
+│   │   ├── terrain/
+│   │   │   ├── api/
+│   │   │   ├── runtime/
+│   │   │   ├── streaming/
+│   │   │   ├── render_bridge/
+│   │   │   ├── physics_bridge/
+│   │   │   └── navigation_bridge/
 │   │   ├── audio/
 │   │   │   ├── frontend/
 │   │   │   ├── mixer/

--- a/docs/architecture/foundation/system-design.md
+++ b/docs/architecture/foundation/system-design.md
@@ -260,6 +260,9 @@ src/
     backends/
       recast_detour/    target-private Recast & Detour implementation
       null/             explicit capability absence, shared publication timing
+  terrain/
+    api/                backend-neutral terrain/foliage IDs, revisions, descriptors, commands and snapshots
+    runtime/            dataset/tile/cluster lifecycle, overlays, preparation, readiness and retirement
   render/
     api/                backend-neutral contracts and value types
     frontend/           render submission and resource coordination
@@ -314,6 +317,8 @@ HoroEngine::NavigationApi
 HoroEngine::NavigationRuntime
 HoroEngine::NavigationRecastDetour
 HoroEngine::NavigationNull
+HoroEngine::TerrainApi
+HoroEngine::TerrainRuntime
 HoroEngine::RenderApi
 HoroEngine::RenderFrontend
 HoroEngine::RenderModuleAbi
@@ -403,6 +408,16 @@ leased resources and consumes committed revisions. Background jobs publish via
 and implementation gates are defined by
 [ADR-016](../../adr/016-navigation-target-ownership-and-dependency-boundary.md).
 
+[ADR-137](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md)
+makes Terrain/Foliage a runtime vertical slice rather than generic Foundation,
+RuntimeScene internals or renderer-backend code. `TerrainApi` owns Horo-only IDs,
+revisions, handles, descriptors and narrow command/query/snapshot contracts;
+`TerrainRuntime` owns live dataset/tile/cluster generations, overlays, preparation,
+readiness and retirement. RuntimeScene holds typed bindings, World Streaming owns
+aggregate cell admission/budgets, and Render/Physics/Navigation own their realized
+resources. Hosts compose narrow integration ports without reverse dependencies or
+native handles in the Terrain API.
+
 [ADR-054](../../adr/054-extension-and-package-authority-boundary.md) keeps
 extension package composition in the application boundary. Package resolution,
 verified install records, trust and durable enablement are application/package
@@ -438,10 +453,14 @@ assets / scene-model / render-api / audio-api /
 network-api / navigation-api / gameplay-api /
 extension-api ------------------------------------------> foundation
 
-physics / audio-runtime / network-runtime /
-navigation-runtime / render-frontend / pipeline --------> neutral APIs and models
+terrain-api --------------------------------------------> assets + foundation
 
-runtime-scene -------------------------------------------> runtime + assets + foundation
+physics / audio-runtime / network-runtime /
+navigation-runtime / terrain-runtime /
+render-frontend / pipeline ------------------------------> neutral APIs and models
+
+runtime-scene -------------------------------------------> runtime + assets + terrain-api
+                                                          + foundation
 
 audio-platform / audio-null /
 network-transport-null / network-transport-enet /
@@ -461,7 +480,7 @@ apps ---------------------------------------------------> runtime + adapters + p
 
 Required rules:
 
-- Foundation does not depend on platform, scene, renderer, editor, MCP, or UI.
+- Foundation does not depend on platform, scene, terrain, renderer, editor, MCP, or UI.
 - The foundation logging facade and structured record model do not depend on
   GUI, editor, transport, or a concrete sink backend.
 - Foundation metric descriptors, aggregation, and profiler instrumentation do

--- a/docs/architecture/runtime/navigation-and-ai-architecture.md
+++ b/docs/architecture/runtime/navigation-and-ai-architecture.md
@@ -144,6 +144,14 @@ spatial evaluation. Gameplay consumes typed admission/query interfaces, and navi
 includes behavior nodes or script bindings. Host adapters bridge Assets, World Streaming,
 and scene lifetime without making them providers' dependencies.
 
+[ADR-137](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md)
+keeps Terrain/Foliage on that decoupled boundary. Terrain produces immutable,
+generation-tagged cooked topology/source or runtime-overlay evidence; Navigation owns
+tile preparation, provider objects, query consistency, publication and retirement.
+Visual terrain or a committed hole/deformation cannot mutate live NavMesh state or
+imply navigation readiness. ADR-108 conservative exclusion plus explicit recook/rebuild
+governs topology change, and aggregate scene/cell activation checks exact generations.
+
 ## Navigation Integration Contracts
 
 ### Submission, Jobs, And Publication
@@ -1784,6 +1792,7 @@ These are required downstream runtime/CI tests, not tests implemented by this AD
 - [Concurrency And Jobs](../foundation/concurrency-and-jobs.md): Parallel crowd and perception jobs
 - [Save Game And Persistence](./save-game-and-persistence.md): durable perception-memory capture and staged restore
 - [ADR-114: Canonical Runtime World Persistence Boundary](../../adr/114-canonical-runtime-world-persistence-boundary.md)
+- [ADR-137: Terrain and Foliage Ownership, Data, Tier and Lifecycle](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md)
 - [Navigation Bake UI HTML Reference](./navigation-bake.html): non-normative
   static UI reference
 - [Debug Console And Overlays](./debug-console-and-overlays.md): AI debug visualization

--- a/docs/architecture/runtime/physics-architecture.md
+++ b/docs/architecture/runtime/physics-architecture.md
@@ -139,6 +139,14 @@ work and final generation/budget validation succeed. Replacement failure destroy
 only the candidate and leaves the prior scene/world/query state unchanged. The
 first Physics tick occurs after the complete bundle is authoritative.
 
+[ADR-137](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md)
+keeps terrain/foliage collision on this ownership path. Terrain supplies immutable
+cooked shape-install descriptors tagged with exact dataset/tile/content generations;
+Physics prepares and owns bodies, native shapes, thread affinity and retirement.
+Terrain observes typed readiness/leases only and cannot mutate an active body or claim
+collision ready from visual residency. Replacement publishes through the aggregate
+scene/cell barrier and retains old Physics resources until Physics acknowledges release.
+
 ## Character Query Boundary
 
 [ADR-089](../../adr/089-character-controller-ownership-implementation-and-update-order.md)
@@ -389,6 +397,8 @@ Required tests cover:
 - core collider shape primitives resolve correctly from the primitive catalog
 - origin shift position translation without velocity or momentum alterations
 - sleeping island preservation across origin rebasing transactions
+- terrain/foliage collision descriptor generation, aggregate activation, stale
+  replacement rejection and Physics-owned retirement
 
 ## Related Documents
 
@@ -403,3 +413,4 @@ Required tests cover:
 - [Built-In Scene Primitives](./built-in-scene-primitives.md)
 - [Ownership And Resource Lifetime](../foundation/ownership-and-resource-lifetime.md)
 - [Observability Metrics And Profiling](../observability/observability-performance.md)
+- [ADR-137: Terrain and Foliage Ownership, Data, Tier and Lifecycle](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md)

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -1036,6 +1036,14 @@ consumers apply their own history policy from that evidence. Cinematic Runtime n
 calls backend/provider-specific reset hooks, and rendering never decides whether a
 gameplay, cinematic or editor proposal wins.
 
+[ADR-137](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md)
+applies the same boundary to Terrain/Foliage. TerrainRuntime publishes a bounded,
+immutable, generation/revision-tagged extraction snapshot and retains its lease through
+frame extraction. RenderFrontend owns conversion to RenderApi resources/graph work;
+the selected backend alone owns native buffers, culling commands, draws and deferred
+GPU retirement. Rendering cannot mutate terrain residency/source/overlays, treat a
+native handle as Terrain identity or infer a Terrain tier from the backend name.
+
 The scene runtime produces frame-owned render data:
 
 ```cpp
@@ -1485,6 +1493,8 @@ Required tests cover:
 - deterministic pass ordering
 - stale resource handle rejection
 - upload cancellation and generation replacement
+- terrain/foliage extraction generation, tier/capability rejection and GPU-resource
+  retirement without native identity leaking back to Terrain
 - resize, minimize, and target recreation
 - deferred destruction after frame completion
 - shader reflection/material validation
@@ -1510,3 +1520,4 @@ Required tests cover:
 - [Ownership And Resource Lifetime](../foundation/ownership-and-resource-lifetime.md)
 - [Platform Abstraction](../foundation/platform-abstraction.md)
 - [XR Architecture](./vr-ar-architecture.md)
+- [ADR-137: Terrain and Foliage Ownership, Data, Tier and Lifecycle](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md)

--- a/docs/architecture/runtime/terrain-and-foliage-architecture.md
+++ b/docs/architecture/runtime/terrain-and-foliage-architecture.md
@@ -7,42 +7,84 @@ subsystems for Horo Engine. It covers heightfield-based terrain, layer
 painting, instanced foliage rendering, wind simulation, LOD, collision,
 render extraction, streaming budget integration, and editor authoring tools.
 
+[ADR-137](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md)
+is the foundation contract for this subsystem. Terrain is a backend-neutral runtime
+vertical slice with distinct `TerrainApi` and `TerrainRuntime` ownership; it is not
+part of generic Foundation, RuntimeScene internals or a renderer backend.
+
+## Ownership And Data Boundaries
+
+`HoroEngine::TerrainApi` owns public typed identities, revisions, handles,
+descriptors and narrow command/query/snapshot interfaces. `HoroEngine::TerrainRuntime`
+owns live dataset/tile/cluster generations, mutable overlays, preparation, snapshot
+publication and retirement. Hosts compose it with Assets, Scene, World Streaming,
+Render, Physics and Navigation through backend-neutral ports.
+
+The data path is explicit:
+
+```text
+authored terrain/foliage assets and document commands
+  -> deterministic target/tier-keyed cook
+  -> immutable bounded dataset/tile/cluster payloads
+  -> typed RuntimeScene binding
+  -> TerrainRuntime generation and immutable snapshots
+  -> leased render/physics/navigation/streaming projections
+```
+
+Editor documents own source mutation and undo. Assets/Pipeline own import, cook and
+atomic artifact publication. RuntimeScene owns entity/binding lifetime. World
+Streaming owns cell demand and aggregate reservations. Render, Physics and Navigation
+own their realized resources and native-thread retirement. UI, CLI, MCP and gameplay
+use typed application/Terrain capabilities and never mutate buffers directly.
+
+Stable `TerrainDatasetId`, `TerrainTileId`, `FoliageTypeId`, `FoliageClusterId` and
+`FoliageInstanceId` values are distinct from runtime handles, revisions, `AssetId`,
+entity/cell IDs and native handles. TRF-001.2 freezes their exact encoding. Content,
+residency, mutation and capability revisions advance independently so consumers check
+the state they actually use.
+
 ## Terrain System
 
 ### Heightfield Model
 
-Terrain is a heightfield defined on a regular grid:
+Terrain heightfield source/cooked metadata describes a bounded regular grid. Bulk
+samples remain inside an authored document transaction, immutable asset lease or
+operation-owned decode candidate; the public runtime contract does not expose a
+mutable owning vector for the whole terrain:
 
 ```cpp
-struct TerrainHeightfield {
-    uint32_t  tilesPerSide;
-    float     metersPerTile;
-    float     heightScale;
-    std::vector<float> heights;   // row-major
+struct TerrainHeightfieldDescriptor {
+    TerrainDatasetId dataset;
+    AssetId sourceAsset;
+    TerrainSourceRevision sourceRevision;
+    TerrainTileGrid grid;
+    TerrainSampleEncoding encoding;
+    SceneBounds bounds;
+    TerrainDescriptorLimits limits;
 };
 ```
 
 ### Terrain Component
 
-A `TerrainComponent` attaches to an entity:
+A Scene entity carries only a typed binding to a cooked dataset and product feature
+policy. Decoded tiles, layer arrays and dependent-system resources remain outside the
+component:
 
 ```cpp
-struct TerrainComponent {
-    AssetId             heightfieldAsset;
-    TerrainMaterialLayer layers[16];
-    uint8_t             activeLayerCount;
-    TerrainLODSettings   lod;
+struct TerrainSceneBinding {
+    TerrainDatasetId dataset;
+    AssetId cookedDataset;
+    TerrainSceneTransform transform;
+    TerrainFeatureRequirements requiredFeatures;
+    TerrainTierPolicy tierPolicy;
 };
 ```
 
-**Layer count across tiers**: The `layers[16]` array size is the struct
-maximum across all tiers. At runtime, `activeLayerCount` is clamped to the
-tier's limit: the engine never writes to `layers[i]` for `i >= tierCap`.
-The terrain shader permutation for active layer count is declared as a
-`TerrainLayerCount` feature flag in the shader manifest, following the
-`ShaderPermutationKey` model in material-and-shader-model.md. Lower-tier
-permutations are compiled with the smaller layer counts and those shader
-variants are selected when the tier clamps `activeLayerCount`.
+Layer definitions live in a bounded authored/cooked layer-set asset. The selected
+Terrain plan validates its exact finite layer limit and a compatible cooked shader
+variant before activation. Required content exceeding the resolved limit fails;
+optional reduction is allowed only through an explicitly authored/cooked product
+fallback and is never a runtime clamp that drops layers silently.
 
 Heightfield assets are authored in the editor or imported from external
 formats (heightmap PNG/EXR, RAW16, GeoTIFF, Houdini HeightField).
@@ -56,8 +98,8 @@ time:
   collision resolution (typically coarser than the visual resolution)
 - Collision tiles are fed to the physics system as static concave mesh
   colliders
-- When a terrain tile streams in, its collision tile streams in alongside
-  the visual data
+- A cell prepares required collision and optional/required visual payloads under the
+  same generation-tagged aggregate activation; headless visual absence is explicit
 - Hole-carved vertices are excluded from the collision mesh; the physics
   system treats those areas as passthrough
 - NavMesh generation respects the hole mask: holed areas are excluded from
@@ -157,6 +199,8 @@ appear in the terrain subsystem contract:
 
 ```cpp
 struct FoliageType {
+    FoliageTypeId         id;
+    FoliageDefinitionRevision revision;
     AssetId               meshId;
     FoliagePlacementRules placement;
     FoliageCullingRules   culling;
@@ -168,12 +212,11 @@ struct FoliageType {
 };
 ```
 
-**Instance limits**: `instanceLimit` is a tier-enforced hard cap per
-foliage type. The engine does not silently truncate instances. When the
-limit is exceeded, a typed diagnostic is emitted and instances beyond the
-limit are culled from the draw list (furthest-first). The foliage baker
-warns before baking if the placement density would exceed the target tier's
-cap. Tier caps: `es3` 16K, `dx11` 256K, `dx12_vulkan` 2M, `high_end` 10M+.
+**Instance limits**: `instanceLimit` is validated against the selected finite
+provider-neutral Terrain tier during cook and runtime admission. Required content above
+the limit fails with a typed result. Horo does not silently truncate, hide furthest
+instances or infer limits from a graphics API name. An optional lower-density cooked
+variant must be explicitly authored and selected by declared fallback policy.
 
 ### Foliage Collision
 
@@ -248,20 +291,25 @@ is supported through the `FoliageSpawner` gameplay service:
 
 ```cpp
 struct FoliageSpawnRequest {
-    FoliageTypeId  foliageType;
+    TerrainRuntimeHandle terrain;
+    TerrainMutationRevision expectedRevision;
+    FoliageTypeId foliageType;
     WorldCoordinate position;
-    float          scale;
-    uint32_t       seed;
-    float          lifetime;       // 0 = permanent
+    FoliageScale scale;
+    FoliagePlacementSeed seed;
+    FoliageLifetime lifetime;
+    FoliageOverflowPolicy overflow;
+    GameplayAuthorityContext authority;
 };
 ```
 
 Runtime-spawned instances are stored in a **separate dynamic buffer** per
 foliage type. `TerrainRenderExtractor` merges the baked and dynamic buffers
-during extraction: dynamic instances are appended to the visible instance
-list after baked instances. Dynamic instances respect the same tier cap
-as baked instances; if the combined total exceeds `instanceLimit`, dynamic
-instances are evicted first (oldest-first by spawn time).
+during extraction through one immutable revisioned snapshot. Dynamic and baked
+instances share the resolved finite plan budget. Capacity exhaustion rejects the
+command unless TRF-004 defines and the product explicitly selects a deterministic
+overflow/eviction policy. There is no implicit oldest-first or furthest-first deletion,
+and no partial command commit.
 
 ### LOD And Billboard Impostors
 
@@ -323,6 +371,38 @@ Terrain and foliage authoring tools are registered through the
 The `EditorToolbar` only produces typed results; terrain/foliage domain
 operations are performed by the registered tools consuming those results.
 
+## Runtime Lifecycle And Readiness
+
+TerrainRuntime uses the exhaustive aggregate states `Absent`, `Preparing`, `Prepared`,
+`Active`, `Replacing`, `Suspended`, `Retiring` and `Failed`. Preparation validates the
+Scene binding/effective plan, reserves all peak work and builds a detached candidate.
+Workers return generation-tagged evidence only; the Terrain owner lane publishes the
+candidate at the RuntimeScene safe point after every required participant is Prepared.
+
+Readiness is an immutable generation-scoped snapshot with separate logical, streaming,
+visual, collision, navigation and mutation dimensions. Each dimension is
+`NotRequested`, `Preparing`, `Ready`, `Unavailable`, `Failed`, `Suspended` or
+`Retiring`. Optional visual absence is valid for a headless server, while required
+collision/navigation cannot be inferred from visual tile residency.
+
+Failure or cancellation before publication destroys only candidate-owned state and
+leaves the old Active generation unchanged. Cancellation after publication is an
+explicit unload/replacement. Replacement retains the old dataset, snapshots, tiles,
+GPU work, collision/navigation installs and module/provider dependencies until every
+lease/fence retires; stale worker or participant evidence cannot publish by matching a
+slot, coordinate or asset.
+
+Authored mutation goes through document/application commands and recook. Optional
+runtime deformation/dynamic foliage uses a typed command with terrain generation,
+expected mutation revision, bounded scope, gameplay authority, lifetime and overflow
+policy. The owner builds a separate overlay candidate and atomically advances mutation
+revision. Cooked data is never edited in place.
+
+Shutdown closes admission, cancels/yields owned task groups, invalidates candidates,
+requests exact-generation renderer/physics/navigation retirement and retains assets,
+reservations and dependencies until all consumers acknowledge release. A deadline may
+report `terrain.shutdown.incomplete`; it cannot force-free possibly referenced state.
+
 ## Memory And Streaming
 
 Terrain tiles and foliage instance data are streamed based on camera
@@ -333,6 +413,13 @@ proximity:
   priority
 - Streaming uses the asset pipeline's async I/O with cancellation tokens
 
+World Streaming owns the global cell priority queue and aggregate CPU/GPU/staging/
+retirement ledger. Terrain owns only its provider-local cache policy within an admitted
+slice. It cannot maintain a competing cell-demand scheduler, evict an activation-
+critical pinned cell, borrow another feature's reservation or allocate before budget
+growth is accepted. Every old/new replacement generation, decode/upload copy and
+retiring resource remains accounted until its owner releases it.
+
 ### Streaming Budget
 
 Terrain and foliage streaming budgets are **sub-allocations** carved from
@@ -340,36 +427,73 @@ the world-streaming system's `StreamingBudget`:
 
 ```cpp
 struct TerrainStreamingBudget {
-    size_t   maxResidentTerrainMemoryMB;   // ≤ StreamingBudget.terrainMemoryReservationMB
-    size_t   maxResidentFoliageMemoryMB;   // ≤ StreamingBudget.foliageMemoryReservationMB
+    ByteCount maxResidentTerrainBytes;
+    ByteCount maxResidentFoliageBytes;
     uint32_t maxConcurrentTileLoads;
+    uint32_t maxConcurrentRetirements;
 };
 ```
 
 The world-streaming `StreamingBudget` owns the total memory cap and reserves
-slices for terrain and foliage via `terrainMemoryReservationMB` and
-`foliageMemoryReservationMB`. Terrain operates within its allocated slice;
-if the terrain tile cache exceeds its reservation, terrain evicts internally
-without coordinating with the world-streaming system. Foliage instance
-buffers are loaded per-cluster with distance-based priority. Terrain
-tiles and foliage clusters are payloads within `StreamingCell` objects.
-Load priority is coordinated through the world-streaming priority queue;
-terrain does not maintain an independent priority system.
+slices for terrain and foliage. The resolved byte/count budget is a capability token,
+not an additional allowance. Terrain may evict only disposable provider-local detail
+inside its allocated slice; pressure involving a pinned/activation-critical cell is a
+typed request to World Streaming. Foliage instance buffers are loaded per-cluster with
+distance-based priority. Terrain tiles and foliage clusters are payloads within
+`StreamingCell` objects. Load priority is coordinated through the world-streaming
+priority queue; terrain does not maintain an independent priority system.
 
 ## Feature Tiers
 
-| Feature              | `es3`      | `dx11`      | `dx12_vulkan` | `high_end`   |
-| -------------------- | ----------- | ----------- | -------------- | ------------ |
-| Terrain sculpting    | Read only   | Full editor | Full editor    | Full editor  |
-| Terrain layers       | 4           | 8           | 16             | 16           |
-| Foliage instances    | 16K         | 256K        | 2M             | 10M+         |
-| GPU culling          | CPU only    | GPU (CS)    | GPU (CS)       | GPU (CS)     |
-| Wind animation       | Vertex only | Vertex      | Vertex + CS    | Vertex + CS  |
-| Billboard impostors  | No          | Manual      | Baked          | Baked + GPU  |
-| Terrain LOD          | 2 levels    | 4 levels    | 6 levels       | 8 levels     |
-| Foliage collision    | No          | Optional    | Optional       | Optional     |
-| Runtime spawning     | No          | Yes         | Yes            | Yes          |
-| Hole carving         | No          | Yes         | Yes            | Yes          |
+Terrain tiers are provider-neutral product preference profiles: `Baseline`,
+`Standard`, `High` and `Ultra`. They do not name graphics APIs, platforms, shader
+models or devices and do not grant capability.
+
+Resolution intersects the exact cooked variants with TerrainRuntime, World Streaming,
+Render, Physics, Navigation, host-mode and product-policy capabilities. The immutable
+result records the selected tier, exact finite layer/LOD/instance/byte/work limits,
+enabled algorithms, all provider/cooked revisions and every explicit fallback reason.
+TRF-001.3 owns the versioned numeric table and shared validator.
+
+| Capability family | Baseline | Standard | High | Ultra |
+|---|---|---|---|---|
+| Heightfield/layer/LOD scale | Minimal product-required cooked path | Increased finite authored/cooked limits | Higher finite quality limits | Highest qualified finite product limits |
+| Foliage scale/culling | Bounded required representation with declared CPU/GPU path | Larger qualified plan and optional GPU culling | High-density qualified GPU path where supported | Maximum explicitly qualified plan, never “unlimited” |
+| Wind/impostor quality | Minimal cooked/vertex path when required | Optional cooked impostor and richer wind variants | Higher qualified visual recipe | Highest qualified optional recipe |
+| Collision/navigation | Independently required or unavailable by scene/host policy | Same ownership; quality may use a higher cooked variant | Same | Same |
+| Runtime deformation/spawn | Explicit optional capability, not implied | Explicit optional capability | Explicit optional capability | Explicit optional capability |
+| Editor authoring | Application/editor permission and host capability, not runtime tier | Same | Same | Same |
+
+Required content that cannot fit the selected plan fails cook/activation with a typed
+result. Optional reduction occurs only when the product declares an ordered fallback
+and the compatible cooked variant exists. Runtime never silently clamps layers, drops
+instances, removes collision, changes renderer/provider or switches CPU/GPU algorithms
+to make a tier appear successful.
+
+## Verification
+
+Required coverage includes:
+
+- target/dependency checks for backend-neutral TerrainApi/Runtime and no native/editor/
+  service-locator leakage;
+- strong-type separation for dataset/tile/type/cluster/instance identity, runtime
+  handles, content/residency/mutation/capability revisions and leases;
+- malformed, oversized and incompatible source/cooked/scene descriptors with bounded
+  decode and no mutable whole-dataset buffer crossing the public boundary;
+- every tier/cooked/provider capability combination, required failure and each declared
+  fallback reason without silent clamp/drop/provider selection;
+- candidate failure/cancellation and replacement at every Scene/streaming/render/
+  physics/navigation prepare/commit/retirement boundary;
+- stale worker, snapshot, tile, GPU, collision and navigation evidence rejected across
+  generation/revision changes;
+- runtime mutation authority/revision/capacity/overflow cases with no partial update,
+  cooked-source mutation or implicit foliage eviction;
+- world-streaming reservation/growth/pressure accounting for staging, old/new and
+  retiring generations without double charge or oversubscription;
+- headless, dedicated server, editor preview, Null Render and every interactive backend
+  consuming the same Horo contract; and
+- bounded owner/worker/native-thread handoff, frame-hot allocation/I/O checks, device
+  loss, world unload, repeated shutdown and retirement timeout.
 
 ## Related Documents
 
@@ -393,3 +517,6 @@ terrain does not maintain an independent priority system.
   registration as `ViewportPanel` overlays and `EditorTab` panels
 - [Editor Document Model](../editor/editor-document-model.md): undo system and
   terrain data model snapshots
+- [ADR-137](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md):
+  module/data authorities, typed identity and revisions, provider-neutral tier plan,
+  aggregate lifecycle, readiness and shutdown baseline

--- a/docs/architecture/runtime/world-streaming-architecture.md
+++ b/docs/architecture/runtime/world-streaming-architecture.md
@@ -302,6 +302,15 @@ cannot discard activation-critical resources beneath an Active cell. They reques
 cell eviction or an admitted fallback transition through the authority. Navigation
 scratch and tile leases likewise remain within its share, including retired tiles.
 
+[ADR-137](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md)
+applies this authority to Terrain/Foliage: TerrainRuntime owns provider-local tile/
+cluster semantics and disposable cache policy only inside its admitted slice, while
+this authority retains cell demand, priority, aggregate reservation and commit/evict
+barriers. Terrain readiness is generation-scoped and multi-dimensional; a cell cannot
+infer required collision/navigation/visual readiness from decoded height data alone.
+Old/new dataset generations, staging/upload copies and dependent-system retirement stay
+charged until their respective owners release the shared reservation identity.
+
 ## Streaming Volumes, Priority And Retry Policy
 
 Camera, Gameplay, NetworkRelevance and Preload volumes create bounded residency
@@ -918,6 +927,7 @@ See [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin
 - [Scene Runtime](./scene-runtime.md): ECS entity storage, candidate preparation, and transactional structural mutations.
 - [Asset Pipeline](./asset-pipeline.md): Streaming cell assets, chunked package archives, and async I/O with `CancellationToken`.
 - [Terrain And Foliage Architecture](./terrain-and-foliage-architecture.md): Terrain clipmap streaming and cell-aligned foliage clusters.
+- [ADR-137](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md): Terrain/Foliage data, tier, lifecycle, readiness and reservation ownership.
 - [Physics Architecture](./physics-architecture.md): Static mesh collider registration and scene binding.
 - [Networking Architecture](./networking-architecture.md): Server-authoritative cell relevance and replication.
 - [Concurrency And Job System](../foundation/concurrency-and-jobs.md): Job workers, cancellation tokens, and thread roles.


### PR DESCRIPTION
## Summary

- Adds ADR-137 as the foundation contract for Terrain/Foliage public/runtime ownership,
  data strata, typed identity/revisions, capability tiers, lifecycle, threading,
  replacement, cancellation, and shutdown.
- Establishes `HoroEngine::TerrainApi` and `HoroEngine::TerrainRuntime` as a
  backend-neutral runtime vertical slice instead of placing Terrain in generic
  Foundation, RuntimeScene internals, or renderer backends.
- Reworks the Terrain/Foliage architecture around authored → cooked → Scene binding →
  runtime snapshot → leased integration projections, eliminating public whole-
  heightfield mutable storage and implicit cross-system ownership.
- Replaces graphics-API-named tiers and silent clamping/instance eviction with
  provider-neutral `Baseline`/`Standard`/`High`/`Ultra` product profiles, finite
  effective capability plans, typed failure, and explicit fallback.
- Projects the ownership/readiness boundary into System Design, the desired project
  tree, World Streaming, Rendering, Physics, and Navigation, and indexes the decision
  from the architecture overview.

## Why

The existing Terrain/Foliage document mixed editable heightfield vectors, Scene
components, cooked data, GPU buffers, physics bodies, navigation effects, streaming
budgets, runtime foliage, and editor tools without one lifecycle authority. It also
named feature tiers after graphics APIs (`es3`, `dx11`, `dx12_vulkan`) and described
automatic oldest/furthest instance removal when limits were exceeded.

Those choices leave ownership and failure semantics ambiguous. A worker could publish
partially prepared terrain, a renderer or Scene component could become identity/state
authority, capability could silently change by backend name, and capacity pressure
could erase authored or gameplay-relevant foliage without a result. Replacement and
shutdown could also release asset/native dependencies while snapshots, frames,
physics, navigation, or streaming generations still reference them.

This decision defines one owner for each stage and makes preparation/readiness/
retirement generation-checked before the dependent implementation tickets begin.

## Decision and boundaries

- `TerrainApi` owns Horo-only IDs, revisions, handles, descriptors, commands, queries,
  and immutable snapshots. `TerrainRuntime` owns live dataset/tile/cluster generations,
  overlays, candidate preparation, publication, and retirement. Neither selects a
  concrete backend/provider or uses ambient registration/service lookup.
- Responsibility is explicit across Editor/Application, Assets/Pipeline, RuntimeScene,
  World Streaming, TerrainRuntime, Render, Physics, Navigation, gameplay, and
  presentation adapters. Each notification follows the owning commit and carries exact
  generation/revision evidence.
- Authored, cooked, Scene, runtime, and extraction data are separate strata. Bulk
  samples remain in document transactions, immutable asset leases, or operation-owned
  decode candidates; no public runtime API returns a mutable whole-dataset vector.
- Stable dataset/tile/foliage IDs, live slot/generation handles, content/residency/
  mutation/capability revisions, and leases are non-interchangeable. TRF-001.2 owns
  exact stable-ID encoding; this PR prohibits publishing ad hoc hashes/indexes first.
- Terrain tier resolution intersects available cooked variants, TerrainRuntime support,
  World Streaming reservations, effective Render/Physics/Navigation capabilities,
  host mode, and product policy. Required unsatisfied content fails; optional fallback
  must be declared and observable. Exact numeric tables remain TRF-001.3 scope.
- Runtime state is exhaustive: Absent, Preparing, Prepared, Active, Replacing,
  Suspended, Retiring, and Failed. Candidate work is detached; required participants
  prepare before one aggregate safe-point publication; replacement preserves the old
  Active generation until all leases retire.
- Readiness is multi-dimensional across logical, streaming, visual, collision,
  navigation, and mutation state. A headless host may explicitly omit visual readiness,
  while visual residency cannot imply required collision/navigation readiness.
- Authored changes recook through document/application transactions. Optional runtime
  deformation and dynamic foliage use revision/authority/budget-checked overlay
  commands. Capacity failure is typed; automatic oldest/furthest instance deletion is
  forbidden until an explicit TRF-004 policy owns the outcome.
- World Streaming keeps aggregate demand, priority, reservation, and cell commit/evict
  authority. Terrain operates only inside its slice. Render/Physics/Navigation retain
  native resource/thread/retirement authority and expose readiness through typed
  integration evidence.
- Shutdown closes admission, cancels/yields owned tasks, requests exact-generation
  dependent retirement, and retains assets/reservations/providers until every lease or
  fence releases. A deadline reports incomplete shutdown instead of force-freeing.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md docs/architecture/README.md docs/architecture/desired-project-tree.md docs/architecture/foundation/system-design.md docs/architecture/runtime/terrain-and-foliage-architecture.md docs/architecture/runtime/world-streaming-architecture.md docs/architecture/runtime/rendering-architecture.md docs/architecture/runtime/physics-architecture.md docs/architecture/runtime/navigation-and-ai-architecture.md`
- `git diff --check`
- `git diff --cached --check`
- Staged added-Markdown-link resolution check: passed.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully, including public-header inventory and
dependency-direction policy checks. The existing mbedTLS minimum-version deprecation
warning remains, and repository Python tests were skipped because pytest is unavailable
in this environment.

## Risk and rollout

- This PR establishes new target and public-contract direction but does not create the
  CMake targets or headers. Implementation must update public-header ownership,
  dependency policy, consumers, and tests in the same change that materializes them.
- Exact stable-ID encoding, descriptor schemas, numeric limits, and tier matrices are
  deliberately blocked on TRF-001.2/TRF-001.3. Implementations must not treat the
  reserved types/profile names here as permission to invent interim serialized values.
- Aggregate activation across streaming/render/physics/navigation is intentionally
  stricter than independent publication. It may increase staging/overlap cost during
  replacement, which must be admitted and measured rather than hidden.
- Required capability failure and removal of silent clamps may expose content that did
  not fit historical backend-specific assumptions. Migration needs explicit cooked
  fallback variants or a visible failure, not a compatibility shim that preserves both
  models.
- Dynamic terrain/foliage can affect gameplay, replication, persistence, collision, and
  navigation. This PR reserves typed authority/revision/capacity gates; TRF-004/TRF-005
  must finish detailed policies before runtime mutation is enabled.

## Issue links

- Jira: [HORO-1891](https://horo-engine.atlassian.net/browse/HORO-1891)
- GitHub: Closes #1935
- Domain ticket: `[TRF-001.1]`
- Parent capability: `HORO-1881` / `[TRF-001]`
- Follow-up contracts: `HORO-1889` (`[TRF-001.2]`) and `HORO-1888`
  (`[TRF-001.3]`)

## Reviewer Notes

Please review the responsibility table and dependency direction first. TerrainRuntime
should coordinate logical terrain state but must not absorb RuntimeScene, World
Streaming, Render, Physics, Navigation, Assets/Pipeline, or Editor authority. In
particular, native GPU/physics/navigation handles must remain private to their owners;
Terrain receives only Horo descriptors, readiness evidence, and leases.

The second focus is atomic activation/replacement. Workers build detached candidates;
required participants prepare against exact generations; one aggregate safe-point
publication occurs; and the old Active generation survives until every reader/native
lease retires. Please look for any wording that could allow partial readiness or stale
evidence to publish.

Finally, check the tier migration: provider/API names are no longer product tiers,
finite limits are always explicit in the resolved plan, and no runtime clamp/drop/
provider switch is permitted unless a declared cooked/product fallback owns it.

## Stack

- Base branch: `docs/HORO-1848_offline_queue_ownership_replay`
- Previous PR: #2471 (`HORO-1848`, `[PLS-007.1]`)
- This is the first Terrain/Foliage ADR in the stack and introduces ADR-137 after the
  Platform Services sequence. Review/merge it after #2471 to preserve linear ADR and
  architecture history.


[HORO-1891]: https://horo-engine.atlassian.net/browse/HORO-1891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ