### PR TITLE
docs(xr): define XR input ownership HORO-2082 #2128 [XRA-003.1]

### DIFF
--- a/docs/adr/159-xr-action-tracking-and-input-projection-ownership.md
+++ b/docs/adr/159-xr-action-tracking-and-input-projection-ownership.md
@@ -1,0 +1,392 @@
+# ADR-159: XR Action, Tracking and Input-Projection Ownership
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: XR action schemas and native action sets, tracking/device/pose snapshots, interaction-profile bindings, Input projection, fixed-tick consumption, gesture derivation, haptic requests, privacy-sensitive hand/eye data, lifecycle, migration and validation
+- **Issue**: [XRA-003.1](https://github.com/abdullahbodur/horo-engine/issues/2128)
+- **Jira**: [HORO-2082](https://horo-engine.atlassian.net/browse/HORO-2082)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-026](026-large-world-precision-and-floating-origin-strategy.md), [ADR-073](073-runtime-ui-ownership-scope-and-update-order.md), [ADR-078](078-runtime-ui-input-context-and-player-routing.md), [ADR-135](135-platform-identity-session-generation-privacy-and-consent.md), [ADR-157](157-xr-ownership-runtime-composition-and-capability-tier.md), [ADR-158](158-openxr-loader-backend-packaging-and-host-composition.md)
+- **Normative documents**: [XR Architecture](../architecture/runtime/vr-ar-architecture.md), [Input Architecture](../architecture/runtime/input-architecture.md), [Runtime Lifecycle](../architecture/runtime/runtime-lifecycle.md), [Application Security](../architecture/security/application-security.md)
+
+## Context
+
+ADR-157 assigns native OpenXR actions, spaces and tracking to XROpenXR, Horo-visible
+XR state to XRRuntime and canonical action routing to Input. Existing architecture also
+requires immutable snapshots, neutralization on loss and fixed-tick input frames. It
+does not yet define the exact ownership handoff between product action schemas, native
+action sets, live tracking, Input contexts, fixed simulation, gestures and haptics.
+
+Without a single policy, Input could poll OpenXR directly, gameplay could read mutable
+latest poses during a fixed tick, Renderer-late poses could overwrite simulation input,
+native interaction paths could become durable gameplay identity, or gestures could
+mutate gameplay from runtime callbacks. Hand joints and eye gaze add a second risk: a
+feature being discoverable does not grant collection, retention, diagnostics, UI focus
+or approval authority.
+
+This ADR fixes the owners, typed handoffs, sample domains, loss behavior and privacy
+boundary. XRA-003.2 through XRA-003.8 may freeze exact binary schemas, binding catalogs,
+interaction-profile rules, haptic scheduling and test harnesses without moving the
+authorities established here.
+
+## Decision
+
+### 1. Native XR input and canonical Input remain separate layers
+
+The data path is:
+
+```text
+product action/profile declarations
+            |
+            v
+Input canonical action registry + XR product requirements
+            |
+            v
+XROpenXR native action sets/actions/spaces/suggested bindings
+            |
+            v
+XRRuntime bounded tracking/action snapshot
+            |
+            v
+XR-to-Input projection adapter
+            |
+            v
+Input contexts, player/device assignment and immutable InputSnapshot
+            |
+            +-- Runtime UI / Interaction
+            +-- gameplay tick-assigned InputFrame
+```
+
+OpenXR is a physical/runtime input provider, not Input's public model. `XRApi` owns the
+backend-neutral XR IDs, snapshot values and narrow command/query ports. `XRRuntime`
+owns Horo-visible XR device/session/sample generations and snapshot publication.
+`XROpenXR` owns every native action set, action, action space, path, interaction-profile
+query, sync/locate call and haptic call. Input owns canonical semantic actions, binding
+resolution, context/focus/capture, player assignment, transition consumption,
+neutralization and simulation-frame projection.
+
+No native callback, event-poll function, Renderer pass, Runtime UI widget, gesture
+recognizer or gameplay system may publish directly into another owner's mutable state.
+
+### 2. Every action, tracking and haptic responsibility has one owner
+
+| Responsibility | Sole owner | Deliberate non-owner |
+|---|---|---|
+| Product gameplay/editor action declarations and required XR profile | Project/application policy | OpenXR runtime |
+| Canonical action IDs, value types, contexts, user/player assignment and consumption | Input | XROpenXR and gameplay systems |
+| Horo XR device/role/control/pose/gesture capability IDs | XRApi registries | Native paths and display labels |
+| Native action sets/actions/subaction paths/action spaces/suggested bindings | XROpenXR | Input and XRRuntime frontend |
+| Native action synchronization, space location and result normalization | XROpenXR | Platform Input collector |
+| Session-generation-scoped XR action/tracking snapshot and publication revision | XRRuntime | Renderer and Input |
+| XR snapshot to canonical Input projection | Host-composed XR/Input adapter | Native callbacks and gameplay |
+| Tick assignment, edge consumption, replay/network command form | Input/runtime simulation boundary | Live XR queries |
+| World-space UI focus, ray/direct interaction and capture semantics | Runtime UI/Interaction | XR tracking source |
+| Gameplay meaning, locomotion, grab/use and authoritative transforms | Gameplay/Character/Physics owners | XRRuntime and gesture recognizers |
+| Haptic request admission, scope and cancellation | Input/application haptic coordinator | Native backend callbacks |
+| Native haptic apply/stop and runtime capability result | XROpenXR | Input core implementation |
+| Consent purpose, privacy class, retention/export and child/region policy | Application Security/privacy owner | XRRuntime, Input and diagnostics |
+| OS permission request/state primitive | Platform | OpenXR capability discovery |
+| Presentation-time view/head pose and visual late update | XR/Renderer frame bridge | Fixed simulation input |
+
+Device identity, local player, Input user, interaction profile, physical control,
+tracked role and semantic action are distinct typed identities. A runtime path, array
+index, controller product name, hand label, display string or native handle cannot
+substitute for any of them.
+
+### 3. Product actions are Horo schema; native action sets are backend realizations
+
+The application validates a finite immutable action plan before native action creation.
+It joins:
+
+- registered Horo `ActionId`, value type and Input context;
+- product-required or optional XR action capability;
+- permitted tracked roles and physical-control classes;
+- finite interaction-profile binding catalogs supplied by XROpenXR;
+- user overrides owned and persisted by Input;
+- conflict, fallback and unbound-required policy; and
+- the accepted XR product-profile and privacy plan.
+
+XROpenXR compiles the accepted plan into native action sets, actions, subaction paths,
+spaces and suggested bindings. Native names/paths remain backend-private registered
+data. Input persists Horo action and registered physical-control identities plus schema
+versions, not arbitrary runtime paths. Presentation obtains glyphs/labels through the
+existing provider boundary; display text is not binding identity.
+
+Native action sets do not mirror Input contexts one-for-one. Input contexts may be
+pushed, focused or consumed every frame, while native action-set creation/attachment is
+session lifecycle. The accepted plan defines which native sets XROpenXR activates for
+the current sample; Input remains the authority for which projected semantic action can
+reach GUI, Runtime UI, editor or gameplay.
+
+Missing required controls, value-type mismatch, duplicate binding, ambiguous role,
+unsupported interaction profile or conflicting user override fails plan admission
+before a Ready session. Optional absence follows only a declared fallback. Runtime-
+selected profile changes produce a new binding revision and neutral boundary; they do
+not rewrite project schema or silently migrate incompatible overrides.
+
+### 4. Tracking snapshots are immutable, bounded and generation-safe
+
+Each published `XRTrackingSnapshot` records at least:
+
+- XR backend, runtime and session generation;
+- sample sequence, source clock domain and sample/predicted time evidence;
+- reference-space identity/generation and world-origin revision;
+- bounded device records with device generation, tracked role and capability set;
+- bounded pose samples for declared pose kinds;
+- bounded action values/transitions and active binding/profile revision; and
+- focus, visibility, tracking, permission and loss state.
+
+A pose records position and orientation validity independently, optional linear/angular
+velocity validity, source space, target space, timestamp, confidence provenance and
+device/session generations. Invalid components are explicitly absent/invalid; they are
+not replaced by identity transforms, zeros, the last valid sample or inferred confidence.
+Confidence is a finite Horo state derived from documented runtime evidence, not an
+invented floating-point probability.
+
+Snapshots use fixed-capacity or owner-backed immutable storage with explicit maximum
+devices, poses, actions, joints and transitions. A lease preserves memory only; focus,
+permission, tracking, profile, reference-space, origin, device or session revision can
+make its values logically stale. Consumers reject wrong-owner and stale generations
+before use.
+
+Head/view poses located for predicted presentation are a separate XR frame snapshot.
+Renderer may use a newer admitted pose for visual presentation/late update, but that
+pose cannot rewrite the committed Input snapshot, simulation state, network command or
+earlier tick. Correlation records both sample identities where needed.
+
+### 5. XR sampling joins the existing Input frame without a second input authority
+
+The host gives XRRuntime one bounded owner-thread sampling opportunity after runtime
+event handling and before `BuildInputSnapshot` commits. XROpenXR synchronizes the
+accepted native action sets and locates input-owned action spaces through its private
+port. XRRuntime validates and publishes one candidate snapshot; the XR/Input adapter
+projects it into the same Input collection transaction as other devices.
+
+The Input snapshot commit is the only point at which projected XR transitions become
+eligible for context routing. A callback or worker result arriving after the cutoff is
+deferred to the next input frame. XR sampling failure publishes an explicit unavailable/
+lost state and neutralization candidate; Input never reuses an old snapshot as current.
+
+The adapter maps backend-neutral XR physical controls/roles to canonical action values.
+It cannot create project actions, bypass context priority, assign itself to a player,
+consume transitions, mutate Runtime UI focus or call gameplay. High-frequency poses,
+actions and joints do not travel through `EngineDataBus`.
+
+### 6. Fixed simulation consumes tick-assigned values, never live XR state
+
+After Input routing, the runtime constructs an immutable `GameplayInputFrame` for an
+exact simulation tick, player/input-user assignment and source Input snapshot. It may
+contain bounded semantic locomotion/look/use values and explicitly admitted pose/
+tracking commands required by gameplay. It never contains native paths/handles, mutable
+snapshot views or a query back into XRRuntime.
+
+Multiple catch-up ticks follow each action's declared edge/hold/resampling policy.
+Pressed/released edges cannot fire once per catch-up tick accidentally. Continuous pose
+values retain their source sample time and generation; interpolation/extrapolation, if
+admitted later, is a typed simulation policy and cannot be hidden inside a getter.
+
+Authoritative gameplay transforms change only when Character/Physics/gameplay consumes
+the tick frame at its safe point. A head/controller pose is evidence or command input,
+not permission to write a Transform. Recording, replay and networking serialize the
+bounded Horo tick form and provenance, not OpenXR events or “latest” live state.
+
+Runtime UI and editor interaction may consume the frame/VariableUpdate projection
+appropriate to their context, but their focus, capture, modal and command rules still
+apply. A visual late pose is never retroactively routed as input.
+
+### 7. Gesture recognition is an explicit derived provider
+
+Raw hand joints, controller poses or gaze rays do not become semantic gestures by name
+or heuristic in Input core. A host-composed gesture provider declares:
+
+- provider/version and required source capabilities;
+- accepted roles/joint/pose inputs and privacy class;
+- finite gesture IDs, thresholds, hysteresis, timing and confidence policy;
+- output action value types and cancellation/neutralization behavior; and
+- deterministic-test and qualification requirements.
+
+The provider consumes immutable XR snapshots and publishes bounded, generation-tagged
+gesture candidates before the Input snapshot cutoff. Input maps admitted candidates to
+canonical actions and owns routing/consumption. The provider cannot own player
+assignment, UI focus, gameplay meaning, scene mutation or approval.
+
+Provider replacement, tracking/permission/focus loss, threshold configuration change or
+session replacement ends the old generation and releases active derived actions before
+the new provider can publish. A last recognized pinch, grab or gaze dwell is not held as
+current through loss.
+
+### 8. Haptics are scoped commands with backend acknowledgements
+
+An XR haptic request includes request/owner ID, Input user/player where applicable,
+session/device/target generation, effect kind, bounded amplitude, duration, optional
+frequency, start/deadline policy and cancellation token. Product policy and discovered
+capability bound every field. An unsupported frequency or target is a typed result, not
+silent success or arbitrary clamping unless the accepted plan declares that mapping.
+
+The Input/application haptic coordinator validates caller scope and routes the command
+through XRRuntime. XROpenXR applies/stops the native haptic and returns a bounded native
+result. Request acceptance, native submission and physical completion are distinct
+states; absence of runtime completion evidence cannot be reported as confirmed output.
+
+Focus/context loss, owner destruction, device/profile/session change, permission loss,
+timeout, shutdown or explicit cancellation stops or invalidates the effect. Shutdown
+cancels producers before native action/session destruction. No detached timer or
+callback may outlive the request owner or dispatch/session generation.
+
+### 9. Hand and eye data require capability plus purpose-bound consent
+
+Controller aim/grip and head tracking required by an admitted baseline profile follow
+that profile's declared product purpose and platform notice. Articulated hand joints,
+eye gaze and gaze-derived foveation/interaction remain optional privacy-sensitive
+capabilities. Discovery alone does not enable collection.
+
+Admission requires the conjunction of product policy, runtime capability, applicable OS
+permission, purpose-specific user/administrator/parental consent and the current privacy
+policy revision. States distinguish `NotRequested`, `PermissionRequired`, `ConsentRequired`,
+`Granted`, `Denied`, `Revoked`, `DisabledByPolicy`, `TemporarilyUnavailable` and `Lost`.
+Permission and consent are not interchangeable.
+
+The accepted purpose constrains which derived consumers receive data. Renderer may
+receive an admitted gaze-foveation descriptor without receiving raw gaze history;
+Runtime UI may receive a validity-aware ray without gaining diagnostic retention;
+gesture providers receive only required joints. Gameplay, AIA and telemetry do not gain
+access merely because another consumer is admitted.
+
+Raw joints, gaze, continuous pose history and derived biometric/behavioral signals are
+excluded from ordinary logs, crash dumps, metrics dimensions, replay, analytics, AI
+context and support bundles. Explicit diagnostic/capture products require a separate
+purpose, visible state, bounded duration, retention/export policy and redaction.
+Revocation closes new collection, cancels dependent work, neutralizes derived actions
+and invalidates outstanding snapshot leases at the next owner safe point.
+
+Gaze, a gesture, tracked contact or haptic response never constitutes approval for an
+editor, purchase, privacy or destructive operation. Approval remains a typed UI/
+application transaction.
+
+### 10. Lifecycle and loss are transactional
+
+The action/tracking path follows:
+
+```text
+SchemaValidated
+  -> NativeActionsCreated
+  -> Attached
+  -> Sampling
+  -> Published
+  -> Focused / Unfocused / TrackingLost / PermissionLost
+  -> Neutralized
+  -> Detached
+  -> Destroyed
+```
+
+Schema and binding-plan validation is inert. Native candidates are created and attached
+before Ready publication. One sample transaction collects native values, validates
+bounded output, publishes XRRuntime state, then joins Input commit. Publication failure
+does not partially update actions, poses or device assignment.
+
+Focus/visibility/tracking loss, interaction-profile replacement, device removal,
+reference-space/origin change, permission revocation, instance/session loss and shutdown
+advance relevant revisions. Input releases active projected actions/capture and commits
+neutral state before a replacement generation becomes eligible. Old haptic work is
+cancelled, and outstanding native/sample work cannot publish into the replacement.
+
+Shutdown closes sampling and haptic admission, neutralizes Input projections, drains or
+cancels gesture providers, releases snapshot/consumer leases, destroys native action
+spaces/actions/action sets, then releases dispatch/session dependencies in the order
+owned by ADR-157/ADR-158.
+
+### 11. Migration and contract coverage are explicit
+
+The repository has no production XR input implementation to preserve. Initial work must
+extend typed XRApi/Input contracts and host composition; it must not add OpenXR types to
+Input, poll native actions from gameplay, expose latest-pose singletons or serialize
+native paths as project action identity. Existing broad hand/gaze examples are
+aspirational until capability and privacy gates are implemented.
+
+Required automated coverage includes:
+
+- target/public-header checks proving OpenXR types and native paths do not enter Input,
+  XRApi or gameplay contracts;
+- finite action-plan validation, binding conflicts, required/unbound failure, profile
+  changes and compatible/incompatible override migration;
+- bounded device/action/pose/joint snapshots, independent validity components, wrong-
+  owner/stale generation rejection and capacity failure;
+- XR sampling cutoff, late callback deferral, atomic Input commit and immediate loss
+  neutralization;
+- fixed-tick assignment, multi-tick edge policy, replay provenance and proof that live/
+  presentation-late poses cannot mutate a committed tick;
+- gesture provider determinism, hysteresis, replacement and loss neutralization without
+  direct gameplay/UI mutation;
+- haptic validation, unsupported fields, cancellation, timeout, focus/device/profile/
+  session loss and shutdown;
+- hand/eye permission and consent combinations, purpose isolation, revocation and
+  diagnostic/telemetry/replay redaction; and
+- failure/cancellation/shutdown at every lifecycle boundary with no action space,
+  snapshot, callback, haptic, provider or consumer lease surviving its owner.
+
+Deterministic fake snapshots and runtimes cover ordering and faults. They do not qualify
+tracking quality, interaction-profile correctness, physical haptics, hand joints or eye
+tracking on a device/runtime tuple.
+
+## Consequences
+
+### Positive
+
+- Input remains backend-neutral while XR has one native sampling owner and one
+  generation-safe projection path.
+- Simulation, presentation and interaction can use deliberately different samples
+  without corrupting deterministic tick input.
+- Loss and replacement release actions, gestures and haptics instead of preserving
+  stale state.
+- Hand and eye capabilities have purpose-bound privacy gates and data-minimizing derived
+  interfaces.
+- Downstream binding, snapshot, haptic and harness tickets can implement against fixed
+  owners and lifecycle order.
+
+### Negative
+
+- XR input needs explicit schema compilation, snapshot storage and a host-composed
+  projection adapter instead of direct native queries.
+- Renderer-late and simulation tracking snapshots require correlation and cannot share
+  a mutable “latest pose” cache.
+- Gesture and haptic providers require lifecycle/cancellation machinery and finite
+  schemas.
+- Hand/eye features need consent, permission, redaction and qualification work beyond
+  runtime extension discovery.
+
+## Rejected Alternatives
+
+### Let Input poll OpenXR and own native action sets
+
+Rejected because Input would acquire native session/path/space lifecycle, lose backend
+neutrality and duplicate XRRuntime generation/focus state.
+
+### Let gameplay read the latest XR pose during a fixed tick
+
+Rejected because reads would depend on scheduling and presentation timing, undermine
+record/replay/network determinism and allow one tick to observe inconsistent samples.
+
+### Use presentation-late poses as simulation input
+
+Rejected because a visual latency optimization cannot rewrite already committed input
+or authoritative gameplay state.
+
+### Persist OpenXR paths as gameplay action identity
+
+Rejected because runtime paths are backend physical bindings, not Horo semantic actions,
+localized labels or portable project schema.
+
+### Implement gestures directly in Input core
+
+Rejected because joint/pose interpretation is provider-, policy- and privacy-dependent;
+Input should route admitted semantic candidates, not own every recognizer.
+
+### Treat permission or runtime discovery as consent
+
+Rejected because OS access, runtime capability, product purpose and informed consent are
+independent requirements with different owners and revocation behavior.
+
+### Preserve the last valid action or pose through loss
+
+Rejected because stale held inputs, grabs, rays and haptics create unsafe and
+non-deterministic behavior. Loss publishes invalid/neutral state with provenance.

--- a/docs/architecture/runtime/input-architecture.md
+++ b/docs/architecture/runtime/input-architecture.md
@@ -424,6 +424,13 @@ The XR backend publishes bounded pose/action snapshots and projects admitted
 OpenXR actions into the same canonical Horo action router. Input does not poll
 OpenXR or retain native action/path handles.
 
+[ADR-159](../../adr/159-xr-action-tracking-and-input-projection-ownership.md)
+defines the normative handoff. Application/project policy declares canonical actions
+and product requirements; Input owns semantic schemas, contexts, player assignment,
+overrides, routing and transition consumption; XROpenXR owns native action sets/actions/
+spaces/paths, synchronization and location; XRRuntime owns the generation-scoped Horo
+snapshot. A host-composed adapter is the only XR-to-Input publisher.
+
 XR device identities include the XR session generation. Grip/aim poses,
 buttons, axes, hand joints, and haptic targets become invalid when tracking,
 focus, interaction profile, device, or session generation changes. The next
@@ -444,10 +451,32 @@ gameplay action IDs. Presentation uses the existing glyph/label provider model.
 Frame-hot hand joints use fixed-capacity or owner-backed spans rather than one
 heap allocation per hand per frame.
 
+XR sampling has one bounded owner-thread opportunity after native runtime-event handling
+and before the normal `BuildInputSnapshot` commit. Late callback/worker results enter the
+next frame. The adapter cannot create actions, choose a player, bypass context priority
+or consume a transition. On focus, tracking, profile, device, permission or session loss,
+it supplies explicit unavailable state and Input commits neutralization rather than
+reusing the last snapshot.
+
+Gameplay fixed ticks receive an immutable tick-assigned Horo projection with exact
+source sample/generation. They never query XRRuntime for a latest pose. Rendering-time
+late poses cannot rewrite that projection. Catch-up ticks follow declared edge/hold
+policy, and any pose interpolation/extrapolation must be an explicit simulation policy.
+
+Gestures are produced by finite host-composed recognizers from immutable admitted data,
+then routed as canonical action candidates by Input. A recognizer owns neither focus nor
+gameplay meaning. Hand joints and eye gaze additionally require purpose-bound privacy
+admission; derived access does not grant logging, replay, telemetry or AI retention.
+
 XR haptics follow the same ownership principles as gamepad haptics but include
 session/device generation, action/subpath target, duration, frequency where
 supported, cancellation, and explicit unsupported fallback. Ordinary input or
 focus loss cancels effects owned by the lost scope.
+
+The Input/application haptic coordinator owns request scope, validation and cancellation;
+XROpenXR owns native apply/stop. Accepted, submitted and physically completed are
+distinct states. Device/profile/session changes, timeout and shutdown cancel old work;
+no timer or callback outlives its owner generation.
 
 ## Data Bus Relationship
 

--- a/docs/architecture/runtime/runtime-lifecycle.md
+++ b/docs/architecture/runtime/runtime-lifecycle.md
@@ -144,6 +144,14 @@ required by fixed simulation is committed before fixed steps begin. Destructive
 scene and renderer lifecycle changes are committed only at their documented
 safe points.
 
+[ADR-159](../../adr/159-xr-action-tracking-and-input-projection-ownership.md)
+adds no runtime phase. After native XR event handling and before `BuildInputSnapshot`
+commits, XRRuntime gets one bounded owner-thread action/tracking sample and the
+host-composed adapter joins it to Input's transaction. Results after the cutoff wait for
+the next frame. FixedUpdate consumes only its tick-assigned immutable Horo projection;
+presentation-late poses used during render execution cannot rewrite simulation input.
+Loss commits Input neutralization before a replacement XR generation is eligible.
+
 [ADR-033](../../adr/033-presentation-and-display-ownership.md) specializes these
 safe points for presentation: apply host/window intent and publish a revisioned
 pending output candidate through owner-thread commands before layout/extraction.

--- a/docs/architecture/runtime/vr-ar-architecture.md
+++ b/docs/architecture/runtime/vr-ar-architecture.md
@@ -29,6 +29,11 @@ specializes the first-party OpenXR target/package boundary, verified loader inpu
 application composition and platform-specific loader policy. Loader discovery does not
 constitute product support, and the backend is not an ambient ExtensionHost plugin.
 
+[ADR-159](../../adr/159-xr-action-tracking-and-input-projection-ownership.md)
+specializes native action, tracking snapshot, Input projection, fixed-tick, gesture,
+haptic and privacy ownership. Input never polls OpenXR, and presentation-late tracking
+never rewrites committed simulation input.
+
 ## Ownership
 
 ```text
@@ -341,6 +346,25 @@ revocation, and session replacement neutralize affected actions immediately.
 Haptic requests have explicit owner, duration, cancellation, device generation,
 and capability fallback.
 
+Application/project policy declares canonical actions and XR profile requirements;
+Input owns semantic action IDs, contexts, player assignment, user overrides and
+consumption. XROpenXR compiles the admitted plan into native action sets/actions/spaces,
+synchronizes and locates them, and keeps native paths private. XRRuntime publishes one
+bounded generation-scoped snapshot, and the host-composed XR/Input adapter joins it to
+the normal Input snapshot transaction before the cutoff.
+
+Rendering-time view/head poses are a distinct predicted-frame snapshot. They may reduce
+visual latency but cannot overwrite the Input snapshot, a tick-assigned gameplay frame,
+recording or network command. Fixed simulation receives only immutable Horo values tied
+to an exact tick, player/input-user assignment and source sample; it never queries live
+XR state.
+
+Gesture recognition is an explicit host-composed derived provider. It consumes admitted
+immutable joints/poses/gaze, publishes bounded candidates before Input commit and owns
+no focus, routing, gameplay meaning or scene mutation. Haptic admission/cancellation is
+owned by the Input/application coordinator; XROpenXR owns native apply/stop and reports
+submission separately from physical completion.
+
 ## Interaction, Runtime UI, And Comfort
 
 XR interaction adapts ray, direct-touch, proximity, grab, and spatial hit
@@ -372,6 +396,11 @@ failure states.
 - Raw camera frames do not enter ordinary engine logs, captures, or public APIs.
 - Eye gaze, continuous poses, environment geometry, voice, and spatial anchors
   are privacy-sensitive diagnostic inputs.
+- Articulated hand joints and eye gaze require product policy, runtime capability,
+  applicable OS permission and purpose-bound consent. Discovery or permission alone is
+  insufficient.
+- Raw joints/gaze and continuous pose history are excluded from ordinary logs, crash
+  dumps, metrics, replay, analytics, AI context and support bundles.
 - Permission revocation removes derived capability state and invalidates
   outstanding work.
 - Persistent anchors identify localization state and failure; they do not imply
@@ -483,6 +512,7 @@ device release gate.
 
 - [XR Ownership, Runtime Composition and Capability Tier](../../adr/157-xr-ownership-runtime-composition-and-capability-tier.md)
 - [OpenXR Loader, Backend Packaging and Host Composition](../../adr/158-openxr-loader-backend-packaging-and-host-composition.md)
+- [XR Action, Tracking and Input-Projection Ownership](../../adr/159-xr-action-tracking-and-input-projection-ownership.md)
 - [XR Setup UI Reference](./xr-setup.html)
 - [Rendering Architecture](./rendering-architecture.md)
 - [Render Backend Parity Contract](./render-backend-parity-contract.md)

--- a/docs/architecture/security/application-security.md
+++ b/docs/architecture/security/application-security.md
@@ -177,6 +177,14 @@ Personal/social presentation is bounded, untrusted and ephemeral by default. Gen
 logs, metrics, crash bundles, saves/journals and ordinary tools exclude raw account/
 handle values, friends graphs, display data, presence free text and credentials.
 
+[ADR-159](../../adr/159-xr-action-tracking-and-input-projection-ownership.md)
+applies the same intersection to articulated hand joints, eye gaze and their derived
+gesture/behavior signals. Runtime capability discovery and OS permission do not replace
+purpose-bound consent. An admitted consumer receives only its minimum typed derivation;
+raw joints/gaze and continuous pose history remain excluded from ordinary logs, crash
+bundles, metrics, replay, analytics, AI context and support capture. Revocation closes
+collection, invalidates snapshot generations and neutralizes dependent Input actions.
+
 ## Process Execution
 
 Process policy validates:


### PR DESCRIPTION
## Summary

- Add ADR-159 to define ownership across native OpenXR actions, XRRuntime tracking snapshots, canonical Input projection, fixed-tick consumption, gestures and haptics.
- Separate input-sampling poses from presentation-time late poses so rendering cannot rewrite committed simulation input.
- Establish generation-safe loss neutralization and purpose-bound privacy gates for articulated hand joints and eye gaze.
- Align XR, Input, runtime lifecycle and application-security architecture documents with the decision.

## Why

The XR foundation assigns broad subsystem owners but does not yet define the input handoff precisely. Downstream work otherwise risks polling OpenXR from Input, reading mutable latest poses from fixed simulation, persisting native paths as gameplay identity, allowing gesture callbacks to mutate gameplay or treating runtime support/OS permission as consent for hand and gaze collection. This PR fixes those boundaries before XRA-003 implementation begins.

## Decision and boundaries

- Keeps native action sets, actions, paths, action spaces, synchronization, location and native haptic calls inside `XROpenXR`.
- Keeps canonical actions, contexts, player assignment, overrides, routing, consumption and neutralization inside Input.
- Defines a bounded `XRTrackingSnapshot` model with sample/reference-space/device/session generations, independent validity and explicit lease semantics.
- Gives XR one bounded owner-thread sample before the existing `BuildInputSnapshot` cutoff; late results defer to the next frame.
- Requires fixed simulation to consume an immutable tick-assigned Horo projection rather than query live XR state.
- Treats gestures as finite host-composed derived providers and haptics as scoped cancellable commands with distinct acceptance/submission/completion states.
- Requires product policy, runtime capability, OS permission and purpose-bound consent for hand/eye data, with data minimization and revocation neutralization.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/159-xr-action-tracking-and-input-projection-ownership.md docs/architecture/runtime/vr-ar-architecture.md docs/architecture/runtime/input-architecture.md docs/architecture/runtime/runtime-lifecycle.md docs/architecture/security/application-security.md`
- `git diff --check`
- `git diff --cached --check`
- Added-Markdown-link resolution check against the staged diff
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. It emitted the existing mbedTLS minimum-version deprecation warning. Repository Python tests were skipped because `pytest` is unavailable in the current environment.

## Risk and rollout

- This is an architecture-only change; exact public schemas and native binding catalogs remain dependent XRA-003 work.
- Separating simulation and presentation samples adds correlation and storage complexity, but prevents timing-dependent simulation behavior.
- Hand/eye privacy gates intentionally keep optional features unavailable until product-purpose, permission, consent and retention policies are implemented.

## Issue links

- Closes #2128
- Jira: [HORO-2082](https://horo-engine.atlassian.net/browse/HORO-2082)
- Parent capability: [XRA-003 / #2127](https://github.com/abdullahbodur/horo-engine/issues/2127)
- Prerequisite: [XRA-001.1 / #2109](https://github.com/abdullahbodur/horo-engine/issues/2109)
- Blocks: [XRA-003.2 / Jira HORO-2083](https://horo-engine.atlassian.net/browse/HORO-2083)

## Reviewer Notes

Please review the sampling-domain boundary first: XRRuntime publishes one immutable candidate before Input commit, fixed ticks consume only their assigned projection, and later rendering poses are visual-only. Then verify the hand/eye policy: capability discovery, OS permission, product purpose and consent are independent gates, and every derived consumer receives only the minimum admitted representation.

## Stack

- Base PR: #2493 — `docs/HORO-2072_openxr_loader_backend_packaging_composition`
- This PR: `docs/HORO-2082_xr_action_tracking_input_projection_ownership`
- Merge order: #2493, then this PR


[HORO-2082]: https://horo-engine.atlassian.net/browse/HORO-2082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ