### PR TITLE
docs(aia): define immersive authoring authority HORO-2227 #2288 [AIA-004.1]

### DIFF
--- a/docs/adr/172-immersive-agent-ownership-authoring-mode-and-risk.md
+++ b/docs/adr/172-immersive-agent-ownership-authoring-mode-and-risk.md
@@ -1,0 +1,216 @@
+# ADR-172: Immersive Agent Ownership, Authoring Mode and Risk
+
+- **Status**: Proposed
+- **Date**: 2026-09-02
+- **Supersedes**: None
+- **Scope**: Immersive editor-agent audience, mode admission, multimodal evidence, proposal approval, mutation authority, cross-system ownership, privacy and risk
+- **Issue**: [AIA-004.1](https://github.com/abdullahbodur/horo-engine/issues/2288)
+- **Jira**: [HORO-2227](https://horo-engine.atlassian.net/browse/HORO-2227)
+- **Parent**: [AIA-004](https://github.com/abdullahbodur/horo-engine/issues/2287)
+- **Related**: [ADR-018](018-command-registration-permissions-threading-and-packaged-build-policy.md), [ADR-021](021-gameplay-ai-ownership-scheduling-and-behavior-boundary.md), [ADR-070](070-capture-and-voice-io-ownership.md), [ADR-157](157-xr-ownership-runtime-composition-and-capability-tier.md), [ADR-159](159-xr-action-tracking-and-input-projection-ownership.md), [ADR-161](161-xr-interaction-runtime-ui-locomotion-and-accessibility-ownership.md)
+- **Normative documents**: [Editor AI Agent Architecture](../architecture/editor/editor-ai-agent-architecture.md), [Editor Document Model](../architecture/editor/editor-document-model.md), [MCP Architecture](../architecture/interfaces/mcp-architecture.md), [XR Architecture](../architecture/runtime/vr-ar-architecture.md)
+
+## Context
+
+Immersive authoring combines voice, gaze, pointing, tracked poses, controller actions,
+physical interaction, editor selection, scene state and agent tool calls. Those signals
+have different owners, reliability, privacy classes and meanings. Treating their temporal
+proximity as authority would let a glance, spoken discussion, grab, collision or tracking
+error approve a destructive edit.
+
+The agent also observes three distinct worlds: persistent Edit documents, disposable
+Simulate clones and Play runtime state. A tool that does not bind its proposal to the
+correct mode, project, scene, document revision and XR session can apply an answer to a
+different world than the user reviewed. Remote providers and MCP transports add prompt-
+injection, data disclosure, confused-deputy and delayed-result risks.
+
+The architecture already assigns microphone capture to Audio, transcription to a speech
+service, XR state to XR, mutations to editor commands and tool admission to MCP. This ADR
+fixes the immersive product boundary and the authority protocol that connects them.
+
+## Decision
+
+### 1. Immersive AI is developer authoring tooling
+
+The initial capability is an Editor AI surface for a locally present, authenticated
+developer in a trusted project. It is absent from packaged games and dedicated servers.
+It is not gameplay AI, an NPC/dialogue system, a player UGC runtime, a remote-administration
+channel or network authority.
+
+An editor host may compose the capability only when the exact XR, Audio/speech, agent
+provider, MCP tool, document and security policies pass preflight. Missing components
+produce a typed unavailable/degraded result; they never silently widen authority or fall
+back to player/runtime mutation.
+
+### 2. Authoring modes have different admission
+
+| Mode | Admitted reads and operations | Forbidden authority |
+|---|---|---|
+| Edit | Bounded context queries, transcription, planning, ghost preview, explicit approval and one editor transaction | Direct scene storage, asset or file mutation outside the transaction owner |
+| Simulate | Bounded queries/captures against the isolated simulation generation; proposal and preview against a named authoring revision | Mutation of the simulation world or authoring document while simulation is active |
+| Play / PIE | Bounded diagnostics and capture when product policy admits them | Runtime/gameplay mutation, authoring mutation, approval carry-over or apply-to-runtime |
+| Packaged game/server | None in the initial capability | Agent composition, editor tools and authoring credentials |
+
+A proposal prepared during Simulate or Play can be retained only as a non-authoritative
+candidate. Applying it requires return to Edit, fresh context and permission checks, exact
+document-revision revalidation, regenerated preview when relevant and new approval. Mode
+changes invalidate outstanding approval tokens.
+
+### 3. Evidence, request, proposal and approval are distinct
+
+The multimodal pipeline classifies data before it reaches a mutation boundary:
+
+```text
+bounded voice / transcript ----+
+XR pose, gaze, ray, action -----+--> timestamped evidence envelope
+Physics query/contact ----------+                |
+Editor selection/revision ------+                v
+                                         interpreted request
+                                                |
+                                                v
+                                  bounded proposal + ghost preview
+                                                |
+                                  explicit proposal-bound approval
+                                                |
+                                                v
+                                    editor command transaction
+```
+
+Voice may express a request but never approves a proposal. Gaze, pointing, dwell, head
+motion, proximity, selection, grab, contact, throw, collision, trigger events, tracking
+recovery and their combinations are context only. Confidence scores and model assertions
+cannot promote evidence to approval.
+
+Approval is a distinct non-voice UI/controller/accessibility action presented as an
+unambiguous review control. It binds the authenticated local user, proposal digest,
+human-readable impact summary, project/document identity and revision, target object
+generations, mode, permission snapshot, tool plan and expiry. It is single-use. Any bound
+change, timeout, cancellation, focus loss, XR session replacement or tracking invalidation
+returns to review or cancels the proposal.
+
+### 4. Owners and deliberate non-owners are fixed
+
+| Concern | Owner | Deliberate non-owner |
+|---|---|---|
+| Capture device, PCM timestamps, buffer/backpressure lifecycle | Audio under ADR-070 | AIA and XR do not open the microphone |
+| Speech model/provider, partial/final transcript and confidence | Speech/application service | Audio does not interpret intent; transcript does not approve |
+| XR session, pose/gaze/ray/action snapshots and validity | XR | AIA does not poll OpenXR or reinterpret tracking validity |
+| Spatial queries, contacts and simulated body state | Physics and the target world | AIA does not write solver state; contact is not intent |
+| Gameplay input, interaction and locomotion meaning | Input/Runtime UI/gameplay owners | AIA does not convert ordinary player actions into tool authority |
+| Multimodal envelope, request interpretation, proposal and preview orchestration | Editor AIA | AIA does not commit documents or runtime state |
+| Tool schema, transport, caller/session checks and capability admission | MCP | MCP does not own business rules or documents |
+| Validation, undo/redo, dirty state, atomic commit/save and conflict handling | Editor document/application command owner | Providers, AIA and MCP handlers do not mutate storage directly |
+| Network transport, peers and gameplay authority grants | Networking | AIA sessions and local presence do not grant network authority |
+| Consent, provider/data policy, audit retention and redaction | Security plus host/project policy | Provider responses do not choose disclosure or retention |
+
+Cross-owner data is immutable, bounded and generation checked. Native handles, writable
+references and owner-private service instances never enter the evidence envelope or model
+context.
+
+### 5. Every mutation is a reviewable editor transaction
+
+The model produces typed tool-plan candidates. MCP validates schemas and authorization;
+the application resolves them into a complete editor transaction candidate without
+publishing state. Ghost previews use transient editor-owned overlays and cannot affect
+queries, simulation, save data, networking or runtime authority.
+
+After explicit approval, the editor owner revalidates all bound identities, permissions,
+locks, preconditions, cost limits and document revisions at its safe point, then commits
+the whole transaction or none of it. Undo/redo uses normal semantic history. Provider or
+transport success is not commit success. Direct document/ECS/Physics/file mutation,
+generic data-bus commands and speculative authoritative edits are forbidden.
+
+Deletion, broad hierarchy/asset changes, script or executable changes, external process/
+network actions, project settings, camera/world transforms with high spatial impact and
+irreversible export require a heightened warning and policy-selected additional
+confirmation. The agent cannot split a high-risk plan to evade that classification.
+
+### 6. Context and privacy are purpose bounded
+
+Every request displays the admitted context categories and whether inference is local or
+remote. Raw microphone data, transcripts, gaze/pose history, hand/body features, room
+geometry, camera frames, paths, identities and tool results remain separate privacy
+classes. OS permission, XR feature availability or project trust does not authorize cloud
+disclosure, retention, training use or a later request.
+
+Context assembly prefers typed scene/document state and bounded spatial queries. It uses
+time-windowed samples with source, clock, timestamp, confidence, scene/document revision,
+object generation and XR session generation. Stale, hidden, locked, cross-project or
+unauthorized targets fail before planning. Raw captures are excluded unless an explicit
+purpose and policy admit them.
+
+Audit records contain safe identities, admitted category summaries, proposal digest,
+approval/denial, tool/result classes, transaction receipt and provider/policy revisions.
+They exclude raw voice, continuous gaze/pose, room/camera content, secrets and unrestricted
+payloads. Retention and export are bounded and user-visible.
+
+### 7. Remote and untrusted inputs cannot become authority
+
+Transcripts, scene text, asset metadata, provider output and network content are untrusted
+data. They cannot modify the system/tool policy, request hidden context, self-approve,
+increase budgets, enable tools, change modes or suppress review. Tool capabilities are
+computed by the host from caller identity, local presence, project trust, build profile,
+mode, permissions and policy; the model sees only the resulting finite set.
+
+MCP authentication or connection locality alone grants no authority. An immersive local
+session cannot mint Networking gameplay authority, and a remote MCP/network participant
+cannot impersonate local physical approval. Long-running capture, transcription,
+inference, planning and execution are cancellable and generation fenced. Late results
+become discarded candidates, not actions.
+
+### 8. Migration, failure and qualification fail closed
+
+Prototype gesture-to-command paths migrate to evidence envelopes; direct agent mutations
+migrate to proposal/preview/approval/transaction; mode-agnostic context caches gain exact
+world/document/session generations; and raw provider logs migrate to the bounded audit
+schema. Old approvals are not imported.
+
+Typed outcomes distinguish unavailable composition, permission/consent denial, invalid or
+stale context, unsupported mode, tracking/capture/transcription/provider failure, budget
+exhaustion, unauthorized tool, approval expiry/mismatch, transaction conflict and partial
+diagnostic evidence. Cancellation and shutdown close admissions and retain owner leases
+only until bounded acknowledgement.
+
+Qualification covers duplicate/out-of-order multimodal samples, ambiguous speech, gaze or
+gesture near approval controls, tracking loss, mode/document/session replacement, stale
+and malicious provider output, permission revocation, cloud-denied/local operation, high-
+risk confirmation, transaction conflict/rollback, audit redaction and packaged-build
+absence. Tests must prove forbidden mutation, not merely successful happy paths.
+
+## Consequences
+
+- Immersive authoring can combine rich spatial evidence without turning natural behavior
+  into authority.
+- Simulate and Play are useful observation environments but cannot bypass persistent
+  document review or mutate runtime worlds.
+- Every accepted change has an attributable proposal, explicit approval and ordinary
+  editor transaction receipt.
+- The initial capability deliberately excludes player-facing and packaged-runtime agents;
+  adding either requires a separate product, security and authority decision.
+
+## Rejected Alternatives
+
+### Treat a voice confirmation or gesture as approval
+
+Rejected because speech recognition is probabilistic, conversation is not a secure
+confirmation channel, and natural spatial behavior is ambiguous and accessibility-hostile.
+
+### Let the agent edit the active Simulate or Play world
+
+Rejected because ephemeral/runtime state has different ownership and may diverge from the
+document the user believes they are changing.
+
+### Give the provider direct editor or Physics access
+
+Rejected because it bypasses tool admission, owner-thread rules, document history,
+generation checks, rollback and auditable authority.
+
+### Enable the same agent in packaged games
+
+Rejected because developer project trust, editor documents, provider credentials and MCP
+mutation tools are not a player-facing security or gameplay-authority model.
+
+### Infer approval from several weak signals
+
+Rejected because combining gaze, pointing, speech confidence and contact does not make
+any signal intentional, authenticated or bound to the reviewed proposal.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -183,6 +183,7 @@ to the replacement.
 | [169](169-vtx-producer-terrain-world-streaming-packaging-and-server-ownership.md) | VTX Producer, Terrain, World Streaming, Packaging and Server Ownership | Proposed | 2026-09-02 |
 | [170](170-vtx-settings-diagnostics-capture-and-qualification-ownership.md) | VTX Settings, Diagnostics, Capture and Qualification Ownership | Proposed | 2026-09-02 |
 | [171](171-android-host-target-and-ownership.md) | Android Host, Target and Ownership | Proposed | 2026-09-02 |
+| [172](172-immersive-agent-ownership-authoring-mode-and-risk.md) | Immersive Agent Ownership, Authoring Mode and Risk | Proposed | 2026-09-02 |
 
 ## Conventions
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -586,6 +586,9 @@ dependency direction in [System Design](./foundation/system-design.md).
 - [Editor AI Agent Architecture](./editor/editor-ai-agent-architecture.md):
   editor-integrated conversational agent, viewport inline editing, MCP tool-calling,
   magic AI tools, conversation persistence, and privacy model.
+- [Immersive Agent Ownership, Authoring Mode and Risk](../adr/172-immersive-agent-ownership-authoring-mode-and-risk.md):
+  developer-only XR authoring, Edit/Simulate/Play admission, multimodal evidence,
+  proposal-bound approval, transaction authority and privacy/risk boundaries.
 - [Project Model](./editor/project-model.md): project directory, settings, workspace
   persistence, scene documents, and asset index.
 

--- a/docs/architecture/editor/editor-ai-agent-architecture.md
+++ b/docs/architecture/editor/editor-ai-agent-architecture.md
@@ -19,9 +19,15 @@ contextual entry points include viewport inline prompts, magic AI tools, and an
 optional immersive XR authoring surface. Every surface shares the same provider,
 context, permission, transaction, history, and audit owners.
 
+[ADR-172](../../adr/172-immersive-agent-ownership-authoring-mode-and-risk.md)
+is the normative authority for the immersive surface's developer-only audience,
+Edit/Simulate/Play admission, multimodal evidence classification, explicit
+approval, transaction boundary, privacy and cross-system non-ownership. Voice,
+gaze, pointing and physical interaction never constitute proposal approval.
+
 ## System Overview
 
-```
+```text
 ┌──────────────────────────────────────────────────────────┐
 │  Editor UI (HTML / ImGui)                                │
 │  ┌──────────────────────┐  ┌────────────────────────────┐│
@@ -178,6 +184,19 @@ Voice, gaze, a pointing gesture, contact, or a physical throw cannot transition
 `ReadyForReview` to `Applying`. Approval uses an explicit admitted controller,
 keyboard, or accessible UI action bound to the exact proposal and document
 revision. Camera and world-transform changes receive heightened impact warning.
+
+Authoring mode is part of admission, not presentation state:
+
+| Mode | Immersive agent contract |
+|---|---|
+| Edit | Query, propose, preview and explicitly approve one editor transaction |
+| Simulate | Inspect the isolated simulation and prepare a candidate; return to Edit, revalidate and approve before document mutation |
+| Play / PIE | Bounded diagnostics/capture only; no runtime or document mutation |
+| Packaged game/server | Capability absent |
+
+Mode, document, project or XR-session replacement invalidates outstanding
+approval. A retained proposal remains non-authoritative and must be reviewed
+against fresh context.
 
 Long-running transcription, planning, tool execution, and preview generation
 are cancellable and expose stable progressive feedback. They do not hide
@@ -440,7 +459,7 @@ request reaches the LLM.
 
 ## Request Pipeline
 
-```
+```text
 User types message
       │
       ▼
@@ -561,7 +580,7 @@ and UI refresh. Agent tools do not bypass it.
 
 ### Communication Flow
 
-```
+```text
 Viewport / Side Panel / AI Brush
       │
       ▼
@@ -892,7 +911,7 @@ changes receive a more prominent impact summary.
 
 ### Example: Fix This Corner
 
-```
+```text
 User: "clean up this area"
 Context:
   - editor camera pose

--- a/docs/architecture/interfaces/mcp-architecture.md
+++ b/docs/architecture/interfaces/mcp-architecture.md
@@ -415,6 +415,14 @@ enabled by a remote caller or archive field.
 
 ## Security
 
+[ADR-172](../../adr/172-immersive-agent-ownership-authoring-mode-and-risk.md)
+specializes immersive editor-agent tools. Multimodal input is bounded evidence,
+not MCP authorization: voice, gaze, pointing, contact and physical interaction
+cannot approve a tool plan. Mutating plans require a local proposal-bound approval
+and still pass through application validation and an atomic editor transaction.
+Mode, document, project or XR-session replacement invalidates approval; remote MCP
+identity cannot impersonate locally present physical approval.
+
 [ADR-122](../../adr/122-cinematic-trigger-sources-and-capability-policy.md)
 specializes cinematic start/control tools. A registered tool remains an MCP adapter
 over the common application `ICinematicPlaybackCapability`; it never receives the

--- a/docs/architecture/runtime/networking-architecture.md
+++ b/docs/architecture/runtime/networking-architecture.md
@@ -471,6 +471,13 @@ unpublishes the client session view and cannot promote a client to standalone.
 Shutdown unpublishes views and invalidates grants before worlds, sessions,
 listeners or transports are destroyed.
 
+Immersive Editor AI under
+[ADR-172](../../adr/172-immersive-agent-ownership-authoring-mode-and-risk.md)
+does not alter this authority model. Local XR presence, an agent/MCP session,
+voice or physical interaction cannot mint a peer, session, object or server-world
+grant. Remote participants cannot impersonate local proposal approval, and
+network content remains untrusted context rather than editor-tool authority.
+
 ## Project Configuration and Product Capability
 
 [ADR-103](../../adr/103-network-project-configuration-and-build-profile-ownership.md)

--- a/docs/architecture/runtime/physics-architecture.md
+++ b/docs/architecture/runtime/physics-architecture.md
@@ -288,6 +288,12 @@ Events are stored in a world-owned bounded buffer and consumed during the
 declared post-physics phase. They are not individually published to the
 process-wide data bus.
 
+An immersive editor agent admitted under
+[ADR-172](../../adr/172-immersive-agent-ownership-authoring-mode-and-risk.md)
+may consume bounded, generation-checked query or contact summaries as context.
+Physics events remain simulation facts: contact, overlap, grab and throw evidence
+never grants agent intent, proposal approval or solver-mutation authority.
+
 If overflow occurs, the world records a metric and emits one diagnostic summary.
 
 ## Queries

--- a/docs/architecture/runtime/vr-ar-architecture.md
+++ b/docs/architecture/runtime/vr-ar-architecture.md
@@ -54,6 +54,12 @@ separates portable project intent, effective runtime snapshots, editor tooling,
 Observability/captures and release evidence. Metrics use finite dimensions, and runtime
 compatibility never substitutes for physical-device qualification.
 
+[ADR-172](../../adr/172-immersive-agent-ownership-authoring-mode-and-risk.md)
+specializes the optional developer-only immersive Editor AI consumer. XR supplies
+validity- and generation-checked poses, rays, gaze and actions as bounded evidence;
+it does not interpret agent intent, approve proposals, own editor transactions or
+expose the capability in packaged games.
+
 ## Ownership
 
 ```text


### PR DESCRIPTION
## Summary

Defines the product boundary, authority model, mode admission, and safety invariants for immersive multimodal AI authoring.

- Adds ADR-172 as the normative decision for developer-only immersive authoring.
- Separates multimodal evidence, interpreted requests, proposals, explicit approval, and editor transaction commit.
- Defines distinct admission for Edit, Simulate, Play/PIE, and packaged builds.
- Assigns ownership and deliberate non-ownership across AIA, Audio/speech, XR, Physics, Input/gameplay, MCP, editor documents, Networking, and Security.
- Projects the decision into Editor AI, MCP, XR, Physics, Networking, and architecture navigation documents.
- Labels previously unlabeled text diagrams in the touched Editor AI document so the full changed-document Markdown gate passes.

## Why

Voice, gaze, pointing, tracked poses, controller input, physical contacts, editor selection, and model output are useful context but are not equivalent forms of authority. Without an explicit protocol, temporal proximity or model confidence could turn an ambiguous glance, spoken discussion, grab, collision, or delayed provider response into a destructive edit.

Edit documents, Simulate clones, and Play runtime worlds also have different owners and lifetimes. A proposal prepared against one mode or revision must not be applied to another. This decision gives the dependent immersive-agent tickets a single boundary for mode changes, local approval, stale context, privacy, remote providers, MCP tools, and ordinary editor history.

## Decision and boundaries

- The initial capability is an Editor AI surface for a locally present authenticated developer in a trusted project. It is absent from packaged games and dedicated servers.
- Edit admits bounded query, proposal, ghost preview, and explicit approval followed by one atomic editor transaction.
- Simulate admits observation and proposal preparation only. Applying requires returning to Edit, refreshing context, revalidating the document revision, regenerating preview when relevant, and obtaining new approval.
- Play/PIE admits only policy-bounded diagnostics and capture; neither runtime nor authoring mutation is available.
- Voice can express a request, but voice, gaze, dwell, pointing, selection, grabbing, contact, throws, collisions, tracking recovery, or any combination of them never approves a proposal.
- Approval is a separate non-voice UI/controller/accessibility action bound to the local user, proposal digest, impact summary, project/document revision, object generations, mode, permissions, tool plan, and expiry. It is single-use.
- MCP validates tool schema and admission; the application builds a candidate; the editor document/command owner alone revalidates and commits. Providers and transport success cannot mutate state.
- High-risk operations receive heightened warnings and additional policy-selected confirmation. A plan cannot evade classification by splitting itself.
- Privacy and audit policy keep raw voice, continuous gaze/pose, room/camera data, secrets, paths, and unrestricted payloads out of ordinary provider context and audit records.

## Review findings addressed

- The individual Codacy analysis succeeded before admission to `develop`.
- Inline and summary findings from this source PR are retained in the final
  finding ledger and fixed or reasoned about in integration PR #2508.
- Inclusion in `develop` is not the final quality gate; combined validation
  and Codacy run on the complete architecture stack before `main` merge.

## Validation

- `npx --yes markdownlint-cli --disable MD013 MD060 -- docs/adr/172-immersive-agent-ownership-authoring-mode-and-risk.md docs/adr/README.md docs/architecture/README.md docs/architecture/editor/editor-ai-agent-architecture.md docs/architecture/interfaces/mcp-architecture.md docs/architecture/runtime/vr-ar-architecture.md docs/architecture/runtime/physics-architecture.md docs/architecture/runtime/networking-architecture.md`
- `git diff --check`
- `git diff --cached --check`
- Added-Markdown-link existence check over the staged diff
- `cmake -S . -B build/skeleton -DBUILD_TESTING=ON`

CMake configuration completed successfully. The existing mbedTLS minimum-CMake deprecation warning remains. Repository Python tests were skipped by CMake because `pytest` is unavailable in the current environment.

## Risk and rollout

- The developer-only baseline deliberately excludes player-facing or packaged-runtime agents. Adding those later requires a separate security, product, gameplay-authority, credential, and privacy decision.
- Non-voice approval must remain accessible without allowing ordinary XR actions to become accidental confirmations; UI and input design will require targeted usability and safety testing.
- Simulate/Play observations can become stale quickly. Every downstream implementation must carry exact world, scene, document, object, mode, and XR-session generations.
- Remote inference increases disclosure and prompt-injection exposure. Tool availability and context disclosure remain host-computed, finite, purpose-bound, and visible to the user.
- This ADR defines authority and qualification obligations; it does not claim an implemented speech provider, XR editor surface, or safe physical-device interaction flow.

## Issue links

- Jira: [HORO-2227](https://horo-engine.atlassian.net/browse/HORO-2227)
- GitHub issue: [#2288](https://github.com/abdullahbodur/horo-engine/issues/2288)
- Parent capability: [#2287 — AIA-004](https://github.com/abdullahbodur/horo-engine/issues/2287)
- Closes #2288

## Reviewer Notes

Please focus review on authority and failure behavior:

1. Does any voice, gaze, pointing, contact, tracking, or provider signal still have a path to implicit approval?
2. Are Edit, Simulate, Play/PIE, and packaged-build capabilities sufficiently distinct and fail-closed?
3. Is approval bound to enough identity and revision data to prevent delayed or cross-world application?
4. Does every subsystem retain its existing authority, with AIA limited to orchestration/presentation and MCP limited to the automation boundary?
5. Are high-risk classification, privacy categories, remote-input handling, cancellation, and audit evidence implementable by downstream tickets?

## Stack

- Base: `docs/HORO-2196_android_host_target_ownership`
- Depends on: #2506
- This PR is one commit and one Jira/GitHub ticket in the M0 architecture stack.


[HORO-2227]: https://horo-engine.atlassian.net/browse/HORO-2227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ