### PR TITLE
docs(terrain): define tile and streaming ownership HORO-1893 #1937 [TRF-002.1]

### DIFF
--- a/docs/adr/138-terrain-source-cooked-tile-cache-and-streaming-ownership.md
+++ b/docs/adr/138-terrain-source-cooked-tile-cache-and-streaming-ownership.md
@@ -1,0 +1,416 @@
+# ADR-138: Terrain Source, Cooked Tile, Cache and Streaming Ownership
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Terrain/foliage imported and canonical source ownership, deterministic cook inputs/outputs, dataset/tile manifests, cache authorities, world-streaming integration, decoded residency, consumer-native artifacts, replacement generations, cancellation and shutdown
+- **Issue**: [TRF-002.1](https://github.com/abdullahbodur/horo-engine/issues/1937)
+- **Jira**: [HORO-1893](https://horo-engine.atlassian.net/browse/HORO-1893)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-010](010-job-waiting-and-operation-store-ownership.md), [ADR-012](012-world-streaming-partition-authority-and-subsystem-boundaries.md), [ADR-023](023-world-index-and-cell-format-architecture-decision.md), [ADR-027](027-renderer-resource-identity-and-descriptors.md), [ADR-034](034-gpu-memory-and-residency-ownership.md), [ADR-085](085-physics-shape-authoring-cook-and-runtime-boundary.md), [ADR-105](105-navigation-asset-and-scene-ownership-boundary.md), [ADR-137](137-terrain-foliage-ownership-data-tier-and-lifecycle.md)
+- **Normative documents**: [Asset Pipeline](../architecture/runtime/asset-pipeline.md), [Terrain and Foliage Architecture](../architecture/runtime/terrain-and-foliage-architecture.md), [World Streaming Architecture](../architecture/runtime/world-streaming-architecture.md)
+
+## Context
+
+ADR-137 establishes TerrainApi/Runtime ownership and separates authored, cooked,
+Scene, runtime and integration data. The current Terrain document still says that
+heightmaps can be imported from several formats, tiles are rasterized, an LRU cache is
+used and Terrain/Foliage payloads live in streaming cells, without defining the
+canonical source, exact cooked generation, cache authorities or load/replace protocol.
+
+The generic Asset pipeline already owns tracked source bytes, cooker registration,
+dependency-aware keys, immutable cache entries, staging and atomic `current.json`
+publication. World Streaming owns cell demand, priority, aggregate reservation and
+cell commit/eviction. Render, Physics and Navigation own their native resources. If
+Terrain duplicates any of these, two caches may claim the same bytes, a tile may load
+outside cell budget, or a source/cook watcher may replace an active terrain behind
+readers.
+
+Large terrain also cannot be one eagerly loaded artifact. Dataset and tile manifests
+must preserve seam/dependency integrity while allowing bounded independent reads.
+Hot reload cannot mix incompatible old/new neighbor tiles, and cancellation or cache
+corruption must preserve the last valid published and resident generations.
+
+This ADR assigns source, derived output, cache, streaming and replacement ownership.
+TRF-002.2 owns exact external heightmap parsing/canonical normalization. Later TRF-002
+tickets may freeze binary layouts and algorithms without changing these authorities.
+
+## Decision
+
+### 1. Assets owns generic storage/publication; Terrain owns domain semantics
+
+| Responsibility | Authority |
+|---|---|
+| Source path trust, tracked `AssetId`, sidecar/source byte snapshot and immutable borrow | Assets/Application import operation |
+| External heightmap/container decode and canonical Terrain source schema/validation | Terrain Import/Model contribution |
+| Generic cooker catalog, dependency scheduling, cache keys/store, staging, generation manifest and atomic publication | Assets Cook |
+| Terrain tiling, seam/mip/LOD derivation, layer/hole/spline semantics, foliage clustering and Terrain artifact schemas | Terrain Cook contribution |
+| Selected immutable cooked generation and runtime byte leases | Assets provider |
+| Dataset/tile/cluster validation, decoded cache, logical residency and feature-local eviction | TerrainRuntime |
+| Cell demand/priority, aggregate reservations, provider sequencing and cell commit/evict barrier | World Streaming authority |
+| GPU/native render resource cache/residency | Render |
+| Solver-native collision shape/body cache and lifetime | Physics |
+| Provider-native navigation tile/cache and query publication | Navigation |
+
+Terrain contributions use the same host-owned importer/cooker catalogs and bounded
+borrowed source/output writers as other domains. They create no second asset ID,
+dependency graph, scheduler, cache root, generation directory, current pointer or
+package authority. Assets treats Terrain payloads as bounded typed contribution data
+and does not interpret height, layer, seam, foliage placement or LOD semantics.
+
+Provider descriptors are inert. Registration validates stable contribution/type/schema
+IDs and dependencies but performs no source scan, decode, cache access or global
+mutation. The application host explicitly composes the contributions.
+
+### 2. External source and canonical authoring source are separate
+
+PNG/EXR/RAW/GeoTIFF/Houdini files are untrusted import inputs, not runtime assets or
+canonical height truth. Import captures exact bytes plus explicit options and produces
+a detached canonical Terrain source candidate containing finite grid/coordinate/units,
+sample encoding, height/layer/hole data, provenance and diagnostics.
+
+TRF-002.2 freezes format-specific parsing, orientation, endianness, nodata, color/
+numeric conversion, units, geospatial policy and canonical encoding. Until then, no
+importer may infer these from filename/platform defaults and publish a permanent schema.
+
+The editor-owned Terrain source asset is the only mutable authoring truth after import.
+It records stable Terrain identity and semantic revision, not the external absolute
+path as identity. Reimport is an explicit transaction comparing expected source/
+document revision; it cannot overwrite sculpt/paint changes silently. Imported bytes,
+editor selection/brush state, timestamps and filesystem enumeration order are not
+runtime data.
+
+Source admission checks dimensions, sample/layer counts, integer overflow, decoded
+bytes/work, finite numeric values, coordinates/bounds and project trust before
+allocation/publication. Failure leaves the existing source revision unchanged.
+
+### 3. One immutable dataset manifest indexes independently verifiable tiles
+
+Terrain Cook emits a bounded `CookedTerrainDataset` envelope containing:
+
+```cpp
+struct CookedTerrainDatasetManifest {
+    TerrainDatasetId dataset;
+    TerrainContentRevision content;
+    TerrainCookSchemaVersion schema;
+    TerrainFeatureTier tier;
+    TerrainCoordinateProfile coordinates;
+    TerrainDatasetBounds bounds;
+    TerrainDependencyFingerprint dependencies;
+    BoundedArray<TerrainTileManifestEntry> terrainTiles;
+    BoundedArray<FoliageClusterManifestEntry> foliageClusters;
+    TerrainDatasetDigest digest;
+};
+```
+
+Each sorted tile/cluster entry carries its stable ID, integer grid/LOD address, exact
+bounds, semantic/seam/dependency signatures, artifact identity, byte size, content
+digest, peak decode/prepare estimates and declared consumer payloads. Entries are
+ordered by canonical typed address, never filesystem or job completion order.
+
+Tile payloads are immutable independently readable artifacts. They contain bounded
+Terrain-owned neutral height/layer/hole/foliage/render-source data and references to
+separate dependencies. They do not contain source paths, editor state, runtime handles,
+world-streaming reservations, native GPU buffers, solver shapes/bodies, navigation
+provider objects or backend commands.
+
+Collision/navigation neutral source descriptors may be declared Terrain outputs, but
+ADR-085 Physics and ADR-105 Navigation own their separately keyed consumer artifacts
+and native conversion. A Terrain cache hit never proves a native consumer hit or
+readiness.
+
+The dataset envelope binds the complete canonical manifest bytes. Missing, duplicate,
+overlapping, out-of-bounds, digest-mismatched or seam-incompatible entries fail the
+candidate. Runtime never scans a directory and infers membership.
+
+### 4. Cook identity closes over every semantic input
+
+Terrain extends the Assets dependency-aware cook key with a canonical fingerprint of:
+
+- exact canonical Terrain source identity/revision/digest;
+- every material/layer/texture/mesh/foliage-rule/spline/mask dependency artifact;
+- coordinate/unit, tiling, border/seam, LOD/mip, compression/quantization and hole
+  policies;
+- selected Terrain tier and exact finite effective limit/profile revision;
+- Terrain source/cooked/manifest/payload/cooker algorithm versions;
+- generic Assets cooker/target/envelope/toolchain identity; and
+- each neutral consumer-source schema whose emitted bytes are included.
+
+No timestamp, path, editor layout, machine locale, thread count, job order, cache
+location or active runtime/provider handle enters semantic identity. A provider-native
+Physics/Navigation/Render artifact fingerprint belongs to that consumer's own derived
+key, not the Terrain tile key.
+
+Same complete inputs produce byte-identical canonical manifest/tile payloads and
+diagnostics order. Any byte-affecting input/version changes the key. Fresh output and
+cache reuse pass the same envelope, requested-key, size, digest, bounds, dependency and
+Terrain semantic validation before generation assembly.
+
+### 5. Cache names identify different owners and lifetimes
+
+“Terrain cache” is never used without one of these explicit classes:
+
+| Cache/store | Owner | Contents/lifetime | Eviction authority |
+|---|---|---|---|
+| Terrain source/document storage | Editor/Assets | Mutable canonical authored revisions | Document/asset transaction only; not a cache |
+| Cook cache | Assets | Immutable content-addressed contribution artifacts | Assets cache policy; never changes active generation |
+| Cooked generation | Assets | Verified manifest and immutable packaged/runtime artifacts selected by `current.json` | New atomic generation publication/package lifecycle only |
+| Provider byte/chunk cache | Assets provider/package system | Immutable artifact bytes under provider leases | Provider policy after leases release |
+| Decoded Terrain tile/cluster cache | TerrainRuntime | Horo-neutral decoded/prepared payloads for one dataset generation | Terrain policy inside granted World Streaming slice |
+| GPU residency/cache | Render | Native resources and frames-in-flight retirement | Render under ADR-027/034 |
+| Collision artifact/body cache | Physics | Solver artifacts and installed bodies | Physics |
+| Navigation artifact/tile cache | Navigation | Neutral/provider artifacts and installed query topology | Navigation |
+
+Each physical allocation has one charge identity and one release acknowledgement.
+Shared leases may project the same charge across ledgers but cannot count it twice or
+make it unaccounted. Evicting a derived cook-cache entry does not unload a resident
+tile; evicting decoded Terrain data cannot release a GPU/Physics/Navigation lease;
+publishing a new generation does not delete the old while readers remain.
+
+TerrainRuntime may evict only disposable decoded/prepared data inside its admitted
+slice. A tile required by an Active/pinned cell, mutation candidate, frame snapshot or
+consumer install is leased and not evictable. Pressure outside the slice or requiring
+cell removal is reported to World Streaming rather than solved by a private global LRU.
+
+### 6. World Streaming commands; Terrain executes feature-local residency
+
+World Streaming resolves demands into a generation-scoped command equivalent to:
+
+```cpp
+struct TerrainResidencyRequest {
+    StreamingCellHandle cell;
+    TerrainRuntimeHandle terrain;
+    TerrainContentRevision content;
+    BoundedArray<TerrainTileId> tiles;
+    BoundedArray<FoliageClusterId> clusters;
+    StreamingReservationToken reservation;
+    TerrainRequiredReadiness required;
+    StreamingRequestGeneration request;
+};
+```
+
+The request contains approved work and reservation, not a native target or mutable
+cache pointer. Terrain validates exact dataset/manifest membership, revisions, bounds,
+cost and reservation before starting one operation-owned task group. Unknown cost is
+not zero. Growth must be reserved before allocation.
+
+Terrain owns the per-request feature pipeline:
+
+```text
+Absent -> Requested -> Loading -> Decoded -> PreparingConsumers -> Ready
+   \          \           \              \                    -> Failed
+    +---------------------------------------------------------> Retiring -> Absent
+```
+
+Assets provider reads immutable exact artifacts. Workers validate envelope/digest,
+decode into operation-owned candidates and produce Horo-only consumer descriptors.
+Render/Physics/Navigation prepare their own exact-generation resources through owner
+queues. Terrain reports readiness evidence; World Streaming alone commits the cell
+after every required provider is prepared.
+
+Terrain has no independent camera/distance cell scheduler. It may order bounded units
+inside an already admitted request, but cannot change global priority, invent demand,
+borrow reservation, commit/evict a cell or silently lower required readiness. Optional
+detail fallback must be declared in the captured Terrain plan and reported.
+
+### 7. Loading, cancellation and failure publish no partial tile
+
+All source/provider reads, allocation, decode and consumer preparation occur in owned
+candidates. No snapshot exposes partially decoded height/layers, half a foliage
+cluster, or a tile whose required consumers are not prepared.
+
+Cancellation before cell/tile commit stops new work, joins/yields workers and retires
+candidate consumer resources in reverse ownership order. Cancellation is not evidence
+that provider/native work stopped; payload/reservation/module leases remain until each
+owner acknowledges retirement. A cancelled candidate never becomes a cache hit or
+active generation by side effect.
+
+Malformed/corrupt/oversized bytes, missing dependencies, stale dataset/cell/request/
+capability revision, reservation denial and consumer failure return typed results to
+World Streaming. Required failure aborts the aggregate cell candidate. Optional
+failure is visible only when the plan declared absence/fallback. The prior resident
+tile/cell generation remains unchanged.
+
+### 8. Replacement is manifest-driven and seam-safe
+
+Assets atomically publishes a complete new cooked generation; that alone does not
+mutate a running TerrainRuntime. Editor hot reload/application code pins the new Assets
+generation, validates the dataset manifest and requests a Terrain replacement candidate
+against the old content/runtime generation.
+
+The manifest declares a dependency/seam closure for changed tiles. Terrain may retain
+unchanged old payloads only when their full artifact identity and neighbor seam/
+dependency signatures match the new manifest. Otherwise it prepares the affected
+closure together. A visible/physical/nav-required cohort cannot mix incompatible
+old/new seams or consumer-source schemas.
+
+The coordinator publishes one new immutable Terrain root/content revision at a safe
+point after required resident cohorts and consumers prepare. Unrequested tiles refer
+only to the new manifest and load from it later. Old snapshots/cells/GPU/Physics/
+Navigation state remain pinned to the old generation until retirement. Equality of
+tile coordinate, `AssetId` or cache path cannot revalidate them.
+
+Failure, cancellation, stale source, newer replacement supersession or cache corruption
+destroys only the candidate and preserves the old Active root. Runtime never follows
+`current.json` repeatedly, combines files from two generation directories or repairs a
+manifest from directory contents.
+
+### 9. Runtime mutation does not rewrite cook/cache truth
+
+ADR-137 runtime deformation and dynamic foliage live in separate mutation-overlay
+state. They may reference stable base tile/type identities and exact content/mutation
+revisions, but never alter source assets, cooked payloads, cache entries, generation
+manifests or Assets provider bytes.
+
+Persistence/replication records product-owned semantic changes or typed overlay state,
+not decoded-cache/native buffers. A recook/replacement explicitly rebases or rejects
+overlays by later TRF policy; it cannot apply them to a coordinate-matched new tile
+without generation/semantic validation.
+
+### 10. Packaging and runtime validation retain complete provenance
+
+Packaging includes only the selected verified generation closure and required tile/
+cluster/dependency artifacts for the product/world chunks. Source files, import
+candidates, editor transactions and cook-cache entries are excluded from normal runtime
+packages. Streaming cell Terrain/Foliage blocks reference exact manifest/artifact
+identities; they are not a second copy of identity or publication authority.
+
+Runtime validates dataset/tile schema compatibility, expected target/tier/profile,
+manifest membership, size/digest/bounds and dependencies before allocation/publication.
+A newer unsupported schema, missing required tile, stale cell reference or wrong target
+fails rather than invoking a cooker, scanning source or selecting another artifact.
+
+### 11. Shutdown retires in owner order and preserves durable truth
+
+TerrainRuntime shutdown closes new residency/replacement admission, cancels/yields
+owned jobs, invalidates candidates and asks consumer owners to retire exact generations.
+It retains decoded bytes, Assets leases, reservations and module/provider dependencies
+until worker, snapshot, Render, Physics and Navigation acknowledgements complete.
+
+World Streaming retains cells/reservations in Retiring while Terrain retirement is
+pending. Assets generation/cache storage remains independently valid; runtime shutdown
+does not delete source, cooked generations or cook cache. A deadline reports typed
+incomplete retirement and cannot force-free or mark a cell Absent early.
+
+### 12. Errors, diagnostics and qualification are typed and bounded
+
+Stable outcomes include:
+
+```text
+terrain.source.invalid
+terrain.source.stale
+terrain.cook.dependency_missing
+terrain.cook.nondeterministic
+terrain.manifest.invalid
+terrain.tile.not_found
+terrain.tile.corrupt
+terrain.tile.stale
+terrain.cache.invalid
+terrain.streaming.reservation_denied
+terrain.streaming.capacity_exceeded
+terrain.streaming.consumer_failed
+terrain.streaming.cancelled
+terrain.streaming.retirement_stalled
+terrain.replacement.incompatible
+```
+
+Diagnostics expose safe dataset/tile IDs, generations/revisions, stage, bounded sizes/
+counts, cache class/hit outcome, reservation state and normalized nested cause. They do
+not dump source/payload bytes, paths, native handles, pointers or unbounded provider
+messages. Metrics remain aggregate by stage/cache class/result, not per tile/asset.
+
+Required evidence includes:
+
+- source import/reimport ownership and stale document/source transaction rollback;
+- canonical source candidates with malformed/hostile dimensions, numeric values,
+  overflow, work and byte limits;
+- deterministic dataset/manifest/tile output across thread counts/job order/hosts for
+  qualified inputs, plus every dependency/key/schema invalidation;
+- fresh-versus-cache-hit parity and corrupt/wrong-key/truncated/oversized/symlinked
+  cache entries never entering a candidate generation;
+- manifest duplicate/missing/overlap/order/bounds/seam/dependency/digest rejection;
+- explicit proof that Terrain payloads contain no native Render/Physics/Navigation
+  handles and each consumer owns its derived/native cache;
+- World Streaming request/reservation/growth/priority/cell-generation races with no
+  private Terrain global scheduler or budget escape;
+- cancellation/failure at provider read, decode, each consumer prepare, aggregate
+  commit and retirement with old resident state preserved;
+- changed-tile seam closure, compatible unchanged reuse, incompatible cohort rejection,
+  superseding hot reload and old/new lease-safe retirement;
+- cook cache, active generation, provider bytes, decoded Terrain, GPU, Physics and
+  Navigation cache eviction independently affecting only their owned lifetime;
+- packaging closure and runtime wrong-target/tier/schema/membership/digest/dependency
+  validation without runtime cook/source fallback; and
+- partial initialization, cell eviction, device/provider loss, world unload and repeated
+  shutdown with reservations/dependencies retained until safe acknowledgement.
+
+## Consequences
+
+- Assets remains the sole generic source/cook/cache/publication authority while Terrain
+  owns heightfield/foliage semantics and independently verifiable feature payloads.
+- World Streaming controls global demand and budget; Terrain can optimize/evict only
+  decoded feature-local state inside the granted slice.
+- Cooked generations, decoded tiles and consumer-native resources have distinct owners,
+  identities and retirement, eliminating ambiguous “terrain cache” behavior.
+- Manifest-driven seam/dependency closure permits bounded tile streaming and safe hot
+  replacement without mixing incompatible generations.
+- Native Physics/Navigation/Render artifacts remain consumer-owned and cannot leak into
+  Terrain public/cooked contracts.
+- Implementation requires versioned Terrain schemas, deterministic cook tests, bounded
+  manifest validation and coordinated multi-owner preparation/retirement.
+
+## Rejected Alternatives
+
+### Let Terrain own a separate importer/cooker scheduler and cache root
+
+Rejected because Assets already owns source snapshots, catalogs, dependencies, atomic
+publication and cache integrity. A second path would create incompatible truth.
+
+### Store one monolithic eagerly loaded terrain artifact
+
+Rejected because large worlds need bounded independent tile reads, cost estimates,
+cell packaging and eviction. A verified manifest owns membership and seams.
+
+### Put native Physics or Navigation objects in Terrain tiles
+
+Rejected because provider build identity, thread affinity, readiness and retirement
+belong to the consumer. Terrain may emit only neutral source descriptors.
+
+### Let Terrain prioritize cells from camera distance
+
+Rejected because World Streaming combines camera, gameplay, network and preload demand
+under one global budget/fairness authority. Terrain executes admitted feature work.
+
+### Treat any file under a tile directory as manifest membership
+
+Rejected because stale/orphan/partial files could become active. The canonical verified
+manifest is the only dataset membership authority.
+
+### Follow Assets `current.json` on every tile request
+
+Rejected because one running Terrain generation could mix artifacts across publications.
+Runtime pins one verified generation until explicit replacement.
+
+### Replace changed tiles independently without seam/dependency closure
+
+Rejected because neighbors and consumer artifacts may be incompatible, causing cracks
+or visual/physical/navigation disagreement. Compatible reuse requires exact signatures.
+
+### Use one LRU to evict cook, decoded, GPU, Physics and Navigation data
+
+Rejected because these stores have different owners, leases, budgets and safety gates.
+Each owner releases only its own resources; World Streaming coordinates global pressure.
+
+### Publish decoded terrain before required consumers prepare
+
+Rejected because a cell could appear Active without required collision/navigation or
+with stale GPU state. Required readiness participates in the aggregate commit.
+
+### Rewrite cooked/cache bytes for runtime deformation
+
+Rejected because it destroys deterministic artifact identity and reader safety. Runtime
+mutation is a separate revisioned overlay.
+
+### Force-remove retiring tiles when a shutdown deadline expires
+
+Rejected because workers, snapshots, frames or provider objects may still reference
+them. Typed incomplete retirement preserves ownership truth.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -302,6 +302,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Terrain and Foliage Ownership, Data, Tier and Lifecycle](../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md):
   public/runtime module boundaries, authored/cooked/live data strata, typed identity
   and revisions, provider-neutral tier resolution, aggregate lifecycle and retirement.
+- [Terrain Source, Cooked Tile, Cache and Streaming Ownership](../adr/138-terrain-source-cooked-tile-cache-and-streaming-ownership.md):
+  canonical Terrain import/cook ownership, deterministic dataset manifests, cache
+  authorities, typed World Streaming residency and seam-safe generation replacement.
 - [World Streaming Architecture](./runtime/world-streaming-architecture.md):
   streaming cells, volumes, priority, budgets, server authority, and editor
   world-composition tools.

--- a/docs/architecture/runtime/asset-pipeline.md
+++ b/docs/architecture/runtime/asset-pipeline.md
@@ -647,6 +647,34 @@ ownership, and C++ object ownership do not cross that ABI. The adapter must
 validate all output before it can enter the cache or a candidate cooked
 generation, so external and built-in contributions cannot bypass host invariants.
 
+### Terrain Domain Import And Cook Boundary
+
+[ADR-138](../../adr/138-terrain-source-cooked-tile-cache-and-streaming-ownership.md)
+applies the generic-Assets/domain-semantics split to Terrain and Foliage. Assets owns
+tracked source bytes and `AssetId`, immutable input borrows, cooker registration and
+scheduling, dependency-aware keys, cache storage, staging, verified generation
+manifests, atomic `current.json` publication and provider byte leases. It does not
+interpret height, layer, hole, seam, foliage placement, coordinate or LOD semantics.
+
+Terrain Import/Model owns external format decoding and canonical authored Terrain
+source validation. Terrain Cook owns deterministic tiling, seam/mip/LOD derivation,
+layer/hole/spline semantics, foliage clustering and Terrain manifest/tile schemas. Both
+are bounded catalog contributions; they create no second asset identity, dependency
+graph, scheduler, cache directory or publication authority.
+
+The dependency-aware key closes over the exact canonical Terrain source revision and
+digest, every accepted dependency artifact, tiling/seam/LOD/compression policy,
+effective tier/limit profile, Terrain source/cooked/manifest/algorithm versions and the
+generic target/toolchain envelope. The resulting immutable dataset manifest binds a
+canonically ordered set of independently verifiable tile/cluster artifacts with exact
+bounds, digests, seam/dependency signatures and peak costs. Native Render, Physics and
+Navigation artifacts are excluded and remain separately keyed by their owners.
+
+Runtime pins one verified published generation through the Assets provider. It never
+scans an output directory, follows `current.json` independently for each tile, imports
+source or cooks a missing variant. Package validation applies the same manifest, digest,
+limit and dependency checks used by fresh cook and cache reuse.
+
 ### VFX Domain Import And Cook Boundary
 
 [ADR-126](../../adr/126-vfx-graph-compilation-and-runtime-representation-convergence.md)
@@ -1378,6 +1406,13 @@ public:
 Hot reload is editor-only. Release builds do not support asset modification at
 runtime; they rely on chunk loading and unloading.
 
+Terrain dataset reload is a generation replacement, not an in-place reaction to
+`AssetReloadedEvent`. TerrainRuntime pins its current verified generation, prepares the
+new manifest and its seam/dependency closure under World Streaming reservations, and
+publishes only after all required consumers are ready. A failed/cancelled candidate
+leaves the old generation Active; old artifact and native-resource leases retire after
+their last reader rather than when `current.json` changes.
+
 ## Asset Cache
 
 AST-001C's cache is a derived, immutable content-addressed store. The canonical
@@ -1553,6 +1588,10 @@ adapters only; they do not own pipeline policy.
   runtime loading, and audio memory budgets.
 - [Prefab Architecture](./prefab-architecture.md): prefab asset format, expansion,
   and cook-time inlining.
+- [Terrain And Foliage Architecture](./terrain-and-foliage-architecture.md): canonical
+  Terrain source, deterministic dataset/tile cooking and runtime residency.
+- [ADR-138](../../adr/138-terrain-source-cooked-tile-cache-and-streaming-ownership.md):
+  Terrain import/cook contribution, cache, publication and generation-pinning boundary.
 - [Release Architecture](../release/release.md): packaging and verification.
 - [Horo Package System](../packages/package-system.md): bulk asset import from packages.
 - [Asset Import Modal](./asset-import-modal.html): HTML reference design for the

--- a/docs/architecture/runtime/terrain-and-foliage-architecture.md
+++ b/docs/architecture/runtime/terrain-and-foliage-architecture.md
@@ -11,6 +11,9 @@ render extraction, streaming budget integration, and editor authoring tools.
 is the foundation contract for this subsystem. Terrain is a backend-neutral runtime
 vertical slice with distinct `TerrainApi` and `TerrainRuntime` ownership; it is not
 part of generic Foundation, RuntimeScene internals or a renderer backend.
+[ADR-138](../../adr/138-terrain-source-cooked-tile-cache-and-streaming-ownership.md)
+defines the complementary source, cook, tile-manifest, cache, residency and generation-
+replacement contract.
 
 ## Ownership And Data Boundaries
 
@@ -88,6 +91,31 @@ fallback and is never a runtime clamp that drops layers silently.
 
 Heightfield assets are authored in the editor or imported from external
 formats (heightmap PNG/EXR, RAW16, GeoTIFF, Houdini HeightField).
+
+### Source, Cook And Dataset Ownership
+
+External files are untrusted import inputs, not canonical terrain identity or runtime
+data. Assets/Application owns tracked source bytes, `AssetId`, generic importer/cooker
+orchestration, dependency scheduling, immutable cache storage, generation staging and
+atomic publication. Terrain Import/Model owns format interpretation and the canonical
+authored height/layer/hole/coordinate semantics; Terrain Cook owns deterministic tiling,
+seams, LOD/mips, foliage clustering and Terrain artifact schemas. Neither contribution
+creates a parallel asset graph, cache root, scheduler or publication pointer.
+
+One immutable `CookedTerrainDatasetManifest` binds the selected content revision, tier,
+coordinate profile, bounds, dependency fingerprint and canonically sorted tile/cluster
+entries. Every entry declares stable typed address, exact bounds, seam/dependency
+signatures, artifact identity, digest, byte/peak-work bounds and required neutral
+consumer payloads. Tile artifacts are independently readable and verifiable, but the
+verified manifest is the only membership authority; runtime never infers a dataset by
+enumerating files.
+
+The Terrain cook fingerprint includes the exact canonical source revision/digest, every
+accepted dependency artifact, tiling/seam/LOD/compression policy, effective tier/limits,
+Terrain schemas and algorithm versions, and generic target/toolchain envelope identity.
+Paths, timestamps, locale, job order and runtime/provider handles are excluded. Native
+GPU resources, solver objects and navigation-provider tiles remain separately keyed and
+owned by Render, Physics and Navigation.
 
 ### Terrain Collision
 
@@ -405,13 +433,19 @@ report `terrain.shutdown.incomplete`; it cannot force-free possibly referenced s
 
 ## Memory And Streaming
 
-Terrain tiles and foliage instance data are streamed based on camera
-proximity:
+World Streaming converts camera, gameplay, network and preload demand into typed,
+generation-scoped Terrain residency requests. Terrain executes admitted work as a
+bounded `Queued -> Reading -> Validating -> Decoding -> PreparingConsumers -> Prepared`
+pipeline using immutable provider byte leases and cancellation tokens. It cannot create
+a private camera-distance queue or begin allocation before the shared reservation is
+accepted. Foliage clusters use the same authority and lifecycle.
 
-- Terrain height and weight data uses a tile cache with LRU eviction
-- Foliage instance buffers are loaded per-cluster with distance-based
-  priority
-- Streaming uses the asset pipeline's async I/O with cancellation tokens
+“Terrain cache” must identify its owner. Assets owns immutable cook-cache entries and
+published cooked generations; the Assets provider owns leased artifact/chunk bytes;
+TerrainRuntime owns Horo-neutral decoded tile/cluster data; Render owns GPU residency;
+Physics owns solver artifacts/bodies; Navigation owns provider artifacts and installed
+query tiles. Each allocation has one charge and one release acknowledgement. Evicting
+one class never implies release of another.
 
 World Streaming owns the global cell priority queue and aggregate CPU/GPU/staging/
 retirement ledger. Terrain owns only its provider-local cache policy within an admitted
@@ -439,9 +473,17 @@ slices for terrain and foliage. The resolved byte/count budget is a capability t
 not an additional allowance. Terrain may evict only disposable provider-local detail
 inside its allocated slice; pressure involving a pinned/activation-critical cell is a
 typed request to World Streaming. Foliage instance buffers are loaded per-cluster with
-distance-based priority. Terrain tiles and foliage clusters are payloads within
-`StreamingCell` objects. Load priority is coordinated through the world-streaming
-priority queue; terrain does not maintain an independent priority system.
+the priority assigned by World Streaming. Terrain tiles and foliage clusters are
+payloads within `StreamingCell` objects. Active cells, replacement candidates, immutable
+snapshots and consumer installs pin their exact dataset generation and leases.
+
+Hot replacement validates a complete candidate generation before publication. A changed
+tile expands to its manifest-declared seam/dependency closure; exact-signature matches
+may reuse old immutable payloads, while incompatible neighbors prepare together. World
+Streaming commits the aggregate cell only after every required Terrain, Render, Physics
+and Navigation participant is prepared. Failure or cancellation discards candidate-
+owned state and preserves the prior Active generation. Old generations retire only
+after all byte, snapshot, native-resource and provider leases acknowledge release.
 
 ## Feature Tiers
 
@@ -480,6 +522,10 @@ Required coverage includes:
   handles, content/residency/mutation/capability revisions and leases;
 - malformed, oversized and incompatible source/cooked/scene descriptors with bounded
   decode and no mutable whole-dataset buffer crossing the public boundary;
+- canonical dataset membership/order, tile digest/bounds/seam/dependency validation,
+  complete cook-key invalidation and byte-identical deterministic recook/cache reuse;
+- independent corruption/missing-artifact rejection and package-time verification with
+  no directory enumeration or mixed-generation tile admission;
 - every tier/cooked/provider capability combination, required failure and each declared
   fallback reason without silent clamp/drop/provider selection;
 - candidate failure/cancellation and replacement at every Scene/streaming/render/
@@ -490,6 +536,8 @@ Required coverage includes:
   cooked-source mutation or implicit foliage eviction;
 - world-streaming reservation/growth/pressure accounting for staging, old/new and
   retiring generations without double charge or oversubscription;
+- source/cook/provider-byte/decoded/GPU/Physics/Navigation cache ownership, pinning and
+  release tests, including pressure and replacement seam-closure cases;
 - headless, dedicated server, editor preview, Null Render and every interactive backend
   consuming the same Horo contract; and
 - bounded owner/worker/native-thread handoff, frame-hot allocation/I/O checks, device
@@ -520,3 +568,6 @@ Required coverage includes:
 - [ADR-137](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md):
   module/data authorities, typed identity and revisions, provider-neutral tier plan,
   aggregate lifecycle, readiness and shutdown baseline
+- [ADR-138](../../adr/138-terrain-source-cooked-tile-cache-and-streaming-ownership.md):
+  canonical source and deterministic tile cooking, cache authorities, World Streaming
+  residency, seam-safe replacement and generation retirement

--- a/docs/architecture/runtime/world-streaming-architecture.md
+++ b/docs/architecture/runtime/world-streaming-architecture.md
@@ -311,6 +311,16 @@ infer required collision/navigation/visual readiness from decoded height data al
 Old/new dataset generations, staging/upload copies and dependent-system retirement stay
 charged until their respective owners release the shared reservation identity.
 
+[ADR-138](../../adr/138-terrain-source-cooked-tile-cache-and-streaming-ownership.md)
+defines the concrete asset/residency handoff. This authority issues typed cell- and
+generation-scoped tile/cluster requests with an accepted reservation token; Terrain
+performs provider reads, manifest/digest validation, decode and consumer preparation.
+The verified dataset manifest, not directory contents or a Terrain-private camera queue,
+defines membership. Terrain may evict disposable decoded detail inside its slice, but
+Active/pinned cells and candidate/native leases remain charged. Changed tiles replace
+with their manifest-declared seam/dependency closure, and this authority commits only
+after the aggregate required readiness barrier succeeds.
+
 ## Streaming Volumes, Priority And Retry Policy
 
 Camera, Gameplay, NetworkRelevance and Preload volumes create bounded residency
@@ -928,6 +938,7 @@ See [Coordinate Precision And Origin Rebasing](./coordinate-precision-and-origin
 - [Asset Pipeline](./asset-pipeline.md): Streaming cell assets, chunked package archives, and async I/O with `CancellationToken`.
 - [Terrain And Foliage Architecture](./terrain-and-foliage-architecture.md): Terrain clipmap streaming and cell-aligned foliage clusters.
 - [ADR-137](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md): Terrain/Foliage data, tier, lifecycle, readiness and reservation ownership.
+- [ADR-138](../../adr/138-terrain-source-cooked-tile-cache-and-streaming-ownership.md): Terrain dataset/tile manifests, cache authorities, typed residency requests and seam-safe generation replacement.
 - [Physics Architecture](./physics-architecture.md): Static mesh collider registration and scene binding.
 - [Networking Architecture](./networking-architecture.md): Server-authoritative cell relevance and replication.
 - [Concurrency And Job System](../foundation/concurrency-and-jobs.md): Job workers, cancellation tokens, and thread roles.


### PR DESCRIPTION
## Summary

Defines the normative ownership boundary for Terrain source import, deterministic
dataset/tile cooking, cache layers, World Streaming residency, and generation-safe
replacement.

This change adds ADR-138 and projects its decisions into the Terrain/Foliage, Asset
Pipeline, and World Streaming architecture contracts. It establishes that:

- Assets owns tracked source bytes, generic importer/cooker orchestration, dependency
  scheduling, immutable cook storage, generation publication, and provider byte leases.
- Terrain owns external-format semantics, canonical authored source validation,
  deterministic tiling/seam/LOD/foliage derivation, dataset manifests, decoded tile
  residency, and feature-local preparation.
- World Streaming owns global demand, priority, aggregate reservations, cell-level
  commit/eviction barriers, and pressure decisions.
- Render, Physics, and Navigation retain exclusive ownership of their native derived
  artifacts, caches, installation, and retirement.

The PR also replaces ambiguous “Terrain LRU” and direct hot-reload language with explicit
cache classes, exact generation pinning, seam/dependency closure replacement, and
lease-safe retirement.

## Why

The existing documents named the major participants but did not assign the full source
to runtime chain. In particular, they did not define which representation is canonical,
what closes the Terrain cook key, how independently streamed tiles prove membership,
which subsystem owns each cache, or how a changed tile replaces an active generation
without mixing incompatible neighbors.

Without a single decision, implementations could accidentally introduce a second asset
cache or scheduler, scan directories to infer tile membership, follow `current.json` per
tile, count the same allocation in multiple budgets, or free old GPU/Physics/Navigation
state while readers still hold it. Those failure modes can produce terrain cracks,
visual/collision/navigation disagreement, nondeterministic cooks, hidden budget
oversubscription, and use-after-retirement hazards.

ADR-138 closes those gaps before TRF-002 implementation tickets freeze external format
normalization and concrete binary layouts.

## Decision and boundaries

- Adds `ADR-138: Terrain Source, Cooked Tile, Cache and Streaming Ownership`.
- Separates untrusted external import inputs from the mutable canonical Terrain source
  asset; reimport is an explicit revision-checked transaction.
- Defines one immutable `CookedTerrainDatasetManifest` as dataset membership authority.
  Its canonically ordered tile/cluster entries carry exact bounds, digests,
  seam/dependency signatures, artifact identities, peak costs, and consumer payload
  declarations.
- Requires the Terrain cook key to include the exact canonical source and dependencies,
  tiling/seam/LOD/compression policy, selected tier and finite limits, Terrain schemas and
  algorithm versions, and generic target/toolchain envelope identity.
- Distinguishes authored storage, Assets cook cache, published generations, provider
  byte cache, Terrain decoded cache, GPU residency, Physics artifacts, and Navigation
  artifacts. Eviction of one class never implies release of another.
- Defines typed, cell- and generation-scoped Terrain residency requests. Terrain performs
  bounded read/validate/decode/consumer preparation only after World Streaming admission.
- Makes replacement manifest-driven: changed tiles expand to their seam/dependency
  closure, exact-compatible artifacts may be reused, and aggregate publication waits for
  all required Terrain/Render/Physics/Navigation readiness.
- Keeps runtime deformation and dynamic foliage in separate revisioned overlays; runtime
  mutation never rewrites cooked or cache bytes.
- Projects the decision into the architecture index and all three owning subsystem
  documents so ADR and normative contracts do not drift.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/138-terrain-source-cooked-tile-cache-and-streaming-ownership.md docs/architecture/README.md docs/architecture/runtime/asset-pipeline.md docs/architecture/runtime/terrain-and-foliage-architecture.md docs/architecture/runtime/world-streaming-architecture.md`
- `git diff --check`
- `git diff --cached --check`
- Added-Markdown-link resolver over the staged diff: passed.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`: configured and generated
  successfully; public-header inventory and dependency-direction policy passed.

Known environment warnings: the fetched mbedTLS project reports a CMake minimum-version
deprecation, and repository Python tests are skipped because `pytest` is unavailable.
This documentation-only change did not build or run executable targets.

## Risk and rollout

- This is an architecture decision, not an implementation. Follow-up TRF-002 tickets
  must define external-format normalization and concrete artifact layouts within these
  authorities.
- The decision intentionally rejects per-tile live following of `current.json`; runtime
  implementations need an explicit generation replacement coordinator.
- Seam/dependency closure can temporarily retain old and new data. World Streaming peak
  reservations must include both generations and all dependent consumer staging.
- Cache terminology is now strict. Existing or future code that uses a generic “terrain
  cache” name will need to identify the actual owner and lifetime.

## Issue links

- Jira: [HORO-1893](https://horo-engine.atlassian.net/browse/HORO-1893)
- GitHub: [#1937](https://github.com/abdullahbodur/horo-engine/issues/1937)
- Domain ticket: `[TRF-002.1]`
- Parent capability: `HORO-1883 / [TRF-002]`
- Follow-up normalization decision: `HORO-1896 / [TRF-002.2]`

Closes #1937

## Reviewer Notes

Please focus review on the authority splits rather than concrete struct spelling:

1. Does Assets retain every generic import/cook/cache/publication responsibility while
   Terrain owns only domain semantics and decoded residency?
2. Is the dataset manifest sufficient as the sole membership and compatibility authority
   for independently readable tile/cluster artifacts?
3. Does the cook fingerprint include every byte-affecting input without absorbing native
   Render/Physics/Navigation artifact identity?
4. Are cache charges, leases, eviction, cancellation, replacement, and shutdown owned by
   exactly one subsystem at each stage?
5. Does World Streaming remain the sole global demand/budget/commit authority while
   allowing Terrain to execute bounded provider-local work?

The largest normative change is the replacement rule: an active dataset remains pinned,
and changed tiles publish only with their required seam/dependency closure after every
required consumer is prepared.

## Stack

- Base: `docs/HORO-1891_terrain_foliage_ownership_lifecycle`
- Previous PR: #2472 (`HORO-1891 / [TRF-001.1]`)
- This PR: `HORO-1893 / #1937 / [TRF-002.1]`

This PR must merge after #2472. Subsequent M0 Terrain decisions will stack on this branch
unless their Jira rank changes.


[HORO-1893]: https://horo-engine.atlassian.net/browse/HORO-1893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ