### PR TITLE
docs(terrain): define render and lod boundary HORO-1903 #1947 [TRF-003.1]

### DIFF
--- a/docs/adr/139-terrain-render-extraction-material-lod-and-tier-boundary.md
+++ b/docs/adr/139-terrain-render-extraction-material-lod-and-tier-boundary.md
@@ -1,0 +1,429 @@
+# ADR-139: Terrain Render Extraction, Material, LOD and Tier Boundary
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Terrain/Foliage render-candidate extraction, render-resource realization, material/permutation admission, per-view visibility and LOD ownership, Terrain-tier/render-profile interaction, 1.0 CPU baseline, post-1.0 GPU-driven recipes, replacement, cancellation, device loss and shutdown
+- **Issue**: [TRF-003.1](https://github.com/abdullahbodur/horo-engine/issues/1947)
+- **Jira**: [HORO-1903](https://horo-engine.atlassian.net/browse/HORO-1903)
+- **Related**: [ADR-027](027-renderer-resource-identity-and-descriptors.md), [ADR-028](028-renderer-capability-limits-and-product-profiles.md), [ADR-034](034-gpu-memory-and-residency-ownership.md), [ADR-035](035-shader-source-and-intermediate-representation.md), [ADR-036](036-raster-render-path-and-quality-architecture.md), [ADR-038](038-gpu-scene-and-instance-data-model.md), [ADR-137](137-terrain-foliage-ownership-data-tier-and-lifecycle.md), [ADR-138](138-terrain-source-cooked-tile-cache-and-streaming-ownership.md)
+- **Normative documents**: [Terrain and Foliage Architecture](../architecture/runtime/terrain-and-foliage-architecture.md), [Rendering Architecture](../architecture/runtime/rendering-architecture.md), [Material and Shader Model](../architecture/runtime/material-and-shader-model.md), [LOD and Culling Architecture](../architecture/runtime/lod-and-culling-architecture.md)
+
+## Context
+
+ADR-137 makes Terrain/Foliage a backend-neutral runtime vertical slice and assigns all
+native GPU resources and execution to Renderer. ADR-138 defines immutable dataset/tile
+artifacts, decoded residency and generation replacement. The current Terrain document
+still describes extraction as pushing draw commands into opaque/transparent arrays,
+selects LOD by camera distance inside Terrain, and describes foliage indirect draws as
+if they were mandatory. Those statements do not define the boundary between logical
+resident content and view-dependent presentation.
+
+Several authorities meet at that boundary. Terrain knows tile topology, semantic layer
+bindings, baked LOD error data, foliage type/instance membership, holes, mutations and
+residency. Material/Shader cooking knows legal shader interfaces and permutations.
+World Streaming decides which cells are resident. RenderFrontend knows active views,
+raster recipe, effective device capabilities, GPU budgets, visibility history, native-
+resource generations and pass execution. A private backend only translates an admitted
+plan.
+
+If Terrain emits commands or owns per-view GPU state, it becomes backend-dependent and
+can disagree with the render graph. If Renderer treats resident content as permission to
+choose arbitrary layers or LODs, it can violate Terrain seams and authored requirements.
+If profile names or backend names select features implicitly, missing variants can
+silently drop layers, foliage or visual quality. If the 1.0 contract requires compute,
+indirect draws or GPU Scene, Null/headless and baseline interactive compositions cannot
+validate the same public boundary.
+
+This ADR assigns render-candidate, material, resource, visibility, LOD and tier/profile
+ownership. TRF-003.2 freezes the exact Terrain material-layer and permutation model;
+TRF-003.3 freezes concrete GPU resource and snapshot schemas. This decision constrains
+those contracts without prematurely declaring their layouts implemented.
+
+## Decision
+
+### 1. Terrain publishes render meaning; Renderer owns presentation
+
+| Responsibility | Authority |
+|---|---|
+| Resident tile/cluster/instance membership, semantic surface/layer bindings, holes, baked LOD topology/error, mutation state and immutable snapshot lifetime | TerrainRuntime |
+| View-independent projection from an immutable Terrain snapshot into bounded Horo render candidates | Terrain render-extraction adapter |
+| Material/shader authoring schemas, semantic validation and deterministic cooked permutation requests | Material/Shader domain through Assets Cook |
+| Product raster recipe, per-view visibility/LOD plan, RenderObject/GPU-resource mapping, batching, passes, uploads and deferred GPU retirement | RenderFrontend |
+| Global cell residency, aggregate streaming reservation and cell activation/eviction | World Streaming |
+| Native buffer/image/pipeline/descriptor/command realization and API synchronization | Selected private render backend |
+| Gameplay visibility, targeting, collision, navigation and authoritative distance rules | Their owning gameplay/Physics/Navigation systems, never render results |
+
+The Terrain adapter depends only on TerrainApi and RenderApi value contracts. It does
+not include backend headers, query a native device, register a renderer, select a raster
+recipe, allocate a GPU resource, compile a shader, submit a pass or wait for GPU work.
+Its descriptor construction and registration remain inert until the application host
+explicitly composes the adapter.
+
+RenderFrontend cannot edit Terrain residency, mutation, material-layer meaning or LOD
+topology. It may consume only an immutable leased generation and returns typed readiness,
+pressure and retirement evidence through the composed integration boundary.
+
+### 2. Extraction publishes a bounded view-independent candidate snapshot
+
+The logical boundary is equivalent to:
+
+```cpp
+struct TerrainRenderExtractionSnapshot {
+    TerrainRuntimeHandle terrain;
+    TerrainSnapshotRevision terrainRevision;
+    TerrainContentRevision content;
+    TerrainRenderSchemaVersion schema;
+    TerrainCoordinateFrame coordinates;
+    TerrainRenderRequirements requirements;
+    BoundedSpan<TerrainTileRenderCandidate> tiles;
+    BoundedSpan<FoliageRenderCandidate> foliage;
+    TerrainSnapshotLease lease;
+};
+```
+
+Each candidate carries stable Terrain identity, exact source generation/revisions,
+camera-relative-convertible bounds/transform inputs, neutral cooked geometry/artifact
+references, material-layer-set or material binding identities, baked LOD descriptors and
+seam/neighbor compatibility, hole/visibility semantics, shadow/depth/motion requirements,
+and finite cost estimates. Foliage candidates also carry type, cluster and bounded baked/
+dynamic instance ranges with stable logical instance identity.
+
+Candidates do not contain:
+
+- native handles, addresses, descriptor indices, command buffers, fences or API enums;
+- mutable Terrain pointers, editor state, source paths or provider-owned byte pointers;
+- selected per-view LOD, visible lists, indirect arguments or occlusion results;
+- compiled pass order, pipeline state objects or backend shader modules; or
+- gameplay visibility/collision/navigation truth.
+
+The snapshot is view-independent. Multiple compatible views may consume the same leased
+snapshot without advancing Terrain state. Extraction performs no file I/O, source decode,
+asset cook, blocking shader/pipeline build or unbounded allocation. Capacity is reserved
+before iteration; overflow rejects the frame/view candidate with a typed result rather
+than truncating or silently dropping tiles/instances.
+
+Terrain stable identities are not `RenderObjectId`. RenderFrontend derives stable,
+generation-checked render-object identities from the Terrain runtime/generation and
+tile/subobject or foliage-instance identity, preserving distinct subobjects and retiring
+old mappings under ADR-038.
+
+### 3. Residency, visibility and LOD are independent facts
+
+World Streaming residency means neutral Terrain content and required cell consumers are
+prepared/Active. It does not mean a tile is visible in a particular view. RenderFrontend
+owns per-view frustum, distance, occlusion and presentation classification because those
+depend on the active camera, output, raster recipe, history and effective render plan.
+Render results never evict a cell or become gameplay/streaming truth.
+
+Terrain Cook/Runtime owns the legal representation set:
+
+- canonical LOD identities and geometric-error/transition data;
+- seam, skirt, morph and neighbor-compatibility rules;
+- material/layer/hole semantics preserved at each representation;
+- exact resident/available artifacts and their generation; and
+- required versus optional representation/fallback declarations.
+
+RenderFrontend selects one admitted representation per view from that finite set. The
+selection uses a versioned `TerrainRenderLodPolicy` with camera projection, viewport,
+screen-space error thresholds, hysteresis/transition state, effective profile limits and
+finite work/memory budgets. Distance alone is not the identity or full policy.
+
+Adjacent selections must satisfy the candidate's seam/neighbor constraint. A transition
+may use only declared cooked skirts, morph data or dual-LOD cross-fade. Renderer cannot
+invent geometry, change a Terrain seam signature or independently clamp a neighbor. If
+no compatible required selection is resident/admitted, the view returns explicit
+`Preparing`, `Unavailable` or `Failed` readiness under product policy; it does not render
+a crack, an unrelated tile, flat ground or nothing while reporting success.
+
+Per-view LOD/visibility may emit bounded, generation-tagged demand/pressure observations
+to the application/World Streaming authority for future frames. It cannot synchronously
+load/evict tiles or mutate the current snapshot while planning a frame.
+
+### 4. Material semantics and renderer realization remain separate
+
+Terrain authoring/cook owns the ordered semantic layer set, weight/hole encodings,
+material-function references, required blend features and legal per-tile layer masks.
+Material/Shader cook validates those inputs and emits explicit target artifacts plus
+Horo reflection for a finite permutation family. TRF-003.2 owns the exact key, layer
+limits and blend rules.
+
+At minimum, a Terrain material permutation is distinguished by declared shader/material
+identity, pass, neutral Terrain vertex/payload layout, required layer/blend/hole/wind/
+shadow/motion feature set and target artifact identity. Product profile names are
+admission preferences, not hidden compile flags. A profile-only numeric parameter remains
+a parameter; a byte/code-affecting choice must appear in the declared permutation or
+artifact key.
+
+RenderFrontend resolves material bindings and selects only cooked permutations that
+satisfy the active raster recipe, candidate requirements, effective capabilities/formats/
+limits and exact Terrain content generation. The private backend realizes the selected
+shader/pipeline and bindings; it never chooses another layer count, disables holes,
+changes blend semantics or substitutes a fallback shader.
+
+Opaque, Masked, TransparentSorted and TransparentAdditive are material/render
+classifications, not guesses based on “terrain”, “trunk” or “leaf”. Masked foliage stays
+in depth-writing masked passes; genuinely translucent authored foliage follows the
+declared transparency recipe. Extraction preserves classification requirements and the
+frontend maps them into ADR-036 passes. No candidate is rendered twice or moved between
+classes by backend convenience.
+
+Missing required textures, reflection, target variants, layer capacity, pass
+compatibility or bindings fail preparation before publication. Optional fallback is
+legal only when the authored/cooked material and product plan declare the exact alternate
+variant and observable reason.
+
+### 5. Terrain tier and render product profile are independent axes
+
+ADR-137 `TerrainFeatureTier` (`Baseline`, `Standard`, `High`, `Ultra`) describes a
+provider-neutral Terrain content/runtime preference and its finite layer/LOD/instance/
+work limits. ADR-028 `RenderProductProfile` uses similar labels for renderer recipe
+preference. Equal spelling does not make the values interchangeable, ordered together or
+implicitly convertible.
+
+The application composition resolves a generation-scoped `TerrainRenderPlan` from:
+
+- the requested Terrain tier and its exact finite resolved limits/features;
+- the requested renderer profile and resolved ADR-036 raster recipe;
+- the selected Terrain cooked dataset/material/permutation variants;
+- TerrainRuntime, RenderFrontend and backend effective capability revisions;
+- active view/output requirements and host mode; and
+- World Streaming plus renderer CPU/GPU/staging/retirement budgets.
+
+The result records both requested and selected axes, every exact variant/algorithm,
+numeric capacity, revision, required predicate and fallback edge/reason. A Terrain tier
+cannot grant compute/indirect/bindless support. A renderer profile cannot increase a
+Terrain layer/instance limit, discard required Terrain content or select a different
+dataset. Backend/API names and Debug/Release builds select neither axis.
+
+Fallback traverses only a declared edge with a cooked compatible result. It may lower an
+optional visual recipe while retaining all required Terrain/material semantics. It cannot
+silently drop layers, holes, shadow/collision agreement, instances or required quality;
+switch renderer/backend; invent a runtime shader; or alter World Streaming residency.
+
+### 6. The 1.0 baseline is bounded CPU planning with neutral draw batches
+
+Core 1.0 requires no Terrain-specific compute shader, GPU Scene residency, GPU-driven
+culling, Hi-Z, indirect-count draw, bindless material access, mesh shader, virtual
+texture or native multi-draw facility.
+
+The 1.0 path is:
+
+1. TerrainRuntime publishes one bounded immutable candidate snapshot.
+2. RenderFrontend performs deterministic per-view CPU frustum/distance tests and LOD/
+   seam selection using preallocated work storage.
+3. RenderFrontend resolves cooked material permutations/resources and emits bounded
+   backend-neutral direct or instanced draw batches into the compiled raster graph.
+4. The selected backend translates validated batches and owns native execution.
+
+CPU planning is presentation-only and may run in bounded jobs over frame-owned storage;
+the frontend owns final deterministic merge/order and capacity checks. Normal extraction
+and planning perform no blocking asset I/O or native resource creation. Foliage may use
+renderer-owned instancing, but the public contract does not require indirect execution.
+
+The Null backend validates candidate, plan, pass, capacity, fallback and lifetime
+contracts with deterministic summaries. It claims no raster image, native culling or GPU
+performance qualification. A headless/server host may omit the render adapter entirely;
+Terrain logical/streaming/collision/navigation readiness remains valid without visual
+readiness.
+
+### 7. GPU-driven Terrain/Foliage is an explicit post-1.0 recipe
+
+Post-1.0 may add a renderer-owned GPU-driven recipe using ADR-038 GPU Scene or a dedicated
+renderer-internal Terrain projection, compute frustum/distance/occlusion/LOD selection,
+Hi-Z, compaction and generated indirect batches. That recipe requires a separate accepted
+contract, implemented backend operations, cooked shader/material variants, finite GPU
+buffers/counters, overflow policy, synchronization, observability and cross-backend
+qualification.
+
+Even in that recipe:
+
+- Terrain publishes the same semantic candidate boundary and owns no native work;
+- RenderFrontend owns logical GPU records, per-view work, selected LOD, generated batches
+  and resource generations;
+- the backend owns only native translation/resources/synchronization;
+- GPU visibility and LOD results do not become gameplay or streaming truth;
+- normal frames perform no same-frame CPU readback or GPU wait; and
+- overflow never writes beyond capacity or silently loses required candidates.
+
+GPU unavailability may select the 1.0 CPU path only when the product plan declares it,
+the required content fits its finite limits, and compatible cooked variants exist. A
+required GPU-driven product fails admission instead of pretending CPU equivalence.
+
+### 8. Resource preparation and aggregate publication are transactional
+
+Terrain render readiness is a joint generation fact, not “decoded tile exists”. For each
+candidate generation, RenderFrontend validates the snapshot/schema, effective plan,
+material/permutation artifacts and peak allocation estimates before staging resources.
+CPU preparation may occur on workers; native creation/upload and registry publication
+occur through renderer-owned queues and `RenderSafePoint` rules.
+
+Candidate resources are detached from the Active set. Failure, cancellation, stale
+Terrain/content/capability/view evidence, budget denial or device loss before publication
+destroys only candidate-owned work and preserves the prior valid generation. World
+Streaming/Terrain aggregate commit accepts visual readiness only for the exact requested
+generation and plan.
+
+Terrain snapshot/provider-byte leases remain alive until upload no longer reads them.
+Published render resources retain exact material/artifact dependencies. In-flight frames,
+GPU Scene/draw work and backend submissions pin old generations; Terrain replacement or
+cell eviction cannot force-free them. Render acknowledges retirement only after GPU
+completion and resource-dependency release, allowing Terrain/World Streaming to release
+their corresponding shared charge/lease.
+
+### 9. Replacement, device loss and shutdown never cross ownership
+
+Terrain content, mutation, residency, material, renderer-profile, view/output and device
+changes each create a new tagged candidate/plan generation. They never patch values
+visible to an in-flight frame. Exact-compatible immutable artifacts may be reused only
+when their full Terrain/material/render signatures match; a same tile or material name is
+insufficient.
+
+On device loss, RenderFrontend invalidates native resource generations and rebuilds from
+its declared reconstruction sources under ADR-027/034. Terrain remains logical truth and
+may lend the same still-valid snapshot/artifacts; it does not recreate native objects or
+pretend visual readiness. Failed reconstruction reports visual failure while independent
+Terrain/Physics/Navigation state follows its own policy.
+
+Shutdown closes new extraction/resource admission, cancels or drains renderer-owned
+candidate work, rejects late generations, stops new frame use and retires native state on
+the required owner thread. The render adapter releases Terrain snapshots only after its
+CPU and upload reads end. A deadline may report incomplete renderer retirement; it cannot
+force Terrain or Renderer to release possibly referenced state.
+
+### 10. Errors and observability preserve both domains
+
+The boundary returns typed errors with safe context such as Terrain runtime/content/
+snapshot revisions, tile/cluster/type identity, render plan/profile/capability revision,
+view/output generation, material/permutation/artifact identity, required feature, budget
+and nested provider cause. Stable categories include:
+
+```text
+terrain.render.snapshot_incompatible
+terrain.render.candidate_capacity_exceeded
+terrain.render.required_representation_unavailable
+terrain.render.seam_plan_unsatisfied
+terrain.render.material_variant_missing
+terrain.render.material_binding_incompatible
+terrain.render.profile_plan_unsatisfied
+terrain.render.resource_budget_denied
+terrain.render.stale_generation
+terrain.render.device_lost
+terrain.render.retirement_incomplete
+```
+
+Metrics use bounded registered dimensions and distinguish candidate/visible/drawn counts,
+CPU planning time, LOD selections/transitions, material/variant batches, resource bytes,
+upload/backpressure, fallback reason and retirement depth. Tile/instance/material IDs,
+paths and native handles do not become metric dimensions. Detailed per-item evidence is
+available only through bounded explicit diagnostics/captures and never drives policy.
+
+### 11. Verification proves the boundary and both recipe classes
+
+Required coverage includes:
+
+- compile/dependency tests proving Terrain and extraction public contracts expose no
+  backend/native header, handle, command or service-locator dependency;
+- deterministic bounded extraction from immutable snapshots, multi-view reuse, capacity
+  failure and stale Terrain/content/mutation/residency/capability generation rejection;
+- strong separation of Terrain identity, RenderObject/resource identity, material/
+  permutation identity, view visibility and World Streaming residency;
+- material classification, layer/hole/blend requirements, pass mapping and missing/
+  incompatible required variant failures without silent fallback;
+- Terrain-tier × render-profile × raster-recipe × cooked-variant × effective-capability
+  matrices, including declared fallback reasons and forbidden implicit conversions;
+- CPU 1.0 frustum/distance/LOD/seam planning with direct/instanced neutral batches, finite
+  workspaces, deterministic merge/order and no indirect/compute dependency;
+- optional post-1.0 GPU recipe admission, overflow, synchronization and declared CPU
+  fallback behavior without same-frame readback or gameplay authority;
+- adjacent-tile LOD compatibility, transition/hysteresis, unavailable representations and
+  view/output/history changes without cracks or mixed generations;
+- candidate failure/cancellation and replacement at validation, upload, prepare, aggregate
+  commit, in-flight frame and deferred-retirement boundaries;
+- World Streaming/ADR-034 shared charge accounting for staging, active, old/new and
+  retiring resources without double counting or early release;
+- device loss/reconstruction, backend replacement, project/world close, repeated shutdown
+  and incomplete-retirement reporting; and
+- Null/headless/dedicated-server plus every interactive backend composition, with native
+  visual/performance qualification only on supported hardware lanes.
+
+## Consequences
+
+- TerrainRuntime has a stable, backend-neutral render-candidate boundary that remains
+  valid for CPU, future GPU-driven, Null and no-renderer hosts.
+- RenderFrontend becomes the sole owner of per-view visibility, LOD selection, draw/pass
+  planning and GPU resource lifetime while respecting Terrain-authored legal choices.
+- Terrain feature tiers and renderer product profiles can evolve independently without
+  string coupling or silent capability claims.
+- The 1.0 implementation has a concrete bounded CPU/direct-or-instanced path and does not
+  inherit optional GPU Scene/compute/indirect requirements.
+- Post-1.0 GPU-driven work can optimize the same semantic boundary but requires explicit
+  recipe, budget, fallback and qualification contracts.
+- Resource overlap during replacement is visible and budgeted; old Terrain and renderer
+  generations may live longer until all frame/upload/native leases retire.
+- TRF-003.2 and TRF-003.3 must specify exact material/permutation and GPU-resource/schema
+  details without moving the authorities fixed here.
+
+## Rejected Alternatives
+
+### Let Terrain emit backend or render-graph draw commands
+
+Rejected because Terrain would own pass ordering, native capability assumptions and GPU
+lifetime. Terrain emits immutable semantic candidates; Renderer compiles execution.
+
+### Push Terrain candidates directly into generic opaque/transparent arrays
+
+Rejected because this loses Terrain revisions, seam/LOD constraints, material-layer
+requirements and aggregate readiness. A typed bounded Terrain candidate snapshot is the
+handoff.
+
+### Let Terrain select LOD and visibility from camera distance
+
+Rejected because selection is per view and depends on projection, output, raster recipe,
+history and renderer budgets. Terrain owns legal representations and seam rules.
+
+### Treat residency, visibility and gameplay relevance as the same boolean
+
+Rejected because they have different owners and timelines. Renderer visibility cannot
+evict World Streaming cells or authorize gameplay.
+
+### Assume all foliage leaves are translucent
+
+Rejected because Masked and true translucent materials have different depth, sorting and
+raster-recipe behavior. Authored/cooked material classification is authoritative.
+
+### Map Terrain Baseline/Standard/High/Ultra directly to renderer profiles
+
+Rejected because the domains have independent capabilities, limits, required content and
+fallback edges. Equal labels do not imply equal values or conversion.
+
+### Choose Terrain features from `opengl`, `metal`, `vulkan` or `d3d12`
+
+Rejected because API identity grants no effective feature, format, limit, cooked variant
+or budget. The aggregate typed plan uses actual capabilities and content.
+
+### Require GPU culling and indirect draws for core 1.0 Terrain/Foliage
+
+Rejected because it would exclude the bounded baseline, Null and some qualified devices.
+Core 1.0 uses CPU planning plus neutral direct/instanced batches.
+
+### Read GPU visibility/LOD back to drive streaming or gameplay
+
+Rejected because normal-frame synchronization would stall and presentation results are
+not authoritative simulation facts. Only delayed bounded observations may inform future
+owner decisions.
+
+### Compile a missing Terrain shader variant during frame execution
+
+Rejected because it creates unbounded frame-hot work and non-reproducible packaged
+behavior. Required variants are cooked/prepared; missing required artifacts fail.
+
+### Reuse a renderer resource because tile or material names match
+
+Rejected because content, schema, material, permutation, device and capability generations
+may differ. Reuse requires exact compatible signatures and leases.
+
+### Free render resources immediately when Terrain evicts or replaces a tile
+
+Rejected because uploads, frames and GPU submissions may still reference them. Renderer
+owns deferred retirement and acknowledges release after completion.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -305,6 +305,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Terrain Source, Cooked Tile, Cache and Streaming Ownership](../adr/138-terrain-source-cooked-tile-cache-and-streaming-ownership.md):
   canonical Terrain import/cook ownership, deterministic dataset manifests, cache
   authorities, typed World Streaming residency and seam-safe generation replacement.
+- [Terrain Render Extraction, Material, LOD and Tier Boundary](../adr/139-terrain-render-extraction-material-lod-and-tier-boundary.md):
+  immutable Terrain/Foliage render candidates, material/permutation admission,
+  renderer-owned per-view LOD/visibility and core-1.0 versus post-1.0 GPU recipes.
 - [World Streaming Architecture](./runtime/world-streaming-architecture.md):
   streaming cells, volumes, priority, budgets, server authority, and editor
   world-composition tools.

--- a/docs/architecture/runtime/lod-and-culling-architecture.md
+++ b/docs/architecture/runtime/lod-and-culling-architecture.md
@@ -172,7 +172,7 @@ GPU-driven culling consumes an immutable published GPU Scene generation from
 checked view descriptor, Hi-Z/history inputs when admitted and finite output
 capacities:
 
-```
+```text
 1. Compute shader: frustum + occlusion + distance culling
 2. Compact visible instance list
 3. Write indirect draw commands to GPU buffer
@@ -191,6 +191,28 @@ validated batches to private native indirect execution. Culling parameters
 readback is required for normal drawing, and optional diagnostics are asynchronous,
 bounded and generation tagged. GPU visibility is presentation data, not gameplay
 or streaming truth.
+
+## Terrain And Foliage Boundary
+
+[ADR-139](../../adr/139-terrain-render-extraction-material-lod-and-tier-boundary.md)
+separates Terrain representation authority from renderer selection. Terrain Cook/Runtime
+owns the finite legal tile/foliage LOD set, geometric-error inputs, seam/skirt/morph and
+neighbor compatibility, material/hole preservation, resident availability and exact
+content generation. The Terrain extractor publishes those facts in a bounded immutable,
+view-independent candidate snapshot.
+
+RenderFrontend owns selection per view because projection, output extent, raster recipe,
+history/hysteresis and render budgets are presentation inputs. It may select only a
+resident compatible representation and must satisfy adjacent-tile seam constraints. No
+compatible required selection yields explicit preparing/unavailable/failure state rather
+than a crack, flat substitute, silent omission or independent neighbor clamp.
+
+Core 1.0 performs deterministic bounded CPU frustum/distance/LOD/seam planning and emits
+neutral direct or instanced batches. The GPU-driven pipeline above is an optional post-1.0
+Terrain/Foliage recipe requiring separately cooked shaders, complete effective compute/
+storage/indirect capability, finite work buffers and an admitted fallback. GPU-selected
+visibility/LOD remains per-view presentation data and cannot synchronously mutate World
+Streaming residency or become gameplay truth.
 
 ## Debug And Visualization
 
@@ -221,6 +243,7 @@ switches backend, silently drops candidates or changes gameplay visibility.
 
 - [Rendering Architecture](./rendering-architecture.md): draw call submission and indirect draws
 - [Terrain And Foliage Architecture](./terrain-and-foliage-architecture.md): foliage LOD and impostors
+- [ADR-139](../../adr/139-terrain-render-extraction-material-lod-and-tier-boundary.md): Terrain/Foliage representation, per-view selection and CPU/GPU recipe ownership
 - [World Streaming Architecture](./world-streaming-architecture.md): visibility cell streaming
 - [Advanced Rendering Architecture](./advanced-rendering-architecture.md): ray-traced occlusion
 - [Scene Runtime](./scene-runtime.md): renderable component and bounding data

--- a/docs/architecture/runtime/material-and-shader-model.md
+++ b/docs/architecture/runtime/material-and-shader-model.md
@@ -125,10 +125,12 @@ a core workflow but may be added through custom shaders.
 | `ClearCoat` | Optional; dual normal/roughness layer. |
 
 New shading models must register their required vertex attributes, permutation
-keys, and render passes. The renderer may skip unsupported shading models on
-lower feature tiers. For example, `Hair`, `Cloth`, `Subsurface`, and `ClearCoat`
-are typically disabled on `es3`; `dx11` and above may support them depending on
-the renderer backend.
+keys, and render passes. Required shading models fail admission when unavailable.
+Optional models may select only an authored, cooked and product-declared fallback;
+the renderer records that edge and never skips a model from an API name or profile
+label. `Hair`, `Cloth`, `Subsurface`, and `ClearCoat` therefore depend on exact
+effective capabilities, limits and target variants rather than legacy `es3`/`dx11`
+tiers.
 
 ### Material Input Types
 
@@ -335,20 +337,43 @@ layout or another backend's reflection cannot substitute for that map.
 
 ## Renderer Integration
 
+### Terrain Material Boundary
+
+[ADR-139](../../adr/139-terrain-render-extraction-material-lod-and-tier-boundary.md)
+applies this model to Terrain/Foliage. Terrain authoring/cook owns semantic layer order,
+weights, holes, material-function references, legal per-tile layer masks and required
+blend behavior. Material/Shader cook validates those inputs and emits explicit finite
+target permutations with normalized reflection. RenderFrontend selects and binds only a
+cooked permutation compatible with the exact Terrain payload, raster recipe and effective
+capabilities; the backend cannot change layer count, disable holes or substitute a shader.
+
+Terrain `Baseline`/`Standard`/`High`/`Ultra` and renderer product profiles are independent
+typed axes. Equal labels do not imply conversion or a hidden compile flag. Profile-only
+numeric changes remain parameters; shader-byte or interface changes appear as declared
+features, pass/layout identity or target-artifact identity. TRF-003.2 owns the exact
+Terrain material permutation key and layer/blending limits within this boundary.
+
+Opaque, Masked, TransparentSorted and TransparentAdditive classification is authored and
+cooked material meaning, not an extractor guess from foliage type. Missing required
+texture, reflection, permutation, layer capacity or pass compatibility fails preparation.
+An optional lower variant must be explicitly declared, cooked and recorded by the product
+plan.
+
 ### Material Table
 
 The scene runtime owns a `MaterialTable` that maps `MaterialId` to:
 
 - parent material asset
 - resolved parameter block
-- selected shader variant
-- pipeline state object reference
+- declared feature/classification and permutation requirements
 
-The table is populated during scene conversion. Changing the parent material or
+This semantic table contains no resident shader, pipeline state object or native binding.
+RenderFrontend owns a generation-scoped realization that maps `MaterialId` plus packed
+`MaterialBindingId` to the admitted cooked variant, renderer resources and pipeline.
+The semantic table is populated during scene conversion. Changing the parent material or
 feature flags at runtime requires an explicit material swap. Editing per-instance
-parameter overrides does not require a swap; the scene runtime updates the
-instance's entry in the material table under a new override hash while the parent
-material remains shared.
+parameter overrides does not require a swap; the scene runtime updates the instance's
+entry under a new override hash while the parent material remains shared.
 
 ### Render Extraction
 
@@ -371,7 +396,8 @@ Materials declare which render passes they participate in:
 - `MotionVectors`
 - `CustomN`
 
-The render graph queries the material table for the correct variant per pass.
+The render graph queries the RenderFrontend realization for the exact admitted variant
+per pass and retains its generation through execution.
 
 ### GBuffer Contract
 
@@ -432,6 +458,8 @@ Cook-time diagnostics:
 - Cook tests that verify variant emission for each standard feature flag.
 - Runtime tests for explicit optional-feature fallback, missing required variants,
   driver restrictions, stale capability revisions and profile-policy rejection.
+- Terrain tests for layer/hole/blend permutation admission, material classification and
+  Terrain-tier/render-profile independence without implicit backend/profile fallback.
 - Visual regression tests for standard material spheres under representative
   lighting.
 
@@ -449,3 +477,7 @@ Cook-time diagnostics:
   lighting, shadows, global illumination, post-processing.
 - [Built-In Scene Primitives](./built-in-scene-primitives.md): default material
   assignment and vertex layout.
+- [Terrain And Foliage Architecture](./terrain-and-foliage-architecture.md): Terrain
+  layer, candidate and render-plan ownership.
+- [ADR-139](../../adr/139-terrain-render-extraction-material-lod-and-tier-boundary.md):
+  Terrain material/permutation, profile and renderer-realization boundary.

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -1044,6 +1044,26 @@ the selected backend alone owns native buffers, culling commands, draws and defe
 GPU retirement. Rendering cannot mutate terrain residency/source/overlays, treat a
 native handle as Terrain identity or infer a Terrain tier from the backend name.
 
+[ADR-139](../../adr/139-terrain-render-extraction-material-lod-and-tier-boundary.md)
+refines that handoff. The Terrain adapter emits one bounded view-independent candidate
+snapshot with neutral geometry/artifact references, material requirements, legal LOD/
+seam data and finite costs. RenderFrontend derives `RenderObjectId` mappings and owns
+per-view visibility, compatible LOD/transition selection, material/permutation admission,
+resource realization, pass mapping and retirement. Residency, render visibility and
+gameplay relevance remain independent facts.
+
+Core 1.0 Terrain/Foliage uses deterministic bounded CPU frustum/distance/LOD/seam
+planning and backend-neutral direct or instanced batches. It does not require compute,
+GPU Scene, Hi-Z or indirect draws. A post-1.0 GPU-driven recipe may consume the same
+semantic candidates only through a separately admitted, cooked, budgeted and qualified
+renderer plan. Its GPU visibility/LOD results remain presentation-only and normal frames
+perform no readback to drive streaming or gameplay.
+
+`TerrainFeatureTier` and `RenderProductProfile` are distinct values even when labels
+match. An aggregate plan records both axes, exact variants/limits/revisions and every
+declared fallback. The renderer cannot use its profile to raise Terrain limits, discard
+required layers/holes/instances or invent a missing shader representation.
+
 The scene runtime produces frame-owned render data:
 
 ```cpp
@@ -1495,6 +1515,10 @@ Required tests cover:
 - upload cancellation and generation replacement
 - terrain/foliage extraction generation, tier/capability rejection and GPU-resource
   retirement without native identity leaking back to Terrain
+- Terrain view-independent candidate capacity/multi-view tests, CPU 1.0 per-view LOD/
+  seam selection and explicit post-1.0 GPU-recipe admission/fallback
+- Terrain material classification/permutation failure and Terrain-tier/render-profile
+  independence without silent layer, hole, instance or required-quality loss
 - resize, minimize, and target recreation
 - deferred destruction after frame completion
 - shader reflection/material validation
@@ -1521,3 +1545,4 @@ Required tests cover:
 - [Platform Abstraction](../foundation/platform-abstraction.md)
 - [XR Architecture](./vr-ar-architecture.md)
 - [ADR-137: Terrain and Foliage Ownership, Data, Tier and Lifecycle](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md)
+- [ADR-139: Terrain Render Extraction, Material, LOD and Tier Boundary](../../adr/139-terrain-render-extraction-material-lod-and-tier-boundary.md)

--- a/docs/architecture/runtime/terrain-and-foliage-architecture.md
+++ b/docs/architecture/runtime/terrain-and-foliage-architecture.md
@@ -14,6 +14,9 @@ part of generic Foundation, RuntimeScene internals or a renderer backend.
 [ADR-138](../../adr/138-terrain-source-cooked-tile-cache-and-streaming-ownership.md)
 defines the complementary source, cook, tile-manifest, cache, residency and generation-
 replacement contract.
+[ADR-139](../../adr/139-terrain-render-extraction-material-lod-and-tier-boundary.md)
+defines the render-candidate, material, per-view LOD/visibility, product-profile and
+core-1.0 versus post-1.0 GPU-driven boundary.
 
 ## Ownership And Data Boundaries
 
@@ -147,10 +150,14 @@ Terrain is split into tiles at authoring time:
 
 - Each tile is `N x N` vertices (default 129×129, corresponding to
   128×128 quads)
-- Tiles are rasterized into GPU-friendly vertex/index buffers per LOD
-- LOD selection uses screen-space error relative to camera distance
-- Tile skirts prevent cracks between adjacent LOD levels
-- `TerrainLODSettings` controls LOD count, transition distance, and morph
+- Terrain Cook emits neutral bounded representation payloads and geometric-error,
+  seam, skirt/morph and neighbor-compatibility metadata per LOD
+- TerrainRuntime exposes only resident legal representations in its immutable snapshot
+- RenderFrontend selects a compatible LOD per view from screen-space error, projection,
+  output, hysteresis, profile and finite budget; distance alone is not the policy
+- Native vertex/index resources and draw execution remain renderer-owned
+- `TerrainLODSettings` contributes authored/cooked intent; it is not a backend command
+  or permission to invent an unavailable representation
 
 ```cpp
 struct TerrainLODSettings {
@@ -205,25 +212,30 @@ struct TerrainMaterialLayer {
 };
 ```
 
-GPU blending uses the vertex weight attributes and samples layer textures
-proportionally. The terrain shader permutation is selected based on active
-layer count, declared as a `TerrainLayerCount` feature flag in the shader
-manifest. Height-based blending, slope-based blending, and noise-based
-transitions are supported through the material-function graph.
+Terrain authoring/cook owns layer order, weight/hole encodings, material-function
+references and required blend semantics. Material/Shader cook validates those semantics
+and emits an explicit finite target permutation family. RenderFrontend selects only a
+cooked variant compatible with the active raster recipe, neutral Terrain payload layout,
+required features and effective limits; the backend realizes it without changing layer,
+hole or blend meaning. Height-, slope- and noise-based transitions are permitted only
+when declared by the material graph and cooked permutation contract. TRF-003.2 freezes
+the exact layer limit, key and blend rules.
 
 ## Foliage System
 
 ### Instanced Rendering
 
-Foliage uses GPU instancing with indirect draws dispatched through
-backend-neutral indirect draw batches. Backend-specific command names never
-appear in the terrain subsystem contract:
+Foliage exposes bounded neutral instance candidates. The core 1.0 renderer may group
+them into backend-neutral direct or instanced batches after CPU per-view visibility and
+LOD planning; it does not require compute, GPU Scene or indirect execution. A post-1.0
+GPU-driven recipe may use renderer-owned compute culling and generated indirect batches
+only after explicit capability, artifact, budget, fallback and backend qualification.
+Backend-specific command names never appear in the Terrain contract:
 
 - Each foliage type maps to one or more static meshes
-- Instance transforms are stored in structured GPU buffers
-- Culling (frustum, distance, occlusion) is performed via compute shader on
-  the GPU
-- Draw calls use the backend's indirect draw submission
+- TerrainRuntime owns baked/dynamic logical instance membership and immutable transforms
+- RenderFrontend owns native instance storage, per-view culling/LOD results and batching
+- the private backend owns native resources, commands and synchronization
 
 ```cpp
 struct FoliageType {
@@ -277,23 +289,22 @@ failure/absence remains conservative and observable.
 
 ### Render Extraction
 
-Terrain and foliage submit instances to the frame via `TerrainRenderExtractor`:
+`TerrainRenderExtractor` leases one immutable Terrain generation and publishes a bounded,
+view-independent `TerrainRenderExtractionSnapshot`. Tile and foliage candidates carry
+typed Terrain identities/revisions, neutral geometry/artifact references, bounds/
+transform inputs, material requirements, legal LOD/seam data, hole/visibility semantics,
+stable logical instance identity and finite cost estimates.
 
-```text
-TerrainRenderExtractor::Extract(RenderWorldSnapshot& snapshot)
-  1. Iterate CPU/streaming/frustum-visible terrain tile candidates
-  2. For each tile, push terrain draw commands to snapshot.opaque
-  3. Iterate CPU/streaming/frustum-visible foliage cluster candidates
-  4. For each cluster, push foliage draw commands:
-     - Opaque foliage (trunks, bark) → snapshot.opaque
-     - Masked/translucent foliage (leaves) → snapshot.transparent with SortMode::DistanceToCamera
-```
+The snapshot contains no selected per-view LOD, visible list, draw command, indirect
+argument, native handle, pipeline object or mutable Terrain pointer. Multiple views may
+consume it without advancing Terrain state. Capacity exhaustion fails extraction rather
+than truncating candidates.
 
-This follows the same `RenderInstance` snapshot model defined in
-rendering-architecture.md. The extractor emits candidates; a later render-graph
-GPU culling pass consumes those candidates and produces indirect draw lists for
-the backend. The extractor runs alongside `VfxRenderExtractor` and the main
-scene extractor.
+RenderFrontend derives generation-checked `RenderObjectId` values, performs per-view
+visibility/LOD/seam planning, resolves cooked material variants/resources and maps the
+candidates into ADR-036 pass classifications. Opaque, Masked, TransparentSorted and
+TransparentAdditive come from authored/cooked material semantics; “trunk” or “leaf” does
+not imply a pass. The private backend only translates the validated plan.
 
 ### Decal Interaction
 
@@ -347,6 +358,11 @@ Foliage LOD uses:
 - Billboard impostors for the farthest LOD
 - Cross-fade between LOD levels to avoid popping
 - Aggregate distance culling per foliage cluster
+
+These are legal cooked representations and transition rules owned by Terrain content.
+RenderFrontend selects among resident compatible representations per view. The 1.0
+baseline uses bounded CPU selection; post-1.0 GPU selection remains renderer-owned and
+cannot feed gameplay or World Streaming truth back synchronously.
 
 Impostors are pre-baked at authoring time. The baker renders the foliage
 mesh from multiple view angles and stores the result in a texture atlas.
@@ -528,6 +544,10 @@ Required coverage includes:
   no directory enumeration or mixed-generation tile admission;
 - every tier/cooked/provider capability combination, required failure and each declared
   fallback reason without silent clamp/drop/provider selection;
+- view-independent render-candidate extraction, deterministic capacity failure, multi-
+  view reuse and strict separation of residency, presentation visibility and gameplay;
+- Terrain tier/render profile independence, material/pass classification, CPU 1.0 LOD/
+  seam planning and optional post-1.0 GPU recipe admission/fallback;
 - candidate failure/cancellation and replacement at every Scene/streaming/render/
   physics/navigation prepare/commit/retirement boundary;
 - stale worker, snapshot, tile, GPU, collision and navigation evidence rejected across
@@ -571,3 +591,6 @@ Required coverage includes:
 - [ADR-138](../../adr/138-terrain-source-cooked-tile-cache-and-streaming-ownership.md):
   canonical source and deterministic tile cooking, cache authorities, World Streaming
   residency, seam-safe replacement and generation retirement
+- [ADR-139](../../adr/139-terrain-render-extraction-material-lod-and-tier-boundary.md):
+  immutable render candidates, material/permutation boundary, renderer-owned per-view
+  visibility/LOD, independent profile axes and CPU/GPU recipe split


### PR DESCRIPTION
## Summary

Defines the normative boundary between Terrain/Foliage semantic render candidates and
renderer-owned material realization, per-view visibility, LOD selection, GPU resources,
passes, and execution.

This PR adds ADR-139 and projects it into the Terrain/Foliage, Rendering, Material/Shader,
and LOD/Culling architecture documents. The resulting contract establishes:

- TerrainRuntime owns resident logical content, legal cooked representations, seam/LOD
  constraints, material requirements, immutable candidate snapshots, and their leases.
- RenderFrontend owns per-view visibility and compatible LOD selection, RenderObject and
  resource realization, material/permutation admission, batching, pass mapping, and GPU
  retirement.
- The private backend owns native translation, resources, commands, and synchronization;
  it never changes Terrain/material semantics or selects fallback policy.
- Core 1.0 uses bounded deterministic CPU planning plus neutral direct/instanced batches.
  GPU-driven Terrain/Foliage is an explicit post-1.0 renderer recipe.

## Why

The existing Terrain document blurred semantic extraction and presentation by describing
the extractor as pushing draw commands, classifying foliage leaves as transparent,
selecting LOD from camera distance, and assuming indirect GPU culling. It also left the
similar-looking Terrain tier and renderer product-profile names vulnerable to implicit
conversion.

Those ambiguities would allow Terrain to own render-graph/native behavior, Renderer to
violate authored seam/layer/hole requirements, or an API/profile label to silently remove
content. They also made compute, GPU Scene, Hi-Z, and indirect execution appear mandatory
for the 1.0 baseline, excluding otherwise valid baseline, Null, and headless compositions.

ADR-139 creates one stable semantic handoff that supports both a bounded 1.0 CPU path and
future GPU-driven optimization without moving ownership or exposing backend-native types.

## Decision and boundaries

- Adds a view-independent `TerrainRenderExtractionSnapshot` boundary carrying typed
  Terrain identities/revisions, neutral artifact references, material requirements,
  legal LOD/seam data, bounded instance ranges, and finite cost estimates.
- Explicitly excludes selected per-view LOD, visible lists, draw/indirect commands, native
  handles, pipelines, mutable Terrain pointers, and gameplay truth from that snapshot.
- Separates World Streaming residency, renderer visibility, and gameplay relevance.
  Renderer may publish delayed bounded demand observations, but cannot synchronously load
  or evict cells from per-view results.
- Assigns legal representation/error/seam/morph data to Terrain and per-view selection,
  hysteresis, transitions, batching, and pass execution to RenderFrontend.
- Makes material classification authored/cooked meaning. Opaque, Masked,
  TransparentSorted, and TransparentAdditive are not inferred from “terrain”, “trunk”,
  or “leaf”.
- Defines Terrain tier and renderer product profile as independent typed axes. The
  aggregate plan records both, exact limits/variants/revisions, and every fallback edge.
- Defines core 1.0 as CPU frustum/distance/LOD/seam planning with neutral direct or
  instanced batches; post-1.0 compute/Hi-Z/GPU Scene/indirect work needs a separately
  accepted and qualified renderer recipe.
- Specifies transactional resource preparation, aggregate visual-readiness publication,
  exact-generation leases, device-loss reconstruction, and deferred retirement.
- Corrects the MaterialTable contract: Scene Runtime owns semantic material data, while
  RenderFrontend owns the generation-scoped admitted variant/pipeline realization.
- Removes legacy API-tier language that allowed the renderer to skip unsupported shading
  models based on `es3`/`dx11` labels.

TRF-003.2 remains responsible for the exact Terrain layer/permutation key and blend rules;
TRF-003.3 remains responsible for concrete GPU-resource and snapshot schemas.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/139-terrain-render-extraction-material-lod-and-tier-boundary.md docs/architecture/README.md docs/architecture/runtime/terrain-and-foliage-architecture.md docs/architecture/runtime/rendering-architecture.md docs/architecture/runtime/material-and-shader-model.md docs/architecture/runtime/lod-and-culling-architecture.md`
- `git diff --check`
- `git diff --cached --check`
- Added-Markdown-link resolver over the staged diff: passed.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`: configured and generated
  successfully; public-header inventory and dependency-direction policy passed.

Known environment warnings: the fetched mbedTLS project reports a CMake minimum-version
deprecation, and repository Python tests are skipped because `pytest` is unavailable.
This documentation-only change did not build or run executable targets or native GPU
qualification lanes.

## Risk and rollout

- This is a boundary decision, not an implemented renderer path. Exact data layouts and
  material keys remain intentionally deferred to TRF-003.2/TRF-003.3.
- The new core-1.0 classification changes expectations for existing aspirational indirect
  foliage text: indirect execution is no longer a baseline requirement.
- Compatible adjacent Terrain LOD selection may require more CPU planning and temporary
  dual-LOD resources than a distance-only selector; those costs must be admitted in the
  resolved plan.
- Terrain and renderer profile labels remain visually similar. Implementations must keep
  their C++ types and serialized identities distinct to prevent accidental conversion.
- Resource replacement can retain old/new Terrain and renderer generations concurrently;
  World Streaming and renderer reservations must cover that overlap through final GPU
  retirement acknowledgement.

## Issue links

- Jira: [HORO-1903](https://horo-engine.atlassian.net/browse/HORO-1903)
- GitHub: Closes #1947
- Domain ticket: `[TRF-003.1]`
- Parent capability: [HORO-1882](https://horo-engine.atlassian.net/browse/HORO-1882) / `[TRF-003]`
- Material follow-up: [HORO-1906](https://horo-engine.atlassian.net/browse/HORO-1906) / `[TRF-003.2]`
- GPU-resource follow-up: [HORO-1907](https://horo-engine.atlassian.net/browse/HORO-1907) / `[TRF-003.3]`


## Reviewer Notes

Please review the following ownership invariants closely:

1. Is the Terrain snapshot semantic and view-independent while still carrying enough
   topology/material/LOD evidence for deterministic renderer planning?
2. Does RenderFrontend own every per-view and GPU-facing decision without gaining
   permission to mutate Terrain residency or authored semantics?
3. Are residency, visibility, and gameplay relevance kept separate across normal,
   replacement, headless, and device-loss paths?
4. Is the core 1.0 CPU/direct-or-instanced path complete without compute, GPU Scene,
   Hi-Z, bindless, or indirect requirements?
5. Are post-1.0 GPU-driven responsibilities still renderer-owned and unable to feed
   same-frame presentation results into gameplay/streaming authority?
6. Do the independent Terrain-tier and render-profile axes prevent both silent content
   loss and backend-name capability inference?

The most important compatibility correction is in MaterialTable: a semantic Scene table
must not own the selected resident shader variant or pipeline object. That realization is
now explicitly RenderFrontend-owned and generation-scoped.

## Stack

- Base branch: `docs/HORO-1893_terrain_source_tile_cache_streaming`
- Depends on: #2473 (`HORO-1893` / `[TRF-002.1]`)
- This PR: `HORO-1903` / `[TRF-003.1]`
- Merge order: #2473, then this PR.


[HORO-1903]: https://horo-engine.atlassian.net/browse/HORO-1903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ