### PR TITLE
docs(editor): define terrain authoring boundary HORO-1925 #1969 [TRF-006.1]

### DIFF
--- a/docs/adr/142-terrain-foliage-document-tool-undo-and-preview-ownership.md
+++ b/docs/adr/142-terrain-foliage-document-tool-undo-and-preview-ownership.md
@@ -1,0 +1,288 @@
+# ADR-142: Terrain/Foliage Document, Tool, Undo and Preview Ownership
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Terrain/Foliage authoring-document identity, editor tool routing, bounded tile-patch operations and history, live preview isolation, source save/cook boundaries, stale work, cancellation, replacement and shutdown
+- **Issue**: [TRF-006.1](https://github.com/abdullahbodur/horo-engine/issues/1969)
+- **Jira**: [HORO-1925](https://horo-engine.atlassian.net/browse/HORO-1925)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-010](010-job-waiting-and-operation-store-ownership.md), [ADR-012](012-world-streaming-partition-authority-and-subsystem-boundaries.md), [ADR-056](056-external-editor-ui-boundary.md), [ADR-093](093-prefab-override-property-identity-and-delta-operations.md), [ADR-121](121-cinematic-editor-document-and-authoring-context.md), [ADR-129](129-vfx-editor-document-live-preview-and-module-authoring.md), [ADR-137](137-terrain-foliage-ownership-data-tier-and-lifecycle.md), [ADR-138](138-terrain-source-cooked-tile-cache-and-streaming-ownership.md), [ADR-139](139-terrain-render-extraction-material-lod-and-tier-boundary.md), [ADR-140](140-foliage-placement-baked-dynamic-state-and-eviction-ownership.md), [ADR-141](141-terrain-foliage-cross-system-ownership-and-readiness.md)
+- **Normative documents**: [Editor Document Model](../architecture/editor/editor-document-model.md), [Editor Panel Host](../architecture/editor/editor-panel-host.md), [Terrain and Foliage Architecture](../architecture/runtime/terrain-and-foliage-architecture.md), [Asset Pipeline](../architecture/runtime/asset-pipeline.md), [Project Model](../architecture/editor/project-model.md)
+
+## Context
+
+Terrain sculpting, layer painting, hole carving, spline deformation and foliage
+painting can touch large source datasets continuously. The existing architecture says
+that editor documents own source mutation and undo, while Assets owns cooking and
+TerrainRuntime owns live data. It does not define the concrete authoring document,
+which owner expands a brush into affected tiles, how history remains bounded, or how
+an interactive preview is kept separate from canonical source and a live runtime.
+
+That ambiguity permits incompatible implementations. A viewport tool could write
+directly into a heightfield, store one whole-heightfield copy per stroke, ask a worker
+to mutate the document after the gesture ends, or preview by modifying active runtime
+state. Save could then publish preview state, cook success could incorrectly clear
+dirty state, and undo could depend on current brush settings or random generation.
+
+Terrain operations also cross tile seams and can invalidate dependent layer,
+collision, navigation, foliage-placement and preview products. The affected closure
+must be known and charged before mutation. This ADR specializes the shared Editor
+Document Model. TRF-006.2 owns the final serialized edit-operation and patch schemas;
+it may refine layouts without moving these authorities.
+
+## Decision
+
+### 1. Canonical authoring state lives in persistent domain documents
+
+Each editable canonical terrain dataset opens as one persistent
+`TerrainAuthoringDocument` rooted at stable `AssetId`, `TerrainDatasetId` and accepted
+source revision. Dataset-local foliage placement source is an explicit section of that
+same document; it never becomes a parallel document or hidden state in a palette,
+viewport or runtime instance. Reusable foliage-type definitions remain separate asset
+documents because their material, mesh and placement-rule content can be referenced by
+multiple datasets.
+
+Editor document services own session/source identity, canonical height/weight/hole/
+spline/placement state, committed revision, typed commands, bounded history, dirty and
+saved state, save/autosave/recovery/conflict, close guards, and derived validation/cook/
+preview revisions. `EditorPanelHost` owns route, focus and surface lifetime. Tools and
+palettes own presentation only. Assets owns cook/artifact publication; TerrainRuntime
+and Render/Physics/Navigation own only derived runtime generations.
+
+One writable session per canonical asset is admitted in a workspace. Reopening focuses
+it. Read-only compare, recovery and historical views have distinct capabilities and
+cannot edit or save over canonical source.
+
+### 2. Tools emit typed intent and own no source storage
+
+Sculpt, layer, hole, spline and foliage controllers translate routed input into a typed
+`TerrainEditOperation`. They may own brush radius/falloff/strength, active layer/type,
+pointer capture, gizmo geometry and an ephemeral stroke accumulator. They own no
+canonical samples, placements, dirty state, history, serializer or cooked artifact.
+
+```cpp
+struct TerrainEditOperationHeader {
+    DocumentSessionId document;
+    TerrainDocumentRevision expectedRevision;
+    TerrainEditOperationId operation;
+    TerrainEditKind kind;
+    TerrainAuthoringCapability capability;
+    TerrainEditLimits limits;
+};
+```
+
+Payloads use stable dataset, tile, patch, layer, spline, foliage-type and placement
+identities plus bounded semantic parameters. They contain no ImGui state, native file/
+GPU/Physics/Navigation handle, mutable document pointer, runtime object, service locator
+or arbitrary callback. Toolbar results remain presentation intent. GUI, CLI, MCP and
+automation submit through the same permissioned document/application path.
+
+### 3. Preflight freezes an exact bounded affected closure
+
+Before mutation, the document executor validates session, expected revision,
+capability, source schema, coordinates, parameters and finite limits. It expands intent
+deterministically into canonically ordered affected tile/patch rectangles:
+
+```cpp
+struct TerrainAffectedPatch {
+    TerrainTileId tile;
+    TerrainPatchRect rect;
+    TerrainChannelMask channels;
+};
+
+struct TerrainEditPlan {
+    TerrainEditOperationHeader header;
+    std::vector<TerrainAffectedPatch> patches;
+    TerrainDependencyInvalidation invalidation;
+    TerrainEditCost upperBound;
+};
+```
+
+The set includes every sample apron, shared seam, dependent placement region and source
+channel needed for deterministic apply/revert. Rectangles are clipped, merged and
+sorted; overlap cannot record or apply one source element twice. Dependency
+invalidation names affected cook inputs but never mutates cooked/native state.
+
+The executor rejects empty, malformed, oversized, out-of-bounds or unsupported plans.
+It reserves patch bytes, temporary work, history bytes and completion capacity before
+reading mutable state. Large import/fill/procedural work uses an explicitly admitted
+bounded batch whose complete patch set and atomic commit group are known up front. It
+does not bypass history or commit partially completed tiles.
+
+### 4. One transaction records exact before and after patches
+
+For an accepted plan, the document owner captures canonical `before` values, applies
+to detached or journaled candidate storage, validates seams and invariants, and captures
+canonical `after` values. It atomically publishes source state, a new state identity/
+revision, dirty state, one history entry and one bounded change summary.
+
+```cpp
+struct TerrainEditRecord {
+    TerrainEditOperationId operation;
+    TerrainDocumentRevision baseRevision;
+    TerrainDocumentRevision committedRevision;
+    std::vector<TerrainPatchSnapshot> before;
+    std::vector<TerrainPatchSnapshot> after;
+    TerrainDependencyInvalidation invalidation;
+};
+```
+
+Snapshots contain only exact affected canonical regions and stable placement deltas.
+Compression/deduplication must be lossless, deterministic and bounded. A full-
+heightfield or whole-dataset copy per operation is prohibited. Brush settings alone are
+not history, and committed records hold no live pointers or external leases.
+
+Failure, cancellation or stale revision before commit leaves source, revision, dirty
+state, selection and history unchanged. No observer sees a partial patch set.
+
+### 5. Undo and redo replay committed results, not algorithms
+
+The document/history owner applies `before` or `after` patches through the same atomic
+publication boundary. Undo never reruns brush, noise, spline or foliage-scatter code and
+does not read current tool parameters, random seeds or viewport state.
+
+Undo/redo advances the monotonic revision while restoring the appropriate content state
+identity. A new edit after undo clears redo. History has item and byte budgets; eviction
+never changes canonical data. Dirty remains `current_state_id != saved_state_id` and is
+not inferred from history depth.
+
+A continuous gesture coalesces only while capture, document, expected revision,
+capability and budget remain valid. Its final closure and before values cover the whole
+gesture exactly once. Release commits one entry. Escape, modal capture, tool switch,
+document/revision change, capacity denial or shutdown cancels and restores the
+committed view.
+
+### 6. Heavy work stages immutable candidates and returns to the owner
+
+Expensive preflight/apply work runs in a document-owned cancellable task group against
+immutable inputs and reserved candidate storage. Completion carries operation, session,
+base revision and generation plus a typed candidate/diagnostic. Only the document owner
+may revalidate and commit it.
+
+A result for a closed/replaced session, advanced revision, cancelled operation,
+unloaded provider, changed capability or expired generation is stale and discarded.
+Workers never publish document state, dirty flags, history, artifacts or preview/runtime
+generations. Conflicting mutations are rejected or serialized by explicit policy; a
+completion is never silently merged into a newer revision.
+
+### 7. Interaction overlays and cooked previews are separate
+
+Low-latency brush feedback is an `InteractionPreviewOverlay` keyed by document session,
+base revision, operation and generation. It may show a candidate, affected bounds or an
+estimate, but does not advance revision, dirty state, history, source save or registry.
+Cancel discards it exactly.
+
+A high-fidelity preview captures an immutable document revision and uses ordinary
+Terrain validation/cook schemas under a transient editor envelope. Its artifacts
+activate through normal TerrainRuntime, World Streaming, Render, Physics and Navigation
+contracts in an isolated `TerrainPreviewSession`, never in a live gameplay world.
+
+Preview identity includes source revision, dependency fingerprint, target/tier plan,
+settings and generation. New edits cancel or stale older work. The UI may retain a
+leased last-good result marked stale, but cannot call it current. Camera, visualization,
+selection, brush cursor, wind toggle, clock, fixture and runtime handles are disposable
+preview/presentation state. Applying preview-derived content is a new explicit edit.
+
+### 8. Save, recovery, cook and runtime persistence stay distinct
+
+Source save captures one immutable canonical revision and uses the shared deterministic,
+durable atomic replacement flow. Only successful source publication updates saved state.
+Cook/preview success does not clear dirty; save success does not claim a later cook or
+preview succeeded.
+
+Autosave writes recovery state outside canonical source. Recovery restores a validated
+dirty document and need not restore evicted history; it never overwrites source
+silently. Assets/Pipeline observes a published source revision or an explicit immutable
+unsaved preview snapshot and owns cook/cache/artifact publication. Cook callbacks cannot
+mutate the document. Runtime Save/Persistent World owns ADR-140 gameplay foliage deltas;
+it never saves editor source or becomes an undo owner.
+
+Scene documents store typed terrain/foliage bindings, not source copies. A
+`TerrainAuthoringDocument` references reusable foliage-type assets by stable typed
+identity and does not copy or mutate their definitions. An operation that changes the
+terrain source plus a Scene binding or reusable foliage-type document uses a staged
+multi-document application transaction with sessions, revisions, permissions and
+publication effects declared before commit. The viewport cannot simulate this through
+two callbacks.
+
+### 9. Close, replacement and shutdown retire owned work
+
+Close first stops tool admission, releases capture, cancels overlays and document task
+groups, invalidates generations, and requests preview teardown. The document retains
+snapshots, task records, artifacts, module leases and runtime dependencies until their
+owners acknowledge release. Project replacement and shutdown use the same order.
+
+A deadline may report incomplete close with retained ownership; it cannot force-free
+data referenced by a job, renderer fence, Physics step, Navigation query or runtime
+snapshot. Duplicate acknowledgements are idempotent, and stale ones cannot retire a new
+session sharing an asset or tile identity.
+
+### 10. Errors, observability and limits are explicit
+
+Operations return typed results such as `WrongDocument`, `StaleRevision`,
+`InvalidPatch`, `AffectedSetTooLarge`, `HistoryBudgetExceeded`,
+`CapabilityUnavailable`, `Cancelled`, `SourceConflict`, `PreviewStale` and
+`ShutdownInProgress`. There is no silent clamp, partial edit, fallback to direct
+mutation/full-dataset history, or runtime/backend/provider switch.
+
+Bounded metrics include operation kind/result, patch/tile counts, reserved/actual bytes,
+latency, cancellation reason and stale-result count. They exclude raw height/weight
+payloads, user paths and unbounded placement lists. Frame-hot overlay rendering performs
+no unbounded allocation, I/O or synchronous cook/runtime wait.
+
+## Consequences
+
+- Every terrain/foliage mutation has one authoritative transaction and one revision-
+  correlated result for GUI, CLI, MCP and automation.
+- History cost scales with affected patches, while exact before/after values make undo
+  independent of algorithms and UI state.
+- Tools and previews are replaceable adapters because they own no canonical source,
+  history or persistence.
+- Source save, transient preview cook, published cook and runtime persistence expose
+  separate UI states rather than one ambiguous saved/ready flag.
+- Large operations may be refused or require an admitted batch plan; this makes their
+  cost explicit instead of allowing hidden unbounded memory or partial commits.
+
+Required coverage includes canonical seam-aware closure for every tool; exact apply/
+undo/redo without whole-heightfield copies or algorithm replay; one commit per gesture;
+malformed/oversized operation rejection before mutation; cancellation/failure at every
+stage; stale work across edit/reload/close/shutdown; dirty state across save and history
+eviction; save/recovery/cook/runtime-persistence separation; isolated preview parity;
+cross-document failure/reconciliation; and bounded memory, queues and teardown.
+
+## Rejected Alternatives
+
+### Store a complete heightfield snapshot for every undo entry
+
+Rejected because cost scales with total dataset size rather than the edit and hides
+affected-tile dependencies.
+
+### Re-execute the tool algorithm during undo/redo
+
+Rejected because settings, algorithms, dependencies, job order or randomness can differ.
+History restores the exact committed before/after result.
+
+### Let viewport tools mutate document or runtime buffers directly
+
+Rejected because presentation code would become a second owner, bypass revision checks
+and expose partial state to history, save or runtime consumers.
+
+### Use a live world as the authoring preview
+
+Rejected because source edits would inherit runtime streaming, mutation and save
+lifetimes. Preview is isolated and generation-fenced.
+
+### Treat cook or preview success as source save
+
+Rejected because derived artifact publication and canonical source durability are
+independent states.
+
+### Keep an undo stack in each tool or palette
+
+Rejected because cross-tool ordering, dirty state, recovery and automation would have
+competing histories.
+
+### Let oversized edits bypass undo or commit tile by tile
+
+Rejected because failure would leave partial source that cannot be reverted atomically.
+Oversized work is rejected or admitted as one fully bounded batch transaction.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -314,6 +314,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Terrain/Foliage Cross-System Ownership and Readiness](../adr/141-terrain-foliage-cross-system-ownership-and-readiness.md):
   immutable producer snapshots, typed Render/Physics/Navigation receipts, owner-safe-
   point staging, aggregate activation, rollback and reverse-dependency retirement.
+- [Terrain/Foliage Document, Tool, Undo and Preview Ownership](../adr/142-terrain-foliage-document-tool-undo-and-preview-ownership.md):
+  persistent authoring documents, typed tool routing, bounded tile-patch history,
+  isolated preview and distinct source-save/cook/runtime-persistence boundaries.
 - [World Streaming Architecture](./runtime/world-streaming-architecture.md):
   streaming cells, volumes, priority, budgets, server authority, and editor
   world-composition tools.

--- a/docs/architecture/editor/editor-document-model.md
+++ b/docs/architecture/editor/editor-document-model.md
@@ -434,6 +434,31 @@ diagnostics and fixture inputs are disposable generation-fenced state. They do n
 mutate documents or publish into live gameplay/Audio/event authorities. Close/project
 teardown cancels derived work and retires resources through normal runtime boundaries.
 
+## Terrain And Foliage Authoring Documents
+
+[ADR-142](../../adr/142-terrain-foliage-document-tool-undo-and-preview-ownership.md)
+specializes this contract for asset-rooted terrain datasets. Their dataset-local
+foliage placement source is part of the same document, while reusable foliage-type
+definitions remain separate referenced asset documents. Document services own
+canonical height/weight/hole/spline/placement state,
+revision, typed commands, bounded history, dirty/save/recovery/conflict and derived
+preview revisions. Toolbars, viewport tools, palettes and overlays own presentation and
+input only; runtime and cooked tiles are never editable document storage.
+
+Each `TerrainEditOperation` preflights an exact canonical closure of affected tile/patch
+rectangles, including seams, aprons and placement dependencies. One atomic history
+record stores lossless bounded `before` and `after` values. Whole-heightfield/dataset
+copies per edit, partial tile commits and undo by rerunning a brush, noise or scatter
+algorithm are prohibited. A continuous gesture may show a disposable revision-fenced
+overlay but commits at most one history transaction.
+
+Heavy work uses immutable snapshots and document-owned cancellable task groups; only
+the document owner may revalidate and commit a matching completion. Source save, editor
+autosave/recovery, transient preview cook, published Asset cook and Runtime Save/
+Persistent World foliage deltas remain independent. High-fidelity preview activates
+ordinary Terrain runtime contracts in an isolated generation-fenced session and never
+mutates the document or a live gameplay world.
+
 ## Runtime Conversion
 
 The document converts to `RuntimeSceneDefinition` through an editor service.
@@ -534,6 +559,14 @@ Required tests cover:
 - VFX preview compiles an immutable document revision and executes normal runtime
   services; stale derived work, tab/project teardown and decal-gizmo cancel/commit
   cannot mutate either VfxEffectDocument or SceneDocument unexpectedly
+- terrain/foliage tools produce canonical bounded affected tile/patch closures and one
+  exact before/after history entry per gesture without whole-heightfield copies
+- terrain/foliage apply, undo and redo are symmetric without reading current tool state
+  or rerunning brush/noise/scatter algorithms
+- stale/cancelled terrain edit and preview completions cannot mutate document, dirty,
+  history, cook or live runtime state across edit, reload, close or project shutdown
+- terrain source save, autosave/recovery, preview cook, published cook and Runtime Save
+  foliage persistence advance independently
 
 ## Related Documents
 
@@ -548,3 +581,4 @@ Required tests cover:
 - [Save Game And Persistence](../runtime/save-game-and-persistence.md)
 - [Cinematic Sequencer](../runtime/cinematic-sequencer-architecture.md)
 - [VFX And Particles](../runtime/vfx-and-particles-architecture.md)
+- [Terrain And Foliage](../runtime/terrain-and-foliage-architecture.md)

--- a/docs/architecture/editor/editor-panel-host.md
+++ b/docs/architecture/editor/editor-panel-host.md
@@ -789,6 +789,20 @@ directly. Singular parents, non-finite input, and unrepresentable transform
 updates terminate the transient preview through a typed error; they must not
 substitute identity axes or commit a partial result.
 
+Terrain/Foliage viewport tools follow
+[ADR-142](../../adr/142-terrain-foliage-document-tool-undo-and-preview-ownership.md).
+Their controllers own routed pointer capture, brush/spline visualization and an
+ephemeral revision-fenced stroke accumulator only. The foliage palette owns active type
+and filters as workspace presentation state. Tools submit typed edit intent to the
+active asset-rooted document; they cannot write canonical samples/placements, dirty
+state, history, cooked tiles, TerrainRuntime or renderer/physics/navigation state.
+
+The viewport may render a disposable interaction overlay or an immutable isolated
+preview-session result. Modal capture, tool/document switch, revision change, capacity
+denial, panel detachment or shutdown cancels the interaction without a document edit.
+Pointer release submits at most one bounded operation whose exact affected tile/patch
+closure and before/after history are owned by the document executor.
+
 ### Right Dock
 
 Visible as the Properties panel.
@@ -1064,6 +1078,10 @@ Required coverage:
   modal blocks their interaction
 - viewport panels receive a render-target view without owning backend resources
 - transform editing publishes one document event only after transaction commit
+- terrain/foliage gestures commit at most one bounded document operation and cancel
+  exactly across modal capture, tool/document switch, stale revision and panel detach
+- terrain palettes/overlays own no canonical source/history/runtime state, and isolated
+  preview close rejects stale work before retiring generation-owned resources
 
 ## Why Not Put This in Application?
 

--- a/docs/architecture/runtime/terrain-and-foliage-architecture.md
+++ b/docs/architecture/runtime/terrain-and-foliage-architecture.md
@@ -23,6 +23,9 @@ capacity, persistence handoff and eviction ownership.
 [ADR-141](../../adr/141-terrain-foliage-cross-system-ownership-and-readiness.md)
 defines immutable consumer snapshots, typed readiness receipts, owner-safe-point
 publication, aggregate activation, rollback and reverse-DAG retirement.
+[ADR-142](../../adr/142-terrain-foliage-document-tool-undo-and-preview-ownership.md)
+defines persistent authoring documents, typed tool routing, bounded tile-patch history,
+isolated preview and distinct source-save/cook/runtime-persistence boundaries.
 
 ## Ownership And Data Boundaries
 
@@ -183,12 +186,18 @@ The editor terrain tools support:
 - Hole carving (per-vertex visibility mask)
 - Spline-based path/road deformation
 
-Paint operations use the terrain data model with undo support. Undo captures
-the terrain data model state change (height/weight snapshot), not brush
-settings. Brush parameters (radius, falloff, strength) are transient UI
-state preserved per-session in the editor workspace state; the undo stack
-does not scroll brush settings. Changing the brush mid-session does not
-invalidate prior undo entries.
+Paint operations use the terrain authoring document and typed edit-operation path from
+[ADR-142](../../adr/142-terrain-foliage-document-tool-undo-and-preview-ownership.md).
+Before mutation, the document executor freezes and reserves the exact canonical set of
+affected tile/patch rectangles, including seam/apron and placement dependencies. One
+atomic history entry owns lossless bounded `before` and `after` patch snapshots. A full
+heightfield/dataset copy per edit and partial tile-by-tile commit are prohibited.
+
+Undo/redo restores those committed patches and never reruns brush/noise/scatter
+algorithms or reads current tool settings. Brush radius, falloff, strength, active layer
+and foliage type are transient per-session workspace state; changing them does not alter
+prior entries. A continuous gesture owns one revision-fenced preview overlay and commits
+at most one operation, while cancellation restores the exact committed view.
 
 Hole carving sets a per-vertex visibility flag in the terrain data. Holes
 propagate to collision (excluded from collision mesh) and NavMesh (excluded
@@ -433,6 +442,26 @@ Terrain and foliage authoring tools are registered through the
 The `EditorToolbar` only produces typed results; terrain/foliage domain
 operations are performed by the registered tools consuming those results.
 
+Each canonical dataset and its dataset-local foliage placement source are edited through
+one persistent asset-rooted authoring document. Reusable foliage-type definitions remain
+separate referenced asset documents. The panel host owns route/focus/lifetime; document
+services own source identity, revision, command/history, dirty/save/recovery/conflict
+and derived preview state. Viewport tools, the foliage palette and overlays own input
+and presentation only. They submit revision-checked `TerrainEditOperation` intent and
+cannot mutate source, cooked tiles, TerrainRuntime or consumer-native state directly.
+
+Interactive brush feedback is a disposable document interaction overlay. Higher-
+fidelity preview captures one immutable source revision, uses the ordinary Terrain cook
+contract and activates through an isolated generation-fenced preview session. Preview
+success never clears dirty state, and stale results cannot become current by matching a
+tile coordinate. Closing the document cancels owned work and retains its leases until
+preview/runtime consumers acknowledge retirement.
+
+Canonical source save is the shared atomic document-save path. Asset cook/publication,
+editor autosave/recovery and ADR-140 Runtime Save foliage deltas are separate owners and
+states. An intentional edit spanning a Scene binding and terrain/foliage source uses a
+staged multi-document application transaction rather than two UI callbacks.
+
 ## Runtime Lifecycle And Readiness
 
 TerrainRuntime uses the exhaustive aggregate states `Absent`, `Preparing`, `Prepared`,
@@ -617,7 +646,13 @@ Required coverage includes:
 - headless, dedicated server, editor preview, Null Render and every interactive backend
   consuming the same Horo contract; and
 - bounded owner/worker/native-thread handoff, frame-hot allocation/I/O checks, device
-  loss, world unload, repeated shutdown and retirement timeout.
+  loss, world unload, repeated shutdown and retirement timeout;
+- exact bounded affected-patch planning for every authoring tool, no whole-heightfield
+  history entry, deterministic apply/undo/redo symmetry and one commit per gesture;
+- authoring failure/cancel/stale completion preserving source revision, dirty state,
+  history and notifications at every staged boundary; and
+- source save, autosave/recovery, transient preview cook, published cook and Runtime Save
+  state separation, including isolated preview teardown and stale-result rejection.
 
 ## Related Documents
 
@@ -656,3 +691,6 @@ Required coverage includes:
 - [ADR-141](../../adr/141-terrain-foliage-cross-system-ownership-and-readiness.md):
   consumer snapshots and receipts, owner-safe-point staging, aggregate readiness,
   rollback, runtime failure and reverse-dependency retirement
+- [ADR-142](../../adr/142-terrain-foliage-document-tool-undo-and-preview-ownership.md):
+  persistent authoring documents, typed tool routing, bounded tile-patch undo/redo,
+  isolated preview and source-save/cook/runtime-persistence separation


### PR DESCRIPTION
## Summary

- Add ADR-142 to define the Terrain/Foliage authoring document, tool, undo, preview, save, cancellation, and shutdown boundaries.
- Make each terrain dataset and its dataset-local foliage placement source one persistent `TerrainAuthoringDocument`; reusable foliage-type definitions remain separately referenced asset documents.
- Require every sculpt/paint/hole/spline/foliage gesture to preflight an exact bounded tile-patch closure and commit one lossless before/after history record.
- Align the Terrain/Foliage Architecture, Editor Document Model, Editor Panel Host, and architecture index with the decision.

## Why

The existing documents assigned source mutation and undo to editor documents, but left the transaction shape ambiguous. In particular, “height/weight snapshot” could be implemented as a full-heightfield copy, viewport tools could become direct data owners, and preview or cook success could be confused with canonical source save.

Terrain edits also cross tile seams and invalidate dependent layer, collision, navigation, foliage-placement, and preview products. Without a revision-fenced affected-set contract, cancellation or stale worker completion could expose partial changes or apply work to the wrong source generation.

This decision establishes one source of truth and makes cost, ownership, atomicity, and lifecycle behavior reviewable before TRF-006.2 freezes the concrete operation and snapshot schemas.

## Decision and boundaries

- `TerrainAuthoringDocument` owns canonical height, weight, hole, spline, and dataset-local foliage-placement state together with revision, history, dirty/save/recovery/conflict, and derived-work revisions.
- Toolbars, palettes, and viewport controllers own only routed input and presentation state. They submit typed `TerrainEditOperation` intent and cannot mutate source, cooked data, TerrainRuntime, or Render/Physics/Navigation state.
- Preflight validates the expected document revision and computes a canonical seam/apron-aware `TerrainEditPlan`. Patch, temporary-work, history, and completion capacity must be reserved before mutation.
- A successful edit atomically publishes source state, one state/revision transition, one dirty-state update, one history entry, and one bounded notification. Failed, cancelled, oversized, or stale work leaves all of them unchanged.
- Undo and redo replay exact lossless before/after patches. They never rerun brush, noise, spline, or scatter algorithms and never consult current UI settings. Per-operation whole-heightfield copies and partial tile commits are prohibited.
- Heavy work operates on immutable snapshots in document-owned cancellable task groups; only the document owner can revalidate and commit a completion.
- Low-latency interaction overlays do not dirty the document. High-fidelity preview uses the normal cook/runtime contracts inside an isolated generation-fenced preview session, never a live gameplay world.
- Source save, autosave/recovery, transient preview cook, published Asset cook, and Runtime Save/Persistent World foliage deltas remain independent state machines.
- Cross-document edits involving a Scene binding or reusable foliage-type document require an explicit staged application transaction.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/142-terrain-foliage-document-tool-undo-and-preview-ownership.md docs/architecture/README.md docs/architecture/editor/editor-document-model.md docs/architecture/editor/editor-panel-host.md docs/architecture/runtime/terrain-and-foliage-architecture.md`
- `git diff --check`
- `git diff --cached --check`
- Staged-added Markdown link resolution check: passed.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`: passed configuration and generation.
- Known non-blocking configure warnings: upstream mbedTLS CMake minimum-version deprecation; pytest unavailable, so repository Python tests were skipped by CMake.

This is a documentation/architecture-only change; no C++ target or runtime behavior changed, so a build/test execution was not required beyond the repository configure gate.

## Risk and rollout

- The ADR fixes ownership and behavioral invariants but intentionally leaves exact serialized operation/patch layouts to TRF-006.2.
- Patch-history memory use still depends on the future concrete encoding; the decision mitigates this with mandatory item/byte budgets, pre-reservation, and explicit refusal of oversized work.
- Isolated high-fidelity preview introduces lifecycle complexity across cook and runtime consumers; generation fencing and acknowledged retirement are required to prevent stale publication or premature release.
- Existing prototype tools that mutate buffers directly will require migration to the document operation path rather than compatibility shims.

## Issue links

- Jira: [HORO-1925](https://horo-engine.atlassian.net/browse/HORO-1925)
- GitHub: Closes #1969
- Domain ticket: `[TRF-006.1]`
- Parent capability: [HORO-1885](https://horo-engine.atlassian.net/browse/HORO-1885) / `[TRF-006] Terrain and Foliage Editor Authoring`
- Follow-up schema work: [HORO-1927](https://horo-engine.atlassian.net/browse/HORO-1927) / `[TRF-006.2] Revisioned Terrain Edit Model, Typed Operations and Undo Snapshots`

## Reviewer Notes

Please focus review on four invariants:

1. Dataset-local foliage placement has exactly one canonical owner alongside its terrain dataset, while reusable foliage-type definitions remain separate assets.
2. Every gesture produces an exact bounded affected closure and at most one atomic history entry; no full-heightfield history fallback exists.
3. Interaction overlays and isolated cooked previews cannot advance document revision, dirty state, saved state, or live gameplay-world state.
4. Save, recovery, cook publication, runtime persistence, cancellation, and teardown retain their existing owners and cannot acknowledge one another implicitly.

The most consequential rejected alternative is algorithmic undo: replaying a brush or scatter operation was rejected because current settings, algorithm versions, dependency state, worker order, or randomness could differ from the committed edit.

## Stack

- Base branch: `docs/HORO-1919_terrain_cross_system_readiness`
- Depends on: #2476 (`HORO-1919` / `[TRF-005.1]`)
- This PR: `HORO-1925` / `[TRF-006.1]`
- Merge order: #2476, then this PR.


[HORO-1925]: https://horo-engine.atlassian.net/browse/HORO-1925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ