### PR TITLE
docs(destruction): define runtime ownership boundary HORO-1948 #1994 [DFR-001.1]

### DIFF
--- a/docs/adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md
+++ b/docs/adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md
@@ -1,0 +1,361 @@
+# ADR-144: Destruction Ownership, Authority, State and Runtime Geometry Boundary
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Destruction module and world ownership, canonical semantic state, command authority, fixed-tick transition order, cooked chunk activation, cross-system publication, persistence/replication, provider-neutral tiers, runtime geometry exclusion, cancellation, replacement and shutdown
+- **Issue**: [DFR-001.1](https://github.com/abdullahbodur/horo-engine/issues/1994)
+- **Jira**: [HORO-1948](https://horo-engine.atlassian.net/browse/HORO-1948)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-010](010-job-waiting-and-operation-store-ownership.md), [ADR-012](012-world-streaming-partition-authority-and-subsystem-boundaries.md), [ADR-016](016-navigation-target-ownership-and-dependency-boundary.md), [ADR-017](017-prefab-role-ownership-and-capability-tiers.md), [ADR-023](023-world-index-and-cell-format-architecture-decision.md), [ADR-027](027-renderer-resource-identity-and-descriptors.md), [ADR-054](054-extension-and-package-authority-boundary.md), [ADR-085](085-physics-shape-authoring-cook-and-runtime-boundary.md), [ADR-087](087-scene-to-physics-ownership-and-conversion.md), [ADR-099](099-replication-ownership-authority-and-compatibility.md), [ADR-114](114-canonical-runtime-world-persistence-boundary.md)
+- **Normative documents**: [Destruction and Fracture Architecture](../architecture/runtime/destruction-and-fracture-architecture.md), [Scene Runtime](../architecture/runtime/scene-runtime.md), [Physics Architecture](../architecture/runtime/physics-architecture.md), [Asset Pipeline](../architecture/runtime/asset-pipeline.md), [Networking Architecture](../architecture/runtime/networking-architecture.md), [Save Game and Persistence](../architecture/runtime/save-game-and-persistence.md)
+
+## Context
+
+The current Destruction document describes an ECS component with mutable health/state,
+pre-fractured meshes, runtime fracture, Physics chunks, VFX debris and network events.
+It does not assign the canonical state machine to one runtime owner or distinguish a
+gameplay damage decision from a Physics contact, a renderer visibility change, a Scene
+structural batch or a replicated command.
+
+It also uses backend-named feature tiers and calls “runtime fracture” both activation of
+offline chunks and generation of new geometry. Those are different capabilities.
+Selecting pre-cooked chunks is bounded runtime state mutation; cutting an arbitrary mesh
+requires topology generation, interior surfacing, collision cooking, material mapping,
+budgeting and cross-client compatibility. Treating them as one 1.0 feature would permit
+unbounded work or a silent fallback from missing cooked content.
+
+Cross-system publication must be coherent. Hiding the intact render object before the
+required chunk bodies and render objects are prepared creates a partially destroyed
+world. Conversely, Physics cannot create destruction state by directly deleting a body,
+and VFX/Audio cannot be the success signal merely because a cosmetic effect played.
+
+This ADR establishes the ownership and capability baseline. DFR-001.2 owns concrete
+stable identities, DFR-001.3 owns descriptor/tier limits, and later DFR decisions own
+asset cooking, Physics, rendering, persistence, networking and diagnostics details.
+
+## Decision
+
+### 1. Destruction is a runtime domain with narrow module boundaries
+
+`HoroEngine::DestructionApi` owns backend-neutral public identities, revisions,
+descriptors, commands, results and immutable query snapshots. It depends only on
+approved lower-level Horo contracts. `HoroEngine::DestructionRuntime` owns live
+world-scoped semantic state, command admission, transition planning, bounded queues,
+snapshot publication and retirement.
+
+Destruction Cook owns semantic validation and transformation from authored fracture
+intent to neutral cooked fracture graphs/chunk payload descriptors. Assets owns source
+identity, dependency scheduling, cache/package storage and atomic artifact publication.
+Hosts compose Scene, Destruction, Physics, Render, World Streaming, Network, Runtime
+Save, Audio and VFX through explicit ports. No public API contains Jolt, graphics API,
+audio middleware, transport, ImGui or filesystem-native types.
+
+Module descriptors are inert metadata. Construction/validation cannot discover a
+service, register a global, create a world, load an asset, allocate native resources or
+invoke lifecycle callbacks.
+
+### 2. Every mutable state has exactly one authority
+
+| State or decision | Authority |
+|---|---|
+| Authored destructible/fracture source and editor history | Owning Scene/asset document |
+| Source identity, cook scheduling, cache/package publication | Assets |
+| Fracture schema, chunk graph semantics and deterministic cook | Destruction Cook |
+| Live health, semantic phase, broken/support sets, command/revision history and canonical events | Scene-scoped `DestructionWorld` |
+| Entity/component lifetime and aggregate scene activation root | RuntimeScene |
+| Gameplay permission, damage meaning and command issuance | Product gameplay authority |
+| Body/shape/constraint state, contacts and Physics safe point | Physics |
+| Render objects, visibility, materials, GPU resources and fences | Render |
+| Cell demand, reservations and eviction barrier | World Streaming |
+| Durable destruction state capture/dormancy | Runtime Save/Persistent World |
+| Replication capture, transport and remote apply delivery | NetworkRuntime |
+| Debris/impact presentation | VFX, Audio and Decal owners |
+
+The component contains stable binding and authored policy, not a second mutable state
+machine:
+
+```cpp
+struct DestructibleSceneBinding {
+    DestructibleId destructible;
+    AssetId fractureAsset;
+    DestructionPolicyId policy;
+    DestructionFeatureRequirements requiredFeatures;
+};
+```
+
+RuntimeScene maps the binding to one generation-checked `DestructionHandle`. Gameplay,
+Physics, Network, Renderer and effects query immutable state or submit typed commands;
+they never mutate a component field or chunk bitset directly.
+
+### 3. Semantic state and runtime lifecycle are separate
+
+Canonical semantic state is equivalent to:
+
+```cpp
+enum class DestructionSemanticPhase : uint8_t {
+    Intact,
+    Damaged,
+    Fractured
+};
+
+struct DestructionStateSnapshot {
+    DestructibleId destructible;
+    DestructionGeneration generation;
+    DestructionStateRevision revision;
+    DestructionSemanticPhase phase;
+    DestructionHealth health;
+    DestructionChunkSet broken;
+    DestructionSupportState support;
+};
+```
+
+`Damaged` preserves non-terminal health/support changes. `Fractured` means at least one
+cooked chunk transition has committed; it does not imply every chunk is active or that
+the whole object is destroyed. Exact broken, supported, detached, dormant and removed
+chunk membership uses stable IDs and bounded sets, not enum inference.
+
+The world/object lifecycle is independently `Absent`, `Preparing`, `Prepared`, `Active`,
+`Replacing`, `Suspended`, `Retiring` or `Failed`. Preparing is not Damaged; Retiring is
+not Destroyed. Content, semantic state, active representation, capability and
+persistence revisions advance independently.
+
+### 4. All mutations are authority- and revision-checked commands
+
+```cpp
+struct DestructionCommandHeader {
+    DestructibleId destructible;
+    DestructionGeneration generation;
+    DestructionStateRevision expectedRevision;
+    DestructionCommandId command;
+    SimulationTick tick;
+    GameplayAuthorityGrant authority;
+    DestructionCommandLimits limits;
+};
+```
+
+Typed kinds include admitted damage, radial damage, explicit fracture, repair/reset
+where policy permits, support change and durable-state restore. Commands carry finite
+Horo-space values, stable source/instigator identity when required and explicit
+criticality. Display names, entity slots, native body IDs and network connection IDs are
+not authority.
+
+Gameplay is the normal command issuer. A Physics contact is immutable evidence with
+world/body/subshape/tick/generation identity; a gameplay/domain policy may translate it
+to a command. Physics callbacks do not mutate Destruction. A script uses the same
+capability. Network delivery contains a validated server-authoritative command/state
+apply envelope; packet arrival or client prediction does not grant authority.
+
+The Destruction owner validates capability, authority, generation, expected revision,
+finite values, duplicate command ID, cooked graph membership and all count/byte/work
+limits before mutation. One accepted command yields one atomic semantic revision and
+canonical event batch. Invalid, unauthorized, stale or over-budget work changes nothing.
+
+### 5. Fixed-tick ordering prevents callbacks from becoming authority
+
+One simulation tick orders destruction as follows:
+
+1. NetworkPoll and gameplay enqueue bounded normalized commands for the target tick.
+2. Before Physics, Destruction admits commands not dependent on this tick's contacts and
+   prepares any required cooked transition candidate.
+3. Physics applies previously committed body/shape changes, steps once and publishes
+   bounded generation-tagged contact evidence.
+4. Destruction consumes eligible contact evidence after Physics, evaluates canonical
+   policy in stable order and stages resulting semantic/representation transitions.
+5. At the next legal Scene/Physics/Render safe-point bundle, required chunk entities,
+   bodies and render objects publish privately, then RuntimeScene commits one aggregate
+   root with the semantic revision.
+6. Only after aggregate commit are canonical destruction events captured for gameplay,
+   Network and Runtime Save; VFX/Audio/Decal receive bounded presentation requests.
+
+A contact-triggered fracture therefore cannot add a body inside a Physics callback or
+make a half-published result visible in the same step. Immediate cosmetic feedback may
+be explicitly predictive and disposable; it is never canonical success.
+
+### 6. Core 1.0 activates only pre-cooked geometry
+
+The core path consumes an immutable validated fracture artifact containing stable chunk
+graph identity, hierarchy/support relations, chunk render payload references, interior
+surface/material mapping, pre-cooked convex Physics shapes/mass properties, bounds and
+finite activation costs. Exact schemas and limits belong to DFR-001.2/.3 and the asset-
+cook decision.
+
+At runtime Destruction may select a bounded subset of existing chunks, update semantic
+membership, and coordinate activation/retirement of their pre-cooked representations.
+It may not in core 1.0:
+
+- cut, boolean, voxelize, remesh or triangulate an arbitrary mesh;
+- generate Voronoi cells, interior faces, UVs, normals or material slots;
+- decompose convex collision, cook a triangle mesh or derive mass properties;
+- infer fracture from a Render mesh/LOD or Physics native shape;
+- change topology/connectivity or synthesize missing chunks; or
+- write generated geometry into source, cache or package paths.
+
+Missing/incompatible/corrupt cooked geometry fails preparation or required activation.
+It never falls back to runtime cutting, an intact box collider, visual-only fracture,
+another asset/provider/backend or silent no-destruction behavior.
+
+### 7. Runtime geometry generation is a post-1.0 capability
+
+A future runtime-geometry capability requires its own typed request/result, source
+eligibility, topology and material schema, deterministic/cross-network policy, CPU/GPU/
+scratch/resident budgets, task ownership, cancellation, cache/persistence rules,
+Physics cook boundary and backend qualification. It produces a detached candidate and
+still uses aggregate publication.
+
+It is not implied by a feature tier, damage type, renderer/Physics backend, high-end
+device, editor availability or missing fracture asset. Products that require it fail
+capability resolution until an explicitly qualified implementation exists. Core 1.0
+never queues runtime mesh cutting “for later” while reporting fracture success.
+
+### 8. Provider-neutral tiers describe pre-cooked capability
+
+```cpp
+enum class DestructionFeatureTier : uint8_t {
+    Baseline,
+    Standard,
+    High
+};
+```
+
+`Baseline` provides bounded one-level pre-cooked fracture and optional cosmetic effects.
+`Standard` may admit larger graphs, staged activation and richer pre-cooked support
+rules. `High` may admit pre-cooked hierarchical fracture/collapse and larger qualified
+budgets. Exact chunk/depth/event/active-body/byte/work limits belong to DFR-001.3.
+
+Tier names do not encode APIs/platforms and grant nothing. Resolution intersects the
+product request, cooked variants, DestructionRuntime, World Streaming, Physics, Render,
+host mode and budget capabilities into an immutable plan. Required unsatisfied content
+fails. Optional fallback follows only an ordered product declaration and records its
+reason. Runtime geometry generation is an independent post-1.0 capability, not a fourth
+tier or automatic High behavior.
+
+### 9. Fracture publication is detached and aggregate
+
+The owner builds a transition plan with exact old/new semantic revision, affected chunk
+closure, required consumers, entity/body/render counts, staging/resident/retirement
+bytes and event capacity. World Streaming/host reserves the complete peak before work.
+Workers may validate/decode immutable artifacts but never mutate the active world.
+
+Physics and Render prepare native candidates under their own thread/safe-point rules.
+VFX/Audio/Decal are post-commit optional presentation unless the product explicitly
+defines another required participant. RuntimeScene exposes new semantic state, intact/
+chunk visibility, entities and required bodies only after all required candidates are
+Prepared and privately published under one activation ticket.
+
+Failure/cancellation before aggregate commit destroys only candidates and preserves the
+old state. Replacement retains old/new artifacts, bodies, render resources, snapshots
+and reservations until readers/fences acknowledge release. Post-commit consumer loss is
+Suspended/Failed/recovery according to policy, never retroactive rollback or fabricated
+success.
+
+### 10. Chunk lifetime and cleanup are explicit policy
+
+Chunks are classified as gameplay-authoritative, durable dormant or cosmetic before
+activation. Gameplay-authoritative chunks remain in canonical state and cannot be
+deleted because they sleep, leave the camera or exceed a render budget. Physics sleep
+is solver state, not destruction cleanup permission.
+
+Durable dormancy serializes the canonical semantic delta through Runtime Save/Persistent
+World before the last live representation retires. Cosmetic debris is VFX-owned with an
+explicit finite lifetime/pool policy and never appears in canonical chunk sets. Capacity
+exhaustion rejects, defers or uses a predeclared eligible replacement policy; it never
+silently removes authoritative/durable chunks or another owner's state.
+
+### 11. Persistence and replication preserve semantic ownership
+
+ADR-114 Runtime Save registers one Destruction canonical adapter. It captures stable
+destructible/chunk identities, content/state revisions, health, broken/support/dormant
+sets and policy-required event progress. It excludes native bodies/shapes, render
+resources, VFX particles, audio voices, contacts, jobs, caches and pointers. Restore
+prepares against exact compatible cooked content and aggregate Scene/Physics/Render
+activation; it never writes source documents.
+
+Authority server worlds commit canonical commands/state. NetworkRuntime captures bounded
+versioned state/deltas and delivers validated apply commands; I/O threads never mutate
+Destruction. Late join receives a snapshot plus ordered later deltas. The blanket rule
+“replicate only Intact/Damaged/Destroyed” is rejected because chunk/support identity may
+be gameplay relevant.
+
+Chunk motion is explicitly classified. Gameplay-authoritative chunk bodies use the
+existing Physics/network transform/state contract; Destruction does not invent a second
+transform stream. Cosmetic chunks may simulate locally and are excluded from gameplay,
+persistence and canonical hashes. Clients cannot promote cosmetic evidence to authority.
+
+### 12. Errors, observability and shutdown preserve ownership
+
+Stable results include `WrongWorld`, `Unauthorized`, `StaleGeneration`, `StaleRevision`,
+`DuplicateCommand`, `InvalidDamage`, `CookedContentMissing`, `CookedContentIncompatible`,
+`RuntimeGeometryUnsupported`, `CapabilityUnsatisfied`, `BudgetDenied`, `PrepareFailed`,
+`Cancelled`, `RetirementStalled` and `ShutdownIncomplete`.
+
+Metrics are bounded and low-cardinality: commands/results, active objects/chunks,
+candidate/retiring counts, resident/staging bytes, transition latency, budget denial,
+stale work and retirement depth. Object/chunk/event IDs, coordinates, asset paths and
+native handles are not dimensions. Detailed graphs/state require an explicit bounded
+diagnostic snapshot.
+
+Shutdown closes command/snapshot admission, cancels owned task groups, invalidates
+candidates, detaches Scene/streaming admission, requests exact-generation consumer
+retirement, drains canonical persistence/network handoffs where policy requires, and
+releases artifacts/modules only after acknowledgements. It is idempotent after partial
+initialization. A deadline reports retained ownership and cannot force-free referenced
+geometry, bodies, GPU work or snapshots.
+
+## Consequences
+
+- One scene-scoped Destruction owner commits every canonical semantic transition;
+  components, callbacks, network and presentation systems no longer compete for state.
+- Semantic phase, chunk membership, lifecycle, content, representation and persistence
+  revisions are explicit rather than collapsed into one enum.
+- Core 1.0 has a bounded portable implementation path: activate offline-cooked chunks
+  and never generate topology/collision at runtime.
+- Hierarchical pre-cooked fracture can scale through provider-neutral tiers without
+  making runtime mesh cutting a hidden High feature.
+- Required render/Physics state and canonical events become visible atomically through
+  the aggregate Scene boundary.
+- Existing prototypes with mutable component health/state, callback mutation, backend-
+  named tiers or runtime cutting fallback require migration rather than shims.
+
+Required coverage includes every legal/illegal semantic and lifecycle transition;
+authority/revision/duplicate checks; deterministic contact-command ordering; exact
+cooked chunk closure; proof that core paths invoke no topology/collision cook; required
+consumer failure and rollback; old/new replacement/retirement; capacity and cleanup
+classification; save/restore and late join; authoritative versus cosmetic motion;
+headless/Null/all interactive backends; and cancellation/shutdown at every stage.
+
+## Rejected Alternatives
+
+### Store mutable canonical health/state in the ECS component
+
+Rejected because gameplay, Physics, Network and Scene code could write it without one
+revision, authority check, event order or aggregate publication boundary.
+
+### Let Physics contacts fracture objects directly
+
+Rejected because callbacks run under Physics ownership and cannot perform structural or
+cross-system mutation. Contacts are typed evidence consumed after the step.
+
+### Generate missing fracture geometry at runtime in 1.0
+
+Rejected because mesh/topology/interior/collision generation is unbounded and has no
+qualified deterministic, network, memory or cancellation contract. Missing cook fails.
+
+### Name tiers after graphics APIs or device classes
+
+Rejected because destruction semantics span Scene, Physics, Assets and gameplay; a
+renderer name neither grants capability nor defines portable limits.
+
+### Hide the intact mesh before required chunks are prepared
+
+Rejected because observers would see partial destruction without required collision or
+render state. Publication is aggregate and activation-ticket scoped.
+
+### Delete sleeping or distant authoritative chunks automatically
+
+Rejected because sleep/visibility are not persistence or gameplay authority. Cleanup is
+classified, budgeted and lossless for durable state.
+
+### Replicate only the three phase names
+
+Rejected because broken/support membership and authoritative chunk motion may affect
+gameplay. Replication captures canonical semantic state and delegates motion correctly.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -435,6 +435,9 @@ dependency direction in [System Design](./foundation/system-design.md).
   resources.
 - [Destruction And Fracture Architecture](./runtime/destruction-and-fracture-architecture.md):
   fracture assets, chunk physics, debris, authority, and network reconstruction.
+- [Destruction Ownership, Authority, State and Runtime Geometry Boundary](../adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md):
+  canonical semantic state and commands, cooked chunk activation, aggregate publication,
+  provider-neutral tiers and the post-1.0 runtime mesh-cutting boundary.
 - [Procedural Generation Architecture](./runtime/procedural-generation-architecture.md):
   PCG graphs, point clouds, validation, transactions, server authority, and
   streaming-cell ownership.

--- a/docs/architecture/runtime/destruction-and-fracture-architecture.md
+++ b/docs/architecture/runtime/destruction-and-fracture-architecture.md
@@ -7,20 +7,42 @@ It covers pre-fractured geometry, runtime fracture, debris generation,
 destruction events, physics integration, audio and VFX coupling, and network
 replication of destruction state.
 
+[ADR-144](../../adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md)
+is the foundation contract. Destruction is a scene-scoped runtime domain with one
+semantic state authority, pre-cooked core-1.0 geometry, provider-neutral tiers and
+aggregate Scene/Physics/Render publication. Runtime mesh cutting is post-1.0 only.
+
+## Ownership
+
+`DestructionApi` owns backend-neutral identities, revisions, descriptors, commands,
+results and immutable snapshots. `DestructionRuntime` owns live scene-scoped health,
+semantic phase, broken/support membership, command admission, transition planning and
+canonical events. RuntimeScene owns entity/binding lifetime and aggregate activation;
+Physics and Render own bodies/shapes and render/GPU state; Assets/Destruction Cook own
+source, deterministic artifacts and publication; gameplay owns damage permission.
+
+Physics contacts, replicated records, scripts, UI, Audio, VFX and Decals never mutate
+destruction state directly. They provide typed evidence/commands or consume post-commit
+snapshots/events. Native handles and mutable buffers do not cross the public boundary.
+
 ## Destruction Model
 
-Destruction is modeled through destructible components:
+Scene components carry stable binding and authored policy, not live mutable state:
 
 ```cpp
-struct DestructibleComponent {
-    AssetId                fractureAsset;
-    DestructibleState      state;            // Intact, Damaged, Destroyed
-    float                  health;
-    float                  damageThreshold;  // damage before state transition
-    DestructibleBehavior   behavior;
-    bool                   networkReplicated;
+struct DestructibleSceneBinding {
+    DestructibleId destructible;
+    AssetId fractureAsset;
+    DestructionPolicyId policy;
+    DestructionFeatureRequirements requiredFeatures;
 };
 ```
+
+`DestructionWorld` owns `Intact`, `Damaged` or `Fractured` semantic phase plus exact
+health, broken chunk set and support state under one monotonic state revision.
+`Fractured` means at least one cooked transition committed; exact membership cannot be
+inferred from the phase. The independent runtime lifecycle is `Absent`, `Preparing`,
+`Prepared`, `Active`, `Replacing`, `Suspended`, `Retiring` or `Failed`.
 
 ## Pre-Fractured Geometry
 
@@ -50,7 +72,7 @@ struct FractureChunk {
 };
 ```
 
-## Runtime Fracture
+## Runtime Pre-Cooked Fracture
 
 Runtime fracture can be triggered by:
 
@@ -69,14 +91,24 @@ struct FractureEvent {
 };
 ```
 
-On fracture:
+Every trigger becomes an authority-, generation- and revision-checked typed command.
+Physics contacts are immutable evidence consumed after the Physics step; callbacks do
+not fracture objects directly. On a successful pre-cooked transition:
 
-1. The intact mesh is hidden
-2. Chunks within the damage radius are activated
-3. Physics forces are applied to chunks (explosion, impact direction)
-4. Debris particles are spawned
-5. Audio impact/destruction sound is triggered
-6. Destruction event is broadcast on the data bus
+1. Destruction validates the exact cooked chunk/support closure and complete peak cost.
+2. Physics and Render prepare required chunk representations privately.
+3. RuntimeScene commits semantic state, intact/chunk visibility, entities and required
+   bodies through one activation-ticket-scoped aggregate root.
+4. Canonical gameplay/network/save events publish only after commit.
+5. Optional VFX, Audio and Decal presentation requests consume the committed event.
+
+Failure or cancellation before commit preserves the intact/previous generation. Old
+representations remain leased and charged until every consumer acknowledges retirement.
+
+Core 1.0 never cuts, booleans, voxelizes, remeshes or triangulates source geometry; it
+never creates interior surfaces, convex decomposition or mass properties at runtime.
+Those products must exist in the validated fracture artifact. Missing/incompatible
+content returns a typed failure instead of runtime generation or visual-only fallback.
 
 ## Debris System
 
@@ -124,20 +156,23 @@ Fracture chunks use the physics system:
 - Chunk collision shapes use convex decomposition (pre-computed in the
   fracture asset)
 - Initial velocities are derived from the fracture event
-- Chunks that come to rest (sleep) are frozen to reduce simulation cost
-- After a configurable duration, sleeping chunks may be removed (debris
-  cleanup)
+- Physics sleep remains solver state and does not grant cleanup authority
+- Gameplay-authoritative and durable chunks retire only through explicit policy and,
+  where required, a successful Runtime Save/Persistent World handoff
+- Cosmetic debris is VFX-owned, finite-lived and excluded from canonical chunk state
 
 ## Network Replication
 
-Destruction state is replicated in multiplayer:
+Destruction state is replicated through the normal authority and replication boundary:
 
-- Server authoritatively determines fracture events
-- Destruction state changes are replicated as reliable RPCs
-- Only the final state (Intact/Damaged/Destroyed) is replicated, not
-  individual chunk transforms
-- Debris is client-side cosmetic only (not replicated)
-- Late-joining clients receive the current destruction state
+- The authority server commits canonical destruction commands/state
+- NetworkRuntime captures versioned bounded snapshots/deltas and delivers typed apply
+  commands; I/O threads do not mutate Destruction
+- Late join receives health, phase, broken/support/dormant sets and ordered later deltas
+- Gameplay-authoritative chunk motion uses existing Physics/network state replication;
+  Destruction does not create a second transform stream
+- Cosmetic chunks/debris may simulate client-side but cannot affect gameplay, saves or
+  canonical hashes
 
 ## Editor Authoring
 
@@ -151,14 +186,47 @@ Fracture authoring tools:
 
 ## Feature Tiers
 
-| Feature              | `es3`      | `dx11` / `dx12_vulkan` | `high_end` |
-| -------------------- | ----------- | ------------- | ------------ |
-| Pre-fractured meshes | No          | Yes           | Yes          |
-| Runtime fracture     | No          | Simple        | Full         |
-| Hierarchical fracture| No          | No            | Yes          |
-| Debris particles     | No          | 256           | 2K           |
-| Chunk count per asset| —           | 64            | 512          |
-| Chunk physics        | —           | Convex        | Convex + mesh|
+Tiers are provider-neutral product preference profiles. They do not name a graphics API,
+platform, solver or device and do not grant capability:
+
+| Feature family | `Baseline` | `Standard` | `High` |
+|---|---|---|---|
+| Pre-cooked fracture | Bounded one-level | Larger staged graph | Larger qualified hierarchy |
+| Support/collapse | Minimal cooked policy | Richer cooked policy | Hierarchical cooked policy |
+| Physics | Pre-cooked dynamic convex chunks | Same ownership, larger limits | Same ownership, qualified larger limits |
+| Presentation effects | Optional bounded cosmetic requests | Increased declared limits | Highest qualified declared limits |
+| Runtime geometry generation | Unavailable in core 1.0 | Unavailable in core 1.0 | Unavailable in core 1.0 |
+
+DFR-001.3 freezes exact chunk/depth/body/event/byte/work limits. Resolution intersects
+product request, cooked variants, runtime, World Streaming, Physics, Render and host
+capabilities. Required unsupported content fails; fallback is only an explicitly ordered
+product choice with a typed reason. Runtime geometry is a separate post-1.0 capability,
+not an automatic `High` feature.
+
+## Lifecycle, Persistence And Shutdown
+
+Destruction builds transitions as detached candidates with exact affected chunks,
+consumer requirements and peak reservations. Workers validate immutable artifacts only;
+the owner lane commits state. Stale revision/generation, authority loss, budget denial,
+consumer failure or cancellation changes nothing before aggregate publication.
+
+Runtime Save captures stable destructible/chunk identities, content/state revisions,
+health, broken/support/dormant sets and required progress. Native bodies, shapes, GPU
+resources, particles, voices, contacts and caches are derived/excluded. World Streaming
+cannot evict the last durable state before the persistence owner accepts its handoff.
+
+Shutdown closes admission, cancels task groups, invalidates candidates, requests exact-
+generation consumer retirement and retains artifacts/reservations/modules until every
+reader, job and native owner acknowledges release. A deadline reports incomplete
+shutdown and never force-frees possibly referenced state.
+
+## Verification
+
+Required coverage includes authority/revision checks, every semantic/lifecycle
+transition, deterministic contact ordering, cooked chunk closure, proof that core paths
+perform no runtime geometry/collision cook, aggregate consumer rollback/replacement,
+capacity and durable cleanup, save/restore, late join, authoritative/cosmetic motion,
+headless/Null/all interactive backends, cancellation and repeated shutdown.
 
 ## Related Documents
 
@@ -170,3 +238,9 @@ Fracture authoring tools:
 - [Decal System Architecture](./decal-system-architecture.md): impact decals
 - [Networking Architecture](./networking-architecture.md): destruction state replication
 - [Scene Runtime](./scene-runtime.md): destructible component model
+- [Asset Pipeline](./asset-pipeline.md): source, cook, cache and artifact publication
+- [Save Game And Persistence](./save-game-and-persistence.md): canonical destruction
+  state capture and durable dormancy
+- [ADR-144](../../adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md):
+  module/state authorities, command ordering, cooked activation, tiers, persistence,
+  replication and post-1.0 runtime geometry boundary

--- a/docs/architecture/runtime/physics-architecture.md
+++ b/docs/architecture/runtime/physics-architecture.md
@@ -158,6 +158,15 @@ A stale snapshot/receipt or required Physics failure rolls back the candidate, n
 old collision world. Physics alone acknowledges retirement after steps, queries and shape/
 body readers drain.
 
+[ADR-144](../../adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md)
+keeps fracture semantics outside Physics. Contacts are bounded tick/generation evidence;
+they cannot mutate health, chunk membership or Scene structure from a solver callback.
+Destruction consumes eligible evidence after the step and may stage a later transition.
+Physics prepares only the exact pre-cooked convex chunk shapes/bodies named by that
+transition, publishes them privately at its safe point and returns typed readiness to
+the aggregate Scene commit. Core 1.0 performs no runtime mesh cutting, convex
+decomposition, collision cook or fallback-shape invention.
+
 ## Character Query Boundary
 
 [ADR-089](../../adr/089-character-controller-ownership-implementation-and-update-order.md)
@@ -412,6 +421,9 @@ Required tests cover:
   replacement rejection and Physics-owned retirement
 - Terrain collision snapshot/receipt generations, adversarial owner-safe-point order,
   required/optional failure and no partial query visibility before aggregate commit
+- destruction contacts remain immutable post-step evidence, while pre-cooked chunk
+  bodies prepare/rollback/publish/retire through Physics safe points without runtime
+  geometry or collision cooking
 
 ## Related Documents
 
@@ -428,3 +440,4 @@ Required tests cover:
 - [Observability Metrics And Profiling](../observability/observability-performance.md)
 - [ADR-137: Terrain and Foliage Ownership, Data, Tier and Lifecycle](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md)
 - [ADR-141: Terrain/Foliage Cross-System Ownership and Readiness](../../adr/141-terrain-foliage-cross-system-ownership-and-readiness.md)
+- [ADR-144: Destruction Ownership, Authority, State and Runtime Geometry Boundary](../../adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md)

--- a/docs/architecture/runtime/scene-runtime.md
+++ b/docs/architecture/runtime/scene-runtime.md
@@ -180,6 +180,15 @@ leases, Physics world and the private generation-scoped binding table publish as
 single no-fail bundle. Any earlier failure/cancellation destroys only candidate
 state, consumes no public identities and preserves the prior active scene/world.
 
+[ADR-144](../../adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md)
+uses the same aggregate seam for destruction. Scene data carries only stable
+destructible/fracture-asset/policy binding intent. The scene-scoped Destruction owner
+commits canonical health, semantic phase and chunk/support membership; Physics and
+Render prepare pre-cooked chunk representations privately. RuntimeScene exposes the
+new semantic revision, entity/component set, intact/chunk visibility and required
+bodies only through one complete activation root. Core 1.0 never generates missing
+mesh topology or collision during scene activation.
+
 ## Navigation Authoring And Runtime Boundary
 
 [ADR-105](../../adr/105-navigation-asset-and-scene-ownership-boundary.md)
@@ -582,6 +591,8 @@ Required tests cover:
 - nested reference cancellation and cycle detection
 - scene unload with jobs, physics, and render leases
 - binary format corruption and version behavior
+- destruction binding conversion and aggregate semantic/entity/render/Physics chunk
+  publication with no runtime geometry fallback
 
 ## Related Documents
 
@@ -594,5 +605,6 @@ Required tests cover:
 - [Rendering Architecture](./rendering-architecture.md)
 - [Editor Document Model](../editor/editor-document-model.md)
 - [Save Game And Persistence](./save-game-and-persistence.md)
+- [Destruction And Fracture](./destruction-and-fracture-architecture.md)
 - [ADR-114](../../adr/114-canonical-runtime-world-persistence-boundary.md): canonical
   state classification, Scene base/override composition and adapter ownership.


### PR DESCRIPTION
## Summary

- Add ADR-144 to define Destruction module ownership, canonical semantic state, mutation authority, fixed-tick ordering, aggregate publication, persistence/replication, feature tiers, and lifecycle.
- Make core 1.0 a bounded pre-cooked chunk activation path and explicitly exclude runtime mesh cutting, remeshing, interior generation, convex decomposition, and collision cooking.
- Replace the mutable `DestructibleComponent` state model and graphics-API-named tiers in the normative Destruction architecture.
- Align Scene Runtime and Physics with the destruction command/evidence and aggregate activation boundaries.

## Why

The previous document mixed authored component fields, Physics callbacks, runtime fracture, render visibility, network RPCs, and cleanup without assigning one canonical state owner. Its `Intact/Damaged/Destroyed` enum could not represent exact chunk/support membership, and “runtime fracture” ambiguously covered both selecting offline chunks and generating new geometry.

That ambiguity makes partial publication possible: the intact mesh could disappear before required chunk bodies/render objects exist, a contact callback could perform structural mutation while Physics is stepping, or missing cooked content could trigger unbounded runtime geometry work. The old backend-named tier table also violated the repository’s provider-neutral capability policy.

## Decision and boundaries

- `DestructionApi` owns backend-neutral identities, revisions, descriptors, commands, results, and snapshots; scene-scoped `DestructionWorld` owns live health, semantic phase, broken/support membership, command admission, and canonical events.
- Scene components now carry stable destructible/fracture-asset/policy binding intent rather than mutable health/state. RuntimeScene retains entity lifetime and the aggregate activation root.
- Semantic `Intact`/`Damaged`/`Fractured` state is distinct from `Absent`/`Preparing`/`Prepared`/`Active`/`Replacing`/`Suspended`/`Retiring`/`Failed` lifecycle. Exact chunk sets and independent content/state/representation/persistence revisions remain explicit.
- Gameplay, scripts, and validated replication delivery issue typed authority-, tick-, generation-, and revision-checked commands. Physics contacts are immutable evidence consumed after the step; callbacks never mutate Destruction or Scene.
- Contact-triggered transitions stage after Physics and publish required Scene entities, Physics bodies, Render objects, visibility, and semantic state through a later activation-ticket-scoped aggregate commit.
- Core 1.0 can only select and activate validated pre-cooked chunk graphs, render payloads, interior mappings, convex shapes, and mass properties. Missing/corrupt/incompatible content fails instead of invoking runtime cutting or inventing a collider.
- Runtime geometry generation is a separate post-1.0 capability requiring its own topology/material schema, deterministic/network policy, budgets, tasks, Physics cook boundary, fallback rules, and qualification.
- `Baseline`, `Standard`, and `High` tiers are provider-neutral and cover only qualified pre-cooked capabilities. Runtime geometry is not an implicit `High` feature.
- Gameplay-authoritative, durable dormant, and cosmetic chunk/debris lifetimes are classified explicitly. Physics sleep or camera distance does not authorize deletion of canonical state.
- Runtime Save captures stable semantic state and excludes native/derived resources. NetworkRuntime transports canonical snapshots/deltas; authoritative chunk motion uses the existing Physics/network path rather than a second Destruction transform stream.
- The normative Destruction architecture was expanded and Scene/Physics tests now require no runtime geometry fallback and owner-safe aggregate behavior.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md docs/architecture/README.md docs/architecture/runtime/destruction-and-fracture-architecture.md docs/architecture/runtime/scene-runtime.md docs/architecture/runtime/physics-architecture.md`
- `git diff --check`
- `git diff --cached --check`
- Staged-added Markdown link resolution check: passed.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`: passed configuration and generation.
- Known non-blocking configure warnings: upstream mbedTLS CMake minimum-version deprecation; pytest unavailable, so repository Python tests were skipped by CMake.

This is a documentation/architecture-only change; no C++ target or runtime behavior changed.

## Risk and rollout

- The decision intentionally invalidates prototype designs that store mutable canonical health/state directly in ECS components or mutate from Physics callbacks; migration requires the typed command and scene-scoped owner path.
- Exact stable IDs and descriptor/tier limits are delegated to DFR-001.2 and DFR-001.3. Implementations cannot claim completeness until those schemas land.
- Aggregate publication adds coordination across Scene, Physics, Render, and World Streaming, but it prevents externally visible half-fractured states and preserves rollback.
- Gameplay-relevant chunk motion can increase replication/persistence cost. The decision requires explicit authoritative-versus-cosmetic classification instead of silently under-replicating state.
- Post-1.0 runtime geometry remains unsupported. Products that require arbitrary runtime cutting must fail capability admission rather than treating this ADR as partial support.

## Issue links

- Jira: [HORO-1948](https://horo-engine.atlassian.net/browse/HORO-1948)
- GitHub: Closes #1994
- Domain ticket: `[DFR-001.1]`
- Parent capability: [HORO-1944](https://horo-engine.atlassian.net/browse/HORO-1944) / `[DFR-001] Destruction and Fracture Foundation, State and Authority`
- Identity follow-up: [HORO-1949](https://horo-engine.atlassian.net/browse/HORO-1949) / `[DFR-001.2] Stable Destructible, Fracture Asset, Chunk and Event Identity`
- Descriptor/tier follow-up: [HORO-1950](https://horo-engine.atlassian.net/browse/HORO-1950) / `[DFR-001.3] Typed Destructible Descriptors, Feature Tiers and Limits`

## Reviewer Notes

Please focus review on these invariants:

1. `DestructionWorld` is the only canonical live semantic owner; gameplay grants authority, Physics supplies evidence, and Scene owns aggregate visibility/lifetime.
2. Semantic phase, exact chunk/support membership, runtime lifecycle, and content/representation/persistence revisions are not collapsed into one component enum.
3. Core 1.0 executes only pre-cooked chunk activation. No code path may generate topology, interior surfaces, collision, or mass properties as fallback.
4. A fracture becomes visible only after required Scene/Physics/Render candidates are prepared and atomically exposed by the aggregate root.
5. Sleeping/distant chunks and cosmetic debris cannot cause loss of gameplay-authoritative or durable state.

The fixed-tick decision deliberately introduces at least one safe-point boundary for contact-triggered structural changes: Physics publishes evidence after its step, and the resulting chunk transition becomes authoritative only through a later legal aggregate commit.

## Stack

- Base branch: `docs/HORO-1933_terrain_scale_budgets_observability`
- Depends on: #2478 (`HORO-1933` / `[TRF-007.1]`)
- This PR: `HORO-1948` / `[DFR-001.1]`
- Merge order: #2478, then this PR.


[HORO-1948]: https://horo-engine.atlassian.net/browse/HORO-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ