### PR TITLE
docs(vtx): define feedback and prediction ownership HORO-2159 #2205 [VTX-004.1]

### DIFF
--- a/docs/adr/167-vtx-feedback-readback-prediction-and-camera-data-ownership.md
+++ b/docs/adr/167-vtx-feedback-readback-prediction-and-camera-data-ownership.md
@@ -1,0 +1,279 @@
+# ADR-167: VTX Feedback, Readback, Prediction and Camera-Data Ownership
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: VTX GPU feedback plan, Renderer pass/resource/readback ownership, immutable observations, camera and producer hints, prediction, bounded loss, multiview, lifecycle and privacy
+- **Issue**: [VTX-004.1](https://github.com/abdullahbodur/horo-engine/issues/2205)
+- **Jira**: [HORO-2159](https://horo-engine.atlassian.net/browse/HORO-2159)
+- **Parent**: [VTX-004](https://github.com/abdullahbodur/horo-engine/issues/2204)
+- **Related**: [ADR-008](008-error-model-exception-boundary-and-registry.md), [ADR-010](010-job-waiting-and-operation-store-ownership.md), [ADR-026](026-large-world-precision-and-floating-origin-strategy.md), [ADR-027](027-renderer-resource-identity-and-descriptors.md), [ADR-034](034-gpu-memory-and-residency-ownership.md), [ADR-038](038-gpu-scene-and-instance-data-model.md), [ADR-042](042-cpu-gpu-timestamps-and-pipeline-statistics.md), [ADR-119](119-camera-authority-during-cinematics.md), [ADR-164](164-virtual-texturing-ownership-product-scope-and-capability-tier.md), [ADR-166](166-vtx-feature-local-residency-and-eviction-within-global-reservations.md)
+- **Normative documents**: [Virtual Texturing Architecture](../architecture/runtime/virtual-texturing-architecture.md), [Rendering Architecture](../architecture/runtime/rendering-architecture.md), [Cinematic Sequencer Architecture](../architecture/runtime/cinematic-sequencer-architecture.md)
+
+## Context
+
+ADR-166 makes VTX responsible for feature-local page priority and residency inside a
+global reservation. It does not define where page-demand evidence comes from. The old
+VTX sketch implied a compute pass writing an append buffer followed by CPU readback,
+but combined native GPU resources, CPU request vectors and camera visibility into a
+single `VirtualTextureFeedback` object.
+
+That model could make VTX own native buffers/fences, poll a mapped resource, wait for
+same-frame feedback or read mutable camera state. It could also let a feedback sample
+or producer hint bypass World Streaming admission and directly evict/load pages. Camera
+cuts, origin rebases, dynamic resolution, multiview and delayed readback make such
+assumptions incorrect even when the raw page IDs are valid.
+
+Feedback is optional delayed evidence, not state authority. Renderer must own graph
+placement, encoding resources, copies and GPU-safe lifetime. Camera/view coordinators
+must own canonical per-view snapshots. VTX may aggregate immutable observations and
+predict page demand, but ADR-166 remains the only page scheduling/eviction authority
+and World Streaming retains global admission.
+
+This ADR fixes those boundaries. VTX-004.2 and later tickets freeze exact encoding,
+compaction, readback, prediction, limits and test vectors without changing ownership.
+
+## Decision
+
+### 1. Feedback responsibilities remain split by authority
+
+| Responsibility | Authority | Deliberate non-owner |
+|---|---|---|
+| Logical feedback requirement, sampling policy and bounded semantic descriptor | VTX | Renderer does not invent page-demand semantics |
+| Render-graph pass placement, GPU feedback/compaction/copy resources, native encoding and synchronization | Renderer frontend/backend | VTX never owns/maps native buffers or fences |
+| Asynchronous readback staging, pending-result capacity and GPU/CPU retirement | Renderer under ADR-027/034 | VTX cannot poll, block or refund Renderer resources |
+| Immutable validated feedback observation and gap/overflow evidence | Renderer publishes; VTX consumes | Observation does not mutate residency by itself |
+| Canonical camera/view selection, transforms, projection, viewport and discontinuity | Camera/view authority under ADR-119/038 | VTX cannot select, move or query a global camera |
+| Producer-domain visibility/coverage hints | Owning producer adapter | VTX cannot reinterpret producer state or lifetime |
+| Observation history, prediction and demand-candidate generation | VTX | Prediction does not grant admission or eviction authority |
+| Global admission/criticality/reservations | World Streaming/application under ADR-166 | Renderer feedback cannot enqueue global work directly |
+
+The host composes these ports before VTX activation. Descriptor validation is inert and
+does not create graph passes, allocate readback pools, subscribe globally or capture a
+camera pointer.
+
+### 2. VTX supplies a bounded semantic feedback plan
+
+An admitted generation declares a plan equivalent in semantics to:
+
+```cpp
+struct VtxFeedbackPlan {
+    VtxFeedbackSchemaId schema;
+    VirtualTextureGeneration generation;
+    VtxFeedbackMode mode;
+    CountLimit maximumSamples;
+    CountLimit maximumUniquePages;
+    ByteCount maximumGpuBytes;
+    ByteCount maximumReadbackBytes;
+    CountLimit maximumPendingResults;
+    FrameInterval cadence;
+    VtxFeedbackOverflowPolicy overflow;
+};
+```
+
+Exact layout and limits belong to downstream tickets. The plan contains Horo identities,
+finite costs and semantic encoding requirements, never shader/native resource handles,
+API enums or an arbitrary callback. Its costs participate in ADR-166 global admission
+and ADR-034 Renderer resource admission before graph/resource creation.
+
+Supported modes are `None`, bounded renderer feedback and producer/camera-hint-only.
+They are capabilities orthogonal to ADR-164's `Atlas`/`Sparse` realization tier. A VTX
+path may work without GPU feedback when its declared producer/hint policy is complete;
+missing feedback cannot silently enable a different algorithm.
+
+### 3. Renderer owns pass execution and asynchronous readback lifetime
+
+Renderer validates the plan against the selected backend/device, graph, formats,
+atomics/compaction operations, queue synchronization, copy/readback support and reserved
+capacity. It creates all feedback targets, counters, compacted lists, readback staging
+and fences as generation-checked Renderer resources.
+
+The feedback pass reads only declared render bindings and writes a bounded encoding.
+Overflow saturates a count/flag and never writes out of bounds. Compaction/copy is an
+explicit graph operation with resource usage and barriers. Backends translate the same
+Horo schema privately; native layouts never become the public observation contract.
+
+Normal frames never wait for feedback, map an incomplete buffer or call GPU idle.
+Renderer publishes only after copy completion and CPU ownership of the bounded result
+is established. Readback arenas remain charged and leased until VTX consumption or
+expiry plus all GPU readers retire. Cancellation suppresses publication but does not
+return credits early.
+
+### 4. Published observations are immutable, delayed and generation checked
+
+Renderer publishes a value/lease equivalent in semantics to:
+
+```cpp
+struct VtxFeedbackObservation {
+    VtxFeedbackSchemaId schema;
+    VirtualTextureGeneration textureGeneration;
+    RendererDeviceGeneration deviceGeneration;
+    RenderFrameId sourceFrame;
+    ViewSnapshotId view;
+    ViewSnapshotGeneration viewGeneration;
+    BoundedArray<VtxPageObservation> pages;
+    VtxFeedbackCompleteness completeness;
+    FrameCount observedLatency;
+};
+```
+
+Entries contain stable virtual page identity and bounded evidence such as quantized
+coverage/frequency, not physical atlas slots, native addresses or mutable residency.
+Canonical ordering and duplicate aggregation are defined by schema. Completion repeats
+the exact operation/resource generations and declared bounds.
+
+VTX rejects or retires wrong-schema, stale texture/device/view generation, malformed,
+oversized or impossible entries. Reordered delivery is processed by source identity and
+captured policy, not callback order. Duplicate completion is idempotently ignored.
+Observation age is explicit; VTX never presents delayed data as current-frame truth.
+
+### 5. Camera data arrives as an immutable per-view snapshot
+
+The Camera/view authority resolves one canonical immutable snapshot for each rendered
+view/frame before extraction. The VTX adapter may receive only the fields admitted by
+its versioned hint schema, such as stable view/snapshot identity, world-space origin,
+view/projection parameters, viewport/scale, jitter state and typed discontinuity flags.
+
+VTX does not hold a `Camera*`, query Scene/ECS, select an active camera or infer authority
+from editor/gameplay/cinematic names. Camera cuts, teleports, origin rebases, projection
+changes and large dynamic-resolution changes carry explicit discontinuity evidence.
+Prediction resets or downweights incompatible history; it does not reinterpret the
+change as extreme velocity.
+
+Multiple eyes, editor viewports, reflection/capture views and runtime cameras remain
+separate typed view scopes. The host declares which views contribute and their bounded
+weight; VTX cannot merge them by mutable camera identity or multiply global admission.
+
+### 6. Producer hints are typed evidence with provenance
+
+Terrain, World Streaming and other producers may emit immutable bounded hints containing
+their owner/generation, target VTX generation, page/region evidence, validity window,
+confidence/priority class and cost. They never expose producer pointers, mutable
+containers or backend resources.
+
+VTX validates provenance and generation, normalizes hints under captured policy and
+merges them with feedback/camera evidence deterministically. A producer cannot pin a
+page, allocate budget, override content criticality or evict another consumer. Required
+cell pins and global priorities still originate from ADR-166 owner contracts.
+
+### 7. Prediction produces demand candidates, not commands
+
+VTX owns a finite generation-scoped observation history and deterministic prediction
+policy. Inputs are admitted immutable observations, camera snapshots, producer hints,
+current logical residency snapshot and versioned settings. Output is a bounded,
+canonically ordered batch of demand candidates with reason/provenance and expiry.
+
+Prediction may estimate near-future pages from velocity, mip/coverage trends or producer
+lookahead after downstream algorithms are specified. It cannot mutate Camera, Scene,
+World Streaming or Renderer; invent required content; turn confidence into a pin; or
+submit I/O/GPU work outside ADR-166. Demand candidates enter the same coalescing,
+priority, reservation and fallback path as other evidence.
+
+No wall-clock timing, pointer order, unordered iteration or worker completion order
+affects deterministic output. Prediction history has fixed count/byte/age limits. An
+overflow or missing input drops/downweights optional future evidence according to the
+captured policy and reports a gap; it never expands storage.
+
+### 8. Loss, overflow and capability failure are explicit
+
+Feedback is inherently delayed and may be incomplete. `completeness` distinguishes at
+least complete, sampled, overflowed, skipped-by-cadence, budget-dropped, cancelled and
+device/view discontinuity. Missing observations do not mean no demand.
+
+For optional feedback, capacity pressure may omit the newest observation and publish a
+bounded gap diagnostic. VTX continues from declared producer/camera hints and retained
+residency policy without pretending the sample was complete. If a product declares
+feedback required, unavailable capability or sustained gaps fail/suspend that VTX
+composition or select a separately admitted hint-only/non-VTX fallback. They cannot
+silently downgrade required behavior.
+
+Overflow cannot synchronously read a larger buffer, allocate mid-frame, retry without a
+reservation or turn every possible page into an unbounded demand set. Conservative
+response is bounded by the plan and remains subject to ADR-166 admission.
+
+### 9. Lifecycle and replacement retain every owner generation
+
+Activation admits the feedback plan, creates Renderer resources, registers immutable
+camera/producer snapshot routes and reserves observation/history/completion capacity
+before publication. VTX readiness requires only the declared mode; `None` allocates no
+feedback/readback resources.
+
+On VTX replacement, new feedback resources and history use the new generation. Old
+observations cannot seed it unless the replacement policy proves schema/content/view
+compatibility; default behavior resets history. Old graph/readback resources and
+observations remain leased until Renderer and VTX consumers retire.
+
+Shutdown closes new plans/snapshots, invalidates VTX publication, drains bounded
+completions and asks Renderer to retire exact resources. Camera/producer lifetimes are
+not extended beyond immutable snapshot leases. A deadline reports stalled retirement;
+it cannot clear native pools or publish stale demand.
+
+### 10. Privacy, diagnostics and qualification are bounded
+
+Raw camera trajectories, feedback page streams and content/page identities are not
+durable telemetry by default. Ordinary diagnostics expose aggregate counts, latency,
+completeness/gap reasons, safe generations and bounded prediction outcomes. Capture or
+export requires explicit developer/qualification policy, redaction and retention under
+the owning diagnostics system.
+
+Typed failures distinguish plan invalid/unsupported, graph/resource/readback admission,
+encoding overflow, malformed observation, stale texture/device/view, camera/producer
+snapshot unavailable, history capacity, cancellation and retirement stall.
+
+Qualification covers no-feedback composition; exact-cap/overflow encodings; delayed,
+reordered, duplicate and stale completion; camera cuts/rebases/dynamic resolution;
+multiview bounds; producer provenance; full pending-result/history queues; cancellation
+before/after submission; replacement/device loss; zero same-frame waits; cleanup under
+full queues; and deterministic prediction across scheduling orders.
+
+### 11. Migration removes mixed CPU/GPU feedback objects
+
+Prototype `VirtualTextureFeedback` objects combining a `BufferHandle` and mutable CPU
+page vector are not compatibility contracts. They split into VTX semantic plans,
+Renderer-private resources and immutable observation results. Live camera pointers and
+ad hoc producer callbacks are replaced by versioned snapshots/hints. Any frame loop
+that maps feedback or waits synchronously moves to delayed owner completions.
+
+## Consequences
+
+Positive consequences:
+
+- Renderer owns every GPU/readback resource while VTX retains demand semantics.
+- Camera cuts, multiview and origin rebases are explicit inputs rather than hidden
+  prediction errors.
+- Feedback loss and overflow remain bounded and observable.
+- Prediction cannot bypass global reservation or residency policy.
+
+Costs and trade-offs:
+
+- Feedback reacts after asynchronous latency rather than the same frame.
+- Multiple generations/identities must be correlated through each observation.
+- Hint-only fallback needs explicit cooked/product policy and qualification.
+- Exact encoding and prediction algorithms remain downstream decisions.
+
+## Rejected Alternatives
+
+### Let VTX allocate/map feedback buffers directly
+
+Rejected because graph placement, native synchronization, readback capacity and GPU-safe
+retirement belong to Renderer and must remain backend neutral to VTX.
+
+### Read feedback synchronously in the frame that produced it
+
+Rejected because it creates a CPU/GPU stall and makes streaming behavior backend timing
+dependent. Delayed observations carry source frame and age explicitly.
+
+### Give VTX a live Camera or Scene pointer
+
+Rejected because it bypasses per-view camera authority, creates lifetime/thread races
+and cannot represent cuts, editor/cinematic ownership or multiview consistently.
+
+### Let feedback or prediction directly load/evict pages
+
+Rejected because observations are evidence. ADR-166 owns coalescing, pins, reservations,
+fallback and eviction; World Streaming retains global admission.
+
+### Treat overflow as demand for every page
+
+Rejected because it is unbounded and converts missing evidence into budget authority.
+Overflow follows a finite declared policy and remains observable.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -178,6 +178,7 @@ to the replacement.
 | [164](164-virtual-texturing-ownership-product-scope-and-capability-tier.md) | Virtual Texturing Ownership, Product Scope and Capability Tier | Proposed | 2026-09-02 |
 | [165](165-virtual-texture-source-cooked-artifact-page-store-and-cache-ownership.md) | Virtual Texture Source, Cooked Artifact, Page Store and Cache Ownership | Proposed | 2026-09-02 |
 | [166](166-vtx-feature-local-residency-and-eviction-within-global-reservations.md) | VTX Feature-Local Residency and Eviction Within Global Reservations | Proposed | 2026-09-02 |
+| [167](167-vtx-feedback-readback-prediction-and-camera-data-ownership.md) | VTX Feedback, Readback, Prediction and Camera-Data Ownership | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -442,6 +442,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [VTX Feature-Local Residency and Eviction Within Global Reservations](../adr/166-vtx-feature-local-residency-and-eviction-within-global-reservations.md):
   global versus feature-local scheduling, multidimensional reservation slices, typed
   pins, shared-page charging, two-phase eviction and pressure accounting.
+- [VTX Feedback, Readback, Prediction and Camera-Data Ownership](../adr/167-vtx-feedback-readback-prediction-and-camera-data-ownership.md):
+  Renderer-owned feedback/readback resources, immutable delayed observations, typed
+  camera/producer hints, bounded prediction and non-authoritative demand evidence.
 - [Destruction And Fracture Architecture](./runtime/destruction-and-fracture-architecture.md):
   fracture assets, chunk physics, debris, authority, and network reconstruction.
 - [Destruction Ownership, Authority, State and Runtime Geometry Boundary](../adr/144-destruction-ownership-authority-state-and-runtime-geometry-boundary.md):

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -32,6 +32,10 @@ The equal first-class obligations of interactive backend modules are defined by
   [ADR-164](../../adr/164-virtual-texturing-ownership-product-scope-and-capability-tier.md).
   Renderer owns admitted physical atlas/sparse resources, uploads, mappings, graph
   passes and GPU-safe retirement; it does not become logical page authority.
+- Under [ADR-167](../../adr/167-vtx-feedback-readback-prediction-and-camera-data-ownership.md),
+  Renderer also owns VTX feedback/compaction/copy passes, native resources and delayed
+  readback lifetime. It publishes bounded immutable observations; it neither predicts
+  page demand nor waits for same-frame CPU consumption.
 
 ## Layer Model
 

--- a/docs/architecture/runtime/virtual-texturing-architecture.md
+++ b/docs/architecture/runtime/virtual-texturing-architecture.md
@@ -103,6 +103,25 @@ pages are eviction candidates. Eviction first revokes logical availability, then
 for Assets, worker, snapshot and Renderer acknowledgements. `Evicting` state remains
 charged; cancellation or page-table removal alone never refunds capacity.
 
+## Feedback, Camera Hints And Prediction
+
+[ADR-167: VTX Feedback, Readback, Prediction and Camera-Data Ownership](../../adr/167-vtx-feedback-readback-prediction-and-camera-data-ownership.md)
+owns this boundary. VTX contributes a bounded semantic feedback plan. Renderer owns
+render-graph placement, GPU feedback/compaction/copy resources, asynchronous readback
+and retirement, then publishes immutable delayed observations with exact texture,
+device, frame and view generations.
+
+Camera/view owners publish immutable per-view snapshots with explicit cut, teleport,
+origin-rebase, projection and dynamic-resolution discontinuities. Producers publish
+typed bounded hints with provenance. VTX retains neither live Camera/Scene pointers nor
+producer containers and cannot select camera authority.
+
+VTX deterministically merges observations and predicts bounded demand candidates.
+Feedback and prediction are evidence only: candidates still pass ADR-166 coalescing,
+pin, priority and reservation policy. Missing/sampled/overflowed/cancelled observations
+carry explicit completeness; normal frames never wait for readback or allocate a larger
+buffer in response to overflow.
+
 ## Capability And Product Scope
 
 VTX uses feature-local tiers:


### PR DESCRIPTION
## Summary

- Add ADR-167 to define ownership of VTX feedback plans, renderer GPU/readback resources, immutable observations, camera/producer hints and prediction.
- Keep Renderer authoritative for render-graph placement, feedback/compaction/copy resources, asynchronous readback and GPU-safe retirement.
- Limit VTX to bounded semantic plans, immutable delayed observation consumption and deterministic demand-candidate prediction.
- Preserve Camera/view authority and ADR-166 global admission/residency authority.
- Align Virtual Texturing and Rendering architecture documentation and index the decision.

## Why

The previous VTX sketch combined a renderer `BufferHandle`, mutable CPU requested-page storage and feedback behavior in one object. It did not establish who places the graph pass, owns readback fences, validates delayed results, supplies camera state or decides what an observation is allowed to change.

That ambiguity permits same-frame GPU stalls, native resource ownership in VTX, live Camera/Scene pointers, incorrect history across camera cuts or origin rebases and feedback that bypasses global reservation policy. This decision turns feedback into bounded delayed evidence while retaining each existing authority.

## Decision and boundaries

- VTX declares a finite semantic feedback plan with schema, generation, cadence, sample/result/byte limits and overflow policy. It contains no native handles or arbitrary callbacks.
- Renderer validates effective capability and admitted cost, owns feedback/compaction/copy graph passes and all native/readback resources, and publishes only after asynchronous completion establishes CPU ownership.
- Observations carry exact VTX, renderer-device, source-frame and view-snapshot generations plus explicit latency/completeness. Wrong-schema, stale, duplicate, malformed or oversized results cannot publish demand.
- Camera/view coordinators provide immutable per-view snapshots. Cut, teleport, origin rebase, projection and dynamic-resolution changes are explicit discontinuities that reset or downweight prediction history.
- Multiview, editor, cinematic and capture views remain separate typed scopes selected by host policy; VTX cannot infer or select camera authority.
- Producer hints carry bounded provenance, validity and confidence. Producers cannot pin pages, allocate global budget or override content criticality.
- Prediction is deterministic, generation-scoped and bounded. It outputs demand candidates that still pass ADR-166 coalescing, pins, priority, reservation and fallback; it cannot directly load or evict.
- Feedback gaps distinguish sampled, overflowed, cadence-skipped, budget-dropped, cancelled and discontinuous observations. Missing feedback is never interpreted as no demand.
- `None` and hint-only modes are explicit capabilities independent of Atlas/Sparse realization; a required-feedback product needs a separately admitted fallback or fails visibly.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- <all changed Markdown files>`
- `git diff --check`
- `git diff --cached --check`
- Staged Markdown link checker: all added relative links resolve.
- Commit hooks:
  - `horo clang-format staged` passed.
  - `horo-engine layout configure` passed.
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`
  - Configuration completed successfully.
  - Existing mbedTLS minimum-CMake deprecation warning remains.
  - Repository Python tests remain skipped because `pytest` is unavailable in this environment.

## Risk and rollout

- This ADR intentionally fixes ownership/lifecycle semantics without selecting exact feedback encoding, compaction algorithm, cadence, numeric limits or prediction weights; downstream VTX-004 tickets own those measured choices.
- Asynchronous observations introduce latency, but source frame/age and discontinuity metadata make it explicit and avoid same-frame stalls.
- Hint-only or no-feedback paths require explicit product/artifact policy and qualification; they cannot be assumed from missing hardware support.
- Raw camera trajectories and feedback streams are treated as non-durable by default, so tooling that needs capture/export must add explicit privacy and retention policy.

## Issue links

- Closes #2205
- Jira: [HORO-2159](https://horo-engine.atlassian.net/browse/HORO-2159)
- Parent capability: #2204 / [HORO-2158](https://horo-engine.atlassian.net/browse/HORO-2158)
- Ownership prerequisite: #2176 / [HORO-2130](https://horo-engine.atlassian.net/browse/HORO-2130)

## Reviewer Notes

Please review four seams closely: VTX semantic plan versus Renderer resource ownership; delayed observation generation/age handling; Camera/view snapshot authority across cuts, rebases and multiview; and the final handoff from prediction into ADR-166 rather than directly into page operations.

The intended invariant is that Renderer reports *what bounded GPU evidence completed*, Camera/producer owners report *their immutable view/domain evidence*, and VTX predicts *candidate demand*. None of those facts independently grants global admission, a pin or an eviction.

## Stack

- Depends on #2501 (`docs/HORO-2149_vtx_residency_eviction_budget_reservations`).
- Base branch: `docs/HORO-2149_vtx_residency_eviction_budget_reservations`.
- Head branch: `docs/HORO-2159_vtx_feedback_readback_prediction_camera_ownership`.
- This PR is one Jira issue / one commit / one stacked PR; the next ranked M0 issue will branch from this head.


[HORO-2159]: https://horo-engine.atlassian.net/browse/HORO-2159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ