### PR TITLE
docs(vtx): define artifact and page store ownership HORO-2139 #2185 [VTX-002.1]

### DIFF
--- a/docs/adr/165-virtual-texture-source-cooked-artifact-page-store-and-cache-ownership.md
+++ b/docs/adr/165-virtual-texture-source-cooked-artifact-page-store-and-cache-ownership.md
@@ -1,0 +1,355 @@
+# ADR-165: Virtual Texture Source, Cooked Artifact, Page Store and Cache Ownership
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Virtual-texture source/import ownership, deterministic cook identity, immutable generation manifests and page packs, page-store reads, cache classes, integrity, publication, replacement, packaging and migration
+- **Issue**: [VTX-002.1](https://github.com/abdullahbodur/horo-engine/issues/2185)
+- **Jira**: [HORO-2139](https://horo-engine.atlassian.net/browse/HORO-2139)
+- **Parent**: [VTX-002](https://github.com/abdullahbodur/horo-engine/issues/2184)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-010](010-job-waiting-and-operation-store-ownership.md), [ADR-027](027-renderer-resource-identity-and-descriptors.md), [ADR-034](034-gpu-memory-and-residency-ownership.md), [ADR-035](035-shader-source-and-intermediate-representation.md), [ADR-057](057-package-manifest-v1-typed-model.md), [ADR-138](138-terrain-source-cooked-tile-cache-and-streaming-ownership.md), [ADR-164](164-virtual-texturing-ownership-product-scope-and-capability-tier.md)
+- **Normative documents**: [Asset Pipeline](../architecture/runtime/asset-pipeline.md), [Virtual Texturing Architecture](../architecture/runtime/virtual-texturing-architecture.md)
+
+## Context
+
+ADR-164 assigns logical page identity and residency intent to VTX while Assets owns
+source identity, deterministic cook, immutable publication and byte leases. The
+remaining artifact boundary is not yet implementable. The old VTX description showed
+one mutable file per page beneath a runtime-constructed build/cache path plus an
+`index.json`. It did not distinguish source truth, derived cook cache, selected
+published generation, packaged page storage, provider caches, decoded VTX pages or GPU
+residency.
+
+One-file-per-page storage would couple logical page identity to filesystem layout,
+create very large directory/file counts, make aggregate publication non-atomic and
+invite runtime directory scanning. A single monolithic blob would solve file count but
+force large reads and make localized corruption/retry expensive. Neither approach by
+itself defines complete cook identity, exact-generation reads, integrity boundaries or
+lease lifetime.
+
+Virtual-texture artifacts must support independently requested logical pages without
+making each page a mutable asset. They must work identically from local cache, package,
+archive, memory/test and future remote transports. Cache hits and fresh cook output
+must pass the same validation, while corruption, cancellation or replacement must not
+alter the last valid published or active generation.
+
+This ADR defines those ownership and aggregation rules. VTX-002.2 through VTX-002.9
+will freeze source schemas, exact IDs, binary layouts, algorithms, queue bounds and
+tests without introducing a second store or publication authority.
+
+## Decision
+
+### 1. Assets owns storage and publication; VTX owns page semantics
+
+| Responsibility | Authority | Deliberate non-owner |
+|---|---|---|
+| Tracked source `AssetId`, source/sidecar byte snapshots, path trust and immutable input borrows | Assets/Application import operation | VTX import/cook does not retain paths or mutable source buffers |
+| External image/container decode and canonical VTX source/settings validation | VTX Import/Model contribution | Generic Assets does not interpret page, channel, color or wrap semantics |
+| Generic cooker registry, dependency scheduling, cache keys/store, operation staging and atomic generation publication | Assets Cook | VTX does not create a scheduler, cache root or current-generation pointer |
+| Page geometry, mip/tail derivation, border/addressing/color semantics, page ordering and VTX artifact schema | VTX Cook contribution | Assets does not choose page layout or reinterpret payloads |
+| Selected immutable generation, package membership and artifact byte/range leases | Assets provider/package system | VTX runtime does not select files, archives or transport |
+| Manifest semantic validation, bounded page requests, decoded neutral page cache and logical residency | VTX runtime | Assets provider does not choose pages or publish residency |
+| Physical atlas/sparse resources, uploads, mappings and GPU retirement | Renderer under ADR-027/034 | VTX artifact/cache identity is not a GPU resource identity |
+
+VTX contributions use host-owned importer/cooker catalogs, bounded borrowed input views
+and host-owned output writers. Registration is inert: it validates stable contribution,
+schema and dependency identities but performs no source scan, cook, cache access or
+global mutation. No generic Assets target depends on VTX implementation targets.
+
+### 2. External inputs and canonical authored source are distinct
+
+External images, UDIM sets, layer groups and future provider formats are untrusted
+import inputs. Import captures exact bytes and explicit options into a detached
+candidate, validates finite dimensions/layers/channels/mips, checked decoded sizes,
+color/alpha semantics and dependency closure, then publishes one canonical authored
+VTX source revision through Assets.
+
+Filenames, directory enumeration, locale, codec defaults and external timestamps do
+not determine page ordering or semantic settings. Multi-file inputs are sorted by
+canonical typed coordinate/role, and every member has a stable dependency identity and
+digest. Missing, duplicate, overlapping or changing members fail the candidate.
+
+The authored source remains mutable only through editor/application asset operations.
+Reimport compares expected revisions and cannot overwrite edits silently. It stores
+portable semantic source/settings and provenance, not runtime page packs, absolute
+paths, cache locations, provider handles or GPU state.
+
+### 3. One immutable generation manifest indexes bounded page-pack artifacts
+
+VTX Cook emits a root `CookedVirtualTextureManifest` plus a canonically ordered set of
+immutable page-pack artifacts. Their exact wire layouts are deferred, but the semantic
+contract is:
+
+```cpp
+struct CookedVirtualTextureManifest {
+    VirtualTextureId texture;
+    VirtualTextureContentRevision content;
+    VirtualTextureCookSchemaVersion schema;
+    VirtualTextureCapabilityTier tier;
+    VirtualTextureDescriptor descriptor;
+    BoundedArray<VirtualPagePackEntry> packs;
+    VirtualTextureDependencyFingerprint dependencies;
+    ArtifactDigest rootDigest;
+};
+
+struct VirtualPagePackEntry {
+    VirtualPagePackId pack;
+    ArtifactId artifact;
+    BoundedArray<VirtualPageRangeEntry> pages;
+    ByteCount storedBytes;
+    ByteCount decodedPeakBytes;
+    ArtifactDigest digest;
+};
+
+struct VirtualPageRangeEntry {
+    VirtualPageId page;
+    ByteOffset offset;
+    ByteCount storedBytes;
+    ByteCount decodedBytes;
+    ArtifactDigest digest;
+};
+```
+
+A logical page is the smallest independently requested and integrity-verified VTX
+content unit. A page pack is the smallest generic Assets artifact/range-addressable
+storage unit. Pages do not receive independent source `AssetId`s, sidecars,
+`current.json` pointers or mutable files. The manifest, not directory contents,
+defines complete membership and canonical order.
+
+Packs bound file/object count while permitting finite range reads and localized retry.
+Pack grouping is a deterministic cook-policy input based on typed page coordinates,
+mip/tail policy and declared bounds. Completion order, worker count and storage path do
+not influence grouping. Mip-tail data may use a dedicated pack but remains manifest-
+declared and versioned rather than hidden trailer policy.
+
+Payloads contain VTX-neutral compressed/encoded page content and required semantic
+metadata. They contain no source/editor state, absolute paths, runtime cache slots,
+world reservations, renderer handles, native format enums, commands or fences.
+
+### 4. Cook identity closes over every byte- or meaning-affecting input
+
+The VTX dependency-aware cook key extends the Assets key with:
+
+- exact canonical source identity, revision and digest;
+- canonically ordered input-member and dependency artifact identities/digests;
+- import settings and their schema, including color/alpha/channel/addressing intent;
+- virtual dimensions, page/border/mip/tail geometry and edge-padding policy;
+- target format/encoding/compression and exact VTX capability requirements;
+- pack aggregation/order policy and all finite effective limits;
+- source, manifest, pack, page payload, cooker and algorithm versions; and
+- generic Assets target, envelope and toolchain identity.
+
+Paths, timestamps, editor layout, job order, thread count, active provider/cache state,
+GPU device identity and native runtime handles are excluded unless an explicit target
+artifact format semantically depends on a typed qualified capability fingerprint.
+
+Same complete inputs produce byte-identical manifest/pack/page bytes and diagnostic
+ordering for qualified tools. Any semantic input change changes the key. Fresh output
+and cache reuse pass identical envelope, requested-key, manifest, size, digest, bounds
+and VTX semantic validation before generation assembly.
+
+### 5. Integrity is layered and validated before allocation or publication
+
+Assets validates generic artifact envelopes, requested cache key, declared sizes and
+cryptographic digests. VTX then validates the root manifest and page semantics:
+
+- supported schema/tier/format and exact descriptor compatibility;
+- checked counts, dimensions, offsets, lengths, alignment and decoded peak sizes;
+- canonical unique pack/page IDs and complete required page/mip/tail coverage;
+- sorted non-overlapping ranges wholly inside the declared pack;
+- pack digest plus per-page digest after the specified bounded decode;
+- dependency fingerprint and artifact-generation membership; and
+- no unknown required flags, trailing semantic data or ambiguous aliases.
+
+Validation occurs before corresponding allocation/read work whenever metadata allows.
+Decompression has declared input, output, ratio, time/work and scratch bounds; a
+compressed payload cannot allocate from an untrusted header. A verified pack does not
+waive per-page bounds/digest checks, and a page digest does not authorize bytes from a
+different generation.
+
+Partial pack availability, one corrupt page, wrong target/tier, truncated data,
+duplicate ranges, arithmetic overflow or digest mismatch fails the affected candidate
+with a typed result. It never causes directory repair, source import, runtime cooking or
+publication of the remaining pages as a complete generation.
+
+### 6. Runtime reads use an exact-generation page-store port
+
+The host provides a narrow Assets-owned page-store/range-read capability with semantics
+equivalent to:
+
+```cpp
+struct VirtualPageReadRequest {
+    AssetGenerationId generation;
+    ArtifactId packArtifact;
+    VirtualPageId page;
+    ByteRange verifiedRange;
+    ArtifactDigest expectedPackDigest;
+    ArtifactDigest expectedPageDigest;
+    ByteCount maximumResultBytes;
+    AssetReadOperationId operation;
+};
+
+class IVirtualPageStore {
+public:
+    virtual VirtualPageReadHandle ReadPage(VirtualPageReadRequest request) = 0;
+};
+```
+
+This is a semantic sketch; later API work fixes ABI/layout and may expose a generic
+Assets range-reader instead of a VTX-named interface. In either case, the provider pins
+the exact published/package generation and returns an immutable bounded byte lease plus
+typed completion. It owns filesystem/archive/network/memory access, range coalescing,
+transport retries and provider byte caches.
+
+VTX verifies the request/completion generation, operation and page identity before
+decode and publication. It cannot pass a path, ask for “current”, enumerate a pack,
+mutate provider bytes or retain a borrowed span after its lease. Providers cannot infer
+page priority, choose a fallback artifact or publish VTX residency.
+
+### 7. Every cache name identifies one owner and lifetime
+
+| Cache/store | Owner | Contents | Eviction effect |
+|---|---|---|---|
+| Authored source storage | Assets/editor document | Mutable versioned source truth | Asset transaction only; not a cache |
+| Cook cache | Assets | Immutable content-addressed manifest/pack candidates | Never changes a published/active generation |
+| Published generation | Assets | Verified root plus exact artifact closure | Replaced only by atomic generation publication |
+| Package/archive store | Assets/Release | Immutable selected generation artifacts | Package/mount lifecycle only |
+| Provider byte/range cache | Assets provider | Immutable pack/range bytes under leases | Only after provider leases release |
+| Decoded neutral page cache | VTX runtime | Decoded pages for one VTX generation | VTX may evict disposable pages inside its reservation |
+| Physical page cache | Renderer | Atlas/sparse resources and mappings | Renderer retirement; never by Assets cache policy |
+
+The same bytes may have related accounting projections, but every allocation has one
+charge and release authority. Evicting a cook/provider cache entry does not unpublish a
+generation or unmap a resident GPU page. VTX eviction does not delete artifact bytes or
+refund a Renderer heap. A new published generation does not invalidate leases held by
+the active old VTX generation.
+
+### 8. Publication, loading and replacement are generation atomic
+
+Cook workers write operation-owned staged manifest/pack candidates. Assets verifies
+the complete closure, obtains its publication lock and publishes one immutable
+generation atomically. Cancellation, failure, stale source, lock timeout or process
+interruption leaves the previous published generation selected and staged data
+recoverable/quarantined under generic Assets policy.
+
+Runtime pins one exact generation, validates its root before requesting pages and keeps
+the manifest lease until every page request, decoded cache entry and dependent renderer
+operation releases that generation. It never repeatedly follows `current.json`, mixes
+packs from two generations or revalidates a page by matching coordinates alone.
+
+Hot reload prepares a detached VTX generation. Unchanged packs/pages may be shared only
+when complete artifact/page identity and semantic compatibility match. Publication of
+the Assets generation does not mutate active VTX state; ADR-164 replacement admission
+prepares required pages/resources and atomically publishes the new logical root. Failure
+preserves the last valid active generation. Old leases retire after their last CPU/GPU
+consumer, not when a filesystem pointer changes.
+
+### 9. Packaging preserves the manifest closure and runtime has no build paths
+
+Packaging includes the selected root manifest and exact pack/dependency artifacts for
+the declared product/world chunks. Source inputs, editor state, cook-cache entries,
+staging directories and mutable page side files are excluded. Package tables may
+physically coalesce artifacts, but retain exact artifact/range/digest identity exposed
+through the same provider contract.
+
+Runtime receives artifact identities and leases from the mounted Assets generation. It
+does not construct `<project>/build/...`, cache roots, pack filenames or page paths.
+Local development, packaged archive, in-memory tests and future remote stores must be
+semantically interchangeable at the page-store port.
+
+### 10. Errors, diagnostics and qualification are typed and bounded
+
+Stable result families distinguish invalid/untrusted source, unsupported source/schema/
+tier/format, dependency missing/stale, cook nondeterminism, cache wrong-key/corrupt,
+manifest invalid, pack/page missing/corrupt/oversized, provider capacity/transport,
+stale generation, cancellation and retirement stall. Later tickets assign exact codes.
+
+Diagnostics expose bounded Horo asset/generation/pack/page identities, stage, declared
+and actual byte counts, cache class/hit result and normalized cause. They do not expose
+absolute paths, source/page bytes, credentials, provider URLs, native handles or
+unbounded third-party messages.
+
+Required evidence includes deterministic fresh/cache output; reordered inputs and job
+completion; malformed dimensions/counts/ranges/offset arithmetic; compression bombs;
+wrong key/generation/target/tier; missing/duplicate/overlapping pages; partial/corrupt
+packs; cancellation at every stage; concurrent publication; interrupted staging;
+package/local/memory provider parity; hot replacement; held old leases; and cleanup
+when normal request queues are full.
+
+### 11. Migration removes mutable per-page layouts
+
+The prototype per-page directory and `index.json` tree is not a supported persisted
+format. No compatibility reader, directory scanner or runtime path adapter is retained.
+Existing prototype output is treated as derived cache, invalidated and recooked into a
+versioned root-plus-pack generation when the schemas land.
+
+Downstream tickets must preserve:
+
+| Delivery | Constraint |
+|---|---|
+| VTX-002.2/.3 | Canonical source/settings and exact artifact IDs/layouts refine this model without path identity |
+| VTX-002.4/.5 | Page generation/manifest and packing algorithms remain deterministic, bounded and manifest-driven |
+| VTX-002.6 | Cooker uses generic Assets scheduling, staging, cache and publication |
+| VTX-002.7 | Runtime provider pins exact generation and returns immutable bounded leases |
+| VTX-002.8/.9 | Corruption, cancellation, replacement and tests cover every store/cache boundary |
+
+## Consequences
+
+Positive consequences:
+
+- Runtime page access works across filesystem, package, memory and future transports
+  without exposing their layout to VTX.
+- Root-plus-pack aggregation avoids both mutable per-page file explosion and mandatory
+  whole-texture reads.
+- Layered integrity localizes failures while atomic publication prevents mixed
+  generations.
+- Cook, provider, decoded and GPU caches can evolve independently because their owners
+  and lifetimes are explicit.
+
+Costs and trade-offs:
+
+- Manifests and packs require range tables, two integrity levels and exact-generation
+  lease tracking.
+- A small page request may retain/coalesce a larger provider pack range; later tickets
+  must set evidence-based pack and cache bounds.
+- Hot replacement may temporarily retain old/new manifests, packs, decoded pages and
+  GPU resources.
+- Exact binary layouts and numeric limits remain blocked on downstream schema tickets;
+  this ADR deliberately fixes semantics without guessing those values.
+
+## Rejected Alternatives
+
+### Store one mutable file and sidecar per page
+
+Rejected because logical identity would become filesystem layout, aggregate publication
+would not be atomic, directory/file counts would scale poorly and runtime scanning
+would create a second manifest authority.
+
+### Store each virtual texture as one monolithic artifact
+
+Rejected because independent page demand would require oversized reads or an implicit
+unverified internal range protocol. Bounded immutable packs retain aggregation while
+making range and integrity semantics explicit.
+
+### Let VTX own its cache root and filesystem reader
+
+Rejected because Assets already owns path trust, content-addressed storage, package
+mounts, byte leases and publication. A VTX filesystem creates duplicate security,
+cache, generation and cancellation policy.
+
+### Give every page a normal AssetId and current generation
+
+Rejected because pages are members of one VTX semantic generation, not independently
+authored assets. Per-page publication could combine incompatible cook generations and
+explode registry/dependency state.
+
+### Follow the latest published generation on every page request
+
+Rejected because one live VTX root could then mix page geometry, encoding, dependencies
+or semantic revisions. Runtime pins and retires exact generations.
+
+### Trust a pack digest without page-level verification
+
+Rejected because page-range/decode bugs and localized transport corruption need a
+bounded page integrity boundary. Both layers are required and neither substitutes for
+semantic validation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -176,6 +176,7 @@ to the replacement.
 | [162](162-mixed-reality-ownership-privacy-and-capability-tier.md) | Mixed-Reality Ownership, Privacy and Capability Tier | Proposed | 2026-09-02 |
 | [163](163-xr-tooling-diagnostics-privacy-and-qualification-ownership.md) | XR Tooling, Diagnostics, Privacy and Qualification Ownership | Proposed | 2026-09-02 |
 | [164](164-virtual-texturing-ownership-product-scope-and-capability-tier.md) | Virtual Texturing Ownership, Product Scope and Capability Tier | Proposed | 2026-09-02 |
+| [165](165-virtual-texture-source-cooked-artifact-page-store-and-cache-ownership.md) | Virtual Texture Source, Cooked Artifact, Page Store and Cache Ownership | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -436,6 +436,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Virtual Texturing Ownership, Product Scope and Capability Tier](../adr/164-virtual-texturing-ownership-product-scope-and-capability-tier.md):
   VTX/Assets/Materials/World Streaming/Renderer/producer ownership, typed composition,
   Atlas/Sparse admission and unsupported-path policy.
+- [Virtual Texture Source, Cooked Artifact, Page Store and Cache Ownership](../adr/165-virtual-texture-source-cooked-artifact-page-store-and-cache-ownership.md):
+  canonical source/cook authority, immutable root-plus-pack generations, bounded
+  exact-generation reads, layered integrity and distinct cache lifetimes.
 - [Destruction And Fracture Architecture](./runtime/destruction-and-fracture-architecture.md):
   fracture assets, chunk physics, debris, authority, and network reconstruction.
 - [Destruction Ownership, Authority, State and Runtime Geometry Boundary](../adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md):

--- a/docs/architecture/runtime/asset-pipeline.md
+++ b/docs/architecture/runtime/asset-pipeline.md
@@ -681,6 +681,30 @@ scans an output directory, follows `current.json` independently for each tile, i
 source or cooks a missing variant. Package validation applies the same manifest, digest,
 limit and dependency checks used by fresh cook and cache reuse.
 
+### Virtual Texturing Domain Import And Cook Boundary
+
+[ADR-165](../../adr/165-virtual-texture-source-cooked-artifact-page-store-and-cache-ownership.md)
+applies the generic-Assets/domain-semantics split to virtual textures. Assets owns
+tracked source identity/bytes, immutable input borrows, generic dependency scheduling,
+content-addressed cache storage, staging, atomic generation publication, package
+membership and runtime artifact/range leases. It does not interpret virtual page,
+mip-tail, border, channel, color, addressing, encoding or pack-grouping semantics.
+
+VTX Import/Model owns canonical authored source/settings validation. VTX Cook owns
+deterministic page derivation and a versioned root manifest plus bounded immutable page
+packs. A logical page is independently requested and verified but is not an independent
+authored `AssetId`, sidecar, mutable file or current-generation pointer. The manifest is
+the only page/pack membership and canonical-order authority.
+
+Runtime pins one exact generation and uses an Assets-owned bounded page-store/range-read
+port. It cannot pass paths, request an ambient "current", enumerate storage or mix pack
+bytes from different generations. Generic envelopes/requested keys, root/pack/page
+digests, checked ranges and VTX semantics are all validated before publication.
+
+Cook cache entries, published generations, provider byte caches, VTX decoded-page
+caches and Renderer physical caches retain separate ownership and eviction effects.
+Removing one never silently unloads, unmaps or republishes another.
+
 ### VFX Domain Import And Cook Boundary
 
 [ADR-126](../../adr/126-vfx-graph-compilation-and-runtime-representation-convergence.md)

--- a/docs/architecture/runtime/virtual-texturing-architecture.md
+++ b/docs/architecture/runtime/virtual-texturing-architecture.md
@@ -55,6 +55,29 @@ invalidates the operation/generation before late completions arrive. Stale work 
 its asset leases and reservations without publication. Physical slots and resources are
 reused only after the relevant GPU work and dependent leases retire.
 
+## Source, Artifact And Page-Store Model
+
+[ADR-165: Virtual Texture Source, Cooked Artifact, Page Store and Cache Ownership](../../adr/165-virtual-texture-source-cooked-artifact-page-store-and-cache-ownership.md)
+is the normative source/cook/storage decision. Assets owns tracked source identity,
+generic cook scheduling/cache/staging, atomic generation publication, packages and
+runtime byte leases. VTX import/cook owns page geometry, mip/tail, border, color,
+encoding and deterministic aggregation semantics.
+
+One immutable cooked generation contains a root manifest and canonically ordered,
+bounded page-pack artifacts. A logical page is the independently requested and
+verified content unit; a pack is the range-addressable Assets storage unit. Pages are
+not independent authored assets or mutable side files. The manifest is the sole
+membership/order authority and records exact pack/page ranges, costs and digests.
+
+Runtime pins an exact published/package generation and requests finite ranges through
+an Assets-owned provider port. Local filesystem, archive, memory/test and future remote
+providers have the same semantics. VTX never constructs paths, asks for an ambient
+"current" generation, enumerates storage or combines packs from different generations.
+
+The cook cache, published generation, provider byte cache, VTX decoded-page cache and
+Renderer physical-page cache are distinct owner/lifetime domains. Eviction in one does
+not imply publication, invalidation, unmapping or capacity release in another.
+
 ## Memory And World-Streaming Boundary
 
 [ADR-034: GPU Memory and Residency Ownership](../../adr/034-gpu-memory-and-residency-ownership.md)


### PR DESCRIPTION
## Summary

- Add ADR-165 as the authoritative source, cooked-artifact, page-store and cache ownership decision for Virtual Texturing.
- Separate tracked source/import semantics, generic Assets cook/publication, immutable VTX root-and-pack artifacts, runtime provider reads, decoded page residency and Renderer physical residency.
- Choose an immutable generation root manifest plus bounded page-pack artifacts instead of mutable per-page side files or a mandatory monolithic texture blob.
- Define exact-generation, bounded page range-read semantics and layered manifest/pack/page integrity checks.
- Align the Asset Pipeline and Virtual Texturing architecture documents and register ADR-165 in both architecture indexes.

## Why

The previous VTX sketch used a runtime-constructed build/cache directory containing one mutable file per page and an `index.json`. That layout blurred authored source, derived cache, published generation and runtime residency; it also made directory contents an implicit second manifest and left atomic publication, integrity, cancellation and replacement unspecified.

VTX needs independently requestable pages, but those pages must remain members of one coherent cooked generation. This decision keeps all path trust, cache storage, package mounts, atomic publication and byte leases in Assets while giving VTX ownership of page geometry, ordering, encoding and semantic validation.

## Decision and boundaries

- Source files and multi-file inputs are untrusted import inputs. VTX Import/Model produces one validated canonical authored source revision through the ordinary Assets transaction; paths, timestamps and enumeration order are excluded from semantic identity.
- VTX Cook emits one `CookedVirtualTextureManifest` and canonically grouped immutable page packs. A logical page is the independently requested/verified content unit; a pack is the range-addressable Assets storage unit.
- Pages intentionally do not receive normal `AssetId`s, sidecars, individual current-generation pointers or mutable filesystem files. The root manifest is the sole membership and ordering authority.
- The dependency-aware cook key closes over source/dependency digests, import semantics, page/mip/tail/border geometry, target encoding, capability requirements, pack policy, finite limits and every relevant schema/algorithm/toolchain version.
- Integrity is layered: Assets validates the generic envelope/requested cache key and artifact digest; VTX validates root semantics, pack/page membership, checked non-overlapping ranges, declared decode bounds and per-page digests.
- Runtime pins one exact generation and requests bounded immutable ranges from an Assets-owned provider port. Filesystem, package/archive, memory-test and future remote providers remain interchangeable behind that contract.
- Cook cache, published generation, package store, provider byte cache, VTX decoded page cache and Renderer physical page cache now have explicit, independent owners and eviction effects.
- Publication and hot replacement preserve the last valid generation on cancellation/failure and retain old leases until all CPU/GPU readers retire.
- The prototype per-page directory/`index.json` layout is declared derived data to invalidate and recook; no compatibility directory scanner is retained.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- <all changed Markdown files>`
- `git diff --check`
- `git diff --cached --check`
- Staged Markdown link checker: all added relative links resolve.
- Commit hooks:
  - `horo clang-format staged` passed.
  - `horo-engine layout configure` passed.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`
  - Configuration completed successfully.
  - Existing mbedTLS minimum-CMake deprecation warning remains.
  - Repository Python tests remain skipped because `pytest` is unavailable in this environment.

## Risk and rollout

- This PR fixes artifact semantics but does not freeze binary layouts, ABI, page/pack size limits, compression algorithms or concrete provider class names; those belong to VTX-002.2 and later tickets.
- Root-plus-pack storage introduces range tables and two integrity levels. It is more structured than one-file-per-page storage, but prevents partial generation publication and filesystem-scale coupling.
- Small page requests may retain or coalesce larger pack ranges. Downstream implementation must select evidence-based pack and provider-cache bounds.
- Existing prototype page files are intentionally not migration inputs. Because they were never a supported format, they will be invalidated and deterministically recooked when schemas are implemented.

## Issue links

- Closes #2185
- Jira: [HORO-2139](https://horo-engine.atlassian.net/browse/HORO-2139)
- Parent capability: #2184 / [HORO-2138](https://horo-engine.atlassian.net/browse/HORO-2138)
- Blocked by ownership baseline: #2176 / [HORO-2130](https://horo-engine.atlassian.net/browse/HORO-2130)

## Reviewer Notes

Please review the decision around three key invariants:

1. a page remains an independently readable and verifiable unit without becoming an independently published asset;
2. no runtime VTX code can learn or construct filesystem/package/cache layout; and
3. cache eviction in Assets, VTX or Renderer cannot silently publish, unload, unmap or refund another owner's state.

The main trade-off to scrutinize is root-plus-pack aggregation versus per-page or monolithic artifacts. Exact pack sizing is deliberately deferred, but deterministic grouping, checked ranges, exact-generation pinning and layered integrity are fixed here so later tickets cannot choose incompatible ownership models.

## Stack

- Depends on #2499 (`docs/HORO-2130_virtual_texturing_ownership_product_scope_tiers`).
- Base branch: `docs/HORO-2130_virtual_texturing_ownership_product_scope_tiers`.
- Head branch: `docs/HORO-2139_virtual_texture_artifact_page_store_cache_ownership`.
- This PR is one Jira issue / one commit / one stacked PR; the next ranked M0 issue will branch from this head.


[HORO-2139]: https://horo-engine.atlassian.net/browse/HORO-2139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ