### PR TITLE
docs(vtx): define ownership and capability tiers HORO-2130 #2176 [VTX-001.1]

### DIFF
--- a/docs/adr/164-virtual-texturing-ownership-product-scope-and-capability-tier.md
+++ b/docs/adr/164-virtual-texturing-ownership-product-scope-and-capability-tier.md
@@ -1,0 +1,317 @@
+# ADR-164: Virtual Texturing Ownership, Product Scope and Capability Tier
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Virtual Texturing public/runtime ownership, Assets/Materials/World Streaming/Renderer/producer boundaries, typed composition, capability tiers, product scope, lifecycle, unsupported paths and migration
+- **Issue**: [VTX-001.1](https://github.com/abdullahbodur/horo-engine/issues/2176)
+- **Jira**: [HORO-2130](https://horo-engine.atlassian.net/browse/HORO-2130)
+- **Parent**: [VTX-001](https://github.com/abdullahbodur/horo-engine/issues/2175)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-010](010-job-waiting-and-operation-store-ownership.md), [ADR-012](012-world-streaming-partition-authority-and-subsystem-boundaries.md), [ADR-027](027-renderer-resource-identity-and-descriptors.md), [ADR-028](028-renderer-capability-limits-and-product-profiles.md), [ADR-034](034-gpu-memory-and-residency-ownership.md), [ADR-054](054-extension-and-package-authority-boundary.md), [ADR-137](137-terrain-foliage-ownership-data-tier-and-lifecycle.md)
+- **Normative documents**: [Virtual Texturing Architecture](../architecture/runtime/virtual-texturing-architecture.md), [System Design](../architecture/foundation/system-design.md), [Asset Pipeline](../architecture/runtime/asset-pipeline.md), [Material and Shader Model](../architecture/runtime/material-and-shader-model.md), [World Streaming Architecture](../architecture/runtime/world-streaming-architecture.md), [Rendering Architecture](../architecture/runtime/rendering-architecture.md)
+
+## Context
+
+The current Virtual Texturing architecture combines a logical virtual-texture model,
+CPU residency records, renderer resources, file-system cache layout, asynchronous work
+and backend-named feature rows in one document. That description is useful as an
+exploration, but it does not establish module ownership or an implementable contract.
+It permits several incompatible implementations: VTX could allocate native textures,
+Renderer could become logical page authority, Materials could retain residency state,
+World Streaming could be bypassed by a second global scheduler, and runtime code could
+construct build/cache paths and read loose files directly.
+
+Virtual texturing crosses existing authorities. Assets owns stable asset identity,
+cooked artifact publication and bounded byte access. Materials owns authored sampling
+intent. World Streaming owns cell demand and aggregate admission. ADR-034 Renderer
+owns GPU reservations, native resources and safe retirement. Producers such as Terrain
+own source-domain meaning. VTX must coordinate those authorities without duplicating
+their state or reversing dependency direction.
+
+Product scope is also ambiguous. ADR-034 assigns RND-010.9 the future delivery of
+capability-gated sparse backing and an admitted atlas path. A table keyed by `dx11`,
+`dx12_vulkan` and `high_end` currently implies product support, fixed limits and
+fallbacks that have not been implemented or qualified. Backend/API names are neither
+product profiles nor evidence of effective capability. Horo 1.0 therefore cannot make
+virtual texturing a required content path.
+
+This ADR fixes ownership, composition, capability and lifecycle policy. VTX-001.2 and
+later tickets will specify exact identities, descriptors, artifact schemas, request
+queues, feedback, renderer realization and qualification without changing the
+authorities below.
+
+## Decision
+
+### 1. VTX is an optional runtime vertical slice with a narrow public contract
+
+Horo introduces these logical targets when implementation begins:
+
+```text
+HoroEngine::VirtualTexturingApi
+HoroEngine::VirtualTexturingRuntime
+```
+
+`VirtualTexturingApi` owns backend-neutral fixed-schema values, strong identities and
+generations, immutable descriptors/snapshots, capability requirements and narrow
+command/query/result contracts. It depends only on Foundation and the narrow Horo
+asset/render value types required by its declarations. It exposes no filesystem paths,
+native GPU handles, backend enums, worker implementation, editor types or package
+layout.
+
+`VirtualTexturingRuntime` owns the live logical virtual-texture generations, page
+demand, request coalescing, feature-local page selection and eviction policy,
+residency intent, logical page-table revisions and bounded orchestration. It depends
+on the API plus host-composed ports. It does not select a backend, open files, create
+native GPU resources, own material definitions, admit world cells or create a process-
+global scheduler.
+
+Cook, renderer, material, world-streaming, producer and tooling integrations are
+separate adapters that depend toward their owning public contracts. They may be
+co-located initially, but co-location does not merge authority. Foundation and generic
+Assets/Renderer targets do not depend on the feature runtime.
+
+The application host is the composition root. It supplies validated asset/page-store,
+job, clock, renderer, budget, producer and observability capabilities before activation.
+Descriptors are inert metadata: construction and validation perform no I/O, job
+submission, service discovery, resource allocation or global registration.
+
+### 2. Every responsibility has one authority
+
+| Responsibility | Authority | Deliberate non-owner |
+|---|---|---|
+| Virtual-texture IDs, page coordinates/generations, logical request state, page choice and residency intent | VTX | Renderer, Materials and producers do not mutate logical residency |
+| Source asset identity, import settings, deterministic cook, immutable artifact publication and bounded byte leases | Assets/Pipeline plus the VTX cooker | VTX runtime does not discover files, build paths or recook content |
+| Authored virtual-sampling intent, semantic slots and required/fallback material variants | Materials | Materials do not own page state, physical slots or feedback |
+| Cell relevance, priority, aggregate CPU/GPU/staging reservation and cell activation/retirement barrier | World Streaming under ADR-012 | VTX does not run another world scheduler or evict a cell |
+| VTX feature-local scheduling, coalescing, cancellation and page eviction within admitted reservations | VTX runtime | World Streaming and Renderer do not select logical pages |
+| GPU allocation, physical cache/sparse resources, descriptors, uploads, mappings, graph passes and GPU-safe retirement | Renderer under ADR-027/034 | VTX never exposes or retains native resource/fence identity |
+| Source-domain tile meaning and immutable producer payloads | Producer such as Terrain | Producers do not allocate VTX GPU resources or control global residency |
+| Package membership, target variants and runtime mount policy | Packaging/Assets | VTX does not construct package/cache paths or scan loose files |
+| UI, diagnostics and capture projection | Presentation/Observability adapters | Tools do not become the logical or GPU state authority |
+
+An adapter acknowledgement is evidence owned by its producer, not permission to
+commit another owner's state. VTX publishes a page as usable only after the required
+asset byte lease, renderer mapping completion and matching VTX generation all succeed.
+Renderer completion cannot publish a stale logical generation. A material sample or
+feedback observation is demand evidence, not a residency command.
+
+### 3. Cross-owner communication is typed, immutable and generation checked
+
+The architecture admits contracts with these semantic roles; later tickets freeze
+their exact C++ layout and numeric bounds:
+
+```cpp
+struct VirtualTextureDescriptor;
+struct VirtualTextureGeneration;
+struct VirtualPageId;
+struct VirtualPageDemandBatch;
+struct VirtualPageReadRequest;
+struct VirtualPagePayloadLease;
+struct VirtualPageRealizationPlan;
+struct VirtualPageMappingCompletion;
+struct VirtualTextureResidencySnapshot;
+```
+
+Every asynchronous request carries virtual-texture identity, owner generation,
+operation identity, bounded cost and cancellation context. Every completion repeats
+the matching identity and reports a typed result. Immutable payload leases remain
+owned by Assets until the declared consumer completion; VTX records logical state but
+does not steal storage ownership. Renderer receives finite realization plans and
+returns backend-neutral mapping completions; it never receives permission to rewrite
+VTX priority policy.
+
+The steady-state flow is:
+
+```text
+material/producer/world demand snapshots
+  -> VTX bounded demand merge and page plan
+  -> Assets bounded page-byte request and immutable lease
+  -> Renderer admitted upload/map operation
+  -> generation-checked renderer completion
+  -> VTX committed residency snapshot
+  -> renderer/material binding projection
+```
+
+No step publishes a partially active generation. Cache/package keys include every
+semantic cook input and target capability variant; paths and native resource names are
+adapter-private implementation details rather than identity.
+
+### 4. Capability tiers describe VTX behavior, not hardware rank or milestones
+
+VTX has a closed, feature-local capability tier:
+
+| Tier | Product behavior | Required contract |
+|---|---|---|
+| `Unavailable` | VTX assets are rejected; ordinary non-VTX material/content variants remain usable | No VTX runtime or renderer capability is required |
+| `Atlas` | VTX uses an explicitly budgeted physical atlas and logical page table | Admitted atlas/page-table formats, bounded feedback/readback or producer demand, upload/mapping and shader variant |
+| `Sparse` | VTX may use qualified native sparse/tiled residency | All `Atlas` semantic guarantees plus effective sparse binding, granularity, queue/synchronization and retirement support |
+
+`Sparse` is an implementation capability, not a higher-quality promise. Content
+declares `Required`, `OptionalWithFallback` or `Disabled` VTX policy separately from
+the tier. `Required` fails activation when its exact format/geometry/operation/budget
+requirements are unavailable. `OptionalWithFallback` selects a cooked non-VTX or
+other explicitly named variant during admission. It never silently switches after
+partial activation or substitutes an uncooked lower-quality asset.
+
+Effective support is the intersection of compiled implementation, selected renderer
+backend/device support, exact format/limit/operation support, admitted memory and
+transfer budgets, shader/material variants, artifact availability and product policy.
+An API family, device name, product-profile rank or extension bit alone cannot select a
+tier. Sparse-to-atlas fallback is allowed only when the atlas path and its peak cost
+were independently admitted.
+
+Capability tiers are independent of roadmap milestones. They describe supported VTX
+behavior; the Product Roadmap Model and issue metadata describe delivery timing.
+
+### 5. Virtual texturing remains Post-1.0 and optional
+
+Horo 1.0 does not require `VirtualTexturingApi`, `VirtualTexturingRuntime`, a VTX
+cooker, sparse resources or atlas realization. The 1.0 baseline must render supported
+projects through ordinary texture/material variants and must reject packages that mark
+VTX-only content as required. Headless and dedicated-server compositions use
+`Unavailable` unless a non-rendering producer/validation tool explicitly composes the
+narrow API; they never initialize GPU residency as a side effect.
+
+Post-1.0 may ship `Atlas`, `Sparse` or both after their respective implementation and
+qualification gates pass. RND-010.9 remains the prerequisite for capability-gated
+sparse backing and the admitted atlas path; this ADR does not claim that work is
+implemented. VTX tickets may develop contracts and deterministic Null/test adapters
+before product enablement, but no host advertises a runtime tier without complete
+composition and qualification.
+
+### 6. Lifecycle, threading and cancellation are explicit
+
+The host validates an immutable VTX composition plan before activating a world or
+material that requires it. Activation order is:
+
+1. validate descriptors, artifact variants, material variants and effective tier;
+2. reserve bounded CPU, I/O, transfer, GPU, request and completion capacity;
+3. create the VTX logical generation and renderer resources without publication;
+4. start bounded demand processing and publish readiness only after all required
+   owners acknowledge the same generation.
+
+VTX scheduling uses the injected ADR-010 job/executor contract. Workers prepare and
+decode immutable payloads, but only VTX owner safe points commit logical state and only
+Renderer safe points mutate GPU resources. Callbacks enqueue bounded completions; they
+do not publish inline, block the frame thread or retain borrowed state beyond its lease.
+
+Cancellation invalidates the operation/generation first, stops new admission and lets
+already-submitted owner work reach a terminal completion. Stale completions release
+their leases and reservations without publication. Replacement reserves old/new peak
+overlap and publishes atomically; failure preserves the last valid generation when
+policy permits. Shutdown drains cancellation and CPU ownership, then requests renderer
+retirement. Physical slots/resources are not reused until every relevant GPU queue and
+dependent lease proves retirement.
+
+Cleanup capacity is reserved before producer work. Queue pressure cannot prevent
+cancellation, lease release, renderer retirement or terminal result delivery. VTX may
+evict disposable pages within its allowance, but cannot refund renderer heap capacity,
+expand a World Streaming reservation or evict activation-critical world content on its
+own.
+
+### 7. Failures and unsupported paths are observable and fail closed
+
+Public results distinguish at least unsupported composition/tier, missing artifact or
+fallback, invalid descriptor, stale generation, cancellation, bounded queue/capacity,
+asset I/O/integrity, decode, renderer admission, upload/map, device loss and retirement
+stall. Later contracts assign stable typed codes and bounded diagnostic context.
+
+The following paths are unsupported:
+
+- direct filesystem access or runtime construction of build/cache paths;
+- a VTX-owned process-global worker pool, scheduler, renderer or memory ledger;
+- backend/API names or native handles in public descriptors and persisted assets;
+- treating sparse support as implicit permission to allocate or map;
+- runtime cooking, loose-file discovery or material shader generation on a page miss;
+- silent required-to-optional, sparse-to-atlas or VTX-to-ordinary-texture fallback;
+- frame-index-only slot reuse, blocking GPU waits in normal frames or unbounded queues;
+- UI/debug commands mutating VTX/renderer state without an application operation.
+
+Diagnostics expose bounded Horo identities, generations, counts, costs and typed
+states. Asset paths, source content, native handles and raw page bytes follow their
+own privacy and trust policy and are not included by default.
+
+### 8. Migration replaces speculative policy instead of preserving two models
+
+The Virtual Texturing Architecture becomes the narrative entry point and links to this
+ADR for policy. Its illustrative monolithic structs, direct disk-cache tree,
+backend-named tier table and hard-coded maximums are removed. They are not compatibility
+contracts.
+
+Downstream work proceeds in this order of responsibility, while native issue links own
+the actual execution dependencies:
+
+| Delivery area | Must preserve from this ADR |
+|---|---|
+| VTX-001 identities/descriptors | Strong generation-scoped identity, finite validation and no native/path types |
+| VTX-002 artifacts/page store | Assets-owned immutable artifacts, page byte leases, target variants and no direct filesystem access |
+| VTX-003 residency | Feature-local policy within ADR-034 and World Streaming reservations; bounded injected scheduling |
+| VTX-004 feedback/prediction | Observations are demand evidence; finite readback and camera snapshots do not transfer authority |
+| VTX-005 renderer/material | Renderer owns physical resources and safe mapping; Materials owns semantic sampling intent |
+| VTX-006 producers/packaging | Typed immutable producer payloads; Packaging/Assets own paths, mounts and server variants |
+| VTX-007 tooling/qualification | Read-only snapshots by default, explicit application commands and per-tier evidence |
+
+No persisted format changes in this ADR. When exact schemas arrive, caches/artifacts
+without the new schema/capability key are invalidated and recooked atomically. Runtime
+must not guess old page geometry or reinterpret prototype `index.json` layouts.
+
+## Consequences
+
+Positive consequences:
+
+- Logical page policy, GPU ownership, asset bytes, material semantics and world
+  admission each have one authority.
+- The feature can be omitted from 1.0, headless and unsupported products without
+  contaminating generic renderer or asset contracts.
+- Atlas and sparse paths share semantics while retaining independent admission and
+  qualification.
+- Later VTX tickets have explicit typed seams, lifecycle rules and unsupported paths.
+
+Costs and trade-offs:
+
+- Host composition and generation-checked adapters add more contracts than a
+  singleton streamer that directly owns files and GPU resources.
+- Optional fallback requires separately cooked/material-qualified variants and peak
+  budget admission.
+- Sparse capability cannot be advertised early from extension discovery alone;
+  platform/backend qualification and RND-010.9 must finish first.
+- Atomic replacement may temporarily retain two generations and therefore requires
+  explicit overlap budgets.
+
+## Rejected Alternatives
+
+### Make Renderer own the complete VTX feature
+
+Rejected because Renderer owns GPU realization, not asset/page meaning, producer
+demand, material policy or logical residency. This would pull domain policy into every
+backend and make headless validation depend on rendering.
+
+### Make Assets own runtime residency and scheduling
+
+Rejected because Assets owns artifacts and byte leases, not camera/world demand, GPU
+mapping or frame-safe publication. A generic asset cache cannot become a hidden world
+and GPU residency authority.
+
+### Let World Streaming schedule every VTX page
+
+Rejected because World Streaming admits cells and aggregate budgets; VTX page demand
+is finer-grained and feature-specific. VTX consumes a bounded reservation and reports
+readiness without creating a second cell state machine.
+
+### Select support by backend name or product-profile rank
+
+Rejected because API names do not prove formats, limits, synchronization, memory,
+artifact or shader support. Effective capability and product content policy are
+orthogonal inputs.
+
+### Require virtual texturing for Horo 1.0
+
+Rejected because the sparse/atlas residency foundation assigned to RND-010.9 is not
+implemented or qualified. Ordinary texture variants keep 1.0 coherent; VTX remains a
+post-1.0 opt-in capability.
+
+### Keep direct cache paths and a VTX-global scheduler as temporary compatibility
+
+Rejected because both create competing sources of truth that later migrations would
+have to preserve. Adapters over Assets and the injected job contract provide an
+incremental implementation seam without normalizing ambient state.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -169,6 +169,13 @@ to the replacement.
 | [155](155-pcg-graph-document-preview-bake-and-undo-ownership.md) | PCG Graph Document, Preview, Bake and Undo Ownership | Proposed | 2026-09-02 |
 | [156](156-pcg-scale-budgets-trust-and-release-scope.md) | PCG Scale Budgets, Trust and Release Scope | Proposed | 2026-09-02 |
 | [157](157-xr-ownership-runtime-composition-and-capability-tier.md) | XR Ownership, Runtime Composition and Capability Tier | Proposed | 2026-09-02 |
+| [158](158-openxr-loader-backend-packaging-and-host-composition.md) | OpenXR Loader, Backend Packaging and Host Composition | Proposed | 2026-09-02 |
+| [159](159-xr-action-tracking-and-input-projection-ownership.md) | XR Action, Tracking and Input-Projection Ownership | Proposed | 2026-09-02 |
+| [160](160-xr-rendering-openxr-compositor-and-renderer-ownership.md) | XR Rendering, OpenXR Compositor and Renderer Ownership | Proposed | 2026-09-02 |
+| [161](161-xr-interaction-runtime-ui-locomotion-and-accessibility-ownership.md) | XR Interaction, Runtime UI, Locomotion and Accessibility Ownership | Proposed | 2026-09-02 |
+| [162](162-mixed-reality-ownership-privacy-and-capability-tier.md) | Mixed-Reality Ownership, Privacy and Capability Tier | Proposed | 2026-09-02 |
+| [163](163-xr-tooling-diagnostics-privacy-and-qualification-ownership.md) | XR Tooling, Diagnostics, Privacy and Qualification Ownership | Proposed | 2026-09-02 |
+| [164](164-virtual-texturing-ownership-product-scope-and-capability-tier.md) | Virtual Texturing Ownership, Product Scope and Capability Tier | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -431,8 +431,11 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Decal System Architecture](./runtime/decal-system-architecture.md): deferred
   decals, forward fallbacks, material domain, pooling, ownership, and lifetime.
 - [Virtual Texturing Architecture](./runtime/virtual-texturing-architecture.md):
-  page tables, feedback, streaming, asset-provider cache, and backend-neutral
-  resources.
+  logical page demand/residency, typed asset and renderer integration, capability
+  tiers, lifecycle and Post-1.0 scope.
+- [Virtual Texturing Ownership, Product Scope and Capability Tier](../adr/164-virtual-texturing-ownership-product-scope-and-capability-tier.md):
+  VTX/Assets/Materials/World Streaming/Renderer/producer ownership, typed composition,
+  Atlas/Sparse admission and unsupported-path policy.
 - [Destruction And Fracture Architecture](./runtime/destruction-and-fracture-architecture.md):
   fracture assets, chunk physics, debris, authority, and network reconstruction.
 - [Destruction Ownership, Authority, State and Runtime Geometry Boundary](../adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md):

--- a/docs/architecture/runtime/advanced-rendering-architecture.md
+++ b/docs/architecture/runtime/advanced-rendering-architecture.md
@@ -482,6 +482,11 @@ Virtual texturing allows scenes to use more texture data than GPU memory.
 
 Virtual texturing is optional and admitted through its effective feature/format
 requirements and product residency budgets, not through a profile rank.
+Logical page policy and physical realization remain separate under
+[ADR-164](../../adr/164-virtual-texturing-ownership-product-scope-and-capability-tier.md).
+The feature is Post-1.0; an API/backend name or sparse-resource bit does not advertise
+support without complete artifact, material, budget, synchronization and qualification
+evidence.
 
 ## Occlusion Culling
 

--- a/docs/architecture/runtime/asset-pipeline.md
+++ b/docs/architecture/runtime/asset-pipeline.md
@@ -9,6 +9,12 @@ release.
 The pipeline is host-agnostic. The same importers, cookers, and packagers are
 used by the GUI, CLI, and MCP.
 
+Virtual-texture sources follow this same authority under
+[ADR-164](../../adr/164-virtual-texturing-ownership-product-scope-and-capability-tier.md):
+the pipeline publishes immutable target/capability-keyed artifacts and bounded byte
+leases. The VTX runtime neither constructs cache/package paths nor discovers loose
+files, and the asset pipeline does not own runtime page demand or GPU residency.
+
 ## Asset Lifecycle
 
 ```text

--- a/docs/architecture/runtime/material-and-shader-model.md
+++ b/docs/architecture/runtime/material-and-shader-model.md
@@ -56,6 +56,11 @@ Not covered:
   ownership and compatibility keys.
 - No gameplay code queries raw shader handles. Gameplay sees only material names,
   parameter overrides, and feature flags.
+- Virtual-texture integration follows
+  [ADR-164](../../adr/164-virtual-texturing-ownership-product-scope-and-capability-tier.md):
+  Materials owns semantic sampling intent and required/fallback variants, while VTX
+  owns logical page state and Renderer owns physical resources and bindings. Variant
+  selection is admitted before activation and never generated on a runtime page miss.
 
 ## Shader Graph Editor Surface
 

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -28,6 +28,10 @@ The equal first-class obligations of interactive backend modules are defined by
 - The active renderer backend is selected by configuration or command-line
   override at host startup. Runtime scene, editor, asset, gameplay, and MCP code
   do not branch on concrete backend types.
+- Virtual Texturing owns logical page demand, selection and residency intent under
+  [ADR-164](../../adr/164-virtual-texturing-ownership-product-scope-and-capability-tier.md).
+  Renderer owns admitted physical atlas/sparse resources, uploads, mappings, graph
+  passes and GPU-safe retirement; it does not become logical page authority.
 
 ## Layer Model
 

--- a/docs/architecture/runtime/virtual-texturing-architecture.md
+++ b/docs/architecture/runtime/virtual-texturing-architecture.md
@@ -1,180 +1,116 @@
 # Virtual Texturing Architecture
 
-## Purpose
+## Purpose And Decision Authority
 
-This document defines the virtual-texturing subsystem for Horo Engine. It
-covers sparse virtual texture pages, page table indirection, page residency
-management, feedback-based streaming, page cache compression, and integration
-with the material system and asset pipeline.
+Virtual texturing is an optional Post-1.0 runtime vertical slice that decouples
+logical texture address space from resident GPU backing. It coordinates cooked page
+artifacts, bounded demand, logical residency intent, renderer realization and material
+sampling without taking ownership from Assets, Materials, World Streaming, Renderer
+or source-domain producers.
 
-## Memory Ownership Boundary
+[ADR-164: Virtual Texturing Ownership, Product Scope and Capability Tier](../../adr/164-virtual-texturing-ownership-product-scope-and-capability-tier.md)
+is the normative ownership, composition, product-scope, capability and lifecycle
+decision. Exact identities, numeric bounds, artifact formats, queues, feedback policy
+and renderer contracts are assigned to the dependent VTX tickets. Illustrations in
+this document do not create a second contract.
 
-[ADR-034: GPU Memory and Residency Ownership](../../adr/034-gpu-memory-and-residency-ownership.md)
-owns GPU allocation, reservations and pressure policy. Virtual Texturing selects
-pages and disposable cache entries within its admitted allowance; the renderer
-owns native atlas/sparse backing and safe mapping execution. Page-table updates
-and slot reuse wait for previous GPU readers. Evicting a page from an allocated
-atlas frees a slot, not physical heap capacity from the budget.
+## Ownership Summary
 
-For streamed worlds, this allowance consumes World Streaming's aggregate
-reservation through the host-composed adapter. Missing pages may use an explicitly
-admitted feature fallback, but cannot silently invalidate activation-critical cell
-content. Neither page selection nor renderer pressure independently evicts cells.
-Sparse resources require effective backend support; an atlas fallback has a
-separate cost plan that must fit. Page counts below are recipe sizing inputs,
-not extra memory allowances or proof of backend capability. Include atlas backing,
-page tables, feedback, upload and readback copies in peak-cost admission.
+| Domain | Owns | Does not own |
+|---|---|---|
+| VTX API/runtime | Logical identities/generations, bounded demand merge, page choice, feature-local eviction and residency snapshots | Files, material definitions, world cells, native GPU resources or a global scheduler |
+| Assets/Pipeline | Source identity, deterministic cook, immutable artifact publication and bounded byte leases | Runtime demand, logical residency or GPU mapping |
+| Materials | Authored semantic slots, sampling intent and required/fallback variants | Page priority, physical slots or feedback state |
+| World Streaming | Cell relevance, aggregate admission and activation/retirement barriers | Per-page policy or a second VTX state machine |
+| Renderer | GPU reservations, physical atlas/sparse backing, uploads, mappings, graph passes and safe retirement | Logical page identity, demand policy or artifact discovery |
+| Producers | Source-domain meaning and immutable payload contribution | Global admission, package paths or GPU allocation |
+| Host/application | Composition, product policy and effective-tier admission | Feature/runtime state after ownership transfer |
 
-## Virtual Texture Model
+The host composes VTX through typed ports. VTX uses Assets for page bytes, the injected
+ADR-010 job contract for bounded preparation, ADR-034 reservations for GPU work and
+Renderer requests for realization. It never opens a project/build/cache path, queries a
+service locator, creates its own global worker pool or exposes a backend-native handle.
 
-Virtual texturing decouples logical texture resolution from physical GPU
-memory:
+## Data And Runtime Flow
 
-- A virtual texture appears as a single large texture to shaders (up to
-  128K×128K)
-- Physical GPU memory holds only the currently visible pages
-- An indirection table maps virtual page coordinates to physical page locations
-- Missing pages are streamed from disk asynchronously
-
-```cpp
-struct VirtualTexture {
-    VirtualTextureId   id;
-    uint32_t           virtualWidth;        // up to 131072
-    uint32_t           virtualHeight;
-    uint32_t           pageSize;            // typically 128×128 texels
-    PixelFormat        format;
-    uint32_t           mipLevels;
-    uint32_t           physicalPageCount;   // GPU memory budget in pages
-    VirtualTexturePageTable pageTable;
-};
-```
-
-## Page Table
-
-The page table is a GPU-resident texture that maps virtual to physical:
-
-```cpp
-struct VirtualTexturePageTable {
-    // GPU resource
-    TextureHandle      indirectionTexture;   // backend-neutral page-table texture
-    uint32_t           tableWidth;           // virtualWidth / pageSize / tileSize
-    uint32_t           tableHeight;
-
-    // CPU mirror for residency tracking
-    std::vector<PageTableEntry> cpuMirror;
-};
-
-struct PageTableEntry {
-    uint32_t   physicalPageIndex;   // or INVALID_PAGE if not resident
-    uint32_t   lastAccessFrame;
-    bool       isResident;
-    bool       isRequested;         // loading in progress
-};
-```
-
-The indirection texture is sampled in the material shader before the actual
-texture sample. The GPU computes the virtual page coordinate and looks up the
-physical page UV offset.
-
-## Feedback System
-
-Page residency is driven by GPU feedback:
-
-- A feedback pass writes which virtual pages were accessed during rendering
-- Feedback is read back to the CPU (typically 1-2 frames behind)
-- Pages with high access frequency are prioritized for loading
-- Unused pages are evicted under memory pressure
-
-```cpp
-struct VirtualTextureFeedback {
-    BufferHandle       feedbackBuffer;
-    uint32_t           feedbackWidth;       // viewport-aligned feedback resolution
-    uint32_t           feedbackHeight;
-    std::vector<VirtualPageCoord> requestedPages;  // CPU-side aggregated requests
-};
-```
-
-Feedback uses a compute shader that writes page IDs to an append buffer.
-The buffer is read back using async GPU-CPU transfer.
-
-## Page Streaming
-
-Page loading is asynchronous and priority-driven:
-
-```cpp
-struct VirtualPageStreamRequest {
-    VirtualTextureId   textureId;
-    VirtualPageCoord   pageCoord;        // virtual page (x, y, mip)
-    float              priority;         // derived from feedback frequency
-    CancellationToken  cancelToken;
-};
-```
-
-Streaming uses the asset pipeline's async I/O:
-
-1. Request is queued with priority
-2. Page data is read from the virtual texture page cache on disk
-3. Page is decompressed (BCn on GPU, or CPU decompress for lower tiers)
-4. Page is uploaded to the physical texture atlas
-5. Page table entry is updated on GPU
-6. CPU mirror is marked resident
-
-## Page Cache
-
-Virtual texture pages are cached on disk:
+Authored content is deterministically cooked into immutable target/capability-keyed
+artifacts. Runtime data moves through generation-checked typed requests:
 
 ```text
-<project>/build/<preset>/asset_cache/<target>/virtual_textures/
-├── <textureId>/
-│   ├── page_0_0_0.bin     # mip 0, page (0,0)
-│   ├── page_0_1_0.bin     # mip 0, page (1,0)
-│   ├── ...
-│   └── page_3_5_2.bin     # mip 2, page (5,3)
-└── index.json
+material/producer/world demand snapshots
+  -> VTX bounded demand merge and logical page plan
+  -> Assets page-byte lease
+  -> Renderer admitted upload and mapping
+  -> VTX generation-checked residency commit
+  -> immutable residency/binding projection
 ```
 
-The page cache is content-addressed by texture source hash, virtual
-coordinates, and import settings.
+Demand is evidence, not authority. Renderer completion becomes visible only when it
+matches the active VTX generation and all required leases/readiness records. Workers
+may prepare immutable data, but VTX owner safe points commit logical state and Renderer
+safe points mutate GPU state.
 
-## Material Integration
+Replacement admits old/new peak overlap and publishes atomically. Cancellation
+invalidates the operation/generation before late completions arrive. Stale work releases
+its asset leases and reservations without publication. Physical slots and resources are
+reused only after the relevant GPU work and dependent leases retire.
 
-Materials declare virtual texture usage:
+## Memory And World-Streaming Boundary
 
-```cpp
-struct MaterialVirtualTextureSlot {
-    std::string    slotName;         // e.g., "BaseColor", "Normal"
-    AssetId        virtualTextureId;
-    VirtualTextureSampler sampler;   // trilinear, anisotropic level
-};
-```
+[ADR-034: GPU Memory and Residency Ownership](../../adr/034-gpu-memory-and-residency-ownership.md)
+owns GPU allocation, reservations and pressure policy. VTX selects disposable pages
+within an admitted allowance; Renderer owns native atlas/sparse backing and safe mapping
+execution. Evicting a logical page from an allocated atlas frees a slot, not physical
+heap capacity.
 
-The material shader receives the virtual texture indirection table binding and
-performs the two-level sample:
+For streamed worlds, VTX consumes World Streaming's aggregate reservation through a
+host-composed adapter. Neither VTX page eviction nor Renderer pressure independently
+evicts a world cell. Activation-critical page failure participates in the cell barrier;
+optional content may use only a fallback variant admitted before activation.
 
-```hlsl
-float4 SampleVirtualTexture(VirtualTexture vt, float2 uv, float mip) {
-    float2 pageUV = vt.PageTable.Sample(uv, mip);   // indirection lookup
-    return vt.PhysicalAtlas.Sample(pageUV, mip);     // physical sample
-}
-```
+## Capability And Product Scope
 
-## Performance And Feature Tiers
+VTX uses feature-local tiers:
 
-| Feature              | `es3`      | `dx11`      | `dx12_vulkan` | `high_end`   |
-| -------------------- | ----------- | ----------- | -------------- | ------------ |
-| Virtual texturing    | No          | Yes         | Yes            | Yes          |
-| Max virtual size     | —           | 32K×32K     | 64K×64K        | 128K×128K    |
-| Page size            | —           | 128×128     | 128×128        | 128×128      |
-| GPU feedback         | —           | CPU readback| Append buffer  | Append buffer|
-| Async page upload    | —           | Staged      | Direct         | Direct       |
-| Physical page budget | —           | 4K pages    | 8K pages       | 16K pages    |
+| Tier | Meaning |
+|---|---|
+| `Unavailable` | VTX assets are rejected; supported ordinary texture/material variants remain available |
+| `Atlas` | An explicitly budgeted physical atlas and logical page-table path is implemented and admitted |
+| `Sparse` | Qualified native sparse/tiled backing satisfies the same VTX semantics |
+
+Content policy (`Required`, `OptionalWithFallback`, `Disabled`) is separate from the
+tier. Effective support is the intersection of compiled implementation, selected
+backend/device operations, formats and limits, budgets, shader/material variants,
+cooked artifacts and product policy. Backend names, profile ranks and extension bits do
+not prove support. Sparse-to-atlas fallback requires independent atlas admission.
+
+Horo 1.0 does not require VTX. VTX runtime delivery remains Post-1.0 and depends on the
+RND-010.9 sparse/atlas residency foundation. Headless and dedicated-server hosts do not
+initialize GPU residency; validation/cook tools may compose narrow non-rendering
+contracts explicitly.
+
+## Unsupported Shortcuts
+
+- direct runtime filesystem/cache-path access or loose-file discovery;
+- process-global VTX schedulers, renderer selection or memory ledgers;
+- backend/API names and native handles in public/persisted contracts;
+- runtime cooking or shader generation after a page miss;
+- silent capability, quality or content fallback;
+- unbounded work/queues, normal-frame blocking waits or frame-index-only reuse; and
+- debug UI state acting as runtime authority.
+
+Failures are typed and observable, including unsupported composition, missing artifacts
+or variants, invalid descriptors, capacity, stale generation, cancellation, I/O,
+decode, renderer admission, upload/mapping, device loss and stalled retirement.
 
 ## Related Documents
 
+- [ADR-164: Virtual Texturing Ownership, Product Scope and Capability Tier](../../adr/164-virtual-texturing-ownership-product-scope-and-capability-tier.md)
+- [ADR-034: GPU Memory and Residency Ownership](../../adr/034-gpu-memory-and-residency-ownership.md)
 - [Virtual Texturing Debug UI Reference](./virtual-texturing-debug.html)
-
-- [Rendering Architecture](./rendering-architecture.md): virtual texture bindings and passes
-- [Material And Shader Model](./material-and-shader-model.md): virtual texture material slots
-- [Asset Pipeline](./asset-pipeline.md): page cache and streaming I/O
-- [Terrain And Foliage Architecture](./terrain-and-foliage-architecture.md): terrain virtual texturing
-- [LOD And Culling Architecture](./lod-and-culling-architecture.md): mip-based LOD integration
+- [Rendering Architecture](./rendering-architecture.md): virtual texture realization and passes
+- [Material And Shader Model](./material-and-shader-model.md): semantic virtual-texture slots and variants
+- [Asset Pipeline](./asset-pipeline.md): cooked artifacts and bounded byte access
+- [World Streaming Architecture](./world-streaming-architecture.md): aggregate admission and cell barriers
+- [Terrain And Foliage Architecture](./terrain-and-foliage-architecture.md): typed producer integration
+- [LOD And Culling Architecture](./lod-and-culling-architecture.md): bounded demand inputs

--- a/docs/architecture/runtime/world-streaming-architecture.md
+++ b/docs/architecture/runtime/world-streaming-architecture.md
@@ -25,7 +25,13 @@ budget changes; the manager never maintains a competing residency cache.
 | Scene Runtime | Detached ECS candidates and transactional structural commit | Cell relevance, topology or load priority |
 | Asset Pipeline | Registry/catalog, cooked bytes, validation and bounded I/O | Camera/relevance policy or entity activation |
 | Feature providers | Domain-specific candidate resources, native affinity, readiness/retirement acknowledgement | Independent world-cell loads, residency decisions or budget expansion |
+| Virtual Texturing | Feature-local page demand, selection and eviction within an admitted reservation | Cell relevance, aggregate budgets, activation barriers or independent cell eviction |
 | Editor | Authoring document, independent paging/pins, offline bake and isolated preview | Destructive coupling to runtime cell eviction |
+
+Virtual Texturing participates through the feature-provider boundary defined by
+[ADR-164](../../adr/164-virtual-texturing-ownership-product-scope-and-capability-tier.md).
+Its page readiness may contribute to a cell barrier, but it cannot run a competing
+world scheduler or turn page pressure into an implicit cell transition.
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
## Summary

- Add ADR-164 as the authoritative Virtual Texturing ownership, product-scope and capability-tier decision.
- Define the future `VirtualTexturingApi` and `VirtualTexturingRuntime` boundaries without introducing implementation targets prematurely.
- Assign one owner for logical page state, cooked bytes, material intent, world admission, GPU realization, producer meaning, package paths and diagnostic projection.
- Replace the speculative monolithic VTX model, direct on-disk cache tree and backend-named support matrix with typed host-composed boundaries.
- Align the VTX, Renderer, Assets, Materials, World Streaming and Advanced Rendering architecture documents with the decision.
- Restore ADR index coverage for ADR-158 through ADR-164 so every ADR currently present in this stacked series is discoverable.

## Why

The existing Virtual Texturing document described page tables, CPU mirrors, direct disk-cache reads, asynchronous work and backend-specific support levels together, but did not say which module owned each state transition. An implementation following it could reasonably make VTX allocate native resources, let Renderer own logical residency, bypass Assets with cache paths or create a second global scheduler beside World Streaming.

The product promise was similarly unclear. API-family rows such as `dx11`, `dx12_vulkan` and `high_end` looked like supported product tiers even though RND-010.9 still owns the prerequisite sparse/atlas residency foundation. This change makes VTX explicitly optional and Post-1.0, while preserving ordinary texture/material variants as the 1.0 path.

## Decision and boundaries

- ADR-164 introduces a narrow backend-neutral VTX API/runtime vertical slice and keeps feature adapters pointed toward existing public contracts.
- The ownership table makes VTX authoritative for generation-scoped logical demand, page choice and residency intent; Renderer remains authoritative for GPU reservations, physical atlas/sparse resources, uploads, mappings and retirement.
- Assets/Pipeline retains source identity, deterministic cooking, immutable artifact publication and bounded byte leases. Runtime cache/package paths and loose-file discovery are explicitly unsupported.
- Materials owns semantic sampling intent and required/fallback variants. World Streaming owns cell relevance, aggregate budgets and cell barriers. Terrain and other producers contribute immutable domain payloads without gaining residency or GPU authority.
- Cross-owner work is expressed as bounded, immutable, generation-checked requests, leases, realization plans, completions and snapshots. Stale completions release ownership without publishing state.
- The closed VTX tier model is `Unavailable`, `Atlas` and `Sparse`. Content policy (`Required`, `OptionalWithFallback`, `Disabled`) is orthogonal, and every fallback requires a separately cooked and budget-admitted path.
- Activation, cancellation, replacement overlap, queue-cleanup capacity, shutdown and GPU-safe reuse are specified so dependent tickets do not have to invent lifecycle policy.
- The former illustrative structs, hard-coded size/page limits and prototype `index.json` layout are removed rather than retained as accidental compatibility contracts.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- <all changed Markdown files>`
- `git diff --check`
- `git diff --cached --check`
- Staged Markdown link checker: all added relative links resolve.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`
  - Configuration completed successfully.
  - Existing mbedTLS minimum-CMake deprecation warning remains.
  - Repository Python tests remain skipped because `pytest` is unavailable in this environment.

## Risk and rollout

- This is a documentation/architecture change and does not claim that an Atlas or Sparse runtime path is implemented or qualified.
- Exact public C++ layouts, numeric limits, artifact schemas, feedback policy and queue budgets remain intentionally delegated to downstream VTX tickets; this ADR fixes their ownership and invariants only.
- The product decision makes VTX unavailable as a required Horo 1.0 content path. Projects that eventually require VTX must provide a declared supported tier, while optional projects need an explicitly cooked fallback.
- ADR-158 through ADR-163 index rows are included because those ADR files already exist in the stacked base history but were not indexed; no decision content in those ADRs changes here.

## Issue links

- Closes #2176
- Jira: [HORO-2130](https://horo-engine.atlassian.net/browse/HORO-2130)
- Parent capability: #2175 / [HORO-2129](https://horo-engine.atlassian.net/browse/HORO-2129)
- Prerequisite authority: RND-010.9 / #366 for capability-gated sparse backing and the admitted atlas path

## Reviewer Notes

Please focus review on four policy boundaries:

1. whether the ownership table leaves any competing source of truth between VTX, Assets, Materials, World Streaming, Renderer and producers;
2. whether `Unavailable` / `Atlas` / `Sparse` plus independent content policy is sufficient for downstream admission contracts;
3. whether the explicit Post-1.0 scope accurately reflects the unimplemented RND-010.9 foundation; and
4. whether cancellation, stale completion, replacement overlap and GPU retirement rules close the lifetime hazards without prescribing downstream implementation details.

The intended invariant is that VTX can decide *which logical page it wants*, but only existing owners can supply bytes, admit world/product budgets or realize and retire GPU state.

## Stack

- Depends on #2498 (`docs/HORO-2121_xr_tooling_diagnostics_privacy_qualification_ownership`).
- Base branch: `docs/HORO-2121_xr_tooling_diagnostics_privacy_qualification_ownership`.
- Head branch: `docs/HORO-2130_virtual_texturing_ownership_product_scope_tiers`.
- This PR is one Jira issue / one commit / one stacked PR; the next ranked M0 issue will branch from this head.


[HORO-2130]: https://horo-engine.atlassian.net/browse/HORO-2130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ