### PR TITLE
docs(xr): define XR rendering ownership HORO-2092 #2138 [XRA-004.1]

### DIFF
--- a/docs/adr/160-xr-rendering-openxr-compositor-and-renderer-ownership.md
+++ b/docs/adr/160-xr-rendering-openxr-compositor-and-renderer-ownership.md
@@ -1,0 +1,414 @@
+# ADR-160: XR Rendering, OpenXR Compositor and Renderer Ownership
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Runtime-driven XR views, native swapchains, external image import, render targets, synchronization, frame/composition submission, bounded N-view admission, depth/motion inputs, dynamic resolution, foveation/VRS/density paths, runtime compositor behavior, lifecycle, migration and validation
+- **Issue**: [XRA-004.1](https://github.com/abdullahbodur/horo-engine/issues/2138)
+- **Jira**: [HORO-2092](https://horo-engine.atlassian.net/browse/HORO-2092)
+- **Related**: [ADR-026](026-large-world-precision-and-floating-origin-strategy.md), [ADR-027](027-renderer-resource-identity-and-descriptors.md), [ADR-028](028-renderer-capability-limits-and-product-profiles.md), [ADR-033](033-presentation-and-display-ownership.md), [ADR-034](034-gpu-memory-and-residency-ownership.md), [ADR-037](037-scene-color-and-hdr-architecture.md), [ADR-040](040-reconstruction-frame-generation-and-latency-providers.md), [ADR-157](157-xr-ownership-runtime-composition-and-capability-tier.md), [ADR-158](158-openxr-loader-backend-packaging-and-host-composition.md), [ADR-159](159-xr-action-tracking-and-input-projection-ownership.md)
+- **Normative documents**: [XR Architecture](../architecture/runtime/vr-ar-architecture.md), [Rendering Architecture](../architecture/runtime/rendering-architecture.md), [Render Backend Parity](../architecture/runtime/render-backend-parity-contract.md), [Post-Processing and Effects Architecture](../architecture/runtime/post-processing-and-effects-architecture.md)
+
+## Context
+
+ADR-157 assigns native OpenXR swapchains/composition to XROpenXR and scene/GPU work to
+Renderer. The XR and rendering architecture documents already require runtime-driven
+views, external resources and generation-safe acquire/release. They do not yet freeze
+the complete handoff: who selects formats and view configurations, who calls native
+acquire/wait/release, which owner decides a render target is safe, how composition layers
+are formed, or where foveation, dynamic resolution, depth and motion belong.
+
+Ambiguity here can create double ownership of images, normal-frame CPU/GPU waits,
+fixed two-eye public arrays, native handles in frontend contracts or submission before
+Renderer work completes. It could also turn optional foveation/space-warp features into
+post-process switches, let Renderer own the XR session, or let XR code record general
+scene rendering. Runtime asynchronous reprojection and guardian/chaperone visuals are
+often adjacent to Horo rendering but remain compositor/platform behavior.
+
+The repository has no production OpenXR renderer bridge. This decision fixes the
+owners, bounded schemas, frame transaction, synchronization and capability boundaries
+before XRA-004.2 and later implementation tickets specialize concrete view, swapchain,
+layer and test contracts.
+
+## Decision
+
+### 1. XR owns runtime presentation; Renderer owns Horo rendering
+
+The frame path is:
+
+```text
+OpenXR runtime
+  view configurations, formats, predicted timing, native swapchain images
+        |
+        v
+XROpenXR + XRRuntime
+  session/frame state, accepted view set, image acquisition, composition intent
+        |
+        v
+private XROpenXR/Renderer bridge
+  native image/synchronization translation into typed external leases
+        |
+        v
+RenderFrontend + selected render backend
+  N-view extraction, graph resources/passes, GPU submission and retirement
+        |
+        v
+XROpenXR
+  release images, encode layers, end frame
+        |
+        v
+OpenXR runtime compositor
+  asynchronous reprojection, device composition and physical presentation
+```
+
+XRRuntime owns the engine-visible XR frame transaction and generation-safe Horo plans.
+XROpenXR owns every native wait/begin/end-frame, view-location, swapchain, image acquire/
+wait/release and composition-layer call. RenderFrontend owns backend-neutral scene/view
+extraction, graph compilation, external-resource use and completion evidence. The
+selected renderer backend owns native GPU resources, commands, queues, barriers and
+deferred retirement.
+
+The private bridge translates native images and synchronization for the exact selected
+XROpenXR/renderer-backend tuple. Translation does not make it a second frame, image,
+session or resource authority.
+
+### 2. Every XR rendering responsibility has one owner
+
+| Responsibility | Sole owner | Deliberate non-owner |
+|---|---|---|
+| Product-required XR profile, renderer/backend tuple and optional-feature policy | Application composition | Runtime discovery and post-processing |
+| Runtime view-configuration/format/blend-mode discovery | XROpenXR | Renderer and Platform |
+| Complete capability/admission plan across runtime and Renderer | XRRuntime/application coordinator | Native callbacks and feature passes |
+| Horo view/configuration/frame/target identities and generations | XRRuntime/XRApi contract | Array indexes and native handles |
+| Native swapchain creation, image enumeration and API-valid destruction | XROpenXR | Renderer resource registry |
+| Native wait/begin/locate/acquire/wait/release/end-frame order | XROpenXR | RenderFrontend and Input |
+| External image descriptor/lease translation | Private XR/renderer bridge | Public XRApi and general Platform |
+| Horo external resource registration, graph use and GPU completion proof | RenderFrontend/selected backend | XROpenXR session state |
+| Scene extraction, per-view culling, passes, shading, post-processing and UI pixels | Renderer and owning feature adapters | OpenXR runtime |
+| Backend-neutral composition intent and admitted layers | XRRuntime/application feature owners | Renderer backend native code |
+| Native layer encoding/submission | XROpenXR | Runtime UI and post-processing |
+| Asynchronous reprojection/timewarp, guardian/chaperone and device display composition | OpenXR runtime/platform | Horo Renderer and XRRuntime |
+| Window/display mirror output | ADR-033 host/Renderer surface owners | XR swapchain and compositor |
+| Diagnostics/qualification evidence and support claim | Observability/release owners | Successful frame submission alone |
+
+Renderer never calls `xrEndFrame`, releases a native swapchain image, selects a reference
+space or changes session state. XROpenXR never records general scene draws, owns material/
+post-process histories or destroys Renderer resources still in flight.
+
+### 3. The public contract is bounded N-view, not a two-eye array
+
+Discovery publishes finite view-configuration descriptors with stable configuration
+identity, type/capability identity, runtime order, view count, per-view recommended/max
+extent and sample bounds, supported blend modes and current runtime/system revisions.
+The admitted renderer plan additionally records the configured Horo maximum view count.
+
+One `XRViewSetPlan` contains a bounded ordered span of descriptors. Each view has a
+stable `XRViewId`, semantic role, source/reference-space generation, pose/projection,
+render rectangle, target subresource and per-view capability data. Runtime ordering is
+preserved but an index is never eye identity. Public contracts cannot expose two-element
+arrays, `left/right` booleans or fixed matrix pairs.
+
+The first production `XRProjection1_0` implementation admits exactly one primary opaque
+stereo configuration with exactly two runtime views. One-view data may be used only by
+an explicit simulator/test profile; it does not satisfy `XRProjection1_0`. Quad-view,
+foveated-inset or any other greater-than-two configuration is reported as discovered but
+unsupported until its full Renderer path and product profile are implemented/qualified.
+
+View count, ordering, extents and renderer limits are validated before swapchain/image
+acquisition. An unsupported count returns a typed preflight result and creates no
+truncated plan, partial targets or two-eye fallback. A later N-view implementation can
+admit the same descriptors without changing public identity or ownership.
+
+### 4. Swapchain and external resource identities are distinct
+
+XROpenXR owns native swapchains and their image arrays under exact instance/system/
+session/configuration generations. XRRuntime exposes Horo `XRSwapchainTargetId` and
+`XRSwapchainImageId` values that carry owner and generation but reveal no native handle.
+Renderer imports an acquired image as its own generation-safe external resource lease;
+the imported `RenderResourceId` is correlated with, but not interchangeable with, the
+XR image identity.
+
+The external descriptor records at least:
+
+- XR frame/session/configuration/swapchain/image generations;
+- view/array-slice/subresource mapping and color/depth/motion/density role;
+- native-resolved format translated to a Horo typed format;
+- physical allocation extent, active render rectangle and sample count;
+- declared read/write/attachment/copy/shading-rate usages;
+- required initial/final external state and queue-family/ownership semantics abstracted
+  as backend-neutral synchronization contracts;
+- acquire token, completion/retirement requirement and release owner; and
+- color representation, alpha/blend and composition requirements.
+
+Format matching validates the complete format/usage/sample/layout tuple against both
+runtime enumeration and Renderer effective capabilities before native swapchain
+creation. A format numeric value, image pointer, array index or matching extent cannot
+stand in for the typed identity.
+
+Renderer external registration borrows the native allocation for the lease duration. It
+does not adopt or destroy it. XROpenXR cannot release/reuse the image until Renderer
+returns completion evidence for every queue/reference covered by the lease.
+
+### 5. One XR frame scope owns the cross-system transaction
+
+The admitted frame protocol is:
+
+```text
+Idle
+  -> Waited
+  -> Begun
+  -> ViewsLocated
+  -> ImagesAcquiredAndReady
+  -> RendererSubmitted
+  -> ImagesReleased
+  -> LayersSubmitted
+  -> Idle
+```
+
+Every transition carries one `XRFrameGeneration`, predicted display time, accepted
+configuration and capability-plan generation. A frame that the runtime marks as
+non-rendering still follows its legal begin/end contract with zero admitted Horo render
+work and an explicit layer result.
+
+XROpenXR performs native wait/begin, locates the admitted views at predicted time and
+acquires/waits required images. The bridge opens external leases. XRRuntime publishes
+one immutable render plan. Renderer performs N-view extraction and graph execution,
+then returns a typed submission/completion token. The bridge closes Renderer use;
+XROpenXR releases images only when the native/Renderer synchronization contract permits,
+forms admitted native layers and ends the frame.
+
+An image-ready wait is the bounded native acquire contract, not permission for a normal-
+frame device-idle or queue-idle wait. Renderer uses semaphores/fences/events and deferred
+retirement appropriate to the selected backend. CPU blocking, if an unavoidable native
+API step, is bounded, timed, cancellable where supported and measured separately from
+GPU completion.
+
+Failures after begin resolve the frame through a legal abort/zero-layer/end path when the
+runtime permits it. An acquired image is released exactly once. No exception, cancelled
+job or skipped render leaves an open image or frame; no fabricated success advances
+temporal history.
+
+### 6. Renderer plans views, passes and histories from immutable XR input
+
+Renderer receives a complete `XRRenderPlan`, never an incremental callback sequence. It
+contains the accepted view set, predicted pose/projection snapshot, external targets,
+scene-presentation epoch, render scale/rect, optional depth/motion/foveation inputs,
+layer intent and synchronization requirements.
+
+All views of one XR scene-presentation epoch consume one committed simulation/extraction
+state. Per-view culling, LOD, lighting, effects, UI projection, histories and output
+conversion remain Renderer/feature responsibilities. Rendering the second or Nth view
+does not advance simulation, animation, VFX, audio or input again.
+
+Histories are keyed by XR session/configuration/view, Renderer device/plan, projection,
+extent/render rectangle, origin, color/exposure and relevant feature generations. View
+reorder/count/role, reference-space reset, session replacement, render-scale change,
+foveation-plan change or incompatible target replacement resets/migrates only through a
+declared history policy. An array index never preserves history identity.
+
+The Renderer may implement admitted stereo as multipass or instanced/multiview. That is
+an effective backend capability/performance decision. It cannot change view semantics,
+omit a view, combine histories or claim support for a view configuration the frontend
+rejected.
+
+### 7. Composition layers are XR intent, not arbitrary Renderer submission
+
+Feature owners contribute finite backend-neutral layer candidates through XRRuntime.
+The application/XR capability plan admits layer kinds, ordering bands, blend semantics,
+spaces, view coverage and budgets before the frame. Projection content references
+completed XR external targets; Runtime UI may contribute an admitted quad/cylinder/etc.
+intent only through its own typed adapter. Native handles are absent.
+
+XRRuntime validates one immutable composition plan for the current frame generation.
+XROpenXR encodes that plan into native structures and calls the runtime. It cannot reorder
+semantic bands, add vendor layers, retain frame-local pointers or reinterpret a missing
+required layer as success. Renderer produces pixels and completion evidence; it does not
+call the compositor directly.
+
+Layer count/capacity, space/session generation, pose validity, blend mode, alpha/color
+representation, image rectangle and target completion are validated before submission.
+Optional-layer rejection follows the captured fallback plan. Required projection-layer
+failure ends the frame with a typed failure; it never presents a partial view set as a
+successful XR frame.
+
+### 8. Depth, motion and auxiliary targets have explicit semantics
+
+The external-target model admits roles for projection color, runtime-submitted depth,
+motion/vector data, shading-rate/density inputs and future qualified auxiliary layers.
+Each role declares format, units, coordinate convention, direction, valid range,
+background/invalid encoding, sample/resolve policy, render rectangle and consumer.
+
+Depth submission is an optional 1.0 capability only when runtime and Renderer agree on
+the exact depth contract. Renderer produces the declared per-view depth; XROpenXR encodes
+native composition depth metadata. Scene depth used internally by lighting/post effects
+does not automatically satisfy the runtime contract.
+
+Motion/depth/timing for runtime space warp is post-1.0 until an explicit capability plan
+defines generation, units, disocclusion and submission. Renderer may produce inputs but
+does not own runtime space-warp activation or completion. Missing auxiliary input cannot
+be replaced by zeros or ordinary motion blur data while reporting the feature active.
+
+Auxiliary targets remain bounded and generation-correlated. They never grant same-frame
+CPU readback, gameplay visibility authority or permission to expose native resources.
+
+### 9. Dynamic resolution and foveation are joint XR/Renderer capabilities
+
+The application resolves one immutable XR render-quality plan from runtime limits,
+Renderer capabilities, product policy, privacy state and measured budget. It separates:
+
+- swapchain allocation extent and sample count;
+- active per-view render rectangle/scale;
+- dynamic-resolution controller and finite scale/rate bounds;
+- fixed foveation level/provider;
+- gaze-driven foveation with current consent/tracking validity;
+- Renderer VRS versus runtime-provided density-map mechanism; and
+- fallback plus history-invalidation policy.
+
+Dynamic resolution changes only at the declared frame-plan safe point and stays inside
+runtime/Renderer bounds. It does not recreate native swapchains per frame or relabel a
+smaller render rectangle as a different physical extent. The current plan/revision is
+captured by every frame and temporal history.
+
+Foveation is not a generic post-process. XROpenXR owns runtime extension calls and
+runtime-provided density resources; Renderer owns compatible shading-rate/density use
+and graph binding. Gaze-driven foveation additionally depends on ADR-159 privacy and a
+valid current gaze sample. Loss follows only an admitted fixed/non-foveated fallback;
+the system never retains stale gaze or reports foveation active after capability loss.
+
+Backend absence of VRS/multiview is not automatically XR failure if the accepted profile
+has a qualified multipass/non-foveated path. Required product policy fails preflight
+instead of silently degrading.
+
+### 10. Runtime compositor and Horo post-processing are different owners
+
+Horo post-processing runs inside each admitted Renderer view before the projection
+target reaches its declared external final state. It owns effects, exposure, color and
+histories under the rendering architecture. It does not discover XR, select view
+configuration, acquire/release images, enable foveation or submit composition layers.
+
+Asynchronous reprojection/timewarp, distortion, device scan-out and platform guardian/
+chaperone/boundary composition remain native runtime/platform behavior. Horo does not
+model them as render-graph passes, post-process effects, generated frames or simulation
+ticks. Runtime behavior may be observed through bounded timing/capability evidence but
+does not transfer ownership.
+
+A desktop mirror is a separate ADR-033 output surface and frame plan. It may consume a
+qualified copy/resolution of Horo scene output without borrowing an acquired XR image
+beyond its lease or delaying XR release. Mirror failure cannot corrupt the XR session;
+XR failure cannot be reported as successful because the mirror presented.
+
+### 11. Loss, replacement and shutdown are generation-fenced
+
+View-configuration, format, blend-mode, capability, render-scale, reference-space,
+Renderer device, swapchain/image, session and instance changes advance their relevant
+generations. New frames close admission against the old plan. Outstanding Renderer work
+and image leases retire before XROpenXR destroys or reuses native objects.
+
+Replacement prepares a complete compatible candidate plan/swapchain/resource registry
+before atomic publication. Failure preserves the prior generation only if the runtime
+still declares it valid; otherwise the XR output becomes Lost. Matching native handles,
+formats or view counts never revalidate old Horo identities.
+
+Shutdown stops new XR frames/layers, resolves any begun frame legally, joins Renderer
+submissions, closes external leases, releases acquired images, retires Renderer external
+registrations, destroys native swapchains/session resources and finally releases bridge/
+backend dependencies. It never uses an unconditional device-idle wait as routine
+teardown when generation/fence retirement can prove safety.
+
+### 12. Migration and contract coverage are required
+
+There is no production XR rendering implementation to preserve. Initial work must add
+typed XR/Renderer bridge contracts and external resources without leaking native types
+or adding fixed-eye arrays. Existing stereo examples are profile examples, not license
+to narrow the public contract.
+
+Required automated coverage includes:
+
+- dependency/public-header tests proving native OpenXR/graphics handles remain private;
+- runtime-driven descriptor bounds/order/role/generation validation;
+- exact primary-stereo admission plus one-view test-profile handling and greater-than-two
+  rejection before image acquisition with no truncation/partial targets;
+- format/usage/sample/layout/color-role negotiation across every selected renderer;
+- swapchain versus RenderResource identity, stale/wrong-owner rejection and external
+  lease lifetime;
+- wait/begin/locate/acquire/wait/render/complete/release/end ordering, fault injection at
+  every boundary and exactly-once image/frame cleanup;
+- multipass and multiview semantic parity without repeated simulation/extraction;
+- layer ordering/bounds/space/pose/blend/completion validation and required/optional
+  failure behavior;
+- depth, motion, density/VRS and foveation schemas, privacy loss, fallback and history
+  invalidation;
+- dynamic-resolution scale/rectangle changes without per-frame swapchain recreation;
+- no post-processing ownership of foveation/reprojection/composition and no Horo
+  guardian/chaperone pass; and
+- session/device/swapchain replacement and shutdown with no GPU/native/resource/frame/
+  layer/bridge lease surviving its owner.
+
+Deterministic fake runtime/renderer combinations validate ordering, bounds and faults.
+Physical device/runtime/driver evidence remains required for each supported tuple and
+for timing, visual parity, foveation, depth or motion claims.
+
+## Consequences
+
+### Positive
+
+- Native swapchains/composition and Horo rendering have one explicit lease-based handoff.
+- Public contracts support bounded N-view evolution while first production scope remains
+  exact and testable.
+- Unsupported view configurations fail before acquisition instead of truncating views.
+- External descriptors anticipate depth, motion, dynamic resolution and foveation
+  without exposing native types.
+- Runtime reprojection/guardian behavior and Horo post-processing remain separate.
+
+### Negative
+
+- Every renderer backend needs a private OpenXR bridge and external synchronization
+  qualification.
+- Swapchain, XR image and Renderer resource identities require explicit correlation and
+  lifecycle tracking.
+- Multipass/multiview, dynamic-resolution and foveation paths expand the renderer test
+  matrix even when the initial product admits only stereo.
+- Optional depth/motion/foveation features cannot be enabled until complete semantics and
+  fallback evidence exist.
+
+## Rejected Alternatives
+
+### Let Renderer own the OpenXR session and swapchains
+
+Rejected because Renderer owns GPU work, not runtime events, reference spaces, native
+session state, actions or composition submission.
+
+### Let XROpenXR record scene rendering directly
+
+Rejected because it would duplicate RenderFrontend graph/resource/material/history
+ownership and make one graphics backend privileged.
+
+### Publish fixed left/right arrays
+
+Rejected because runtime view configurations are variable and semantic view identity is
+not an array index. Fixed arrays force a public migration for quad/foveated views.
+
+### Truncate unsupported view configurations to stereo
+
+Rejected because omitted views change the runtime's required composition and can produce
+invalid or unsafe presentation. Admission fails before acquisition.
+
+### Treat native images as ordinary Renderer-owned textures
+
+Rejected because the runtime retains allocation/reuse/destruction authority and requires
+exact acquire/release order. Renderer receives a bounded external lease.
+
+### Release images immediately after CPU command recording
+
+Rejected because command recording is not GPU completion. Release follows the selected
+native/Renderer synchronization proof without normal-frame global idle waits.
+
+### Implement foveation, space warp or reprojection as generic post-processing
+
+Rejected because they require XR/runtime/Renderer capability and submission contracts;
+asynchronous reprojection and device composition remain native runtime behavior.
+
+### Treat mirror presentation as XR presentation success
+
+Rejected because the mirror and XR compositor are separate output owners, clocks,
+surfaces and failure domains.

--- a/docs/architecture/runtime/post-processing-and-effects-architecture.md
+++ b/docs/architecture/runtime/post-processing-and-effects-architecture.md
@@ -13,6 +13,10 @@ Foveation is an admitted XR/Renderer plan and runtime asynchronous reprojection/
 belongs to the native XR compositor; neither is a generic post-process effect. This
 stack may consume an already admitted XR view like any other Render view, but it cannot
 discover/select an XR runtime, choose a view configuration or submit composition layers.
+The external-target, dynamic-resolution, foveation, auxiliary-input and layer boundary is
+fixed by [ADR-160](../../adr/160-xr-rendering-openxr-compositor-and-renderer-ownership.md).
+Post-processing cannot acquire/release runtime images, enable VRS/density/space warp,
+fabricate missing depth/motion inputs or model guardian/chaperone as an effect.
 
 ## Scene Color And Output Contract
 

--- a/docs/architecture/runtime/render-backend-parity-contract.md
+++ b/docs/architecture/runtime/render-backend-parity-contract.md
@@ -591,6 +591,15 @@ from the frontend frame plan. Only ImGui texture resolution remains app-private;
 the public renderer API intentionally exposes no native or GUI texture type.
 
 Migration must not preserve either backend as a privileged composition path.
+
+XR follows the same parity rule under
+[ADR-160](../../adr/160-xr-rendering-openxr-compositor-and-renderer-ownership.md).
+Every renderer advertised for an XR product tuple supplies a private OpenXR external-
+resource bridge and proves equivalent typed format/usage negotiation, image-lease
+synchronization, N-view semantics, completion evidence and deferred retirement. Native
+handles remain private, and XROpenXR retains acquire/release/end-frame ownership. A
+backend may use multipass or native multiview internally, but cannot omit/reorder views
+or claim an unqualified greater-than-two configuration.
 The common module metadata, window requirements, editor lifecycle, generic mesh
 snapshot, target handles, submission contract, and parity test harness are shared.
 

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -1212,6 +1212,12 @@ writes scene depth or renders the same decal twice in one view.
 
 ## XR Views And External Presentation Targets
 
+[ADR-160](../../adr/160-xr-rendering-openxr-compositor-and-renderer-ownership.md)
+is normative for the XR/Renderer handoff. XROpenXR owns native frame, swapchain, image
+and composition calls; Renderer owns Horo extraction, graph/GPU work, external-resource
+registration and completion evidence. The private bridge translates native resources
+without becoming a second owner.
+
 XR supplies a bounded runtime-driven set of view descriptors and
 generation-scoped runtime-owned image identities. Renderer does not assume that
 an XR frame contains exactly two eyes, and public render contracts do not expose
@@ -1223,6 +1229,12 @@ and configuration identity so later quad-view or foveated-inset execution does
 not require a public API migration. An unsupported view configuration is
 rejected before resource acquisition and is never silently truncated.
 
+For `XRProjection1_0`, that first production admission is exactly one primary opaque
+stereo configuration with exactly two runtime views. One-view input is limited to an
+explicit simulator/test profile. Any greater-than-two configuration is retained as
+discovery evidence but fails admission before swapchain-image acquisition until the
+complete N-view path is implemented and qualified.
+
 Runtime-owned images enter the graph as typed external resources with declared:
 
 - format, extent, array/view index, and permitted uses;
@@ -1231,12 +1243,33 @@ Runtime-owned images enter the graph as typed external resources with declared:
 - synchronization and frames-in-flight lifetime;
 - session, swapchain, image, and configuration generations.
 
+An XR image and imported `RenderResourceId` are correlated, non-interchangeable
+identities. Renderer borrows the allocation for one external lease and never destroys
+it. XROpenXR releases/reuses it only after Renderer supplies completion evidence for all
+covered queue references; CPU command recording alone is insufficient. The descriptor
+also carries physical allocation extent versus active render rectangle, typed color
+representation and initial/final external synchronization state.
+
 Dynamic resolution, fixed or gaze-driven foveation, variable-rate shading,
 density maps, depth submission, and motion inputs are renderer capabilities.
 They are negotiated before frame execution. Foveation is not modeled as a
 generic post-process, and Horo does not implement runtime-owned asynchronous
 reprojection. Ordinary projection-layer rendering is the explicit fallback
 when optional features are unavailable.
+
+One immutable XR render-quality plan separates swapchain extent, render rectangle,
+dynamic scale/controller, fixed or gaze-driven foveation, Renderer VRS versus runtime
+density-map mechanism, privacy revision and fallback. Scale/plan changes occur at a safe
+point and invalidate/migrate histories by explicit policy; they do not recreate a
+swapchain every frame. Space-warp depth/motion/timing inputs require their own declared
+semantics and cannot be substituted with generic motion-blur data.
+
+XRRuntime supplies one complete frame and backend-neutral layer intent. Renderer returns
+typed submission/completion evidence but never calls native image release or end-frame.
+XROpenXR validates and encodes native layers after required targets complete. Runtime
+asynchronous reprojection, distortion, scan-out and guardian/chaperone remain outside
+the Horo graph. A desktop mirror is an independent ADR-033 output, not proof that the XR
+compositor presented successfully.
 
 See [XR Architecture](./vr-ar-architecture.md) for session, view, capability,
 privacy, and qualification ownership.

--- a/docs/architecture/runtime/vr-ar-architecture.md
+++ b/docs/architecture/runtime/vr-ar-architecture.md
@@ -34,6 +34,11 @@ specializes native action, tracking snapshot, Input projection, fixed-tick, gest
 haptic and privacy ownership. Input never polls OpenXR, and presentation-late tracking
 never rewrites committed simulation input.
 
+[ADR-160](../../adr/160-xr-rendering-openxr-compositor-and-renderer-ownership.md)
+specializes runtime-driven N-view admission, swapchain/external-resource leases, frame
+and layer submission, auxiliary targets and XR render-quality plans. XROpenXR owns native
+frame/compositor calls; Renderer owns Horo graph/GPU work and completion evidence.
+
 ## Ownership
 
 ```text
@@ -310,6 +315,30 @@ release, and composition submission maintain explicit ownership and
 synchronization. Session or surface loss retires resources only after queued GPU
 references are safe.
 
+The first production `XRProjection1_0` renderer admits exactly one primary opaque
+stereo configuration with two runtime views. The public plan remains bounded N-view.
+One-view inputs require an explicit simulator/test profile, while any greater-than-two
+configuration remains discovered-but-unsupported until fully implemented and qualified;
+it fails before image acquisition and is never truncated.
+
+An XR swapchain image and its imported `RenderResourceId` are correlated but distinct
+identities. XROpenXR retains allocation/acquire/release/destruction ownership; Renderer
+borrows an external lease with typed format, extent, render rectangle, subresource,
+usage, color/depth/motion/density role, synchronization and generations. Release waits
+for Renderer completion evidence, not merely CPU command recording, without a normal-
+frame device-idle wait.
+
+XRRuntime validates one immutable frame/layer intent. XROpenXR performs wait/begin,
+view location, acquire/wait, native layer encoding and end-frame. Renderer performs
+N-view extraction, graph execution and GPU retirement. Required layer/view failure is
+typed; a partial view set is never successful presentation.
+
+Dynamic resolution and fixed/gaze foveation use one immutable XR/Renderer plan that
+separates allocation extent, active render rectangle, scale, VRS/density mechanism,
+privacy state and fallback. Runtime space-warp depth/motion inputs remain post-1.0 until
+their exact semantics are admitted. Runtime asynchronous reprojection and guardian/
+chaperone composition never become Horo passes.
+
 ## Tracking, Actions, And Haptics
 
 OpenXR action sets and suggested bindings are backend data. Engine systems
@@ -513,6 +542,7 @@ device release gate.
 - [XR Ownership, Runtime Composition and Capability Tier](../../adr/157-xr-ownership-runtime-composition-and-capability-tier.md)
 - [OpenXR Loader, Backend Packaging and Host Composition](../../adr/158-openxr-loader-backend-packaging-and-host-composition.md)
 - [XR Action, Tracking and Input-Projection Ownership](../../adr/159-xr-action-tracking-and-input-projection-ownership.md)
+- [XR Rendering, OpenXR Compositor and Renderer Ownership](../../adr/160-xr-rendering-openxr-compositor-and-renderer-ownership.md)
 - [XR Setup UI Reference](./xr-setup.html)
 - [Rendering Architecture](./rendering-architecture.md)
 - [Render Backend Parity Contract](./render-backend-parity-contract.md)


### PR DESCRIPTION
## Summary

- Add ADR-160 to define ownership across OpenXR runtime views/swapchains/composition and Horo Renderer external-resource/GPU work.
- Adopt a bounded runtime-driven N-view contract while limiting the first production `XRProjection1_0` path to exactly two primary-stereo views.
- Define lease-based external image import, cross-owner synchronization, composition-layer submission and generation-safe replacement/shutdown.
- Place depth, motion, dynamic resolution, foveation, VRS/density and space-warp inputs behind explicit XR/Renderer capability plans.
- Align XR, rendering, backend-parity and post-processing architecture documents.

## Why

The XR foundation names broad owners but leaves the native swapchain-to-Renderer handoff under-specified. Downstream implementation could otherwise double-own images, release them after CPU recording rather than GPU completion, expose fixed two-eye arrays/native handles, silently truncate runtime view sets or treat foveation and runtime reprojection as generic post-processing. This PR fixes those contracts before XRA-004 implementation begins.

## Decision and boundaries

- Keeps native wait/begin/locate/acquire/wait/release/end-frame and layer encoding inside `XROpenXR`.
- Keeps Horo view extraction, graph execution, external-resource registration, GPU submission and deferred retirement inside Renderer.
- Defines distinct correlated identities for XR swapchain images and imported `RenderResourceId` leases.
- Requires unsupported greater-than-two view configurations to fail before image acquisition with no partial stereo fallback.
- Records a single XR frame state machine and exactly-once cleanup paths for begun frames and acquired images.
- Separates swapchain allocation extent from active render rectangle and captures dynamic-resolution/foveation/history policy in one immutable plan.
- Leaves asynchronous reprojection, distortion, scan-out and guardian/chaperone composition to the native runtime/platform.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/160-xr-rendering-openxr-compositor-and-renderer-ownership.md docs/architecture/runtime/vr-ar-architecture.md docs/architecture/runtime/rendering-architecture.md docs/architecture/runtime/render-backend-parity-contract.md docs/architecture/runtime/post-processing-and-effects-architecture.md`
- `git diff --check`
- `git diff --cached --check`
- Added-Markdown-link resolution check against the staged diff
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

The first staged link check caught and corrected an outdated ADR-034 filename. The rerun passed. CMake configuration completed successfully with the existing mbedTLS minimum-version deprecation warning; repository Python tests were skipped because `pytest` is unavailable in the current environment.

## Risk and rollout

- This is an architecture-only change; exact public view/target schemas and native bridge implementations remain dependent XRA-004 work.
- Every supported renderer/OpenXR tuple now requires explicit external-resource synchronization and physical-device qualification.
- The public contract anticipates N-view, depth, motion and foveation capabilities that the initial primary-stereo implementation may not enable.

## Issue links

- Closes #2138
- Jira: [HORO-2092](https://horo-engine.atlassian.net/browse/HORO-2092)
- Parent capability: [XRA-004 / #2137](https://github.com/abdullahbodur/horo-engine/issues/2137)
- Prerequisite: [XRA-001.1 / #2109](https://github.com/abdullahbodur/horo-engine/issues/2109)
- Blocks: [XRA-004.2 / Jira HORO-2093](https://horo-engine.atlassian.net/browse/HORO-2093)

## Reviewer Notes

Please review the lease and completion boundary first: XROpenXR owns native image lifetime, Renderer owns GPU use, and release occurs only after typed completion evidence without a normal-frame global idle wait. Then verify the view-admission rule: the public schema remains bounded N-view, but the first production profile admits exactly two primary-stereo views and rejects larger configurations before acquisition.

## Stack

- Base PR: #2494 — `docs/HORO-2082_xr_action_tracking_input_projection_ownership`
- This PR: `docs/HORO-2092_xr_rendering_compositor_renderer_ownership`
- Merge order: #2494, then this PR


[HORO-2092]: https://horo-engine.atlassian.net/browse/HORO-2092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ