### PR TITLE
docs(destruction): define fracture cook ownership HORO-1958 #2004 [DFR-002.1]

### DIFF
--- a/docs/adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md
+++ b/docs/adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md
@@ -174,10 +174,10 @@ be explicitly predictive and disposable; it is never canonical success.
 ### 6. Core 1.0 activates only pre-cooked geometry
 
 The core path consumes an immutable validated fracture artifact containing stable chunk
-graph identity, hierarchy/support relations, chunk render payload references, interior
-surface/material mapping, pre-cooked convex Physics shapes/mass properties, bounds and
-finite activation costs. Exact schemas and limits belong to DFR-001.2/.3 and the asset-
-cook decision.
+graph identity, hierarchy/support relations, canonical chunk/interior geometry,
+solver-neutral convex inputs and references to separately Physics-cooked shape artifacts,
+bounds and finite activation costs. Exact schemas and limits belong to DFR-001.2/.3 and
+the asset-cook decision in ADR-145.
 
 At runtime Destruction may select a bounded subset of existing chunks, update semantic
 membership, and coordinate activation/retirement of their pre-cooked representations.

--- a/docs/adr/145-destruction-source-chunk-geometry-collision-and-cook-ownership.md
+++ b/docs/adr/145-destruction-source-chunk-geometry-collision-and-cook-ownership.md
@@ -1,0 +1,280 @@
+# ADR-145: Destruction Source, Chunk Geometry, Collision and Cook Ownership
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Destruction source mesh and fracture recipe ownership, normalized input, generated chunk/interior geometry, connectivity, solver-neutral collision inputs, deterministic DFR artifact cooking, Assets cache/publication, Physics native shape cooking, runtime loading, replacement, cancellation and compatibility
+- **Issue**: [DFR-002.1](https://github.com/abdullahbodur/horo-engine/issues/2004)
+- **Jira**: [HORO-1958](https://horo-engine.atlassian.net/browse/HORO-1958)
+- **Related**: [ADR-005](005-submodule-compatibility.md), [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-010](010-job-waiting-and-operation-store-ownership.md), [ADR-023](023-world-index-and-cell-format-architecture-decision.md), [ADR-027](027-renderer-resource-identity-and-descriptors.md), [ADR-054](054-extension-and-package-authority-boundary.md), [ADR-085](085-physics-shape-authoring-cook-and-runtime-boundary.md), [ADR-087](087-scene-to-physics-ownership-and-conversion.md), [ADR-138](138-terrain-source-cooked-tile-cache-and-streaming-ownership.md), [ADR-144](144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md)
+- **Normative documents**: [Destruction and Fracture Architecture](../architecture/runtime/destruction-and-fracture-architecture.md), [Asset Pipeline](../architecture/runtime/asset-pipeline.md), [Physics Architecture](../architecture/runtime/physics-architecture.md), [Scene Runtime](../architecture/runtime/scene-runtime.md), [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
+
+## Context
+
+ADR-144 makes core-1.0 destruction an offline-cooked chunk activation system and
+excludes runtime geometry generation. The existing FractureAsset sketch still combines
+source mesh references, generated render pieces, hierarchy and implied collision in one
+unversioned object. It does not identify who owns interior surfaces, canonical chunk
+geometry, convex inputs, native Physics shapes, cache keys or atomic publication.
+
+Destruction and Physics need different derived products. DFR must define stable chunk
+semantics and portable geometry/connectivity independent of a solver. Physics must own
+solver-specific validation, cooking, native shape construction and lifetime. If DFR
+serializes a Jolt shape, or Physics regenerates fracture topology from a render mesh,
+upgrading either domain can silently change the other and invalidate saves/network IDs.
+
+Assets is the physical source/cache/package authority, but it cannot become the owner
+of fracture semantics merely because it schedules work. Renderer likewise consumes
+geometry but does not decide topology, interior material assignment or collision input.
+
+This ADR fixes the representation strata, cook fingerprints and handoff. DFR-002.2
+freezes pre-fractured import/naming validation, DFR-002.3 freezes the offline Voronoi
+algorithm, and later tickets define connectivity details and artifact schemas.
+
+## Decision
+
+### 1. Source, semantic cook and native realization have separate owners
+
+| Representation or responsibility | Authority |
+|---|---|
+| Tracked source bytes, `AssetId`, dependency graph, operation scheduling, physical cache/package storage and atomic publication | Assets |
+| Normalized source-mesh schema and mesh import evidence | Mesh/Asset import domain |
+| Authored fracture recipe, seed, sites, constraints, interior intent and stable local authoring IDs | Fracture asset document |
+| Chunk generation, canonical geometry/interior surfaces, topology, hierarchy/support/connectivity, collision-input derivation and DFR artifact schema | Destruction Cook |
+| Solver-neutral convex input records associated with stable chunks | Canonical DFR artifact |
+| Physics semantic validation, solver/profile/platform cook key, private native payload and runtime shape cache/leases | Physics |
+| Render mesh lowering, GPU buffers, acceleration structures and render-resource retirement | Mesh/Render owners |
+| Live semantic chunk selection and aggregate activation | DestructionRuntime/RuntimeScene under ADR-144 |
+
+Assets invokes registered cook contributions and publishes their immutable results. It
+does not interpret fracture planes, repair topology, assign chunk IDs, cook Jolt bytes or
+select a renderer. Destruction Cook does not open paths, own a private disk cache/package
+root, activate a runtime world or create native Physics/Render resources.
+
+### 2. Inputs are immutable, normalized and explicitly bound
+
+A fracture cook request captures exact immutable identities/revisions for:
+
+- one normalized source mesh with canonical Horo coordinates, units, winding, vertices,
+  indices, submeshes, material slots and source topology diagnostics;
+- one authored fracture recipe with stable identity, algorithm, deterministic seed,
+  site/plane/constraint data, hierarchy/support policy and finite limits;
+- interior surface/material/UV policy and external logical asset dependencies;
+- selected DFR feature tier/limits, target envelope and toolchain generation; and
+- requested neutral collision-input and render-geometry product schemas.
+
+The source mesh is input, not the fracture artifact's identity and not mutable scratch.
+Renderer LODs, GPU buffers and Physics native shapes are not valid source inputs.
+Imported pre-fractured pieces pass through the same normalized semantic model after
+DFR-002.2 validation; names may assist import mapping but never remain runtime identity.
+
+Missing, stale, malformed, non-finite, open/non-manifold where disallowed, self-
+intersecting, degenerate, oversized or inconsistent source/recipe input fails before
+publication. A reviewed authoring repair is a versioned explicit operation and changes
+the normalized source fingerprint; cook does not improvise silent weld/fill/rename.
+
+### 3. DFR owns one canonical portable fracture artifact
+
+The result is one immutable `CanonicalFractureArtifact` envelope containing:
+
+- artifact/schema/algorithm versions and complete semantic fingerprint;
+- source mesh and fracture recipe identities/revisions/digests;
+- stable destructible-local chunk identity table and parent/support/connectivity graph;
+- canonical chunk boundary and interior vertices/indices, submesh/material-slot mapping,
+  normals/tangents/UV data as required by the selected schema;
+- local bounds, center-of-mass integration inputs, volume and density/material intent;
+- solver-neutral convex collision inputs or deterministic convex-piece descriptors per
+  chunk, including stable child/subshape IDs;
+- exact finite counts, offsets, alignments, encoded/decoded sizes and integrity digests;
+  and
+- dependency, tier/limit and compatibility metadata required by consumers.
+
+Chunk identity is derived by the DFR algorithm/schema from canonical semantic inputs and
+stable hierarchy/local ordering, never vector position, display name, file path, worker
+completion, floating address, renderer submesh or native Physics ID. DFR-001.2 freezes
+the exact derivation.
+
+Canonical geometry is Horo-space portable data. The artifact contains no Jolt object or
+serialization, graphics API buffer/format, backend handle, process pointer, editor state,
+job callback, file path or service locator. It is the membership/topology authority;
+consumers never reconstruct the set by enumerating cache files.
+
+### 4. Interior surfaces and material mapping are DFR semantics
+
+Destruction Cook owns which cut faces are interior, their canonical orientation,
+winding, smoothing/tangent policy, UV parameterization, material-slot identity and
+adjacency to exterior faces. The authored recipe selects only registered finite policies.
+Renderer/material systems consume the result and may lower it to target variants; they
+cannot merge/drop/reclassify faces or infer an interior slot from names.
+
+Unknown/missing required materials fail cook/package or activation according to the
+declared boundary. An explicit optional fallback material is part of the product/recipe
+plan and fingerprint. It is not selected silently by Renderer at draw time.
+
+### 5. Collision inputs are neutral; Physics owns native cooking
+
+DFR derives closed finite convex source regions or deterministic convex-piece input for
+each dynamic chunk, with canonical vertices/indices, stable subshape/material binding,
+bounds, volume/density intent and validation evidence. These records express fracture
+semantics but are not Physics runtime shapes.
+
+Physics consumes the exact DFR artifact revision through ADR-085. It independently
+validates dynamic-convex eligibility, mass/inertia policy, material/filter mapping,
+tolerances and limits, then produces one separately identified
+`CookedPhysicsShapeArtifact` set keyed by DFR chunk/revision plus the canonical Physics
+solver/profile/platform/toolchain fingerprint. Private Jolt serialization, native shape
+construction, sharing/cache and retirement remain entirely Physics-owned.
+
+DFR cannot call native Physics during its semantic cook, publish native shape bytes in
+its artifact or claim collision ready. Physics cannot fracture/remesh the source, change
+chunk membership, reassign stable IDs or silently replace an invalid chunk with a box,
+mesh or recomputed hull. Failure blocks the required product; optional collision absence
+must be declared before cook/activation and cannot affect DFR topology.
+
+### 6. Render lowering is also derived and separately owned
+
+Mesh/Render cooking consumes canonical chunk geometry and material slots to produce
+target-specific vertex/index layouts, meshlets/LODs where explicitly configured, shader
+inputs and package dependencies. RenderRuntime owns GPU realization and retirement.
+
+Changing render LOD/compression/backend does not change canonical chunk identity,
+connectivity or collision input. Render cook cannot alter topology to make a draw path
+fit. DFR artifact identity may be shared across compatible render targets while each
+derived render product has its own complete target fingerprint.
+
+### 7. Fingerprints cover all semantic causes without coupling consumers
+
+The DFR fingerprint includes exact normalized source digest/schema; recipe identity and
+canonical fields; algorithm/version/seed; coordinate/tolerance/repair policy; material/
+interior/UV rules; hierarchy/support/connectivity policy; requested tier/limits; DFR
+artifact schema/encoding; dependency digests; and applicable target-neutral toolchain
+identity. Locale, time, path, machine name, job order and consumer-native versions are
+excluded.
+
+Physics and Render fingerprints include the accepted DFR artifact identity/digest plus
+their own complete solver/backend/product inputs. A Physics solver upgrade invalidates
+Physics shape artifacts without changing DFR topology. A DFR semantic change invalidates
+all dependent products. Assets records these dependency edges and never guesses reuse
+from file timestamps or filenames.
+
+### 8. Cooking is deterministic, bounded and staged
+
+The Assets operation validates declared upper bounds and reserves input, scratch,
+candidate, output, queue and publication capacity before starting. Destruction Cook may
+parallelize pure bounded units, but canonical chunk/face/edge order, reduction, floating-
+point policy, seed expansion and serialization are independent of scheduling. Same
+semantic inputs and toolchain fingerprint produce byte-identical DFR artifacts.
+
+The operation state is `Queued`, `Reading`, `Normalizing`, `Validating`, `Fracturing`,
+`BuildingInteriors`, `BuildingConnectivity`, `Encoding`, `Verifying`, `Publishing` and a
+single terminal `Succeeded`, `Failed` or `Cancelled`. Each stage owns finite progress and
+cancellation points. Worker completion returns immutable candidate records; workers do
+not publish cache/registry state.
+
+All DFR output and dependent manifests are written under an operation-owned staging
+namespace, checksummed and reread/validated. Assets atomically publishes the complete
+DFR artifact/manifest only after success. Dependent Physics/Render cooks may then publish
+separate products linked to that exact revision. A package requiring all products is
+admitted only when the complete dependency closure exists and verifies.
+
+Failure/cancellation leaves the prior published generation current and removes only
+candidate-owned state after workers release it. There is no plausible partial artifact,
+mixed old/new chunk set or directory enumeration fallback.
+
+### 9. Cache ownership and preview do not create parallel truth
+
+Assets owns immutable content-addressed cache storage, index, eviction and leases.
+Destruction Cook owns DFR keys/schema/validation but no private “fracture cache.” Physics
+and Render own their semantic derived-product keys while Assets still owns physical
+storage/publication. Eviction of a DFR entry waits for dependent/runtime leases and does
+not imply a native Physics/GPU object is retired.
+
+Editor preview captures an immutable document/source/recipe revision and runs the same
+DFR semantic cook in a transient operation namespace. It may derive preview Physics/
+Render products through their normal owners. Preview success does not publish canonical
+source/artifacts or clear dirty state; accepting a recipe change is an editor command.
+Stale preview completion cannot replace a newer document or published artifact.
+
+### 10. Runtime loads only validated immutable products
+
+RuntimeScene/Destruction resolves the exact DFR artifact plus required Physics/Render
+product identities/digests before preparation. It validates envelopes and bounded tables
+before allocation, acquires immutable leases, and constructs no source model or cook
+service. Required absence/corruption/incompatibility fails candidate activation.
+
+Hot replacement prepares a complete new DFR/dependent-product generation beside the old
+one. ADR-144 aggregate publication changes semantic/content bindings only after required
+consumers prepare; old leases remain through Scene readers, Physics steps/queries and
+Render fences. Runtime never recooks, patches or migrates artifacts in place.
+
+### 11. Compatibility and lifecycle are explicit
+
+DFR artifact schema declares major/minor compatibility and required feature bits.
+Unknown required features, unsupported major versions, excessive limits, digest mismatch
+or inconsistent graphs fail. Older source recipes migrate in authoring/tooling before
+cook; runtime migration does not invent geometry. Unknown optional tables may be skipped
+only through length-delimited validated schema rules.
+
+Shutdown closes cook/load admission, cancels task groups, invalidates candidates, drains
+publication completions and retains source/artifact/cache/module leases until workers and
+runtime consumers acknowledge release. A timeout reports incomplete retirement and
+cannot force-delete a staged namespace or unload code/data still in use.
+
+Errors include source/recipe/artifact identity and stage with bounded diagnostics:
+`SourceMissing`, `SourceInvalid`, `RecipeInvalid`, `TopologyInvalid`,
+`LimitExceeded`, `BudgetDenied`, `NonDeterministicOutput`, `PhysicsInputInvalid`,
+`DependencyMissing`, `ArtifactCorrupt`, `IncompatibleVersion`, `StaleRevision`,
+`Cancelled`, `PublishFailed` and `RetirementStalled`. Native handles, raw geometry and
+unbounded paths are excluded.
+
+## Consequences
+
+- DFR becomes the single authority for canonical fracture geometry, interiors,
+  connectivity and solver-neutral collision inputs.
+- Physics remains the single authority for solver-specific cooking, native shape cache/
+  storage and runtime retirement; Renderer has the equivalent native render boundary.
+- Solver/backend upgrades invalidate only their derived products unless DFR semantics
+  changed, improving cache reuse without coupling identities.
+- Core runtime activation stays bounded and source/cook free as required by ADR-144.
+- Assets owns one physical cache/publication graph instead of DFR, Physics and Render
+  inventing parallel roots.
+- Existing assets containing native collision bytes or name/index-based chunk identity
+  require explicit authoring recook/migration.
+
+Required coverage includes malformed/oversized mesh and recipe inputs; stable chunk/
+face/connectivity order across worker counts/locales; byte-identical recook; interior and
+material golden fixtures; solver-neutral collision validation; proof that DFR artifacts
+contain no native types; independent DFR/Physics/Render invalidation; cache hit/miss/
+eviction leases; partial publication failure; stale preview; package dependency closure;
+runtime corruption/replacement; and cancellation/shutdown at every stage.
+
+## Rejected Alternatives
+
+### Put native Physics shapes inside the DFR artifact
+
+Rejected because solver/platform changes would become fracture topology changes and
+native serialization would leak through a portable canonical boundary.
+
+### Let Physics generate chunks or connectivity
+
+Rejected because collision realization would become canonical destruction semantics and
+could diverge from render, save and network chunk identity.
+
+### Treat rendered submeshes or imported names as chunk identity
+
+Rejected because LOD/import/backend changes and rename/reorder would alter durable state.
+
+### Give Destruction Cook a private disk cache
+
+Rejected because Assets already owns dependency-aware content-addressed storage,
+publication, packaging, eviction and leases. A second cache would split truth.
+
+### Repair bad topology silently during cook
+
+Rejected because output could change across algorithm versions without source revision
+or user review. Repair is an explicit versioned authoring operation.
+
+### Cook fracture or collision on runtime activation
+
+Rejected because runtime work would be unbounded, target/toolchain-dependent and unable
+to preserve aggregate rollback. Required artifacts are prepared offline.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -438,6 +438,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Destruction Ownership, Authority, State and Runtime Geometry Boundary](../adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md):
   canonical semantic state and commands, cooked chunk activation, aggregate publication,
   provider-neutral tiers and the post-1.0 runtime mesh-cutting boundary.
+- [Destruction Source, Chunk Geometry, Collision and Cook Ownership](../adr/145-destruction-source-chunk-geometry-collision-and-cook-ownership.md):
+  normalized source/recipe inputs, canonical DFR geometry/connectivity, solver-neutral
+  collision records, Assets publication and separate Physics/Render derived products.
 - [Procedural Generation Architecture](./runtime/procedural-generation-architecture.md):
   PCG graphs, point clouds, validation, transactions, server authority, and
   streaming-cell ownership.

--- a/docs/architecture/runtime/asset-pipeline.md
+++ b/docs/architecture/runtime/asset-pipeline.md
@@ -832,6 +832,28 @@ leases. It cannot invoke import/cook work or substitute a fallback shape. The Sh
 domain does not create a parallel asset ID, scheduler, cache, package lock or
 publication authority.
 
+### Destruction Domain Source And Cook Boundary
+
+[ADR-145](../../adr/145-destruction-source-chunk-geometry-collision-and-cook-ownership.md)
+gives Assets tracked mesh/recipe identity, immutable input delivery, dependency-aware
+scheduling, physical content-addressed cache/package storage, operation staging and
+atomic publication. Destruction Cook owns fracture semantics: normalized input
+validation, deterministic chunk generation/import mapping, canonical exterior/interior
+geometry, material slots, hierarchy/support/connectivity and solver-neutral convex input.
+
+One canonical DFR artifact is the portable chunk-membership/topology authority. It has a
+complete source/recipe/algorithm/seed/policy/schema/toolchain fingerprint and contains
+no native Physics shape, renderer resource, path, editor state or runtime handle.
+Physics consumes its exact chunk collision inputs to publish separately keyed solver-
+private shape artifacts under ADR-085. Mesh/Render consumes its exact geometry to publish
+separately keyed render products. Solver/backend changes invalidate only their derived
+products unless DFR semantics changed.
+
+Destruction Cook creates no private cache, current-generation pointer or package root.
+Workers produce immutable candidates in the Asset operation namespace; only Assets may
+verify and atomically publish. Runtime loads exact validated DFR plus required dependent
+artifacts and cannot import, repair, fracture or cook a missing product.
+
 ### Navigation Domain Capture And Cook Boundary
 
 [ADR-105](../../adr/105-navigation-asset-and-scene-ownership-boundary.md)

--- a/docs/architecture/runtime/destruction-and-fracture-architecture.md
+++ b/docs/architecture/runtime/destruction-and-fracture-architecture.md
@@ -11,6 +11,10 @@ replication of destruction state.
 is the foundation contract. Destruction is a scene-scoped runtime domain with one
 semantic state authority, pre-cooked core-1.0 geometry, provider-neutral tiers and
 aggregate Scene/Physics/Render publication. Runtime mesh cutting is post-1.0 only.
+[ADR-145](../../adr/145-destruction-source-chunk-geometry-collision-and-cook-ownership.md)
+defines source normalization, canonical DFR chunk/interior/connectivity artifacts,
+solver-neutral collision inputs, Assets cache/publication and separate Physics/Render
+derived products.
 
 ## Ownership
 
@@ -46,31 +50,41 @@ inferred from the phase. The independent runtime lifecycle is `Absent`, `Prepari
 
 ## Pre-Fractured Geometry
 
-Pre-fractured meshes are authored offline:
+Pre-fractured meshes are authored and cooked offline through ADR-145:
 
-- A source mesh is fractured using Voronoi cell decomposition
-- Interior faces are generated with a configurable material
-- Fracture chunks are stored as separate mesh pieces within the asset
-- Chunks support physics collision (convex decomposition per chunk)
-- Chunk connectivity graph defines how chunks relate
+- Assets owns immutable normalized source bytes, dependency scheduling, physical cache,
+  package storage and atomic publication
+- Destruction Cook owns fracture recipes, deterministic generation/import validation,
+  canonical chunk/exterior/interior geometry and connectivity
+- The canonical DFR artifact owns solver-neutral convex input with stable chunk/subshape
+  identities, not native Physics shapes
+- Physics separately cooks solver/profile/platform-specific immutable shape artifacts
+  and owns runtime shape storage/retirement
+- Mesh/Render separately lower canonical chunk geometry and own GPU resources
 
 ```cpp
-struct FractureAsset {
-    AssetId                     sourceMeshId;
-    std::vector<FractureChunk>  chunks;
-    FractureChunkGraph          connectivity;
-    MaterialId                  interiorMaterial;
-};
-
-struct FractureChunk {
-    AssetId      chunkMeshId;
-    float        relativeMass;
-    Vector3      centerOfMass;
-    BoundingBox  localBounds;
-    uint32_t     parentChunkIndex;    // for hierarchical fracture
-    bool         isStructural;        // structural chunks affect stability
+struct CanonicalFractureArtifact {
+    FractureArtifactId artifact;
+    FractureArtifactRevision revision;
+    AssetId sourceMesh;
+    FractureRecipeId recipe;
+    FractureChunkTable chunks;
+    FractureConnectivityGraph connectivity;
+    FractureGeometryTables geometry;
+    FractureCollisionInputTable collisionInputs;
 };
 ```
+
+Stable chunk identity is not an array index, source/display name, cache path, render
+submesh or native shape ID. DFR owns canonical interior classification, winding,
+material slots and UV policy. Render cannot reclassify faces, and Physics cannot change
+chunk membership while realizing collision.
+
+The DFR cook fingerprint includes normalized source/recipe/dependency digests,
+algorithm/version/seed, coordinate/tolerance/repair policy, interior/material/UV and
+connectivity rules, selected tier/limits and artifact/toolchain schemas. Physics and
+Render add their own native target fingerprints to the accepted DFR artifact identity;
+a solver/backend upgrade invalidates its derived product without changing DFR topology.
 
 ## Runtime Pre-Cooked Fracture
 
@@ -244,3 +258,6 @@ headless/Null/all interactive backends, cancellation and repeated shutdown.
 - [ADR-144](../../adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md):
   module/state authorities, command ordering, cooked activation, tiers, persistence,
   replication and post-1.0 runtime geometry boundary
+- [ADR-145](../../adr/145-destruction-source-chunk-geometry-collision-and-cook-ownership.md):
+  normalized source/recipe inputs, canonical DFR chunk/interior/connectivity artifact,
+  solver-neutral collision inputs and separate Physics/Render derived products

--- a/docs/architecture/runtime/physics-architecture.md
+++ b/docs/architecture/runtime/physics-architecture.md
@@ -167,6 +167,14 @@ transition, publishes them privately at its safe point and returns typed readine
 the aggregate Scene commit. Core 1.0 performs no runtime mesh cutting, convex
 decomposition, collision cook or fallback-shape invention.
 
+[ADR-145](../../adr/145-destruction-source-chunk-geometry-collision-and-cook-ownership.md)
+places canonical chunk geometry/connectivity and solver-neutral convex inputs in the DFR
+artifact, not in Physics. Physics consumes one exact artifact/chunk/subshape revision,
+validates dynamic-convex and mass/material/filter policy, and cooks a separately keyed
+solver/profile/platform-private immutable shape artifact under ADR-085. It cannot alter
+chunk topology/identity or substitute a box/mesh/recomputed hull; Destruction cannot
+serialize Jolt data or claim a native shape ready.
+
 ## Character Query Boundary
 
 [ADR-089](../../adr/089-character-controller-ownership-implementation-and-update-order.md)
@@ -441,3 +449,4 @@ Required tests cover:
 - [ADR-137: Terrain and Foliage Ownership, Data, Tier and Lifecycle](../../adr/137-terrain-foliage-ownership-data-tier-and-lifecycle.md)
 - [ADR-141: Terrain/Foliage Cross-System Ownership and Readiness](../../adr/141-terrain-foliage-cross-system-ownership-and-readiness.md)
 - [ADR-144: Destruction Ownership, Authority, State and Runtime Geometry Boundary](../../adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md)
+- [ADR-145: Destruction Source, Chunk Geometry, Collision and Cook Ownership](../../adr/145-destruction-source-chunk-geometry-collision-and-cook-ownership.md)


### PR DESCRIPTION
## Summary

- Add ADR-145 to define source-mesh, fracture recipe, canonical chunk/interior geometry, connectivity, collision-input, cache, and cook ownership.
- Establish the canonical DFR artifact as portable Horo data while keeping Physics solver cooking/native shape storage and Render GPU realization in their existing owners.
- Define deterministic fingerprints, staged atomic publication, cache/package dependency closure, preview, runtime loading, replacement, compatibility, cancellation, and shutdown.
- Align ADR-144, Destruction, Asset Pipeline, Physics, and the architecture index with the refined handoff.

## Why

ADR-144 makes core-1.0 destruction a pre-cooked activation system, but the old `FractureAsset` sketch still combined source references, generated pieces, connectivity, and implied collision without a versioned ownership boundary. That could lead DFR to serialize Jolt state, Physics to regenerate topology, Renderer submeshes or imported names to become durable chunk identity, or each domain to create a private cache.

The decision separates portable fracture semantics from native consumer products. DFR owns what the chunks are; Physics owns how their neutral convex inputs become solver-specific shapes; Render owns how canonical chunk geometry becomes GPU resources; Assets owns the physical dependency/cache/publication graph.

## Decision and boundaries

- Inputs bind an immutable normalized source mesh, authored fracture recipe, deterministic seed/algorithm, interior/material/UV policy, hierarchy/support rules, tier/limits, dependencies, and toolchain generation.
- Mesh/render LODs, GPU buffers, and native Physics shapes are explicitly invalid source inputs. Pre-fractured imports pass through the same normalized semantic model after DFR-owned validation.
- `CanonicalFractureArtifact` owns stable chunk membership/identity, canonical exterior/interior geometry, material mapping, hierarchy/support/connectivity, bounds/mass integration inputs, and solver-neutral convex-piece records.
- Chunk identity cannot derive from vector index, display/import name, cache path, renderer submesh, worker completion, pointer, or native Physics ID.
- Interior face classification, orientation, winding, smoothing/tangent/UV policy, and material slots are DFR semantics. Renderer consumes rather than reinterprets them.
- Physics consumes exact DFR artifact/chunk/subshape revisions, validates dynamic-convex and mass/material/filter policy, and emits separately keyed solver/profile/platform-private `CookedPhysicsShapeArtifact` values under ADR-085.
- Render/Mesh similarly emits separately keyed target products. Solver/backend upgrades invalidate their own derivatives without changing DFR topology; a DFR semantic change invalidates all dependents.
- Assets owns the content-addressed physical cache, staging namespace, manifest, atomic publication, packaging, eviction, and leases. DFR/Physics/Render own semantic keys and validation but no parallel disk roots.
- Cook is deterministic and bounded across read/normalize/validate/fracture/interior/connectivity/encode/verify/publish stages. Only Assets publishes a complete verified candidate; failure preserves the prior generation.
- Editor preview uses the same cook path in a transient namespace. Runtime accepts only exact validated DFR plus required dependent artifacts and never imports, repairs, fractures, cooks, or migrates source in place.
- ADR-144 wording was tightened from “pre-cooked Physics shapes in the fracture artifact” to solver-neutral collision inputs plus references to separate Physics-cooked artifacts.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md docs/adr/145-destruction-source-chunk-geometry-collision-and-cook-ownership.md docs/architecture/README.md docs/architecture/runtime/destruction-and-fracture-architecture.md docs/architecture/runtime/asset-pipeline.md docs/architecture/runtime/physics-architecture.md`
- `git diff --check`
- `git diff --cached --check`
- Staged-added Markdown link resolution check: passed.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`: passed configuration and generation.
- Known non-blocking configure warnings: upstream mbedTLS CMake minimum-version deprecation; pytest unavailable, so repository Python tests were skipped by CMake.

This is a documentation/architecture-only change; no runtime implementation or performance claim is included.

## Risk and rollout

- Existing fracture assets that embed native collision bytes or derive chunk identity from names/indices require explicit authoring migration and recook.
- The portable DFR artifact can increase intermediate storage because native Physics/Render products are separate; content-addressed reuse and dependency-specific invalidation are intended to offset that cost.
- Exact stable-ID derivation and binary table layouts remain follow-up contracts. Implementations must not treat the illustrative structs as the finalized serialized ABI.
- Independently published DFR, Physics, and Render products require package-time dependency-closure validation; missing any required derivative must fail rather than degrade silently.
- Deterministic topology repair is deliberately not automatic. Invalid source may require a user-visible versioned repair operation before cook.

## Issue links

- Jira: [HORO-1958](https://horo-engine.atlassian.net/browse/HORO-1958)
- GitHub: Closes #2004
- Domain ticket: `[DFR-002.1]`
- Parent capability: [HORO-1943](https://horo-engine.atlassian.net/browse/HORO-1943) / `[DFR-002] Fracture Assets, Geometry Cooking and Connectivity`
- Import follow-up: [HORO-1957](https://horo-engine.atlassian.net/browse/HORO-1957) / `[DFR-002.2] Pre-Fractured Mesh Import, Naming and Topology Validation`
- Offline generation follow-up: [HORO-1959](https://horo-engine.atlassian.net/browse/HORO-1959) / `[DFR-002.3] Deterministic Offline Voronoi Fracture Generation`

## Reviewer Notes

Please focus on these ownership invariants:

1. DFR is the sole canonical owner of chunk identity/topology, interior geometry/material semantics, connectivity, and solver-neutral collision inputs.
2. Physics is the sole owner of solver validation/cook keys, private payloads, runtime native shape cache/leases, and retirement; it cannot alter DFR membership.
3. Assets is the sole physical cache/package/publication authority even though each domain owns its semantic fingerprint.
4. Consumer upgrades invalidate only their derived products unless canonical DFR semantics changed.
5. Runtime and preview never create a second fracture/collision cook path or infer membership from cache enumeration.

The key compatibility point is that DFR artifact identity excludes solver and render backend versions. Those versions belong in dependent Physics/Render product identities, preventing an implementation upgrade from changing durable chunk semantics unnecessarily.

## Stack

- Base branch: `docs/HORO-1948_destruction_ownership_geometry_boundary`
- Depends on: #2479 (`HORO-1948` / `[DFR-001.1]`)
- This PR: `HORO-1958` / `[DFR-002.1]`
- Merge order: #2479, then this PR.


[HORO-1958]: https://horo-engine.atlassian.net/browse/HORO-1958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ