### PR TITLE
docs(xr): define XR interaction ownership HORO-2102 #2148 [XRA-005.1]

### DIFF
--- a/docs/adr/161-xr-interaction-runtime-ui-locomotion-and-accessibility-ownership.md
+++ b/docs/adr/161-xr-interaction-runtime-ui-locomotion-and-accessibility-ownership.md
@@ -1,0 +1,384 @@
+# ADR-161: XR Interaction, Runtime UI, Locomotion and Accessibility Ownership
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: XR ray/direct/proximity evidence, Runtime UI hit testing/focus/capture, world-space canvas presentation, gameplay interaction intent, Character locomotion authority, Camera/view composition, tracking-origin/recenter policy, comfort/accessibility preferences, capability tiers, lifecycle, migration and validation
+- **Issue**: [XRA-005.1](https://github.com/abdullahbodur/horo-engine/issues/2148)
+- **Jira**: [HORO-2102](https://horo-engine.atlassian.net/browse/HORO-2102)
+- **Related**: [ADR-026](026-large-world-precision-and-floating-origin-strategy.md), [ADR-061](061-animation-ownership-update-order-and-clock.md), [ADR-073](073-runtime-ui-ownership-scope-and-update-order.md), [ADR-078](078-runtime-ui-input-context-and-player-routing.md), [ADR-082](082-runtime-ui-accessibility-capability-and-ownership.md), [ADR-089](089-character-controller-ownership-implementation-and-update-order.md), [ADR-157](157-xr-ownership-runtime-composition-and-capability-tier.md), [ADR-159](159-xr-action-tracking-and-input-projection-ownership.md), [ADR-160](160-xr-rendering-openxr-compositor-and-renderer-ownership.md)
+- **Normative documents**: [XR Architecture](../architecture/runtime/vr-ar-architecture.md), [Game UI and HUD](../architecture/runtime/game-ui-and-hud.md), [Input Architecture](../architecture/runtime/input-architecture.md), [Character Controller](../architecture/runtime/character-controller-architecture.md), [Accessibility Architecture](../architecture/runtime/accessibility-architecture.md)
+
+## Context
+
+The XR foundation keeps tracking/actions in XR, canonical actions in Input, world-space
+UI semantics in Runtime UI, GPU work in Renderer and authoritative character movement
+in Character/Physics. Existing text says XR supplies rays, touches and poses through
+adapters and that locomotion produces character intent. It does not yet define where a
+ray becomes a hit, where hover becomes focus, who owns pointer capture, how tracked head
+motion composes with a collision root, or which comfort/accessibility controls must be
+available independently of rendering/device tier.
+
+Without explicit boundaries, an XR callback could set UI focus, a gesture could move an
+entity, a camera could teleport the Character capsule, a physics hit could invoke a
+button, or a world-space canvas could maintain a second interaction tree. Recenter and
+room-scale motion could also rewrite authored/world transforms. Treating comfort as a
+premium renderer capability would make accessibility depend on quality tier rather than
+on gameplay semantics.
+
+This ADR fixes the typed evidence/intent/authority chain and the non-gating comfort
+baseline. XRA-005.2 and later tickets may specialize ray/direct adapters, world-space
+projection, focus/capture, locomotion commands, comfort settings and tests without
+moving these owners.
+
+## Decision
+
+### 1. XR supplies evidence; domain owners decide meaning
+
+The interaction path is:
+
+```text
+XRRuntime tracking/action snapshots
+        |
+        v
+host-composed XR interaction adapters
+  ray/direct/proximity evidence with generation and validity
+        |
+        +--> Physics/scene query ports --> bounded hit candidates
+        |
+        +--> Runtime UI interaction input
+        |      hit-test, hover, focus, capture, submit/cancel
+        |
+        +--> gameplay interaction resolver
+               use/grab/teleport/locomotion intents
+                        |
+                        v
+               Character / Physics / gameplay authority
+```
+
+An adapter converts coordinate spaces, validates generations and forms bounded
+candidates. Evidence says where a tracked source was and what it intersected; intent
+says what the user requested; authority validates and commits the resulting state change
+at its safe point. No pose, ray, contact, dwell, gesture, haptic response or native
+action invokes UI or gameplay directly. Input context routing remains the gate through
+which semantic actions become eligible.
+
+### 2. Every interaction and movement responsibility has one owner
+
+| Responsibility | Sole owner | Deliberate non-owner |
+|---|---|---|
+| Tracking/action/device/reference-space snapshots | XRRuntime/XROpenXR under ADR-159 | Runtime UI, Character and Camera |
+| Canonical actions, contexts, player/device assignment and consumption | Input | XR interaction adapters |
+| Ray/direct/proximity coordinate conversion and evidence candidates | Host-composed XR interaction adapter | Native callbacks and UI widgets |
+| World geometry query, collision/contact/overlap truth | Physics/Scene query owners | XRRuntime and Runtime UI |
+| Runtime UI layout, hit-test tree, hover, focus, capture and semantic action | RuntimeUiService | XR and Renderer |
+| World-space canvas semantic ownership and lifecycle | RuntimeUiService owner scope | XR session and scene ECS by proximity |
+| Canvas projection, depth/occlusion and per-view pixels | Runtime UI extraction plus Renderer | UI hit-test semantics and XR tracking |
+| Gameplay use/grab/manipulation meaning and target validation | Gameplay/interaction owner | Input, gesture and Physics callback |
+| Desired locomotion/turn/teleport intent | Gameplay/player locomotion owner | XRRuntime and Camera |
+| Collision-root displacement, support and final transform | Character/Physics | Camera and tracked head pose |
+| Tracked-head/view composition and presentation-only comfort effects | Camera/view coordinator plus Renderer | Character collision authority |
+| Tracking-origin/recenter/calibration policy | Application/XR spatial coordinator | Character Transform and UI widgets |
+| Accessibility/comfort preference values and provenance | Configuration/Accessibility | Renderer quality tier and XR runtime defaults |
+| Effective per-player comfort plan | Gameplay/Camera/UI owners at their boundaries | A global XR manager |
+| Haptic request scope/cancellation and native output | ADR-159 owners | Interaction hit candidates |
+
+Local player, Input user, XR device, interaction source, pointer, Runtime UI context,
+canvas, focus target, gameplay actor, Character controller, camera view and tracked
+space are distinct identities joined by immutable generation-scoped mappings.
+
+### 3. Interaction sources publish bounded typed evidence
+
+An `XRInteractionSourceSnapshot` names the XR session/device/source generation, Input
+user/player assignment revision, source kind, reference space/origin revision, sample
+time, validity/confidence and enabled capabilities. Source kinds are finite Horo values
+such as controller aim ray, controller direct point, admitted hand pointer, admitted eye
+gaze ray or proximity volume. Native paths, handles and product names are absent.
+
+Ray evidence records origin, normalized direction and bounded maximum distance. Direct
+evidence records a generation-scoped point/shape and contact phase; proximity records a
+bounded volume/range. Invalid orientation/position, missing permission, tracking loss or
+stale origin produces explicit unavailable evidence, never an identity ray, last-known
+hit or zero-length success.
+
+Adapters use narrow read-only Physics/Scene/Runtime UI query ports and return ordered,
+bounded candidates with target-domain identity, distance/depth, surface/element evidence,
+query revision and occlusion policy. A candidate is not hover, focus, capture, selection,
+grab, use or teleport approval. Each destination validates its own target generation.
+
+The adapter runs only at the host-declared interaction boundary from one immutable XR
+and presented-layout snapshot. It retains no mutable target pointers, blocks on no query,
+allocates no unbounded candidate list and publishes no high-frequency evidence on a
+general data bus.
+
+### 4. Runtime UI remains the sole UI interaction authority
+
+World-space canvases are ordinary Runtime UI documents/instances under an exact game,
+player, scene or viewport owner scope. XR session lifetime does not silently own them.
+They use the same element IDs, layout, localization, semantic accessibility tree, route
+bands, focus graph and action-command model as screen-space UI.
+
+The XR/UI adapter projects an eligible source into the last successfully presented
+`UiInteractionSnapshot` for the exact player/viewport/view/canvas revisions. Runtime UI
+alone performs semantic hit testing and resolves hover, focus, press/release, drag,
+scroll, submit/cancel and capture. A Renderer depth result may participate as bounded
+occlusion evidence but cannot choose focus or invoke a control.
+
+Each XR pointer has a generation-safe pointer/capture identity. Capture begins only from
+an eligible routed press/action and matching presented target. It ends on release,
+cancel, modal/route exclusion, focus loss, source/device/profile/session loss, tracking
+invalidity, owner/canvas destruction, assignment change or presentation-revision loss.
+Switching between ray and direct modes crosses an explicit neutral boundary.
+
+Failed/skipped presentation leaves new world-space geometry ineligible, just like
+screen-space UI. Pointer visuals may show unavailable/blocked state but cannot make
+unpresented layout interactive. UI actions become typed application/gameplay commands;
+widgets never mutate Character, Scene, Physics or XR state directly.
+
+### 5. Rendering owns world-space projection and occlusion, not semantics
+
+Runtime UI publishes immutable per-view world-canvas render and interaction geometry
+from the same document/layout generation. Renderer transforms it through the admitted
+XR view set, performs N-view projection, clipping, depth policy, occlusion and pixel
+composition under ADR-160. It never reconstructs a UI tree from draw calls.
+
+Logical layout/hit geometry is view-independent where possible and remains in Runtime UI
+units/world coordinates. Per-view pixel snapping, depth tests, foveation, render scale or
+visibility do not feed back into semantic element identity. If product policy requires
+visible-only interaction, Renderer provides delayed/bounded typed occlusion evidence for
+the matching view/frame; the UI owner decides eligibility against its revision. There is
+no same-frame GPU readback stall.
+
+Head-locked HUD, world-anchored canvas, hand/controller-attached panel and compositor
+layer are different attachment/presentation policies, not different UI ownership
+systems. A native composition layer remains XROpenXR submission under ADR-160 and cannot
+carry mutable widget pointers or bypass Runtime UI focus/accessibility.
+
+### 6. Gameplay interaction receives intent, never direct mutation
+
+After Input routing, the gameplay interaction resolver may combine an eligible semantic
+action with the exact XR source and bounded Physics/Scene candidate into a typed intent.
+An intent names player/actor, tick, source/candidate generations, requested operation and
+bounded parameters. It contains no native handles, arbitrary target pointers or pre-
+authorized result.
+
+The owning gameplay system revalidates range, line of sight, target capability,
+authority, cooldown, inventory/state and network role at its fixed-tick safe point.
+Physics owns collision/contact evidence; gameplay owns use/grab/throw/equip meaning;
+Character owns its collision root. Multiplayer clients send bounded intentions through
+the normal network authority contract, not trusted XR poses or client hit results.
+
+Focus/capture in Runtime UI and grab/capture in gameplay are separate leases. A source
+cannot drive both when its Input context/consumption ledger grants exclusivity. Opening
+a modal, changing assignment or losing tracking neutralizes pending interaction before
+another domain becomes eligible.
+
+### 7. Locomotion is gameplay intent resolved by Character
+
+The player locomotion owner maps canonical Input/XR actions, settings and tracking-space
+evidence into tick-assigned intents such as move, rotate, snap turn, teleport request,
+stance/height mode or recenter request. It owns locomotion state-machine meaning,
+cooldowns and mode policy but never writes Scene Transform directly.
+
+Continuous/snap movement becomes an ordinary Character movement/heading request for the
+exact fixed tick. Character applies platform carry, collision queries, slope/step rules,
+root motion and final displacement under its existing authority. A teleport is a typed
+Character/application command with destination/query provenance, clearance validation,
+network authority and commit/rollback; moving the camera or XR reference space is not a
+collision-safe teleport.
+
+Tracked room-scale head/controller motion is local evidence inside the calibrated
+tracking space. It does not move the collision root each render frame. A product may
+declare a bounded body-follow/room-scale reconciliation policy that produces future
+Character intents at tick boundaries; Character still validates displacement and owns
+the committed root. Boundary violation returns typed blocked/recovery evidence rather
+than silently moving world geometry.
+
+### 8. Camera/view composition does not acquire movement authority
+
+The Camera/view coordinator composes the committed Character/world root, tracking-origin
+calibration, current admitted head/view pose and presentation-only offsets into render
+views. Each input carries its generation and clock domain. The coordinator does not
+write Character, XR tracking or authored camera transforms.
+
+Recenter changes an application/XR calibration transform at an owner safe point. It does
+not teleport the Character capsule, rewrite the scene, fabricate a Stage space or modify
+native tracking history. A product may separately request a Character heading/root
+alignment transaction; success is explicit and collision/authority checked.
+
+Camera collision/comfort presentation effects such as vignette, blink/fade, snap-turn
+transition or motion reduction are derived visual/audio/UI outputs. They cannot hide a
+failed Character move, advance simulation, change the native pose or become authority
+for locomotion. Presentation-late pose remains visual-only under ADR-159.
+
+### 9. Comfort and accessibility are non-gating across product tiers
+
+Every XR product declares a finite `XRComfortPlan` per local player/profile. The plan
+resolves configuration preferences against authored locomotion capabilities and current
+session state. Rendering quality, headset class, optional package, ray tracing,
+multiview, hand/eye tracking or post-1.0 capability cannot gate the semantic availability
+of baseline comfort/accessibility controls.
+
+When the product offers artificial locomotion or rotation, its baseline plan exposes:
+
+- a way to disable artificial movement/rotation independently where gameplay permits;
+- snap-turn support with configurable finite angle/cooldown, alongside any smooth turn;
+- configurable move/turn speed and handed/dominant-side control mapping;
+- seated/standing and calibrated height/recenter behavior with explicit availability;
+- motion-reduction presentation policy, including intensity/disable controls for any
+  vignette/tunneling/fade used by the product;
+- teleport/continuous locomotion availability and limitations as separate authored
+  capabilities rather than silent fallbacks; and
+- remappable canonical actions plus existing subtitle, visual, input and semantic UI
+  accessibility families.
+
+An authored experience that fundamentally requires a movement mode may state that
+requirement, but cannot falsely advertise an unavailable alternative or hide comfort
+settings on a lower renderer tier. If a required accessibility/comfort semantic cannot
+be provided, product admission/qualification reports the limitation explicitly; it does
+not silently enable a different movement mode.
+
+Configuration owns desired preference/provenance. Gameplay owns locomotion meaning,
+Character owns movement, Camera/Renderer own presentation effects, Runtime UI owns
+settings/focus semantics and Accessibility owns cross-feature policy/evidence. There is
+no global `XRComfortManager` mutating all owners.
+
+### 10. Focus, tracking and capability loss neutralize the whole chain
+
+Interaction follows explicit source and target lifecycle:
+
+```text
+Unavailable
+  -> Eligible
+  -> Hovering
+  -> Pressed / Captured
+  -> Released / Cancelled
+  -> Neutralized
+  -> Unavailable
+```
+
+Runtime UI owns its state transitions; gameplay interaction and locomotion use their own
+intent/command lifecycles. Source/device/profile/session, Input assignment/context,
+tracking validity, reference-space/origin, target/canvas/scene, presented-layout and
+permission revisions fence every operation.
+
+Loss closes new intent admission, cancels UI/gameplay capture, releases projected Input
+actions, drops pending uncommitted intents, stops owned haptics and publishes neutral/
+unavailable visuals. It never transfers capture to another source, reuses the last ray,
+commits a pending teleport or invokes release on a replacement target.
+
+Replacement publishes complete new mappings/snapshots before eligibility. Matching
+labels, poses, hit points or element IDs do not revalidate stale generations. Shutdown
+disconnects interaction producers, neutralizes Input/UI/gameplay, joins query/provider
+work, releases focus/capture and render leases, then destroys owners in established
+reverse dependency order.
+
+### 11. Unsupported and privacy-sensitive paths are explicit
+
+Eye-gaze and articulated-hand interaction remain optional under ADR-159. Their derived
+ray/gesture is admitted only for a purpose and consumer; it cannot silently replace a
+required controller path or grant UI/gameplay/diagnostic access to raw data. Gaze dwell,
+pinch, contact or voice never constitutes approval for destructive, purchase, privacy or
+editor operations.
+
+Stable typed failures include source unavailable, tracking invalid, permission/consent
+required or revoked, stale assignment/origin/layout/target, query capacity exceeded,
+occluded/ineligible target, Input consumed/blocked, focus/capture conflict, movement mode
+unavailable, teleport invalid/unauthorized, Character obstruction, comfort limitation and
+cancelled/shutdown. Failure retains no raw continuous pose/gaze/joint history in ordinary
+logs or metrics.
+
+Non-XR products use the same Runtime UI, Input, Character and Accessibility semantics
+without XR adapters. Headless/server products omit local XR/UI/camera presentation;
+servers validate received gameplay intentions and never trust client tracking or hits as
+authority.
+
+### 12. Migration and contract coverage are required
+
+There is no production XR interaction implementation to preserve. Initial work must add
+narrow host adapters and typed snapshots/intents. It must not make XR devices into UI
+owners, add camera-driven Character transforms, bypass Input contexts, fork a second
+world-space widget system or gate accessibility settings on renderer tier.
+
+Required automated coverage includes:
+
+- owner/dependency tests across XR, Input, Runtime UI, Renderer, Character, Camera and
+  Accessibility with no native handles or mutable cross-owner pointers;
+- ray/direct/proximity validity, coordinate/origin conversion, bounded query ordering,
+  stale generation and capacity behavior;
+- last-presented UI hit testing, focus/capture/consumption, modal/route arbitration,
+  source-mode change and every loss/cancellation path;
+- world-space canvas N-view projection/occlusion correlation without semantic feedback
+  or same-frame GPU readback;
+- gameplay intent revalidation, fixed-tick/network authority and proof that candidates/
+  gestures cannot mutate Scene/Physics directly;
+- continuous/snap/teleport intent through Character collision/root authority, including
+  room-scale reconciliation and failed recenter/teleport separation;
+- Character root + tracking-origin + head-pose Camera composition with presentation-late
+  pose unable to alter simulation;
+- baseline comfort setting availability across renderer/device/product tiers, explicit
+  authored limitations and no silent movement fallback;
+- hand/gaze purpose isolation and approval/privacy protections; and
+- replacement/shutdown with no pointer, capture, haptic, intent, query, render or
+  snapshot lease surviving its owner.
+
+Deterministic XR/Input/UI/Physics/Character fakes validate order and faults. Physical
+device evidence remains required for ergonomics, tracking, occlusion, motion comfort and
+accessibility qualification.
+
+## Consequences
+
+### Positive
+
+- XR evidence reaches UI and gameplay through one typed, reviewable intent chain.
+- Runtime UI retains authoritative focus/capture and Character retains collision-root
+  movement.
+- Camera/recenter/room-scale behavior cannot silently mutate authoritative transforms.
+- World-space UI reuses existing semantic/accessibility ownership across N views.
+- Baseline comfort settings stay independent of graphics/device tier.
+
+### Negative
+
+- Interaction requires explicit adapters, query snapshots and generation correlation
+  instead of direct callbacks.
+- Visible-only world-space interaction may use delayed occlusion evidence rather than
+  immediate GPU truth.
+- Locomotion and recenter require separate Character and calibration transactions.
+- Products must document authored comfort alternatives and limitations per profile.
+
+## Rejected Alternatives
+
+### Let XR set Runtime UI focus or invoke widgets
+
+Rejected because XR supplies physical evidence while Runtime UI owns the presented hit-
+test tree, focus, capture, semantic actions and command boundary.
+
+### Let Physics hits trigger gameplay directly
+
+Rejected because collision evidence does not own action consumption, gameplay meaning,
+authority, cooldowns or target-state validation.
+
+### Move the Character by writing the camera or tracking-space transform
+
+Rejected because visual/tracking transforms do not perform collision, support, network
+authority or fixed-tick movement and would split collision-root truth.
+
+### Create a separate XR widget system
+
+Rejected because it would duplicate Runtime UI documents, layout, focus, localization,
+accessibility, lifecycle and rendering semantics.
+
+### Gate comfort controls on high-end rendering or headset tiers
+
+Rejected because comfort/accessibility semantics must remain available independently of
+quality tier. Unsupported authored alternatives are explicit product limitations.
+
+### Treat teleport or recenter as the same operation
+
+Rejected because teleport changes an authoritative collision root, while recenter changes
+tracking calibration. They have different owners, validation and rollback.
+
+### Preserve capture or the last hit through tracking loss
+
+Rejected because stale rays/targets can invoke the wrong control or gameplay object.
+Loss neutralizes and requires a complete new generation.

--- a/docs/architecture/runtime/accessibility-architecture.md
+++ b/docs/architecture/runtime/accessibility-architecture.md
@@ -31,6 +31,14 @@ colorblind viewport simulation, screen reader logging, control scheme validation
    quality. Native integration reports actual platform capability. Accessibility
    work cannot introduce unbounded waits into core loops or reverse dependencies.
 
+[ADR-161](../../adr/161-xr-interaction-runtime-ui-locomotion-and-accessibility-ownership.md)
+extends this non-gating rule to XR comfort. When an experience provides artificial
+movement or rotation, its declared disable/snap-turn, speed/handedness, seated/standing/
+recenter, motion-reduction and teleport/continuous-mode controls remain semantically
+available across renderer/device quality tiers. Configuration owns preferences;
+Gameplay, Character, Camera/Renderer and Runtime UI apply them only at their own
+boundaries. Missing authored alternatives are explicit limitations, not silent fallbacks.
+
 ## Runtime UI Semantic And Capability Boundary
 
 [ADR-082](../../adr/082-runtime-ui-accessibility-capability-and-ownership.md)

--- a/docs/architecture/runtime/character-controller-architecture.md
+++ b/docs/architecture/runtime/character-controller-architecture.md
@@ -148,6 +148,13 @@ is the committed projection; arbitrary systems do not write it. Gameplay owns
 desired heading, Animation owns root-motion rotation/visual pose and Physics owns
 platform motion evidence under ADR-089.
 
+[ADR-161](../../adr/161-xr-interaction-runtime-ui-locomotion-and-accessibility-ownership.md)
+applies this authority to XR. Gameplay converts routed XR actions and tracking-space
+evidence into tick-assigned movement, turn or teleport intents. Character validates
+collision/clearance and owns the committed root; Camera motion, room-scale head motion,
+recenter and raw XR poses cannot write it. An optional body-follow policy produces a
+future Character intent rather than a render-frame Transform update.
+
 ## Update Order
 
 ```text

--- a/docs/architecture/runtime/game-ui-and-hud.md
+++ b/docs/architecture/runtime/game-ui-and-hud.md
@@ -9,6 +9,12 @@ serialization, templates, editor authoring, and package boundaries.
 Game UI is runtime game content. It is not the same system as HoroEditor panels,
 tabs, modals, inspectors, or the editor design-system widgets.
 
+[ADR-161](../../adr/161-xr-interaction-runtime-ui-locomotion-and-accessibility-ownership.md)
+keeps XR world-space interaction inside this same Runtime UI authority. XR adapters
+supply generation-scoped ray/direct/proximity evidence, but Runtime UI owns presented
+hit testing, focus, capture, semantic action and command production. Renderer owns
+per-view projection/occlusion/pixels, and neither can create a second XR widget tree.
+
 [ADR-073](../../adr/073-runtime-ui-ownership-scope-and-update-order.md) is the
 single normative owner of RuntimeUiService, game/player/scene/viewport scopes,
 instance lifecycle, frame update order, pause/suspension, input/presentation
@@ -337,6 +343,12 @@ contexts even when no UI element handles an action; only a finite host-owned saf
 passthrough list may bypass them. Assignment change neutralizes old held/captured
 input before a new player/context activates. Focus, restoration, capture and active
 device modality remain per context/audience rather than process global.
+
+An XR pointer is another generation-scoped Input source for the exact player/viewport
+context. It hit-tests the last successfully presented interaction snapshot. Switching
+ray/direct modes, tracking or session loss, assignment change, modal/route exclusion,
+presentation-revision loss and source destruction release capture and neutralize the
+source. A Physics/Renderer hit is evidence only; it cannot set focus or invoke a widget.
 
 ## Runtime Accessibility Semantics
 

--- a/docs/architecture/runtime/input-architecture.md
+++ b/docs/architecture/runtime/input-architecture.md
@@ -478,6 +478,12 @@ XROpenXR owns native apply/stop. Accepted, submitted and physically completed ar
 distinct states. Device/profile/session changes, timeout and shutdown cancel old work;
 no timer or callback outlives its owner generation.
 
+[ADR-161](../../adr/161-xr-interaction-runtime-ui-locomotion-and-accessibility-ownership.md)
+keeps an XR ray, direct point, proximity volume, Physics hit or gesture as evidence until
+normal Input routing admits the associated semantic action. Runtime UI owns UI focus and
+capture; gameplay owns use/grab/locomotion meaning; Character owns movement. The XR
+adapter cannot choose a player, bypass the consumption ledger or mutate either target.
+
 ## Data Bus Relationship
 
 High-frequency input does not travel through `EngineDataBus` or

--- a/docs/architecture/runtime/vr-ar-architecture.md
+++ b/docs/architecture/runtime/vr-ar-architecture.md
@@ -39,6 +39,11 @@ specializes runtime-driven N-view admission, swapchain/external-resource leases,
 and layer submission, auxiliary targets and XR render-quality plans. XROpenXR owns native
 frame/compositor calls; Renderer owns Horo graph/GPU work and completion evidence.
 
+[ADR-161](../../adr/161-xr-interaction-runtime-ui-locomotion-and-accessibility-ownership.md)
+specializes the XR evidence-to-intent boundary across Input, Runtime UI, gameplay,
+Character, Camera and Accessibility. XR never owns UI focus or authoritative movement,
+and baseline comfort semantics are independent of renderer/device tier.
+
 ## Ownership
 
 ```text
@@ -416,6 +421,29 @@ snapshots. Architecture does not prescribe a universal 90 Hz minimum. Each
 qualified tuple records its supported modes and measured comfort/performance
 evidence.
 
+XR interaction sources publish bounded generation-scoped ray/direct/proximity evidence.
+Host adapters may combine it with read-only Physics/Scene queries, but a hit remains a
+candidate. Runtime UI alone resolves its last-presented hit tree, hover, focus, capture
+and semantic action; gameplay alone validates use/grab intent; Character alone commits
+collision-root movement. Source or target loss neutralizes capture/intents rather than
+reusing the last ray/hit.
+
+World-space canvases remain ordinary Runtime UI owner scopes with the same layout,
+localization, semantic accessibility and action-command model. Renderer owns per-view
+projection/depth/occlusion/pixels. A native composition layer does not become a second UI
+tree or bypass UI focus.
+
+Locomotion produces tick-assigned gameplay intent. Continuous/snap movement and teleport
+reach Character through typed commands; moving the camera or recentering tracking space
+is not a collision-safe teleport. Camera/view composition combines committed Character
+root, calibration and tracked head pose without acquiring movement authority.
+
+When artificial locomotion/rotation exists, disable controls where gameplay permits,
+snap-turn configuration, speed/handedness, seated/standing/recenter behavior, motion-
+reduction controls and declared teleport/continuous availability remain visible across
+renderer/device tiers. Missing authored alternatives are explicit limitations, never
+silent fallbacks.
+
 ## Mixed Reality And Privacy
 
 Passthrough, anchors, plane/mesh understanding, hit testing, and light estimation
@@ -543,6 +571,7 @@ device release gate.
 - [OpenXR Loader, Backend Packaging and Host Composition](../../adr/158-openxr-loader-backend-packaging-and-host-composition.md)
 - [XR Action, Tracking and Input-Projection Ownership](../../adr/159-xr-action-tracking-and-input-projection-ownership.md)
 - [XR Rendering, OpenXR Compositor and Renderer Ownership](../../adr/160-xr-rendering-openxr-compositor-and-renderer-ownership.md)
+- [XR Interaction, Runtime UI, Locomotion and Accessibility Ownership](../../adr/161-xr-interaction-runtime-ui-locomotion-and-accessibility-ownership.md)
 - [XR Setup UI Reference](./xr-setup.html)
 - [Rendering Architecture](./rendering-architecture.md)
 - [Render Backend Parity Contract](./render-backend-parity-contract.md)


### PR DESCRIPTION
## Summary

- Add ADR-161 to define the evidence-to-intent-to-authority chain across XR, Input, Runtime UI, Physics, gameplay, Character, Camera and Accessibility.
- Keep world-space UI inside the existing Runtime UI layout/focus/capture/accessibility model while Renderer owns per-view projection and occlusion.
- Route locomotion and teleport through tick-assigned gameplay intents and Character collision-root authority; keep recenter and Camera composition separate.
- Define a non-gating XR comfort baseline whose semantic controls remain available across renderer/device quality tiers.
- Align XR, Runtime UI, Input, Character and Accessibility architecture documents.

## Why

The XR foundation states broad ownership but does not yet define where a tracked ray becomes a hit, where a candidate becomes UI focus, who validates a gameplay interaction, or how room-scale/recenter/camera motion relates to Character movement. Without this decision, callbacks or hits could mutate UI/gameplay directly, XR could fork a second widget system, and comfort features could become high-tier renderer options. This PR fixes those boundaries before XRA-005 implementation begins.

## Decision and boundaries

- Treats ray/direct/proximity data and Physics/Renderer hits as bounded generation-scoped evidence, never as focus, capture, invocation or gameplay authority.
- Keeps last-presented hit testing, semantic focus, pointer capture and UI command production in `RuntimeUiService`.
- Keeps use/grab/teleport validation in gameplay and collision-root displacement in Character/Physics.
- Composes Camera views from the committed Character root, tracking-origin calibration and tracked pose without allowing Camera/recenter to move the capsule.
- Requires source/target/profile/layout/origin loss to neutralize captures, intents, actions and haptics before replacement.
- Keeps baseline movement-disable, snap-turn, speed/handedness, seated/standing/recenter, motion-reduction and declared locomotion-mode settings independent of graphics/device tier.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/161-xr-interaction-runtime-ui-locomotion-and-accessibility-ownership.md docs/architecture/runtime/vr-ar-architecture.md docs/architecture/runtime/game-ui-and-hud.md docs/architecture/runtime/input-architecture.md docs/architecture/runtime/character-controller-architecture.md docs/architecture/runtime/accessibility-architecture.md`
- `git diff --check`
- `git diff --cached --check`
- Added-Markdown-link resolution check against the staged diff
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. It emitted the existing mbedTLS minimum-version deprecation warning. Repository Python tests were skipped because `pytest` is unavailable in the current environment.

## Risk and rollout

- This is an architecture-only change; concrete ray/direct adapters, occlusion evidence and locomotion commands remain dependent XRA-005 work.
- Visible-only world-space interaction may require delayed occlusion evidence instead of same-frame GPU readback.
- Products must explicitly document authored comfort alternatives and limitations instead of relying on implicit fallback.

## Issue links

- Closes #2148
- Jira: [HORO-2102](https://horo-engine.atlassian.net/browse/HORO-2102)
- Parent capability: [XRA-005 / #2147](https://github.com/abdullahbodur/horo-engine/issues/2147)
- Prerequisite: [XRA-001.1 / #2109](https://github.com/abdullahbodur/horo-engine/issues/2109)
- Blocks: [XRA-005.2 / Jira HORO-2103](https://horo-engine.atlassian.net/browse/HORO-2103)
- Blocks: [XRA-005.3 / Jira HORO-2104](https://horo-engine.atlassian.net/browse/HORO-2104)
- Blocks: [XRA-005.5 / Jira HORO-2106](https://horo-engine.atlassian.net/browse/HORO-2106)

## Reviewer Notes

Please review the authority chain first: adapters publish evidence, Input routes actions, Runtime UI owns focus/capture, gameplay owns meaning, and Character owns committed movement. Then verify that recenter versus teleport and Camera versus Character are unambiguous. Finally, check that the comfort baseline is non-gating across technical quality tiers while still allowing authored gameplay limitations to be reported explicitly.

## Stack

- Base PR: #2495 — `docs/HORO-2092_xr_rendering_compositor_renderer_ownership`
- This PR: `docs/HORO-2102_xr_interaction_ui_locomotion_accessibility_ownership`
- Merge order: #2495, then this PR


[HORO-2102]: https://horo-engine.atlassian.net/browse/HORO-2102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ