### PR TITLE
docs(terrain): define scale qualification budgets HORO-1933 #1977 [TRF-007.1]

### DIFF
--- a/docs/adr/143-terrain-foliage-scale-budgets-observability-and-feature-boundary.md
+++ b/docs/adr/143-terrain-foliage-scale-budgets-observability-and-feature-boundary.md
@@ -1,0 +1,339 @@
+# ADR-143: Terrain/Foliage Scale Budgets, Observability and Feature Boundary
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Terrain/Foliage 1.0 core and high-end qualification workloads, active scale, resident and per-frame streaming budgets, cook throughput, editor latency, headless overhead, measurement ownership, regression gates and post-1.0 GPU-driven boundary
+- **Issue**: [TRF-007.1](https://github.com/abdullahbodur/horo-engine/issues/1977)
+- **Jira**: [HORO-1933](https://horo-engine.atlassian.net/browse/HORO-1933)
+- **Related**: [ADR-010](010-job-waiting-and-operation-store-ownership.md), [ADR-012](012-world-streaming-partition-authority-and-subsystem-boundaries.md), [ADR-034](034-gpu-memory-and-residency-ownership.md), [ADR-038](038-gpu-scene-and-instance-data-model.md), [ADR-042](042-cpu-gpu-timestamps-and-pipeline-statistics.md), [ADR-043](043-gpu-memory-and-resource-inspection.md), [ADR-051](051-renderer-benchmark-and-regression-gates.md), [ADR-137](137-terrain-foliage-ownership-data-tier-and-lifecycle.md), [ADR-138](138-terrain-source-cooked-tile-cache-and-streaming-ownership.md), [ADR-139](139-terrain-render-extraction-material-lod-and-tier-boundary.md), [ADR-140](140-foliage-placement-baked-dynamic-state-and-eviction-ownership.md), [ADR-141](141-terrain-foliage-cross-system-ownership-and-readiness.md), [ADR-142](142-terrain-foliage-document-tool-undo-and-preview-ownership.md)
+- **Normative documents**: [Terrain and Foliage Architecture](../architecture/runtime/terrain-and-foliage-architecture.md), [Metrics and Profiling](../architecture/observability/observability-performance.md), [Testing Architecture](../architecture/delivery/testing-architecture.md), [World Streaming Architecture](../architecture/runtime/world-streaming-architecture.md), [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
+
+## Context
+
+The Terrain/Foliage architecture defines provider-neutral feature tiers, exact budget
+admission and a core-1.0 CPU-selected render path. It intentionally leaves scale and
+performance numbers open. Consequently, “supports large terrain,” “high density,” or
+“low overhead” cannot be accepted or regressed objectively. A renderer could pass a
+small scene, a cook could report cache-hit throughput, or a headless host could retain
+visual work while still claiming compliance.
+
+Feature tiers and qualification workloads answer different questions. A tier is a
+resolved content/capability policy whose final numeric descriptor limits belong to
+TRF-001.3. A qualification workload fixes representative content, active scale,
+budgets and expected measurements. Neither implies the other, and neither may grant
+hardware capability.
+
+Performance numbers are meaningful only inside a reproducible environment cohort.
+They also need non-overlapping accounting: resident Terrain bytes, renderer backing,
+process resident memory and World Streaming reservations cannot be summed blindly.
+Missing metrics, fallback algorithms and dropped samples must not become zero or pass.
+
+This ADR establishes two versioned 1.0 qualification workloads and their absolute
+budgets. TRF-007.2 owns concrete runtime metric descriptors and bounded diagnostic
+snapshots. TRF-007.4 owns the representative scene assets and captured baseline data.
+
+## Decision
+
+### 1. Qualification policy coordinates existing owners
+
+| Responsibility | Authority |
+|---|---|
+| Workload descriptors, absolute budgets, required measurements and pass result | Terrain/Foliage qualification policy |
+| Cell demand, aggregate reservations, per-epoch work and active/retiring admission | World Streaming |
+| Logical tile/cluster/instance state and neutral payload accounting | TerrainRuntime |
+| GPU backing, per-view CPU plan, draw execution and native measurement | RenderFrontend/backend owners |
+| Collision and navigation resources/timing | Physics and Navigation owners |
+| Source edit transaction and interaction latency | Editor document/tool owners under ADR-142 |
+| Cook stage timing, cache state and artifact throughput | Assets/Terrain Cook |
+| Metric descriptors, aggregation, availability, retention and profiler capture | Observability |
+| Cohort admission, run orchestration, baselines and regression evaluation | Benchmark/CI service |
+
+The qualification service receives narrow immutable snapshots and typed measurements.
+It owns no tile, instance, document, GPU resource, Physics body, Navigation tile, metric
+store or scheduler. Workload descriptors are inert and cannot activate a backend,
+reserve memory, load content or register ambient services during validation.
+
+### 2. Scale workloads are versioned and orthogonal to feature tiers
+
+Version 1 defines `TerrainCore1_0` and `TerrainHighEnd1_0`. These identifiers are
+qualification workload families, not `TerrainFeatureTier` values, graphics API names,
+product presets or runtime capability tokens. Each concrete workload descriptor also
+fixes content hashes, seed, camera/input trace, target/tier plan, host mode, backend,
+viewport, render profile, fixed tick, cache state and instrumentation revision.
+
+The selected Terrain feature tier may differ between products, but a result belongs to
+one workload only when the resolved plan exactly satisfies its descriptor. A smaller
+scene, lower density, fewer active tiles, disabled required consumer, lower render
+scale, alternate backend, warm cache or undeclared algorithm is a different workload
+and cannot satisfy the gate.
+
+### 3. Version 1 fixes exact scale and memory envelopes
+
+All byte values are binary MiB. A terrain tile has `128 x 128` interior quads and
+`129 x 129` stored height samples before separately declared seam/apron or mip data.
+The workload uses square tiles; changing dimensions creates a new workload revision.
+
+| Required envelope | `TerrainCore1_0` | `TerrainHighEnd1_0` |
+|---|---:|---:|
+| Simultaneously Active terrain tiles | 256 | 1,024 |
+| Active foliage clusters | 1,024 | 8,192 |
+| Active baked + durable + ephemeral foliage instances | 262,144 | 2,097,152 |
+| TerrainRuntime steady resident logical/decoded bytes | 256 MiB | 1,024 MiB |
+| Foliage steady resident logical/decoded bytes | 256 MiB | 1,024 MiB |
+| Candidate/decode/upload staging allowance | 128 MiB | 512 MiB |
+| Retiring old-generation allowance | 128 MiB | 512 MiB |
+| Maximum aggregate Terrain/Foliage charged bytes | 768 MiB | 3,072 MiB |
+
+“Active” means discoverable through the committed aggregate RuntimeScene/World
+Streaming root with all descriptor-required readiness dimensions. Prepared, private,
+candidate and retiring generations are not Active, but their bytes remain charged to
+the staging or retirement allowance. Shared physical allocations use one ADR-034 charge
+identity; renderer/Physics/Navigation views do not duplicate Terrain logical bytes.
+
+The steady resident limits are both required workload capacity and hard qualification
+ceilings. The fixture must reach the exact active counts without exceeding them. A
+content representation that cannot fit fails admission; it cannot silently drop tiles,
+instances, collision, navigation, layers, LODs or quality. Product runtime descriptors
+may choose lower caps, while higher caps require a separately qualified workload/
+revision and sufficient global World Streaming budget.
+
+The existing World Streaming baseline allocates 256 MiB each to Terrain and Foliage;
+therefore `TerrainCore1_0` fits its steady-state provider slices. Its 128 MiB staging
+and 128 MiB retirement allowances consume the remaining general envelope only through
+explicit aggregate reservation. `TerrainHighEnd1_0` requires a product/runner global
+budget of at least 3,072 MiB plus all non-Terrain provider reservations; it does not
+inflate the default baseline implicitly.
+
+### 4. Per-frame streaming and owner work are capped
+
+One `TerrainStreamingBudgetEpoch` is one committed presentation frame for an
+interactive host and one fixed simulation tick for headless. Catch-up frames/ticks do
+not multiply the allowance. The epoch records actual duration, but the byte cap is not
+converted into an unbounded rate after a hitch.
+
+| Streaming gate | `TerrainCore1_0` | `TerrainHighEnd1_0` |
+|---|---:|---:|
+| Newly committed Terrain/Foliage resident payload per epoch | 4 MiB | 16 MiB |
+| Terrain owner-lane streaming work p95 per epoch | 2.00 ms | 3.00 ms |
+| Concurrent tile/cluster load operations | 4 | 16 |
+| Concurrent retirement operations | 4 | 16 |
+
+Provider reads and worker decode may span epochs, but publication cannot commit more
+new resident payload than the epoch cap. Temporary, decoded and upload copies remain
+covered by staging reservation. The owner-work gate measures Terrain coordination,
+validation, snapshot publication and receipt processing; worker I/O/decode, GPU time,
+Physics and Navigation time remain separate measurements.
+
+When a limit is reached, the manager stops admitting new units and returns bounded
+backpressure. It does not preempt native work, exceed the budget, discard required
+content or reinterpret the limit as a target average. A single artifact larger than the
+per-epoch cap requires explicit multi-epoch staging and atomic publication after the
+complete candidate is ready.
+
+### 5. Cold deterministic cook throughput has absolute floors
+
+Cook qualification starts with an empty Terrain cook-cache namespace, fixed source and
+dependency hashes, the workload's target/tier/toolchain envelope, and no previously
+published artifact reuse. It excludes source generation/import and package compression
+unless the workload explicitly includes them. It includes validation, canonical tiling,
+seams/mips, neutral consumer payloads, foliage placement/clustering, hashing and atomic
+artifact/manifest publication.
+
+| Cold cook gate | `TerrainCore1_0` | `TerrainHighEnd1_0` |
+|---|---:|---:|
+| Successfully published terrain tiles per second | at least 16 | at least 64 |
+| Deterministically evaluated foliage placements per second | at least 250,000 | at least 1,000,000 |
+| Failed, missing or non-deterministic output | 0 | 0 |
+
+Rates use successful output divided by measured steady duration; failed/retried work is
+not counted as throughput. Tile and placement rates are reported independently and both
+must pass. A warm-cache reuse workload is diagnostic and cannot satisfy this cold gate.
+Byte-identical manifest/artifact checks and peak memory/scratch budgets pass separately.
+
+Absolute floors apply only to the versioned protected-runner cohorts attached to each
+workload. Other machines report measurements and relative baselines without claiming
+that a different hardware class failed the product contract.
+
+### 6. Editor interaction has bounded latency gates
+
+The editor workload uses ADR-142 typed operations against a resident document, with
+preview resources warmed and no source save/cook publication inside the interaction
+window. A standard gesture touches at most four tiles and sixteen canonical patches;
+its input trace and patch contents are fixed.
+
+| Editor latency gate | `TerrainCore1_0` | `TerrainHighEnd1_0` |
+|---|---:|---:|
+| Input sample to interaction-overlay publication p95 | 16.67 ms | 8.33 ms |
+| Gesture release to atomic document commit p95 | 100 ms | 50 ms |
+| Modal/tool/document cancellation to overlay removal p95 | 16.67 ms | 8.33 ms |
+| Missed/corrupt/partial history commits | 0 | 0 |
+
+Each process iteration performs 200 deterministic gestures after warm-up. Every sample
+is retained; slow samples are not removed because they exceed the gate. Larger edits
+use separate workloads and may be asynchronous. Meeting latency by shrinking the
+affected closure, skipping before/after patches or publishing before validation is a
+correctness failure, not a performance pass.
+
+### 7. Headless overhead excludes visual work exactly
+
+The headless workload uses the same logical Terrain content and descriptor-required
+collision/navigation readiness but composes no render adapter. It runs 10,000 fixed
+ticks after readiness and compares with the identical fixture/trace with the optional
+Terrain visual dimension absent in both cases.
+
+| Headless gate | `TerrainCore1_0` | `TerrainHighEnd1_0` |
+|---|---:|---:|
+| Terrain logical/streaming owner work p95 per fixed tick | 0.50 ms | 1.50 ms |
+| Additional visual CPU work, GPU bytes, draw/dispatch/submit count | exactly 0 | exactly 0 |
+| Terrain observability collection CPU p95 per fixed tick | 0.05 ms | 0.10 ms |
+| Metric/diagnostic memory retained by Terrain | at most 4 MiB | at most 8 MiB |
+
+Physics/Navigation work and their memory are reported by their owners and cannot be
+relabeled as Terrain overhead. Process totals remain useful context but are not summed
+with tagged subsystem values. A Null Render adapter is a separate explicit workload;
+it cannot stand in for a host with no render adapter.
+
+### 8. Core and high-end 1.0 require the CPU-selected render recipe
+
+Both version-1 workloads qualify the ADR-139 core path: TerrainRuntime publishes view-
+independent candidates, and RenderFrontend performs bounded CPU per-view visibility,
+LOD/seam selection and direct/instanced batch construction. Compute, GPU Scene, indirect
+command generation and GPU-driven foliage selection are not required or permitted in
+these workload identities.
+
+The CPU plan must meet the active scale and all absolute budgets on every interactive
+backend/platform cohort declared required by the product. A backend that cannot meet a
+required workload is unqualified; it does not switch recipe, tier, fixture or profile.
+Expected unsupported is legal only when the product descriptor did not require that
+cohort and admission returns its exact typed reason before measurement.
+
+Post-1.0 may define a new `TerrainGpuDriven` recipe/workload revision. It must preserve
+the same candidate semantics and ownership while separately freezing GPU buffer/
+counter capacities, overflow behavior, synchronization, readback, shader/cook identity,
+fallback and cross-backend qualification. It cannot be enabled under either version-1
+workload ID or used retroactively to claim its gates. A declared CPU fallback is a
+separate measured plan, never a silent response to GPU failure or saturation.
+
+### 9. Required measurements have stable, non-overlapping semantics
+
+Qualification consumes typed measurements through Observability/benchmark services:
+
+- active/preparing/retiring tile, cluster and instance counts;
+- Terrain and foliage logical/decoded resident, staging and retirement bytes;
+- committed streaming bytes and owner work per budget epoch;
+- cook tile/placement success, failure, duration and throughput;
+- edit overlay, commit and cancellation latency plus history bytes/patch counts;
+- headless owner/observability time and proof of zero visual resources/work;
+- budget denial, stale result, cancellation, eviction and retirement-stall totals; and
+- active workload, content, plan, capability and measurement schema revisions.
+
+Counts/bytes come from owning ledgers and typed snapshots, not directory enumeration,
+native API queries or parsed logs. GPU/process memory are separate observations with
+their own availability/provenance. IDs, paths, coordinates, tile/cluster/instance keys,
+operation IDs and native handles are prohibited metric dimensions. Detailed per-item
+evidence belongs to a bounded on-demand diagnostic snapshot under TRF-007.2.
+
+Metric unavailability is explicit. A missing required measurement, stale generation,
+dropped sample, series-budget breach, invalid calibration or mismatched revision makes
+the run invalid; it is never zero or pass. Metrics inform qualification and diagnosis,
+not runtime control flow.
+
+### 10. Measurement and regression follow ADR-051
+
+Interactive steady workloads use 300 warm-up frames, at least 1,200 measured frames/
+20 seconds and seven process iterations. They retain at least 99% valid samples. Editor,
+cook and headless workload windows above override operation counts while preserving
+seven independent iterations unless their versioned descriptor explicitly requires a
+stricter plan.
+
+The environment cohort fixes workload revision, source/content, OS, CPU/memory/device
+class, backend/driver, power/thermal policy, build/toolchain, dependency lock, viewport/
+present state, effective capabilities and instrumentation. Candidate and protected-
+branch baseline must match. Adaptive quality, dynamic resolution, unrelated streaming,
+debug layers and profiler captures are off unless part of the workload identity.
+
+A result must satisfy every absolute scale/budget/floor and the applicable ADR-051
+relative regression/stability gate. Passing one does not waive the other. Qualification
+artifacts include exact measurements, availability, fallback decisions, excluded sample
+reasons, budget math and bounded diagnostics; they contain no absolute machine paths,
+native handles or raw source payloads.
+
+### 11. Failure, cancellation, replacement and shutdown remain measurable
+
+Admission fails before work when the fixture, descriptor, capabilities, global budget,
+measurement plan or cohort is incompatible. During execution, cancellation stops new
+admission and retains candidates, samples and native/consumer leases through normal
+acknowledged retirement. Replacement invalidates the run instead of splicing old/new
+generations. Device/provider loss and stale evidence are explicit outcomes.
+
+Shutdown cancels queued/active workloads, closes metric/diagnostic admission, drains
+bounded completion records, retires submitted consumer work and then releases snapshots,
+reservations and modules. A timeout reports incomplete qualification/retirement and
+retains ownership; it cannot force-free or publish a partial pass.
+
+Stable outcomes include `Passed`, `BudgetExceeded`, `ThroughputBelowFloor`,
+`LatencyExceeded`, `RequiredMetricUnavailable`, `InsufficientSamples`,
+`WrongRecipe`, `UnexpectedUnsupported`, `EnvironmentInvalid`, `Regression`,
+`Cancelled`, `StaleGeneration`, `RetirementStalled` and `InfrastructureFailed`.
+
+## Consequences
+
+- “Core” and “high-end” Terrain/Foliage scale now have exact active counts, tile shape,
+  memory, per-epoch bandwidth/work, cook, editor and headless expectations.
+- Capability tiers remain independent; TRF-001.3 can freeze descriptor limits without
+  turning benchmark workloads into product presets.
+- Core/high-end 1.0 cannot depend on hidden GPU-driven work. Post-1.0 optimization must
+  introduce explicit recipe/workload identity and qualification.
+- The core steady-state slices align with existing World Streaming defaults, while
+  staging/retirement overlap and the larger high-end envelope require explicit global
+  reservation.
+- Some prototypes and platforms will become explicitly unqualified until they provide
+  required measurements and pass both absolute and relative gates.
+- TRF-007.2 must implement low-cardinality descriptors/bounded snapshots, and TRF-007.4
+  must publish immutable fixtures and protected-runner cohort manifests.
+
+Required coverage includes exact-boundary and one-over-limit counts/bytes; checked
+aggregate accounting with old/new/staging/retiring overlap; per-epoch backpressure;
+cold/warm cache separation and deterministic cook floors; editor latency without lost
+history; headless zero-visual proof; required metric unavailability/dropped samples;
+cohort mismatch, fallback and wrong-recipe rejection; absolute plus relative gate math;
+and cancellation/replacement/shutdown at every measurement stage.
+
+## Rejected Alternatives
+
+### Use feature tiers as benchmark profiles
+
+Rejected because tiers express resolved product capability/quality, while workloads fix
+content, scale, environment and measurements. Coupling them would let a tier name hide
+different numbers or algorithms.
+
+### Publish only target FPS or average frame time
+
+Rejected because it hides owner cost, streaming bandwidth, tail latency, memory overlap,
+cook/editor/headless behavior and correctness failures.
+
+### Require GPU-driven culling for high-end 1.0
+
+Rejected because it would make compute/GPU Scene/indirect execution an undeclared core
+dependency and undermine backend parity. Both 1.0 workloads prove the CPU-selected path.
+
+### Treat missing metrics as zero or skip their gates
+
+Rejected because absence would look better than real work and reward broken
+instrumentation. Required measurement unavailability invalidates the run.
+
+### Average streaming bandwidth across long windows
+
+Rejected because large one-frame bursts cause hitches and memory overlap even when the
+long-term average is low. Admission is capped per explicit epoch.
+
+### Compare absolute thresholds across arbitrary machines
+
+Rejected because throughput and latency are cohort-dependent. Absolute gates belong to
+versioned protected runners; other cohorts use their own explicit descriptors/baselines.
+
+### Let a GPU recipe satisfy the existing CPU workload identity
+
+Rejected because results would be incomparable and GPU failure could hide a recipe
+switch. Recipe and fallback are explicit workload identity.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -317,6 +317,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Terrain/Foliage Document, Tool, Undo and Preview Ownership](../adr/142-terrain-foliage-document-tool-undo-and-preview-ownership.md):
   persistent authoring documents, typed tool routing, bounded tile-patch history,
   isolated preview and distinct source-save/cook/runtime-persistence boundaries.
+- [Terrain/Foliage Scale Budgets, Observability and Feature Boundary](../adr/143-terrain-foliage-scale-budgets-observability-and-feature-boundary.md):
+  versioned core/high-end active scale, memory, streaming, cook, editor/headless gates,
+  required measurements and core-1.0 versus post-1.0 recipe qualification.
 - [World Streaming Architecture](./runtime/world-streaming-architecture.md):
   streaming cells, volumes, priority, budgets, server authority, and editor
   world-composition tools.

--- a/docs/architecture/delivery/testing-architecture.md
+++ b/docs/architecture/delivery/testing-architecture.md
@@ -650,7 +650,7 @@ python3 scripts/dev.py test --all --coverage
 python3 scripts/dev.py coverage-report
 ```
 
-Coverage reports are merged across compatible jobs. Coverage data is exclusively collected from **Unit**, **Integration**, and **Contract (CLI/MCP)** test layers. 
+Coverage reports are merged across compatible jobs. Coverage data is exclusively collected from **Unit**, **Integration**, and **Contract (CLI/MCP)** test layers.
 
 GUI test coverage is intentionally excluded from official metrics to prevent flaky line-hit variance (due to frame timings) and to avoid artificially inflating coverage numbers with UI layout execution.
 
@@ -684,6 +684,23 @@ Tests have implied performance budgets:
 | Full GUI suite | < 10 min total |
 
 Slow tests must be tagged `[slow]` and excluded from the local fast suite.
+
+Terrain/Foliage performance qualification follows
+[ADR-143](../../adr/143-terrain-foliage-scale-budgets-observability-and-feature-boundary.md).
+Versioned `TerrainCore1_0` and `TerrainHighEnd1_0` descriptors fix active scale, tile
+shape, steady/staging/retiring memory, per-epoch publication, cold cook throughput,
+editor latency, headless overhead and the CPU-selected render recipe. Tests at the exact
+boundary and one unit over must verify success versus typed denial without content
+drops, budget overshoot or recipe changes.
+
+Interactive runs use ADR-051 warm-up, measurement, seven-iteration cohort and sample-
+validity rules. Cold cook starts from an empty Terrain cache namespace; warm reuse is a
+different diagnostic workload. Editor iterations run fixed input/patch traces, and
+headless iterations use fixed ticks with no render adapter. Every absolute gate and the
+matching relative/stability gate must pass. Missing required measurements, mismatched
+cohorts, stale generations, dropped samples, hidden fallback or GPU-driven work under a
+version-1 CPU workload invalidates the result rather than being skipped or recorded as
+zero.
 
 *Note on CI routing: While individual integration tests (< 1 s) have a faster budget than contract tests (< 5 s), integration tests are deferred out of the CI PR Fast Lane. This is because their cross-module fan-out creates higher variance and non-local failure risks. Fast contract tests are kept in the PR Fast Lane to ensure the immediate module's boundaries remain strictly intact.*
 

--- a/docs/architecture/observability/observability-performance.md
+++ b/docs/architecture/observability/observability-performance.md
@@ -379,6 +379,34 @@ CPU frame time, GPU frame time, and presentation/wait time remain separate.
 Adding them together is not generally meaningful because CPU and GPU work can
 overlap.
 
+### Terrain And Foliage Qualification Measurements
+
+[ADR-143](../../adr/143-terrain-foliage-scale-budgets-observability-and-feature-boundary.md)
+requires Terrain/Foliage qualification to consume non-overlapping typed measurements
+from existing owners. Required families cover active/preparing/retiring tile, cluster
+and instance counts; logical/decoded resident, staging and retirement bytes; newly
+committed payload and Terrain owner work per streaming epoch; cold cook tile/placement
+throughput; editor overlay/commit/cancel latency; headless owner/collection time; and
+budget denial, stale, cancellation and retirement outcomes.
+
+Terrain logical bytes come from Terrain/World Streaming charge ledgers. Renderer GPU,
+Physics, Navigation and process memory remain separate measurements with their own
+availability and must not be added as independent copies of shared backing. The
+headless workload additionally proves that visual CPU work, GPU bytes and draw/
+dispatch/submit counts are zero when no render adapter is composed; Null Render is a
+separate workload.
+
+Workload/content/plan/capability/measurement revisions are result provenance, not
+metric dimensions. Asset, operation, dataset, tile, cluster, instance, coordinate,
+path and native-handle values are prohibited dimensions. Per-item evidence belongs to
+an explicitly requested bounded diagnostic snapshot. TRF-007.2 freezes the concrete
+descriptor set, finite allowed values/series counts and snapshot record/byte/time
+limits without changing these semantics.
+
+A required measurement that is unavailable, stale, dropped or from a mismatched
+generation invalidates qualification; it is not recorded as zero. These metrics report
+health and support gates but never drive residency, eviction, recipe or fallback policy.
+
 ### Hitch And Budget Analysis
 
 Frame metrics must preserve enough distribution information to diagnose hitches,
@@ -457,6 +485,7 @@ governs concurrency, data retention, and event propagation as follows:
 ### Concurrency And Write Semantics
 
 To prevent lock contention on hot engine threads (e.g., render, update):
+
 - **Thread-Local Accumulators**: Hot-path metrics (such as draw calls, frames, and allocation counters) write directly to thread-local or sharded atomic slots.
 - **Periodic Aggregation**: The central `MetricsStore` aggregates these sharded buffers at a fixed rate (e.g., once per frame for frame metrics, or every 500ms for system/process counters) using a readers-writer lock (`std::shared_mutex`).
 - **Query Path**: Reads and presentation queries acquire a shared lock (`shared_lock`), while the aggregator thread acquires a unique write lock (`unique_lock`) only during flush phases.
@@ -782,6 +811,7 @@ Python timers use `time.perf_counter_ns()` to guarantee high-resolution monotoni
 ### Registry Thread Safety
 
 To support concurrent scripts and parallel task executions (e.g. `multiprocessing` or `threading` wrappers in release jobs):
+
 - **Locking**: The Python metrics registry in `horo_metrics.py` implements a global `threading.Lock` protecting the creation and updating of instrument handles.
 - **Process Sampler Platform Behavior**: Process CPU and resident memory usage collection uses `psutil` if available. On Linux systems where `psutil` is absent, it parses `/proc/self/stat` directly. On macOS systems without `psutil`, CPU and memory stats default to `Unavailable`. The script will gracefully mark them unavailable without raising import or runtime errors.
 

--- a/docs/architecture/runtime/terrain-and-foliage-architecture.md
+++ b/docs/architecture/runtime/terrain-and-foliage-architecture.md
@@ -26,6 +26,9 @@ publication, aggregate activation, rollback and reverse-DAG retirement.
 [ADR-142](../../adr/142-terrain-foliage-document-tool-undo-and-preview-ownership.md)
 defines persistent authoring documents, typed tool routing, bounded tile-patch history,
 isolated preview and distinct source-save/cook/runtime-persistence boundaries.
+[ADR-143](../../adr/143-terrain-foliage-scale-budgets-observability-and-feature-boundary.md)
+defines versioned core/high-end 1.0 scale and performance workloads, required
+measurements and the explicit post-1.0 GPU-driven qualification boundary.
 
 ## Ownership And Data Boundaries
 
@@ -605,6 +608,39 @@ and the compatible cooked variant exists. Runtime never silently clamps layers, 
 instances, removes collision, changes renderer/provider or switches CPU/GPU algorithms
 to make a tier appear successful.
 
+### Qualification Profiles And Budgets
+
+Feature tiers are not benchmark profiles. ADR-143 defines two version-1 qualification
+workloads that fix content, host/recipe, environment cohort and measurements:
+
+| Required envelope | `TerrainCore1_0` | `TerrainHighEnd1_0` |
+|---|---:|---:|
+| Tile interior/stored samples | 128 x 128 quads / 129 x 129 samples | same |
+| Simultaneously Active terrain tiles | 256 | 1,024 |
+| Active foliage clusters / instances | 1,024 / 262,144 | 8,192 / 2,097,152 |
+| Terrain/Foliage steady resident bytes | 256 MiB / 256 MiB | 1,024 MiB / 1,024 MiB |
+| Staging / retiring allowance | 128 MiB / 128 MiB | 512 MiB / 512 MiB |
+| Newly committed resident payload per frame/tick epoch | 4 MiB | 16 MiB |
+
+Both qualify ADR-139's bounded CPU-selected visibility/LOD/seam and direct/instanced
+render recipe. GPU Scene, compute selection and indirect command generation are outside
+these workload identities. Post-1.0 GPU-driven support requires a new explicit recipe,
+capacities, overflow/synchronization/fallback rules and backend cohorts; it cannot
+silently satisfy or alter a version-1 result.
+
+Cold cook floors are 16/64 published terrain tiles per second and 250,000/1,000,000
+deterministically evaluated foliage placements per second for core/high-end protected
+runner cohorts. Standard editor gestures require p95 overlay/commit latency no greater
+than 16.67/100 ms for core and 8.33/50 ms for high-end. Headless fixed-tick Terrain
+owner work is capped at p95 0.50/1.50 ms; visual CPU work, GPU bytes and draw/dispatch/
+submit counts are exactly zero. Required metric absence invalidates qualification rather
+than becoming zero.
+
+These numbers are workload gates, not automatic runtime allowances or TRF-001.3
+descriptor maxima. World Streaming retains aggregate admission, every byte is charged
+once through its existing ledger, and the high-end envelope requires an explicitly
+larger product/runner global budget.
+
 ## Verification
 
 Required coverage includes:
@@ -652,7 +688,13 @@ Required coverage includes:
 - authoring failure/cancel/stale completion preserving source revision, dirty state,
   history and notifications at every staged boundary; and
 - source save, autosave/recovery, transient preview cook, published cook and Runtime Save
-  state separation, including isolated preview teardown and stale-result rejection.
+  state separation, including isolated preview teardown and stale-result rejection;
+- exact core/high-end active-count, resident/staging/retirement and per-epoch streaming
+  boundaries, including one-over-limit denial with checked accounting;
+- protected-cohort cold cook, editor p95 and headless overhead gates with required metric
+  availability, fixed fixtures and no invalid sample removal; and
+- CPU-selected 1.0 recipe enforcement plus rejection of undeclared GPU-driven/fallback
+  work under the same workload identity.
 
 ## Related Documents
 
@@ -694,3 +736,6 @@ Required coverage includes:
 - [ADR-142](../../adr/142-terrain-foliage-document-tool-undo-and-preview-ownership.md):
   persistent authoring documents, typed tool routing, bounded tile-patch undo/redo,
   isolated preview and source-save/cook/runtime-persistence separation
+- [ADR-143](../../adr/143-terrain-foliage-scale-budgets-observability-and-feature-boundary.md):
+  core/high-end scale, memory, streaming, cook, editor and headless gates, required
+  observability and core-1.0 versus post-1.0 recipe qualification


### PR DESCRIPTION
## Summary

- Add ADR-143 to turn Terrain/Foliage “core,” “high-end,” and “low overhead” claims into versioned, measurable qualification contracts.
- Define exact `TerrainCore1_0` and `TerrainHighEnd1_0` active scale, tile shape, resident/staging/retirement memory, per-epoch streaming, cook, editor, and headless gates.
- Require both 1.0 workloads to use the CPU-selected visibility/LOD/seam and direct/instanced render recipe; post-1.0 GPU-driven work receives a new explicit recipe/workload identity.
- Align Terrain/Foliage, Observability, Testing, and the architecture index with the decision.

## Why

The existing Terrain/Foliage decisions correctly assign ownership and require finite budgets, but deliberately leave scale and performance numbers open. That makes representative capacity impossible to qualify: a small scene, warm cook cache, hidden GPU path, absent metric, or retained headless visual work could all produce a misleading pass.

This ADR separates capability tiers from qualification workloads. Tiers remain product/content resolution policy; workloads fix exact content scale, environment cohort, recipe, measurement semantics, and pass/fail thresholds. This prevents tier names or backend labels from becoming undocumented performance guarantees.

## Decision and boundaries

- `TerrainCore1_0` fixes 256 active 128×128-quad / 129×129-sample tiles, 1,024 clusters, 262,144 instances, 256 MiB each of Terrain/Foliage steady resident data, and a 768 MiB aggregate envelope including staging/retirement.
- `TerrainHighEnd1_0` fixes 1,024 active tiles, 8,192 clusters, 2,097,152 instances, 1,024 MiB each of Terrain/Foliage steady resident data, and a 3,072 MiB aggregate envelope.
- Newly committed resident payload is capped at 4/16 MiB per presentation-frame or fixed-tick budget epoch. Catch-up work does not multiply the allowance.
- Cold deterministic cook floors are 16/64 published terrain tiles per second and 250k/1M evaluated foliage placements per second. Warm-cache reuse is a separate diagnostic workload.
- Standard editor gestures use fixed input/patch traces. Core/high-end p95 gates are 16.67/8.33 ms for overlay publication and 100/50 ms for atomic document commit.
- Headless logical/streaming work is capped at p95 0.50/1.50 ms per fixed tick; visual CPU work, GPU bytes, and draw/dispatch/submit counts must be exactly zero.
- Every byte is accounted once through existing Terrain/World Streaming/renderer ledgers. Staging, replacement, and retirement overlap remain charged until acknowledged release.
- Required measurements preserve owner semantics and availability. Dataset/tile/cluster/instance/operation IDs, coordinates, paths, and native handles are prohibited metric dimensions.
- Both version-1 workloads enforce ADR-139’s CPU-selected recipe. Compute, GPU Scene, and indirect command generation cannot satisfy the same workload identity; post-1.0 requires separate capacities, overflow/synchronization/fallback rules, and backend cohorts.
- Qualification uses ADR-051 cohort, warm-up, sample-validity, absolute, relative, and stability rules. Passing an absolute budget does not waive regression gates, or vice versa.
- Two pre-existing Markdown hygiene issues in touched normative files were normalized so the full changed-file lint gate passes: one trailing space and required blank lines before lists.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/143-terrain-foliage-scale-budgets-observability-and-feature-boundary.md docs/architecture/README.md docs/architecture/runtime/terrain-and-foliage-architecture.md docs/architecture/observability/observability-performance.md docs/architecture/delivery/testing-architecture.md`
- `git diff --check`
- `git diff --cached --check`
- Staged-added Markdown link resolution check: passed.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`: passed configuration and generation.
- Known non-blocking configure warnings: upstream mbedTLS CMake minimum-version deprecation; pytest unavailable, so repository Python tests were skipped by CMake.

This is a documentation/architecture-only change. Representative fixtures and executable performance gates are follow-up work, so no performance claims are reported as measured by this PR.

## Risk and rollout

- The numeric envelopes are normative targets, not observed results. TRF-007.4 must provide immutable fixtures and protected-runner cohort manifests before qualification can be claimed.
- Cold cook and latency floors are cohort-sensitive. The ADR limits absolute claims to versioned protected runners and requires other machines to use explicit workload/cohort identities.
- High-end capacity requires at least a 3,072 MiB Terrain/Foliage global slice plus other providers; it intentionally does not enlarge the current World Streaming defaults implicitly.
- Exact runtime metric descriptors and bounded diagnostic snapshots remain TRF-007.2 scope. Until implemented, required measurement absence invalidates rather than weakens qualification.
- Platforms that currently rely on GPU-driven or hidden fallback behavior will not qualify the version-1 CPU workload without an explicit separate recipe.

## Issue links

- Jira: [HORO-1933](https://horo-engine.atlassian.net/browse/HORO-1933)
- GitHub: Closes #1977
- Domain ticket: `[TRF-007.1]`
- Parent capability: [HORO-1887](https://horo-engine.atlassian.net/browse/HORO-1887) / `[TRF-007] Terrain and Foliage Diagnostics, Scalability and Production Qualification`
- Metrics follow-up: [HORO-1932](https://horo-engine.atlassian.net/browse/HORO-1932) / `[TRF-007.2] Low-Cardinality Metrics and Bounded Diagnostic Snapshots`
- Fixture/budget follow-up: [HORO-1939](https://horo-engine.atlassian.net/browse/HORO-1939) / `[TRF-007.4] Representative Terrain/Foliage Benchmark Scenes and Budgets`

## Reviewer Notes

Please review the decision along four axes:

1. Workload-versus-tier separation: `Core1_0`/`HighEnd1_0` must not become product presets or implicit capability grants.
2. Accounting: active, candidate, staging, old-generation, and retiring bytes must fit one non-duplicated aggregate envelope.
3. Measurement validity: cold/warm cache, headless/Null Render, owner/process/native metrics, missing values, and cohort identity must remain distinct.
4. Feature boundary: neither 1.0 workload may hide compute/GPU Scene/indirect execution; a GPU-driven path must use a new measured recipe and explicit fallback contract.

The core steady resident slices deliberately match the existing 256 MiB Terrain + 256 MiB Foliage World Streaming defaults. Staging and retirement consume the general envelope only through explicit reservation. The high-end workload is intentionally not enabled by those defaults.

## Stack

- Base branch: `docs/HORO-1925_terrain_editor_document_undo_preview`
- Depends on: #2477 (`HORO-1925` / `[TRF-006.1]`)
- This PR: `HORO-1933` / `[TRF-007.1]`
- Merge order: #2477, then this PR.


[HORO-1933]: https://horo-engine.atlassian.net/browse/HORO-1933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ