### PR TITLE
docs(android): define host and target ownership HORO-2196 #2257 [PLT-001.1]

### DIFF
--- a/docs/adr/171-android-host-target-and-ownership.md
+++ b/docs/adr/171-android-host-target-and-ownership.md
@@ -1,0 +1,185 @@
+# ADR-171: Android Host, Target and Ownership
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Android process entry, target/API/ABI baseline, platform and renderer ownership, lifecycle and packaging boundaries
+- **Issue**: [PLT-001.1](https://github.com/abdullahbodur/horo-engine/issues/2257)
+- **Jira**: [HORO-2196](https://horo-engine.atlassian.net/browse/HORO-2196)
+- **Parent**: [PLT-001](https://github.com/abdullahbodur/horo-engine/issues/2256)
+- **Related**: [ADR-004](004-cli-core-gui-boundary.md), [ADR-028](028-renderer-capability-limits-and-product-profiles.md), [ADR-031](031-vulkan-loader-platform-and-version-baseline.md), [ADR-033](033-presentation-and-display-ownership.md), [ADR-158](158-openxr-loader-backend-packaging-and-host-composition.md)
+- **Normative documents**: [Android Platform Host](../architecture/foundation/android-platform-host.md), [Platform Abstraction](../architecture/foundation/platform-abstraction.md), [Rendering Architecture](../architecture/runtime/rendering-architecture.md), [Release Architecture](../architecture/release/release.md)
+
+## Context
+
+Android work cannot start safely from an unspecified "mobile target." The process entry,
+API and ABI floors, graphics baseline, replaceable native-window lifetime, renderer
+boundary, optional XR composition, build topology and package evidence all affect which
+module owns state and when it may be destroyed. Leaving those decisions to individual
+features would create competing activity hosts, native-handle leakage into portable APIs,
+and packages whose support claims cannot be reproduced.
+
+Android currently recommends GameActivity for new C/C++ games and describes it as the
+replacement for NativeActivity. The NDK builds and packages ABIs independently. Android's
+native Vulkan guidance recommends Vulkan 1.1 on 64-bit Android 10 devices and defines an
+Android Baseline profile. Google Play target-level policy advances independently of engine
+architecture. These external policies are inputs to a pinned product profile, not ambient
+runtime discovery.
+
+## Decision
+
+### 1. One application host owns Android composition
+
+The Android product executable owns a private `AndroidHost` composition root. Its single
+interactive entry integration is pinned AndroidX GameActivity. NativeActivity and a custom
+second activity/native loop are not supported alternatives for the initial target.
+
+```text
+Android product application
+  -> private AndroidHost (GameActivity glue, process and lifecycle serialization)
+  -> HoroEngine::PlatformAndroid (private Android platform services)
+  -> portable Horo application/runtime
+  -> HoroEngine::RenderVulkanAndroid or RenderNull for admitted tests
+  -> optional HoroEngine::XROpenXR
+```
+
+Descriptors remain inert. The product host selects and wires concrete adapters before
+activation; Runtime, Renderer, XR and feature modules neither discover an Activity nor
+instantiate Android services.
+
+### 2. The initial target tuple is explicit
+
+| Dimension | Initial decision |
+|---|---|
+| Minimum Android API | API 29 (Android 10) |
+| General Google Play compile/target level | API 36 at this decision date; release policy may advance it without lowering the engine floor |
+| Production CPU ABI | `arm64-v8a` |
+| Development/emulator ABI | `x86_64`, not distribution-qualified until a product profile says otherwise |
+| Unsupported ABIs | `armeabi-v7a` and `x86` |
+| Interactive graphics | Vulkan 1.1 plus the Android Baseline profile's required operations and effective capabilities |
+| Optional graphics tier | Vulkan 1.3 only after separate device/profile qualification |
+| Headless/test graphics | RenderNull through an explicit no-presentation profile |
+| Initially unsupported graphics | OpenGL ES and desktop OpenGL |
+
+Every release profile freezes its actual minimum, compile and target API levels, ABI,
+renderer, device class and required features. A store requirement may force a newer target
+or compile level, but does not silently change `minSdk`, engine capability semantics or
+another distribution profile. Android XR and non-Play distributions declare separate
+tuples and evidence.
+
+### 3. Android Vulkan is a sibling backend specialization
+
+The Android Vulkan target is a sibling of desktop Vulkan behind Horo-owned contracts; it
+does not inherit a desktop host or expose `Vk*`, `ANativeWindow*` or JNI types publicly.
+ADR-031 qualifies only its declared desktop tuple and does not qualify Android by name.
+
+PlatformAndroid owns the retained `ANativeWindow` reference and its generation. The
+Android Vulkan backend borrows the admitted generation while it owns the Vulkan instance,
+device, surface, swapchain, queues, synchronization and deferred retirement. Surface loss
+invalidates presentation for that generation, not the process or logical runtime. Renderer
+support is the intersection of implemented operations, reported facts and product policy;
+a Vulkan version string alone never admits a profile.
+
+### 4. Lifecycle is serialized and generation safe
+
+GameActivity callbacks enqueue typed observations. `AndroidHost` serializes them on the
+application owner thread and drives explicit process, Activity, window and presentation
+generations. Duplicate, reordered and late callbacks are valid inputs and must be idempotent
+or rejected with a typed reason.
+
+Backgrounding is suspension, not shutdown. Window loss stops new presentation against the
+old generation while GPU references retire. Activity replacement may create new platform
+and permission generations without destroying durable application state. Final process
+shutdown cancels owned work and tears down XR, Renderer, Runtime and Platform in reverse
+dependency order.
+
+### 5. Native resources have one owner
+
+| Resource or responsibility | Owner | Deliberate non-owner |
+|---|---|---|
+| GameActivity integration and callback queue | AndroidHost | Runtime and features |
+| Activity, JavaVM/JNI attachment policy | AndroidHost with PlatformAndroid operations | Renderer and XR feature code |
+| `ANativeWindow` retained reference and generation | PlatformAndroid | Renderer only borrows an admitted generation |
+| Vulkan objects and presentation retirement | RenderVulkanAndroid | PlatformAndroid |
+| Input, permissions, sensors, storage and Android services | PlatformAndroid | Portable Runtime |
+| OpenXR loader/session/action objects | XROpenXR | PlatformAndroid and Renderer |
+| Product profile, adapter selection and shutdown order | Android product host | Descriptors and libraries |
+
+Cross-owner exchange uses typed Horo values, capability snapshots, opaque stable IDs and
+bounded operations. No public header contains Android, JNI, GameActivity, Vulkan or OpenXR
+native declarations.
+
+### 6. XR reuses the host without merging owners
+
+Standalone Android XR is an optional product composition over the same AndroidHost and
+PlatformAndroid contracts. The host passes admitted application/activity initialization
+inputs through the private capability defined by ADR-158. XROpenXR retains ownership of
+loader, instance, session, spaces and actions; PlatformAndroid does not call OpenXR, and
+the Vulkan backend does not own XR lifecycle. Android and XR target tuples qualify
+independently and must both pass for a standalone package.
+
+### 7. Toolchain and packages are pinned per ABI
+
+The repository records compatible SDK, NDK, CMake, JDK, Android Gradle Plugin and
+GameActivity dependency versions in target presets/package inputs. CMake configures one
+ABI per build directory. A multi-ABI package composes independently built, verified
+artifacts and records each ABI's native libraries and hashes.
+
+Release preflight rejects missing or drifting tools, unsupported API/ABI pairs, absent
+native dependencies, undeclared permissions/features, unavailable signing inputs, and
+renderer/profile mismatch. Machine SDK paths and credentials never enter source or
+published provenance.
+
+### 8. Migration and qualification fail closed
+
+Prototype native loops migrate behind AndroidHost; direct JNI/platform calls migrate to
+PlatformAndroid; Android graphics code migrates into the private Android Vulkan target;
+and ad hoc Gradle/CMake values migrate to versioned target profiles. There is no temporary
+second source of ownership truth.
+
+Host fakes validate lifecycle permutations and failure paths. Release qualification also
+requires reproducible physical-device evidence for the exact API/ABI/renderer/profile
+tuple, including cold start, suspend/resume, Activity and surface recreation, input and
+permission neutralization, memory/thermal pressure, device loss, packaging and shutdown.
+An emulator, RenderNull run or desktop Vulkan result cannot qualify an Android release.
+
+## Consequences
+
+- Android implementation tickets have a stable entry model, target floor and ownership
+  boundary instead of choosing them locally.
+- API 29 and `arm64-v8a` intentionally exclude older devices and 32-bit products; broader
+  support requires a new admitted and qualified product profile.
+- Android Vulkan, GameActivity integration and packaging require explicit private targets
+  and physical-device evidence before support may be claimed.
+- Store target-level changes remain release-policy updates and do not rewrite runtime
+  ownership or capability contracts.
+
+## Rejected Alternatives
+
+### Use NativeActivity or allow multiple entry models
+
+Rejected because competing event loops and lifecycle owners make callback ordering,
+dependency upgrades and test expectations product-specific.
+
+### Reuse the desktop Vulkan target unchanged
+
+Rejected because Android surface, loader, lifecycle, packaging and qualification concerns
+are different even when portable renderer contracts and some implementation utilities are
+shared.
+
+### Support every NDK ABI and graphics API initially
+
+Rejected because build success is not lifecycle, driver or package qualification and would
+multiply the initial evidence matrix without a product requirement.
+
+### Let runtime code probe policy from the device or Gradle environment
+
+Rejected because ambient probing makes support non-reproducible and moves composition,
+distribution and fallback authority into feature code.
+
+## External References
+
+- [GameActivity introduction and setup](https://developer.android.com/games/agdk/game-activity/get-started)
+- [Android NDK ABI management](https://developer.android.com/ndk/guides/abis)
+- [Android native Vulkan support guidance](https://developer.android.com/games/develop/vulkan/native-engine-support)
+- [Google Play target API requirements](https://developer.android.com/google/play/requirements/target-sdk)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -182,6 +182,7 @@ to the replacement.
 | [168](168-vtx-gpu-page-table-physical-cache-shader-and-material-ownership.md) | VTX GPU Page Table, Physical Cache, Shader and Material Ownership | Proposed | 2026-09-02 |
 | [169](169-vtx-producer-terrain-world-streaming-packaging-and-server-ownership.md) | VTX Producer, Terrain, World Streaming, Packaging and Server Ownership | Proposed | 2026-09-02 |
 | [170](170-vtx-settings-diagnostics-capture-and-qualification-ownership.md) | VTX Settings, Diagnostics, Capture and Qualification Ownership | Proposed | 2026-09-02 |
+| [171](171-android-host-target-and-ownership.md) | Android Host, Target and Ownership | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -80,6 +80,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Android Platform Host](./foundation/android-platform-host.md): Android
   activity lifecycle, replaceable native surfaces, permissions, storage,
   packaging, deployment, resource pressure, and standalone-XR prerequisites.
+- [Android Host, Target and Ownership](../adr/171-android-host-target-and-ownership.md):
+  GameActivity composition, initial API/ABI/Vulkan baseline, native-resource
+  ownership, lifecycle generations, packaging, migration, and qualification.
 - [Engine Data Bus](./foundation/engine-data-bus.md): process-scoped typed
   notifications.
 

--- a/docs/architecture/foundation/android-platform-host.md
+++ b/docs/architecture/foundation/android-platform-host.md
@@ -11,22 +11,38 @@ by ordinary Android applications and standalone Android-class XR targets.
 Android support is a platform capability. XR, game runtime, editor tooling, and
 renderer systems do not call Android APIs directly.
 
+## Decision Authority And Initial Baseline
+
+[ADR-171](../../adr/171-android-host-target-and-ownership.md) owns the Android
+entry, target and native-resource ownership decision. The initial interactive
+host uses pinned AndroidX GameActivity integration, API 29 as its minimum,
+`arm64-v8a` as its production ABI, and Android Vulkan 1.1 plus the Android
+Baseline profile. `x86_64` is a development/emulator ABI until separately
+distribution-qualified. OpenGL ES, `armeabi-v7a`, and `x86` are outside the
+initial product scope.
+
+Every product profile still freezes its actual compile/target API level and
+distribution constraints. Store-policy changes may advance those values; they
+do not silently alter the engine floor, ownership boundaries, or another
+distribution profile.
+
 ## Composition
 
 ```text
-Android application target
-  +-- Horo application composition
-  +-- Android platform adapter
+Android product application (GameActivity)
+  +-- private AndroidHost composition root
+  +-- Horo application/runtime composition
+  +-- private Android platform adapter
   |     activity/process lifecycle
   |     native window generation
   |     input, sensors, permissions
   |     storage and user directories
   |     device/resource snapshots
-  +-- selected renderer backend adapter
+  +-- Android Vulkan renderer or explicit RenderNull test adapter
   +-- optional OpenXR backend
 ```
 
-The process composition root selects the application profile, renderer, and
+The private AndroidHost process composition root selects the application profile, renderer, and
 optional XR backend. The Android host does not discover and activate arbitrary
 renderers after a native surface has already been bound to another backend.
 

--- a/docs/architecture/foundation/platform-abstraction.md
+++ b/docs/architecture/foundation/platform-abstraction.md
@@ -60,6 +60,11 @@ follow [Android Platform Host](./android-platform-host.md). Portable callers use
 the same capability model; they do not branch on Android APIs or lifecycle
 callbacks.
 
+[ADR-171](../../adr/171-android-host-target-and-ownership.md) fixes the initial
+Android composition and ownership boundary: a private GameActivity-based host
+owns lifecycle serialization, PlatformAndroid owns admitted native-window and
+Android-service lifetimes, and native types remain outside public Horo headers.
+
 ## Filesystem And Paths
 
 The engine uses structured path values:

--- a/docs/architecture/release/release.md
+++ b/docs/architecture/release/release.md
@@ -93,6 +93,15 @@ Editor and CLI releases may use Horo-owned update channels. Packaged games own
 their product identity, version, update channel, store integration, privacy
 policy, and patch policy.
 
+Android product profiles additionally follow
+[ADR-171](../../adr/171-android-host-target-and-ownership.md). They freeze the
+minimum, compile and target API levels, CPU ABI, GameActivity dependency,
+renderer profile, permissions/features and device-qualification identity.
+Each ABI is configured and built independently; a multi-ABI package may combine
+only verified native artifacts and records their identities and hashes. Store
+target-level policy may advance without silently broadening the engine's API,
+ABI or graphics support claim.
+
 ## Service Model
 
 ```text

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -185,6 +185,13 @@ portability-subset product support. These are downstream requirements, not a
 claim that a Vulkan backend target exists or that optional engine features are
 already implemented.
 
+[ADR-171](../../adr/171-android-host-target-and-ownership.md) owns the separate
+Android Vulkan baseline: API 29, production `arm64-v8a`, Vulkan 1.1 plus the
+Android Baseline profile, and a replaceable PlatformAndroid-owned native-window
+generation. Android Vulkan is a sibling backend specialization behind the same
+Horo contracts; ADR-031's desktop qualification does not qualify it. OpenGL ES
+is outside the initial Android product profile.
+
 [ADR-030](../../adr/030-metal-platform-and-feature-baseline.md) owns the `metal`
 component's native baseline: macOS 14.0+, Apple7 on native arm64 or Mac2 on native
 x86_64, explicit MSL 2.4 shaders, and conventional command-buffer/encoder APIs.


### PR DESCRIPTION
## Summary

Defines the initial Android host and target contract before the dependent lifecycle, input, storage, toolchain, and packaging work begins.

- Adds ADR-171 as the authority for Android process entry, API/ABI floors, renderer composition, native-resource ownership, lifecycle generations, and release qualification.
- Selects pinned AndroidX GameActivity integration as the single interactive host model.
- Establishes API 29 and `arm64-v8a` as the initial production baseline, with `x86_64` limited to development/emulator use until separately qualified.
- Establishes Android Vulkan 1.1 plus the Android Baseline profile as the initial interactive graphics contract; RenderNull remains explicit headless/test composition.
- Projects the decision into Platform, Renderer, Release, and architecture navigation documents so downstream work has one normative source.

## Why

The Android implementation tickets currently depend on choices that cut across several owners: Activity integration, callback ordering, native-window lifetime, renderer setup, ABI packaging, optional OpenXR composition, and store target policy. If those choices are made independently, the engine can end up with competing host loops, native Android/Vulkan types crossing public boundaries, surface recreation being treated as process shutdown, or packages claiming support without reproducible device evidence.

This decision fixes the ownership seams and an intentionally narrow first target. It also separates the engine minimum from moving store requirements, allowing release profiles to advance target/compile API levels without silently changing runtime capability semantics.

## Decision and boundaries

- `AndroidHost` is the private product composition root and serializes GameActivity callbacks onto the application owner thread.
- PlatformAndroid owns Android services and the retained, generation-scoped `ANativeWindow`; the Android Vulkan backend borrows the admitted generation and owns Vulkan resources and deferred retirement.
- Process, Activity, window, and presentation generations are distinct. Backgrounding is suspension, while final process teardown remains reverse dependency order.
- Android Vulkan is a sibling backend specialization behind Horo-owned contracts. Desktop Vulkan qualification under ADR-031 does not qualify Android.
- Standalone Android XR reuses the host contract without merging Platform, Renderer, and XROpenXR ownership.
- SDK, NDK, CMake, JDK, Android Gradle Plugin, and GameActivity versions are pinned in target inputs. Each ABI is configured and built independently before package composition.
- Unsupported configurations fail closed: `armeabi-v7a`, `x86`, OpenGL ES, desktop OpenGL, and unqualified `x86_64` distribution are outside the initial profile.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/171-android-host-target-and-ownership.md docs/adr/README.md docs/architecture/README.md docs/architecture/foundation/android-platform-host.md docs/architecture/foundation/platform-abstraction.md docs/architecture/runtime/rendering-architecture.md docs/architecture/release/release.md`
- `git diff --check`
- `git diff --cached --check`
- Added-Markdown-link existence check over the staged diff
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. The existing mbedTLS minimum-CMake deprecation warning remains. Repository Python tests were skipped by CMake because `pytest` is unavailable in the current environment.

## Risk and rollout

- API 29 and 64-bit-only production support intentionally reduce the first supported device matrix. Expanding it requires a separately admitted and qualified product profile.
- GameActivity and Android Vulkan introduce pinned external/toolchain inputs that must be kept compatible and recorded in package provenance.
- Store target API requirements can move faster than this ADR; release policy must update the concrete target/compile level while preserving the ownership and engine-floor distinction.
- This is an architecture decision, not an implementation or physical-device qualification claim. Downstream tickets must still provide native lifecycle, package, and device evidence.

## Issue links

- Jira: [HORO-2196](https://horo-engine.atlassian.net/browse/HORO-2196)
- GitHub issue: [#2257](https://github.com/abdullahbodur/horo-engine/issues/2257)
- Parent capability: [#2256 — PLT-001](https://github.com/abdullahbodur/horo-engine/issues/2256)
- Closes #2257

## Reviewer Notes

Please review the boundaries more than the chosen spelling of future implementation targets:

1. Is GameActivity correctly the sole owner-facing interactive entry integration?
2. Are `ANativeWindow`, Vulkan, JNI, and OpenXR lifetimes assigned to exactly one owner with no public native-type leakage?
3. Is the API 29 / `arm64-v8a` / Vulkan 1.1 baseline narrow enough to make downstream work and qualification concrete?
4. Is the separation between moving store target policy and the engine minimum explicit enough?
5. Do lifecycle generations make Activity and surface recreation implementable without conflating them with process shutdown?

## Stack

- Base: `docs/HORO-2187_vtx_settings_diagnostics_capture_qualification_ownership`
- Depends on: #2505
- This PR is one commit and one Jira/GitHub ticket in the M0 architecture stack.


[HORO-2196]: https://horo-engine.atlassian.net/browse/HORO-2196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ