### PR TITLE
feat(render): migrate OpenGL viewport resources HORO-293 #293 [RND-001.4]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
               sudo apt-get update
             fi
             sudo apt-get install -y --no-install-recommends \
-              ninja-build ccache unzip gcovr \
+              ninja-build ccache unzip gcovr xvfb xauth \
               libwayland-dev wayland-protocols libxkbcommon-dev \
               libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
               libxext-dev libxss-dev libxtst-dev libxxf86vm-dev \
@@ -56,11 +56,13 @@ jobs:
               -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
               -DHORO_ENABLE_EDITOR=ON \
+              -DHORO_ENABLE_GPU_SMOKE_TESTS=ON \
               -DHORO_ENABLE_TELEMETRY=ON \
               -DHORO_ENABLE_OPENTELEMETRY=ON
             cmake --build build/sonar --parallel
-            ctest --test-dir build/sonar --output-on-failure -LE gui
+            xvfb-run -a ctest --test-dir build/sonar --output-on-failure -LE gui
             gcovr --sonarqube build/sonar/coverage.xml \
+              --sonarqube-metric line \
               --root "$CIRCLE_WORKING_DIRECTORY" \
               --filter "$CIRCLE_WORKING_DIRECTORY/include" \
               --filter "$CIRCLE_WORKING_DIRECTORY/src" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
               -DHORO_ENABLE_TELEMETRY=ON \
               -DHORO_ENABLE_OPENTELEMETRY=ON
             cmake --build build/sonar --parallel
-            xvfb-run -a ctest --test-dir build/sonar --output-on-failure -LE gui
+            xvfb-run -a ctest --test-dir build/sonar --output-on-failure -LE 'gui|editor'
             gcovr --sonarqube build/sonar/coverage.xml \
               --sonarqube-metric line \
               --root "$CIRCLE_WORKING_DIRECTORY" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,11 +40,13 @@ jobs:
               sudo apt-get update
             fi
             sudo apt-get install -y --no-install-recommends \
-              ninja-build ccache unzip gcovr xvfb xauth \
+              ninja-build ccache unzip python3-venv xvfb xauth \
               libwayland-dev wayland-protocols libxkbcommon-dev \
               libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
               libxext-dev libxss-dev libxtst-dev libxxf86vm-dev \
               libgl1-mesa-dev libglu1-mesa-dev
+            python3 -m venv /tmp/horo-gcovr
+            /tmp/horo-gcovr/bin/pip install --disable-pip-version-check --no-cache-dir gcovr==8.6
       - run:
           name: Configure and build
           command: |
@@ -61,7 +63,7 @@ jobs:
               -DHORO_ENABLE_OPENTELEMETRY=ON
             cmake --build build/sonar --parallel
             xvfb-run -a ctest --test-dir build/sonar --output-on-failure -LE 'gui|editor'
-            gcovr --sonarqube build/sonar/coverage.xml \
+            /tmp/horo-gcovr/bin/gcovr --sonarqube build/sonar/coverage.xml \
               --sonarqube-metric line \
               --root "$CIRCLE_WORKING_DIRECTORY" \
               --filter "$CIRCLE_WORKING_DIRECTORY/include" \

--- a/apps/HoroEditor/app/HoroEditorApp.cpp
+++ b/apps/HoroEditor/app/HoroEditorApp.cpp
@@ -634,7 +634,7 @@ namespace Horo::Editor {
                 if (const Result<void> initialized = guiRenderer->Initialize(); initialized.HasError()) {
                     return Result<EditorRenderComposition>::Failure(initialized.ErrorValue());
                 }
-                auto viewportRenderer = std::make_unique<EditorViewportRendererOpenGL>();
+                auto viewportRenderer = std::make_unique<EditorViewportRendererOpenGL>(*composition.frontend);
                 if (const Result<void> initialized = viewportRenderer->Initialize(); initialized.HasError()) {
                     return Result<EditorRenderComposition>::Failure(initialized.ErrorValue());
                 }
@@ -661,11 +661,13 @@ namespace Horo::Editor {
                 attached.HasError()) {
                 return Result<EditorRenderComposition>::Failure(attached.ErrorValue());
             }
-            auto viewportTarget = composition.frontend->CreateOffscreenTarget({1, 1});
-            if (viewportTarget.HasError()) {
-                return Result<EditorRenderComposition>::Failure(viewportTarget.ErrorValue());
+            if (options.rendererBackend != "opengl") {
+                auto viewportTarget = composition.frontend->CreateOffscreenTarget({1, 1});
+                if (viewportTarget.HasError()) {
+                    return Result<EditorRenderComposition>::Failure(viewportTarget.ErrorValue());
+                }
+                composition.viewportTarget = viewportTarget.Value();
             }
-            composition.viewportTarget = viewportTarget.Value();
 
             return Result<EditorRenderComposition>::Success(std::move(composition));
         }
@@ -846,11 +848,8 @@ namespace Horo::Editor {
                 passCount_ = 0;
                 const EditorViewportSceneView viewportScene = viewportSceneState_->View();
                 if (const EditorViewportExtent viewportExtent = p_->presentation.viewportRenderer.RequestedExtent();
-                    viewportExtent.IsValid()) {
-                    if (const Result<void> resized =
-                            p_->presentation.renderFrontend.ResizeOffscreenTarget(p_->presentation.viewportTarget,
-                                                                                  {viewportExtent.width, viewportExtent.height});
-                        resized.HasError())
+                    CanSubmitViewportPass(viewportExtent)) {
+                    if (const Result<void> resized = ResizeLegacyViewportTarget(viewportExtent); resized.HasError())
                         return resized;
                     passes_[passCount_++] =
                         Render::RenderPassDescriptor{.id = Render::RenderPassId{1},
@@ -884,6 +883,9 @@ namespace Horo::Editor {
             }
 
             Result<bool> BeginRenderFrame(const Runtime::FrameContext &context) {
+                if (const Result<void> prepared = PrepareViewportResources(); prepared.HasError())
+                    return Result<bool>::Failure(prepared.ErrorValue());
+
                 int drawableWidth = 0;
                 int drawableHeight = 0;
                 SDL_GetWindowSizeInPixels(p_->presentation.window, &drawableWidth, &drawableHeight);
@@ -904,6 +906,33 @@ namespace Horo::Editor {
                     return Result<bool>::Failure(begun.ErrorValue());
                 frame_.emplace(std::move(begun).Value());
                 return Result<bool>::Success(true);
+            }
+
+            Result<void> PrepareViewportResources() {
+                const EditorViewportSceneView viewportScene = viewportSceneState_->View();
+                auto prepared =
+                    p_->presentation.viewportRenderer.PrepareResources(p_->presentation.renderFrontend,
+                                                                       Render::RenderSceneView{.camera =
+                                                                                                   ToRenderCamera(viewportScene.camera),
+                                                                                               .meshResources = viewportScene.meshResources,
+                                                                                               .instances = viewportScene.instances,
+                                                                                               .lights = viewportScene.lights});
+                if (prepared.HasError())
+                    return Result<void>::Failure(prepared.ErrorValue());
+                if (prepared.Value().has_value())
+                    p_->presentation.viewportTarget = *prepared.Value();
+                return Result<void>::Success();
+            }
+
+            [[nodiscard]] bool CanSubmitViewportPass(const EditorViewportExtent extent) const noexcept {
+                return extent.IsValid() && p_->presentation.viewportTarget.IsValid() && p_->presentation.viewportRenderer.IsReady();
+            }
+
+            Result<void> ResizeLegacyViewportTarget(const EditorViewportExtent extent) {
+                if (p_->presentation.renderFrontend.Capabilities().supportsRenderTargetResources)
+                    return Result<void>::Success();
+                return p_->presentation.renderFrontend.ResizeOffscreenTarget(p_->presentation.viewportTarget,
+                                                                             {extent.width, extent.height});
             }
 
             Result<void> ExecuteFrame(const Runtime::FrameContext &) {

--- a/cmake/HoroDependencyPolicy.cmake
+++ b/cmake/HoroDependencyPolicy.cmake
@@ -49,7 +49,7 @@ horo_allow_target_dependencies(TARGET HoroEditorServices
         HoroProjectMigrations
         HoroAssets)
 horo_allow_target_dependencies(TARGET HoroEditorViewportOpenGL
-    DEPENDENCIES HoroEditorViewportScene HoroRenderOpenGL)
+    DEPENDENCIES HoroEditorViewportScene HoroRenderOpenGL HoroRenderFrontend)
 horo_allow_target_dependencies(TARGET HoroEditorViewportMetal
     DEPENDENCIES HoroEditorViewportScene HoroRenderMetal)
 horo_allow_target_dependencies(TARGET HoroGui

--- a/cmake/HoroPublicHeaderOwnership.cmake
+++ b/cmake/HoroPublicHeaderOwnership.cmake
@@ -108,6 +108,7 @@ horo_configure_target_header_boundary(HoroInput PUBLIC_HEADERS
 horo_configure_target_header_boundary(HoroRenderApi PUBLIC_HEADERS
     Horo/Runtime/Render/Mesh.h
     Horo/Runtime/Render/RenderBackend.h
+    Horo/Runtime/Render/Texture.h
     Horo/Runtime/Render/RenderResource.h
     Horo/Runtime/Render/RenderScene.h
 )

--- a/docs/architecture/runtime/rendering-architecture.md
+++ b/docs/architecture/runtime/rendering-architecture.md
@@ -992,16 +992,26 @@ remains host-owned. The editor composition root registers the module, selects it
 through `RenderFrontend`, and performs primary-output clear and presentation only
 through the staged frame scope.
 
-The current editor viewport uses frontend-owned logical target identities with
-editor-private OpenGL and Metal texture bridges.
+The OpenGL editor viewport owns generation-safe texture, texture-view, render-target,
+buffer, and mesh handles through `RenderFrontend`. Creation is queued and published
+only at the frontend resource safe point; replacement keeps the previous generation
+usable until the new generation is ready, and release follows dependency order. An
+editor-private OpenGL bridge resolves ready generic handles to backend instances for
+frame-local command encoding. OpenGL names, framebuffer objects, and vertex-array
+objects remain private to the OpenGL module and its matching editor integration.
+The Metal editor viewport still uses its transitional frontend-owned logical target
+identity and editor-private texture bridge until its corresponding resource-migration
+ticket is complete.
 Render extraction resolves versioned primitive descriptors through
 `PrimitiveMeshCache`, emits a deduplicated table of immutable generic mesh
 resource views, and emits instances containing only mesh resource identity,
-transform, bounds, material, and presentation state. Each executor owns its native
-vertex/index buffer registry and an offscreen color/depth target, and exposes
-only a GUI-bridge texture identity to `ViewportPanel`. The GUI identity remains
-app-private and is not a public render texture handle. Render extraction and
-static-mesh submission are backend-neutral. OpenGL and Metal editor integrations must
+transform, bounds, material, and presentation state. The OpenGL executor resolves
+frontend-owned resident meshes and targets at a frame boundary; the transitional
+Metal executor continues to own its native vertex/index buffer registry and
+offscreen color/depth target. Both expose only a GUI-bridge texture identity to
+`ViewportPanel`. The GUI identity remains app-private and is not a public render
+texture handle. Render extraction and static-mesh submission are backend-neutral.
+OpenGL and Metal editor integrations must
 satisfy the same lifecycle and viewport parity suite defined by
 [Render Backend Parity Contract](render-backend-parity-contract.md).
 Selected editor instances carry backend-neutral tint and strength values; both

--- a/include/Horo/Runtime/Render/RenderBackend.h
+++ b/include/Horo/Runtime/Render/RenderBackend.h
@@ -7,6 +7,7 @@
 
 #include "Horo/Foundation/Result.h"
 #include "Horo/Runtime/Render/RenderScene.h"
+#include "Horo/Runtime/Render/Texture.h"
 
 #include <cmath>
 #include <cstddef>
@@ -79,17 +80,6 @@ namespace Horo::Render {
         bool supportsInteractivePresentation{false};
     };
 
-    /** @brief Pixel extent of a render surface or offscreen target. */
-    struct FramebufferExtent {
-        std::uint32_t width{0};
-        std::uint32_t height{0};
-
-        /** @brief Reports whether both dimensions can back a render target. */
-        [[nodiscard]] constexpr bool IsValid() const noexcept {
-            return width > 0 && height > 0;
-        }
-    };
-
     /** @brief Backend-neutral presentation pacing policy. */
     enum class PresentMode : std::uint8_t {
         Fifo,
@@ -129,6 +119,8 @@ namespace Horo::Render {
         bool supportsRayTracing{false};
         bool supportsBufferResources{false};
         bool supportsMeshResources{false};
+        bool supportsTextureResources{false};
+        bool supportsRenderTargetResources{false};
     };
 
     /** @brief Describes one host frame before backend work begins. */
@@ -305,11 +297,55 @@ namespace Horo::Render {
         [[nodiscard]] virtual Result<std::uint64_t> CreateMesh(const RenderMeshDescriptor &descriptor, std::uint64_t vertexBuffer,
                                                                std::uint64_t indexBuffer) = 0;
 
+        /**
+         * @brief Realizes one validated immutable texture allocation.
+         * @param descriptor Backend-neutral allocation policy validated by the frontend.
+         * @return Non-zero backend-private texture identity, or a typed failure.
+         */
+        [[nodiscard]] virtual Result<std::uint64_t> CreateTexture(const RenderTextureDescriptor &descriptor) = 0;
+
+        /**
+         * @brief Realizes one validated view over an exact ready texture instance.
+         * @param descriptor Backend-neutral view policy validated by the frontend.
+         * @param texture Backend-private instance for descriptor.texture.
+         * @return Non-zero backend-private view identity, or a typed failure.
+         */
+        [[nodiscard]] virtual Result<std::uint64_t> CreateTextureView(const RenderTextureViewDescriptor &descriptor,
+                                                                      std::uint64_t texture) = 0;
+
+        /**
+         * @brief Realizes one validated render target over exact ready attachment views.
+         * @param descriptor Backend-neutral attachment policy validated by the frontend.
+         * @param colorAttachment Backend-private color view, or zero when absent.
+         * @param depthAttachment Backend-private depth view, or zero when absent.
+         * @return Non-zero backend-private render-target identity, or a typed failure.
+         */
+        [[nodiscard]] virtual Result<std::uint64_t> CreateRenderTarget(const RenderTargetDescriptor &descriptor,
+                                                                       std::uint64_t colorAttachment, std::uint64_t depthAttachment) = 0;
+
         /** @brief Releases one buffer instance after frontend dependency and submission pins drain. */
         virtual void DestroyBuffer(std::uint64_t backendInstance) noexcept = 0;
 
         /** @brief Releases one mesh instance after frontend dependency and submission pins drain. */
         virtual void DestroyMesh(std::uint64_t backendInstance) noexcept = 0;
+
+        /**
+         * @brief Releases one texture instance after dependency and submission pins drain.
+         * @param backendInstance Backend-private identity previously returned by CreateTexture.
+         */
+        virtual void DestroyTexture(std::uint64_t backendInstance) noexcept = 0;
+
+        /**
+         * @brief Releases one texture-view instance after dependency and submission pins drain.
+         * @param backendInstance Backend-private identity previously returned by CreateTextureView.
+         */
+        virtual void DestroyTextureView(std::uint64_t backendInstance) noexcept = 0;
+
+        /**
+         * @brief Releases one render-target instance after dependency and submission pins drain.
+         * @param backendInstance Backend-private identity previously returned by CreateRenderTarget.
+         */
+        virtual void DestroyRenderTarget(std::uint64_t backendInstance) noexcept = 0;
 
         /** @brief Starts one frame and returns the token required by later frame operations. */
         [[nodiscard]] virtual Result<FrameToken> BeginFrame(const FrameDescriptor &descriptor) = 0;

--- a/include/Horo/Runtime/Render/RenderFrontend.h
+++ b/include/Horo/Runtime/Render/RenderFrontend.h
@@ -12,9 +12,12 @@
 #include <vector>
 
 namespace Horo::Render {
+    class RenderFrontend;
+
     namespace Detail {
         class RenderResourceRegistry;
         class RenderResourceUploadQueue;
+        class RenderFrontendResourceAccess;
     }  // namespace Detail
 
     /** @brief Finite frontend admission and per-drain limits for initial resource uploads. */
@@ -29,8 +32,6 @@ namespace Horo::Render {
                    maximumRequestsPerDrain > 0;
         }
     };
-
-    class RenderFrontend;
 
     /**
      * @brief Move-only owner of one begun backend frame until presentation or abort.
@@ -187,6 +188,27 @@ namespace Horo::Render {
         [[nodiscard]] Result<ResourceCreation<RenderMeshHandle>> CreateMesh(const RenderMeshDescriptor &descriptor);
 
         /**
+         * @brief Queues one immutable texture allocation without initial pixel data.
+         * @param descriptor Valid backend-neutral texture descriptor.
+         * @return Pending typed handle and completion operation, or a validation/admission failure.
+         */
+        [[nodiscard]] Result<ResourceCreation<RenderTextureHandle>> CreateTexture(const RenderTextureDescriptor &descriptor);
+
+        /**
+         * @brief Queues one immutable view over an exact ready texture generation.
+         * @param descriptor Valid view descriptor whose texture belongs to this frontend.
+         * @return Pending typed handle and completion operation, or a validation/admission failure.
+         */
+        [[nodiscard]] Result<ResourceCreation<RenderTextureViewHandle>> CreateTextureView(const RenderTextureViewDescriptor &descriptor);
+
+        /**
+         * @brief Queues one immutable render target over exact ready attachment views.
+         * @param descriptor Valid target descriptor whose views belong to this frontend.
+         * @return Pending typed handle and completion operation, or a validation/admission failure.
+         */
+        [[nodiscard]] Result<ResourceCreation<RenderTargetHandle>> CreateRenderTarget(const RenderTargetDescriptor &descriptor);
+
+        /**
          * @brief Queues a new mesh generation and retires the old generation only after publication.
          * @param current Ready mesh generation to replace without retargeting its dependents.
          * @param descriptor Descriptor for the independent replacement generation.
@@ -207,6 +229,15 @@ namespace Horo::Render {
         /** @brief Returns the current state of one mesh generation. */
         [[nodiscard]] Result<RenderResourceState> ResourceState(RenderMeshHandle mesh) const;
 
+        /** @brief Returns the current state of one texture generation. */
+        [[nodiscard]] Result<RenderResourceState> ResourceState(RenderTextureHandle texture) const;
+
+        /** @brief Returns the current state of one texture-view generation. */
+        [[nodiscard]] Result<RenderResourceState> ResourceState(RenderTextureViewHandle view) const;
+
+        /** @brief Returns the current state of one generic render-target generation. */
+        [[nodiscard]] Result<RenderResourceState> ResourceState(RenderTargetHandle target) const;
+
         /** @brief Returns success, pending, or the stored typed result for one resource operation. */
         [[nodiscard]] Result<void> ResourceOperationResult(ResourceOperationId operation) const;
 
@@ -216,8 +247,18 @@ namespace Horo::Render {
         /** @brief Logically releases one mesh generation and drains newly eligible dependencies. */
         [[nodiscard]] Result<void> ReleaseMesh(RenderMeshHandle mesh);
 
+        /** @brief Logically releases one texture generation after its dependent views retire. */
+        [[nodiscard]] Result<void> ReleaseTexture(RenderTextureHandle texture);
+
+        /** @brief Logically releases one texture-view generation after dependent targets retire. */
+        [[nodiscard]] Result<void> ReleaseTextureView(RenderTextureViewHandle view);
+
+        /** @brief Logically releases one generic render-target generation. */
+        [[nodiscard]] Result<void> ReleaseRenderTarget(RenderTargetHandle target);
+
     private:
         friend class RenderFrameScope;
+        friend class Detail::RenderFrontendResourceAccess;
 
         class ConstructionKey {
             ConstructionKey() = default;
@@ -230,8 +271,15 @@ namespace Horo::Render {
 
     private:
         [[nodiscard]] bool IsLiveTarget(RenderTargetHandle target, FramebufferExtent extent) const noexcept;
+        [[nodiscard]] Result<std::uint64_t> BackendInstance(RenderMeshHandle mesh) const;
+        [[nodiscard]] Result<std::uint64_t> BackendInstance(RenderTextureViewHandle view) const;
+        [[nodiscard]] Result<std::uint64_t> BackendInstance(RenderTargetHandle target) const;
         [[nodiscard]] Result<void> ValidateMeshDependencies(const RenderMeshDescriptor &descriptor) const;
         [[nodiscard]] bool IsMeshBufferLayoutCompatible(const RenderMeshDescriptor &descriptor) const noexcept;
+        [[nodiscard]] Result<void> ValidateTextureViewDependency(const RenderTextureViewDescriptor &descriptor) const;
+        [[nodiscard]] Result<void> ValidateRenderTargetDependencies(const RenderTargetDescriptor &descriptor) const;
+        [[nodiscard]] Result<void> ValidateRenderTargetAttachment(RenderTextureViewHandle handle, RenderTextureAspect requiredAspect,
+                                                                  FramebufferExtent extent, std::uint32_t sampleCount) const;
 
         struct TargetRecord {
             FramebufferExtent extent{};
@@ -242,6 +290,16 @@ namespace Horo::Render {
             RenderBufferDescriptor descriptor;
         };
 
+        struct TextureRecord {
+            std::uint32_t generation{0};
+            RenderTextureDescriptor descriptor;
+        };
+
+        struct TextureViewRecord {
+            std::uint32_t generation{0};
+            RenderTextureViewDescriptor descriptor;
+        };
+
         std::unique_ptr<IRenderBackend> backend_;
         std::unique_ptr<Detail::RenderResourceRegistry> resourceRegistry_;
         std::unique_ptr<Detail::RenderResourceUploadQueue> resourceUploadQueue_;
@@ -249,5 +307,8 @@ namespace Horo::Render {
         IStaticMeshPassExecutor *staticMeshPassExecutor_{nullptr};
         std::vector<TargetRecord> targets_{{}};
         std::vector<BufferRecord> buffers_{{}};
+        std::vector<TextureRecord> textures_{{}};
+        std::vector<TextureViewRecord> textureViews_{{}};
     };
+
 }  // namespace Horo::Render

--- a/include/Horo/Runtime/Render/RenderResource.h
+++ b/include/Horo/Runtime/Render/RenderResource.h
@@ -9,6 +9,19 @@
 #include <cstdint>
 
 namespace Horo::Render {
+    /** @brief Pixel extent of a render surface or offscreen target. */
+    struct FramebufferExtent {
+        std::uint32_t width{0};
+        std::uint32_t height{0};
+
+        /** @brief Reports whether both dimensions can back a render target. */
+        [[nodiscard]] constexpr bool IsValid() const noexcept {
+            return width > 0 && height > 0;
+        }
+
+        [[nodiscard]] constexpr auto operator<=>(const FramebufferExtent &) const noexcept = default;
+    };
+
     /** @brief Process-local identity of one frontend resource-registry lifetime. */
     struct RenderResourceOwnerId {
         std::uint64_t value{0};

--- a/include/Horo/Runtime/Render/Texture.h
+++ b/include/Horo/Runtime/Render/Texture.h
@@ -1,0 +1,103 @@
+#pragma once
+
+/**
+ * @file Texture.h
+ * @brief Backend-neutral texture, view, and render-target descriptors.
+ */
+
+#include "Horo/Runtime/Render/RenderResource.h"
+
+#include <cstdint>
+
+namespace Horo::Render {
+    /** @brief Texture dimensions supported by the baseline resident-resource contract. */
+    enum class RenderTextureDimension : std::uint8_t {
+        TwoD,
+    };
+
+    /** @brief Backend-neutral formats required by editor offscreen rendering. */
+    enum class RenderTextureFormat : std::uint8_t {
+        Rgba8Unorm,
+        Depth24Stencil8,
+        Depth32Float,
+    };
+
+    /** @brief Independent purposes permitted for one resident texture. */
+    enum class RenderTextureUsage : std::uint8_t {
+        None = 0,
+        Sampled = 1U << 0U,
+        RenderAttachment = 1U << 1U,
+    };
+
+    /** @brief Combines independent texture purposes without exposing backend flags. */
+    [[nodiscard]] constexpr RenderTextureUsage operator|(const RenderTextureUsage left, const RenderTextureUsage right) noexcept {
+        return static_cast<RenderTextureUsage>(static_cast<std::uint8_t>(left) | static_cast<std::uint8_t>(right));
+    }
+
+    /** @brief Reports whether every requested texture usage bit is present. */
+    [[nodiscard]] constexpr bool HasTextureUsage(const RenderTextureUsage value, const RenderTextureUsage requested) noexcept {
+        return (static_cast<std::uint8_t>(value) & static_cast<std::uint8_t>(requested)) == static_cast<std::uint8_t>(requested);
+    }
+
+    /** @brief Immutable structural policy for one resident texture. */
+    struct RenderTextureDescriptor {
+        RenderTextureDimension dimension{RenderTextureDimension::TwoD};
+        FramebufferExtent extent;
+        RenderTextureFormat format{RenderTextureFormat::Rgba8Unorm};
+        std::uint32_t mipCount{1};
+        std::uint32_t layerCount{1};
+        std::uint32_t sampleCount{1};
+        RenderTextureUsage usage{RenderTextureUsage::None};
+
+        /** @brief Reports whether the baseline texture policy is structurally valid. */
+        [[nodiscard]] constexpr bool IsValid() const noexcept {
+            constexpr std::uint8_t validUsageBits =
+                static_cast<std::uint8_t>(RenderTextureUsage::Sampled) | static_cast<std::uint8_t>(RenderTextureUsage::RenderAttachment);
+            const std::uint8_t usageBits = static_cast<std::uint8_t>(usage);
+            const bool formatValid = format == RenderTextureFormat::Rgba8Unorm || format == RenderTextureFormat::Depth24Stencil8 ||
+                                     format == RenderTextureFormat::Depth32Float;
+            return dimension == RenderTextureDimension::TwoD && extent.IsValid() && formatValid && mipCount == 1 && layerCount == 1 &&
+                   sampleCount == 1 && usageBits != 0 && (usageBits & static_cast<std::uint8_t>(~validUsageBits)) == 0;
+        }
+    };
+
+    /** @brief Selects the image plane exposed by a texture view. */
+    enum class RenderTextureAspect : std::uint8_t {
+        Color,
+        Depth,
+        DepthStencil,
+    };
+
+    /** @brief Immutable view over one exact resident texture generation. */
+    struct RenderTextureViewDescriptor {
+        RenderTextureHandle texture;
+        RenderTextureFormat format{RenderTextureFormat::Rgba8Unorm};
+        RenderTextureAspect aspect{RenderTextureAspect::Color};
+        std::uint32_t baseMip{0};
+        std::uint32_t mipCount{1};
+        std::uint32_t baseLayer{0};
+        std::uint32_t layerCount{1};
+
+        /** @brief Reports whether ranges and typed policy values are structurally valid. */
+        [[nodiscard]] constexpr bool IsValid() const noexcept {
+            const bool formatValid = format == RenderTextureFormat::Rgba8Unorm || format == RenderTextureFormat::Depth24Stencil8 ||
+                                     format == RenderTextureFormat::Depth32Float;
+            const bool aspectValid =
+                aspect == RenderTextureAspect::Color || aspect == RenderTextureAspect::Depth || aspect == RenderTextureAspect::DepthStencil;
+            return texture.IsValid() && formatValid && aspectValid && mipCount > 0 && layerCount > 0;
+        }
+    };
+
+    /** @brief Immutable framebuffer-compatible attachment set. */
+    struct RenderTargetDescriptor {
+        RenderTextureViewHandle colorAttachment;
+        RenderTextureViewHandle depthAttachment;
+        FramebufferExtent extent;
+        std::uint32_t sampleCount{1};
+
+        /** @brief Reports whether at least one baseline attachment and a valid extent are present. */
+        [[nodiscard]] constexpr bool IsValid() const noexcept {
+            return (colorAttachment.IsValid() || depthAttachment.IsValid()) && extent.IsValid() && sampleCount == 1;
+        }
+    };
+}  // namespace Horo::Render

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -510,7 +510,9 @@ if (HORO_BUILD_EDITOR_GUI AND HORO_BUILD_RENDER_OPENGL)
     add_library(HoroEditorViewportOpenGL STATIC
             editor/renderer/opengl/EditorGuiRendererOpenGL.cpp
             editor/renderer/opengl/OpenGLViewportResourceBridge.cpp
+            editor/renderer/opengl/OpenGLStateSnapshot.cpp
             editor/renderer/opengl/EditorViewportRendererOpenGL.cpp
+            editor/renderer/opengl/OpenGLViewportResources.cpp
             editor/renderer/opengl/SdlOpenGLPresentationPort.cpp
     )
     add_library(HoroEngine::EditorViewportOpenGL ALIAS HoroEditorViewportOpenGL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -250,6 +250,7 @@ target_link_libraries(HoroRenderBackendRegistry PUBLIC HoroEngine::RenderApi)
 
 add_library(HoroRenderFrontend STATIC
         runtime/renderer/frontend/RenderFrontend.cpp
+        runtime/renderer/frontend/RenderFrontendResources.cpp
         runtime/renderer/frontend/RenderFrontendErrors.cpp
         runtime/renderer/frontend/RenderResourceOperations.cpp
         runtime/renderer/frontend/RenderResourceRegistry.cpp
@@ -304,6 +305,8 @@ target_link_libraries(HoroRenderNull
 
 if (HORO_BUILD_RENDER_OPENGL)
     add_library(HoroRenderOpenGL STATIC
+            runtime/renderer/modules/opengl/OpenGLBackendModule.cpp
+            runtime/renderer/modules/opengl/OpenGLCommandFunctions.cpp
             runtime/renderer/modules/opengl/OpenGLRenderBackend.cpp
             runtime/renderer/modules/opengl/OpenGLRenderBackendErrors.cpp
     )
@@ -319,6 +322,7 @@ if (HORO_BUILD_RENDER_OPENGL)
             PUBLIC
             HoroEngine::RenderBackendRegistry
             PRIVATE
+            HoroThirdParty::Glad
             OpenGL::GL
     )
 endif ()
@@ -505,6 +509,7 @@ endif ()
 if (HORO_BUILD_EDITOR_GUI AND HORO_BUILD_RENDER_OPENGL)
     add_library(HoroEditorViewportOpenGL STATIC
             editor/renderer/opengl/EditorGuiRendererOpenGL.cpp
+            editor/renderer/opengl/OpenGLViewportResourceBridge.cpp
             editor/renderer/opengl/EditorViewportRendererOpenGL.cpp
             editor/renderer/opengl/SdlOpenGLPresentationPort.cpp
     )
@@ -522,6 +527,7 @@ if (HORO_BUILD_EDITOR_GUI AND HORO_BUILD_RENDER_OPENGL)
             PUBLIC
             HoroEngine::EditorViewportScene
             HoroEngine::RenderOpenGL
+            HoroEngine::RenderFrontend
             ${HORO_SDL3_TARGET}
             PRIVATE
             HoroThirdParty::Glad

--- a/src/editor/renderer/EditorViewportRenderer.h
+++ b/src/editor/renderer/EditorViewportRenderer.h
@@ -11,6 +11,10 @@
 
 #include <optional>
 
+namespace Horo::Render {
+    class RenderFrontend;
+}
+
 namespace Horo::Editor {
     /** @brief Pixel extent requested by the editor viewport panel. */
     struct EditorViewportExtent {
@@ -21,6 +25,8 @@ namespace Horo::Editor {
         [[nodiscard]] constexpr bool IsValid() const noexcept {
             return width > 0 && height > 0;
         }
+
+        [[nodiscard]] constexpr bool operator==(const EditorViewportExtent &) const noexcept = default;
     };
 
     /** @brief Backend-supplied GUI texture identity and normalized presentation coordinates. */
@@ -59,6 +65,19 @@ namespace Horo::Editor {
     class IEditorViewportRenderer : public Render::IStaticMeshPassExecutor {
     public:
         virtual ~IEditorViewportRenderer() = default;
+
+        /**
+         * @brief Synchronizes backend-neutral viewport resources at a frame boundary.
+         * @param frontend Selected frontend that owns resident resource identity.
+         * @param scene Synchronously borrowed CPU source snapshot.
+         * @return Newly ready viewport target when this integration owns one, otherwise no replacement.
+         */
+        [[nodiscard]] virtual Result<std::optional<Render::RenderTargetHandle>> PrepareResources(Render::RenderFrontend &frontend,
+                                                                                                 const Render::RenderSceneView &scene) {
+            static_cast<void>(frontend);
+            static_cast<void>(scene);
+            return Result<std::optional<Render::RenderTargetHandle>>::Success(std::nullopt);
+        }
 
         /** @brief Records the panel's desired render-target extent for the current frame. */
         virtual void RequestExtent(EditorViewportExtent extent) noexcept = 0;

--- a/src/editor/renderer/opengl/EditorViewportRendererOpenGL.cpp
+++ b/src/editor/renderer/opengl/EditorViewportRendererOpenGL.cpp
@@ -189,8 +189,8 @@ namespace Horo::Editor {
             return Result<void>::Failure(
                 MakeViewportError(RendererErrors::ViewportStaleTarget, "Viewport pass references a stale render target."));
         }
-        const EditorViewportExtent allocatedExtent = resources_.AllocatedExtent();
-        if (requestedExtent.width != allocatedExtent.width || requestedExtent.height != allocatedExtent.height)
+        if (const EditorViewportExtent allocatedExtent = resources_.AllocatedExtent();
+            requestedExtent.width != allocatedExtent.width || requestedExtent.height != allocatedExtent.height)
             return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportStaleTarget, "Viewport target extent is not ready."));
         return Result<void>::Success();
     }
@@ -232,7 +232,7 @@ namespace Horo::Editor {
         return Result<void>::Success();
     }
 
-    Result<void> EditorViewportRendererOpenGL::DrawSceneMeshes(const Render::RenderSceneView &scene, const float aspect) {
+    Result<void> EditorViewportRendererOpenGL::DrawSceneMeshes(const Render::RenderSceneView &scene, const float aspect) const {
         for (const Render::RenderStaticMeshInstance &instance : scene.instances) {
             const auto mesh = resources_.FindMesh(instance.mesh.id.value);
             if (!mesh.has_value()) {
@@ -458,7 +458,7 @@ namespace Horo::Editor {
     }
 
     Result<void> EditorViewportRendererOpenGL::DrawDirectionalShadowMap(const Render::RenderSceneView &scene,
-                                                                        const EditorViewportDirectionalShadowView &shadow) {
+                                                                        const EditorViewportDirectionalShadowView &shadow) const {
         constexpr auto shadowMapResolution = static_cast<GLsizei>(EditorViewportDirectionalShadowMapResolution);
         if (const Result<void> bound = OpenGLViewportResourceBridge::BindRenderTarget(*frontend_, resources_.ShadowTarget());
             bound.HasError())

--- a/src/editor/renderer/opengl/EditorViewportRendererOpenGL.cpp
+++ b/src/editor/renderer/opengl/EditorViewportRendererOpenGL.cpp
@@ -1,5 +1,6 @@
 #include "EditorViewportRendererOpenGL.h"
 
+#include "OpenGLStateSnapshot.h"
 #include "OpenGLViewportShaders.h"
 #include "editor/renderer/EditorRendererErrors.h"
 #include "editor/renderer/grid/EditorViewportGridGeometry.h"
@@ -10,7 +11,6 @@
 #include <bit>
 #include <cmath>
 #include <glad/gl.h>
-#include <limits>
 #include <string>
 #include <utility>
 
@@ -20,59 +20,6 @@ namespace Horo::Editor {
 
         [[nodiscard]] Error MakeViewportError(const ErrorCodeDescriptor &descriptor, std::string message) {
             return MakeError(descriptor, std::move(message));
-        }
-
-        template <typename Handle>
-        [[nodiscard]] Result<bool> ResourceReady(const Render::RenderFrontend &frontend, const Handle handle,
-                                                 const Render::ResourceOperationId operation) {
-            if (!handle.IsValid())
-                return Result<bool>::Success(false);
-            const auto state = frontend.ResourceState(handle);
-            if (state.HasValue())
-                return Result<bool>::Success(state.Value() == Render::RenderResourceState::Ready);
-            if (operation.IsValid()) {
-                const Result<void> completion = frontend.ResourceOperationResult(operation);
-                if (completion.HasError() && completion.ErrorValue().code.Value() != "render.frontend.resource.operation_pending")
-                    return Result<bool>::Failure(completion.ErrorValue());
-            }
-            return Result<bool>::Failure(state.ErrorValue());
-        }
-
-        [[nodiscard]] Result<bool> AdvanceTexture(Render::RenderFrontend &frontend, const Render::RenderTextureDescriptor &descriptor,
-                                                  Render::RenderTextureHandle &handle, Render::ResourceOperationId &operation) {
-            if (!handle.IsValid()) {
-                auto created = frontend.CreateTexture(descriptor);
-                if (created.HasError())
-                    return Result<bool>::Failure(created.ErrorValue());
-                handle = created.Value().handle;
-                operation = created.Value().operation;
-            }
-            return ResourceReady(frontend, handle, operation);
-        }
-
-        [[nodiscard]] Result<bool> AdvanceTextureView(Render::RenderFrontend &frontend,
-                                                      const Render::RenderTextureViewDescriptor &descriptor,
-                                                      Render::RenderTextureViewHandle &handle, Render::ResourceOperationId &operation) {
-            if (!handle.IsValid()) {
-                auto created = frontend.CreateTextureView(descriptor);
-                if (created.HasError())
-                    return Result<bool>::Failure(created.ErrorValue());
-                handle = created.Value().handle;
-                operation = created.Value().operation;
-            }
-            return ResourceReady(frontend, handle, operation);
-        }
-
-        [[nodiscard]] Result<bool> AdvanceRenderTarget(Render::RenderFrontend &frontend, const Render::RenderTargetDescriptor &descriptor,
-                                                       Render::RenderTargetHandle &handle, Render::ResourceOperationId &operation) {
-            if (!handle.IsValid()) {
-                auto created = frontend.CreateRenderTarget(descriptor);
-                if (created.HasError())
-                    return Result<bool>::Failure(created.ErrorValue());
-                handle = created.Value().handle;
-                operation = created.Value().operation;
-            }
-            return ResourceReady(frontend, handle, operation);
         }
 
         [[nodiscard]] Result<std::uint32_t> CompileShader(const std::uint32_t type, const char *source) {
@@ -95,84 +42,11 @@ namespace Horo::Editor {
                 MakeViewportError(RendererErrors::ViewportShaderCompileFailed, "Viewport shader compilation failed: " + log));
         }
 
-        void RestoreCapability(const GLenum capability, const GLboolean enabled) noexcept {
-            if (enabled == GL_TRUE)
-                glEnable(capability);
-            else
-                glDisable(capability);
-        }
-
-        /** @brief Restores host-owned OpenGL bindings and fixed-function state on every pass exit. */
-        class OpenGLStateSnapshot final {
-        public:
-            OpenGLStateSnapshot() noexcept {
-                depthTestEnabled_ = glIsEnabled(GL_DEPTH_TEST);
-                scissorTestEnabled_ = glIsEnabled(GL_SCISSOR_TEST);
-                blendEnabled_ = glIsEnabled(GL_BLEND);
-                cullFaceEnabled_ = glIsEnabled(GL_CULL_FACE);
-                glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &drawFramebuffer_);
-                glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &readFramebuffer_);
-                glGetIntegerv(GL_CURRENT_PROGRAM, &program_);
-                glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &vertexArray_);
-                glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &arrayBuffer_);
-                glGetIntegerv(GL_DEPTH_FUNC, &depthFunction_);
-                glGetIntegerv(GL_CULL_FACE_MODE, &cullFaceMode_);
-                glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTexture_);
-                glActiveTexture(GL_TEXTURE7);
-                glGetIntegerv(GL_TEXTURE_BINDING_2D, &shadowTexture_);
-                glGetIntegerv(GL_VIEWPORT, viewport_.data());
-                glGetFloatv(GL_COLOR_CLEAR_VALUE, clearColor_.data());
-                glGetBooleanv(GL_COLOR_WRITEMASK, colorMask_.data());
-                glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMask_);
-            }
-
-            ~OpenGLStateSnapshot() {
-                glBindVertexArray(static_cast<GLuint>(vertexArray_));
-                glBindBuffer(GL_ARRAY_BUFFER, static_cast<GLuint>(arrayBuffer_));
-                glUseProgram(static_cast<GLuint>(program_));
-                glDepthFunc(static_cast<GLenum>(depthFunction_));
-                RestoreCapability(GL_DEPTH_TEST, depthTestEnabled_);
-                RestoreCapability(GL_SCISSOR_TEST, scissorTestEnabled_);
-                RestoreCapability(GL_BLEND, blendEnabled_);
-                RestoreCapability(GL_CULL_FACE, cullFaceEnabled_);
-                glCullFace(static_cast<GLenum>(cullFaceMode_));
-                glColorMask(colorMask_[0], colorMask_[1], colorMask_[2], colorMask_[3]);
-                glDepthMask(depthMask_);
-                glClearColor(clearColor_[0], clearColor_[1], clearColor_[2], clearColor_[3]);
-                glBindFramebuffer(GL_DRAW_FRAMEBUFFER, static_cast<GLuint>(drawFramebuffer_));
-                glBindFramebuffer(GL_READ_FRAMEBUFFER, static_cast<GLuint>(readFramebuffer_));
-                glViewport(viewport_[0], viewport_[1], viewport_[2], viewport_[3]);
-                glActiveTexture(GL_TEXTURE7);
-                glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(shadowTexture_));
-                glActiveTexture(static_cast<GLenum>(activeTexture_));
-            }
-
-            OpenGLStateSnapshot(const OpenGLStateSnapshot &) = delete;
-            OpenGLStateSnapshot &operator=(const OpenGLStateSnapshot &) = delete;
-
-        private:
-            GLint drawFramebuffer_{0};
-            GLint readFramebuffer_{0};
-            GLint program_{0};
-            GLint vertexArray_{0};
-            GLint arrayBuffer_{0};
-            GLint depthFunction_{0};
-            GLint cullFaceMode_{0};
-            GLint activeTexture_{0};
-            GLint shadowTexture_{0};
-            std::array<GLint, 4> viewport_{};
-            std::array<GLfloat, 4> clearColor_{};
-            std::array<GLboolean, 4> colorMask_{};
-            GLboolean depthMask_{GL_TRUE};
-            GLboolean depthTestEnabled_{GL_FALSE};
-            GLboolean scissorTestEnabled_{GL_FALSE};
-            GLboolean blendEnabled_{GL_FALSE};
-            GLboolean cullFaceEnabled_{GL_FALSE};
-        };
     }  // namespace
 
     /** @copydoc EditorViewportRendererOpenGL::EditorViewportRendererOpenGL */
-    EditorViewportRendererOpenGL::EditorViewportRendererOpenGL(Render::RenderFrontend &frontend) noexcept : frontend_(&frontend) {}
+    EditorViewportRendererOpenGL::EditorViewportRendererOpenGL(Render::RenderFrontend &frontend) noexcept
+        : frontend_(&frontend), resources_(frontend) {}
 
     /** @copydoc EditorViewportRendererOpenGL::~EditorViewportRendererOpenGL */
     EditorViewportRendererOpenGL::~EditorViewportRendererOpenGL() {
@@ -219,13 +93,7 @@ namespace Horo::Editor {
 
     /** @copydoc EditorViewportRendererOpenGL::Shutdown */
     void EditorViewportRendererOpenGL::Shutdown() noexcept {
-        ReleaseTarget();
-        for (auto &[id, mesh] : meshes_)
-            ReleaseMesh(mesh);
-        for (auto &[id, mesh] : pendingMeshes_)
-            ReleaseMesh(mesh);
-        meshes_.clear();
-        pendingMeshes_.clear();
+        resources_.Shutdown();
         if (gridVertexBuffer_ != 0) {
             glDeleteBuffers(1, &gridVertexBuffer_);
             gridVertexBuffer_ = 0;
@@ -246,7 +114,6 @@ namespace Horo::Editor {
         requestedExtent_ = {};
         gridOptions_ = {};
         lightVisualizerOptions_ = {};
-        meshesReady_ = false;
         initialized_ = false;
     }
 
@@ -263,20 +130,7 @@ namespace Horo::Editor {
             return Result<std::optional<Render::RenderTargetHandle>>::Failure(
                 MakeViewportError(RendererErrors::ViewportNotInitialized, "Viewport resource owner is not initialized."));
         }
-        if (const Result<void> meshes = SynchronizeMeshes(scene.meshResources); meshes.HasError())
-            return Result<std::optional<Render::RenderTargetHandle>>::Failure(meshes.ErrorValue());
-        if (const Result<void> shadow = SynchronizeShadowResources(); shadow.HasError())
-            return Result<std::optional<Render::RenderTargetHandle>>::Failure(shadow.ErrorValue());
-        if (requestedExtent_.IsValid()) {
-            if (const Result<void> target = SynchronizeTarget(requestedExtent_); target.HasError())
-                return Result<std::optional<Render::RenderTargetHandle>>::Failure(target.ErrorValue());
-        }
-        if (viewportTarget_.target.IsValid()) {
-            const auto ready = frontend_->ResourceState(viewportTarget_.target);
-            if (ready.HasValue() && ready.Value() == Render::RenderResourceState::Ready)
-                return Result<std::optional<Render::RenderTargetHandle>>::Success(viewportTarget_.target);
-        }
-        return Result<std::optional<Render::RenderTargetHandle>>::Success(std::nullopt);
+        return resources_.Prepare(scene, requestedExtent_);
     }
 
     /** @copydoc EditorViewportRendererOpenGL::RequestGrid */
@@ -293,7 +147,8 @@ namespace Horo::Editor {
 
     /** @copydoc EditorViewportRendererOpenGL::RequestedExtent */
     EditorViewportExtent EditorViewportRendererOpenGL::RequestedExtent() const noexcept {
-        return requestedExtent_.IsValid() && allocatedExtent_.IsValid() ? allocatedExtent_ : requestedExtent_;
+        const EditorViewportExtent allocatedExtent = resources_.AllocatedExtent();
+        return requestedExtent_.IsValid() && allocatedExtent.IsValid() ? allocatedExtent : requestedExtent_;
     }
 
     /** @copydoc EditorViewportRendererOpenGL::ClipDepthRange */
@@ -312,14 +167,14 @@ namespace Horo::Editor {
         const EditorViewportExtent extentRequest = std::exchange(requestedExtent_, {});
         if (!extentRequest.IsValid())
             return Result<void>::Success();
-        const EditorViewportExtent renderExtent = allocatedExtent_.IsValid() ? allocatedExtent_ : extentRequest;
+        const EditorViewportExtent allocatedExtent = resources_.AllocatedExtent();
+        const EditorViewportExtent renderExtent = allocatedExtent.IsValid() ? allocatedExtent : extentRequest;
         if (const Result<void> valid = ValidatePassRequest(descriptor, renderExtent); valid.HasError())
             return valid;
-        viewportTarget_.target = descriptor.target;
         const auto shadow = BuildEditorViewportDirectionalShadowView(descriptor.scene, Math::ClipDepthRange::NegativeOneToOne);
         if (shadow.HasError())
             return Result<void>::Failure(shadow.ErrorValue());
-        const float aspect = static_cast<float>(allocatedExtent_.width) / static_cast<float>(allocatedExtent_.height);
+        const float aspect = static_cast<float>(allocatedExtent.width) / static_cast<float>(allocatedExtent.height);
         const OpenGLStateSnapshot stateSnapshot;
         return RenderViewportPass(descriptor, shadow.Value(), aspect);
     }
@@ -330,11 +185,12 @@ namespace Horo::Editor {
             descriptor.extent.height != requestedExtent.height) {
             return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportInvalidScene, "Editor viewport scene data is invalid."));
         }
-        if (viewportTarget_.target.IsValid() && viewportTarget_.target != descriptor.target) {
+        if (resources_.Target().IsValid() && resources_.Target() != descriptor.target) {
             return Result<void>::Failure(
                 MakeViewportError(RendererErrors::ViewportStaleTarget, "Viewport pass references a stale render target."));
         }
-        if (requestedExtent.width != allocatedExtent_.width || requestedExtent.height != allocatedExtent_.height)
+        const EditorViewportExtent allocatedExtent = resources_.AllocatedExtent();
+        if (requestedExtent.width != allocatedExtent.width || requestedExtent.height != allocatedExtent.height)
             return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportStaleTarget, "Viewport target extent is not ready."));
         return Result<void>::Success();
     }
@@ -347,9 +203,10 @@ namespace Horo::Editor {
                 return renderedShadow;
             }
         }
-        if (const Result<void> bound = resourceBridge_.BindRenderTarget(*frontend_, viewportTarget_.target); bound.HasError())
+        if (const Result<void> bound = OpenGLViewportResourceBridge::BindRenderTarget(*frontend_, resources_.Target()); bound.HasError())
             return bound;
-        glViewport(0, 0, static_cast<GLsizei>(allocatedExtent_.width), static_cast<GLsizei>(allocatedExtent_.height));
+        const EditorViewportExtent allocatedExtent = resources_.AllocatedExtent();
+        glViewport(0, 0, static_cast<GLsizei>(allocatedExtent.width), static_cast<GLsizei>(allocatedExtent.height));
         glDisable(GL_SCISSOR_TEST);
         glDisable(GL_BLEND);
         glDisable(GL_CULL_FACE);
@@ -360,10 +217,11 @@ namespace Horo::Editor {
         glClearColor(descriptor.clearColor.red, descriptor.clearColor.green, descriptor.clearColor.blue, descriptor.clearColor.alpha);
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         glUseProgram(program_);
-        if (const Result<void> boundShadow = resourceBridge_.BindTexture(*frontend_, shadowDepthTextureView_, 7); boundShadow.HasError())
+        if (const Result<void> boundShadow = OpenGLViewportResourceBridge::BindTexture(*frontend_, resources_.ShadowTextureView(), 7);
+            boundShadow.HasError())
             return boundShadow;
         UploadLighting(descriptor.scene, shadow);
-        if (const Result<void> grid = DrawGrid(descriptor.scene.camera, aspect, static_cast<float>(allocatedExtent_.height));
+        if (const Result<void> grid = DrawGrid(descriptor.scene.camera, aspect, static_cast<float>(allocatedExtent.height));
             grid.HasError()) {
             return grid;
         }
@@ -376,12 +234,12 @@ namespace Horo::Editor {
 
     Result<void> EditorViewportRendererOpenGL::DrawSceneMeshes(const Render::RenderSceneView &scene, const float aspect) {
         for (const Render::RenderStaticMeshInstance &instance : scene.instances) {
-            const auto mesh = meshes_.find(instance.mesh.id.value);
-            if (mesh == meshes_.end()) {
+            const auto mesh = resources_.FindMesh(instance.mesh.id.value);
+            if (!mesh.has_value()) {
                 return Result<void>::Failure(
                     MakeViewportError(RendererErrors::ViewportStaleMeshResource, "Viewport instance references a stale mesh resource."));
             }
-            if (const Result<void> bound = resourceBridge_.BindMesh(*frontend_, mesh->second.mesh); bound.HasError())
+            if (const Result<void> bound = OpenGLViewportResourceBridge::BindMesh(*frontend_, mesh->mesh); bound.HasError())
                 return bound;
             const Result<Math::Mat4> mvp =
                 BuildRenderMvp(scene.camera, instance.localToWorld, aspect, Math::ClipDepthRange::NegativeOneToOne);
@@ -391,7 +249,7 @@ namespace Horo::Editor {
             glUniformMatrix4fv(uniforms_.model, 1, GL_FALSE, instance.localToWorld.values.data());
             glUniform3f(uniforms_.selectionColor, instance.presentation.tint.x, instance.presentation.tint.y, instance.presentation.tint.z);
             glUniform1f(uniforms_.selectionStrength, instance.presentation.tintStrength);
-            glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(mesh->second.indexCount), GL_UNSIGNED_INT, nullptr);
+            glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(mesh->indexCount), GL_UNSIGNED_INT, nullptr);
         }
         return Result<void>::Success();
     }
@@ -475,7 +333,7 @@ namespace Horo::Editor {
     /** @copydoc EditorViewportRendererOpenGL::TextureView */
     EditorViewportTextureView EditorViewportRendererOpenGL::TextureView() const noexcept {
         return EditorViewportTextureView{
-            .textureId = viewportTarget_.imageIdentity,
+            .textureId = resources_.ImageIdentity(),
             .u0 = 0.0F,
             .v0 = 1.0F,
             .u1 = 1.0F,
@@ -485,8 +343,7 @@ namespace Horo::Editor {
 
     /** @copydoc EditorViewportRendererOpenGL::IsReady */
     bool EditorViewportRendererOpenGL::IsReady() const noexcept {
-        return initialized_ && meshesReady_ && viewportTarget_.imageIdentity != 0 && viewportTarget_.target.IsValid() &&
-               allocatedExtent_.IsValid();
+        return initialized_ && resources_.IsReady();
     }
 
     Result<void> EditorViewportRendererOpenGL::CreateProgram() {
@@ -539,23 +396,23 @@ namespace Horo::Editor {
         uniforms_.shadowLightIndex = glGetUniformLocation(program_, "uShadowLightIndex");
         uniforms_.selectionColor = glGetUniformLocation(program_, "uSelectionColor");
         uniforms_.selectionStrength = glGetUniformLocation(program_, "uSelectionStrength");
-        const std::array locations{
-            uniforms_.mvp,
-            uniforms_.model,
-            uniforms_.cameraPosition,
-            uniforms_.lightCount,
-            uniforms_.lightPositionKind,
-            uniforms_.lightDirectionRange,
-            uniforms_.lightColorIntensity,
-            uniforms_.lightCone,
-            uniforms_.shadowViewProjection,
-            uniforms_.shadowMap,
-            uniforms_.shadowEnabled,
-            uniforms_.shadowLightIndex,
-            uniforms_.selectionColor,
-            uniforms_.selectionStrength,
-        };
-        if (!std::ranges::all_of(locations, [](const std::int32_t location) {
+        if (const std::array locations{
+                uniforms_.mvp,
+                uniforms_.model,
+                uniforms_.cameraPosition,
+                uniforms_.lightCount,
+                uniforms_.lightPositionKind,
+                uniforms_.lightDirectionRange,
+                uniforms_.lightColorIntensity,
+                uniforms_.lightCone,
+                uniforms_.shadowViewProjection,
+                uniforms_.shadowMap,
+                uniforms_.shadowEnabled,
+                uniforms_.shadowLightIndex,
+                uniforms_.selectionColor,
+                uniforms_.selectionStrength,
+            };
+            !std::ranges::all_of(locations, [](const std::int32_t location) {
             return location >= 0;
         })) {
             return Result<void>::Failure(
@@ -603,7 +460,8 @@ namespace Horo::Editor {
     Result<void> EditorViewportRendererOpenGL::DrawDirectionalShadowMap(const Render::RenderSceneView &scene,
                                                                         const EditorViewportDirectionalShadowView &shadow) {
         constexpr auto shadowMapResolution = static_cast<GLsizei>(EditorViewportDirectionalShadowMapResolution);
-        if (const Result<void> bound = resourceBridge_.BindRenderTarget(*frontend_, shadowTarget_); bound.HasError())
+        if (const Result<void> bound = OpenGLViewportResourceBridge::BindRenderTarget(*frontend_, resources_.ShadowTarget());
+            bound.HasError())
             return bound;
         glViewport(0, 0, shadowMapResolution, shadowMapResolution);
         glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
@@ -615,16 +473,16 @@ namespace Horo::Editor {
         glClear(GL_DEPTH_BUFFER_BIT);
         glUseProgram(shadowProgram_);
         for (const Render::RenderStaticMeshInstance &instance : scene.instances) {
-            const auto mesh = meshes_.find(instance.mesh.id.value);
-            if (mesh == meshes_.end()) {
+            const auto mesh = resources_.FindMesh(instance.mesh.id.value);
+            if (!mesh.has_value()) {
                 return Result<void>::Failure(
                     MakeViewportError(RendererErrors::ViewportStaleMeshResource, "Shadow pass instance references a stale mesh resource."));
             }
             const Math::Mat4 shadowMvp = Math::Multiply(shadow.viewProjection, instance.localToWorld);
             glUniformMatrix4fv(uniforms_.shadowMvp, 1, GL_FALSE, shadowMvp.values.data());
-            if (const Result<void> bound = resourceBridge_.BindMesh(*frontend_, mesh->second.mesh); bound.HasError())
+            if (const Result<void> bound = OpenGLViewportResourceBridge::BindMesh(*frontend_, mesh->mesh); bound.HasError())
                 return bound;
-            glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(mesh->second.indexCount), GL_UNSIGNED_INT, nullptr);
+            glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(mesh->indexCount), GL_UNSIGNED_INT, nullptr);
         }
         glCullFace(GL_BACK);
         return Result<void>::Success();
@@ -668,290 +526,4 @@ namespace Horo::Editor {
         }
     }
 
-    Result<void> EditorViewportRendererOpenGL::SynchronizeMeshes(const std::span<const EditorViewportMeshResourceView> resources) {
-        meshesReady_ = true;
-
-        for (const EditorViewportMeshResourceView &resource : resources) {
-            const auto ready = SynchronizeMesh(resource);
-            if (ready.HasError())
-                return Result<void>::Failure(ready.ErrorValue());
-            meshesReady_ = meshesReady_ && ready.Value();
-        }
-
-        RetireMissingMeshes(resources);
-        return Result<void>::Success();
-    }
-
-    Result<bool> EditorViewportRendererOpenGL::SynchronizeMesh(const EditorViewportMeshResourceView &resource) {
-        const std::uint64_t id = resource.handle.id.value;
-        auto [activePosition, inserted] = meshes_.try_emplace(id);
-        ResidentMesh &active = activePosition->second;
-        if (inserted)
-            return AdvanceResidentMesh(resource, active);
-        if (active.sourceGeneration == resource.handle.generation) {
-            if (auto pending = pendingMeshes_.find(id); pending != pendingMeshes_.end()) {
-                ReleaseMesh(pending->second);
-                pendingMeshes_.erase(pending);
-            }
-            return AdvanceResidentMesh(resource, active);
-        }
-
-        if (!IsResidentMeshReady(active)) {
-            ReleaseMesh(active);
-            return AdvanceResidentMesh(resource, active);
-        }
-
-        ResidentMesh &pending = pendingMeshes_[id];
-        if (pending.sourceGeneration != 0 && pending.sourceGeneration != resource.handle.generation)
-            ReleaseMesh(pending);
-        const auto ready = AdvanceResidentMesh(resource, pending);
-        if (ready.HasError())
-            return Result<bool>::Failure(ready.ErrorValue());
-        if (ready.Value()) {
-            ReleaseMesh(active);
-            active = std::exchange(pending, {});
-            pendingMeshes_.erase(id);
-        }
-        return Result<bool>::Success(true);
-    }
-
-    Result<bool> EditorViewportRendererOpenGL::AdvanceResidentMesh(const EditorViewportMeshResourceView &resource, ResidentMesh &resident) {
-        if (resident.sourceGeneration == 0) {
-            const Result<void> created = CreateResidentMeshBuffers(resource, resident);
-            if (created.HasError())
-                return Result<bool>::Failure(created.ErrorValue());
-        }
-        const auto vertexReady = ResourceReady(*frontend_, resident.vertexBuffer, resident.vertexOperation);
-        if (vertexReady.HasError())
-            return Result<bool>::Failure(vertexReady.ErrorValue());
-        const auto indexReady = ResourceReady(*frontend_, resident.indexBuffer, resident.indexOperation);
-        if (indexReady.HasError())
-            return Result<bool>::Failure(indexReady.ErrorValue());
-        if (!resident.mesh.IsValid() && vertexReady.Value() && indexReady.Value()) {
-            auto mesh = frontend_->CreateMesh({.vertexBuffer = resident.vertexBuffer,
-                                               .indexBuffer = resident.indexBuffer,
-                                               .vertexStride = sizeof(Render::MeshVertex),
-                                               .vertexCount = static_cast<std::uint32_t>(resource.vertices.size()),
-                                               .indexFormat = Render::RenderIndexFormat::UInt32,
-                                               .indexCount = resident.indexCount,
-                                               .topology = Render::RenderPrimitiveTopology::Triangles,
-                                               .localBounds = resource.localBounds});
-            if (mesh.HasError())
-                return Result<bool>::Failure(mesh.ErrorValue());
-            resident.mesh = mesh.Value().handle;
-            resident.meshOperation = mesh.Value().operation;
-        }
-        return ResourceReady(*frontend_, resident.mesh, resident.meshOperation);
-    }
-
-    Result<void> EditorViewportRendererOpenGL::CreateResidentMeshBuffers(const EditorViewportMeshResourceView &resource,
-                                                                         ResidentMesh &resident) {
-        if (resource.vertices.size() > std::numeric_limits<std::uint32_t>::max() ||
-            resource.indices.size() > std::numeric_limits<std::uint32_t>::max()) {
-            return Result<void>::Failure(
-                MakeViewportError(RendererErrors::ViewportGeometryCreationFailed, "Viewport mesh exceeds generic resource count limits."));
-        }
-        auto vertex = frontend_->CreateBuffer({.byteSize = resource.vertices.size_bytes(),
-                                               .usage = Render::RenderBufferUsage::Vertex,
-                                               .access = Render::RenderBufferAccess::DeviceLocal},
-                                              std::as_bytes(resource.vertices));
-        if (vertex.HasError())
-            return Result<void>::Failure(vertex.ErrorValue());
-        resident.vertexBuffer = vertex.Value().handle;
-        resident.vertexOperation = vertex.Value().operation;
-        auto index = frontend_->CreateBuffer({.byteSize = resource.indices.size_bytes(),
-                                              .usage = Render::RenderBufferUsage::Index,
-                                              .access = Render::RenderBufferAccess::DeviceLocal},
-                                             std::as_bytes(resource.indices));
-        if (index.HasError()) {
-            ReleaseMesh(resident);
-            return Result<void>::Failure(index.ErrorValue());
-        }
-        resident.indexBuffer = index.Value().handle;
-        resident.indexOperation = index.Value().operation;
-        resident.indexCount = static_cast<std::uint32_t>(resource.indices.size());
-        resident.sourceGeneration = resource.handle.generation;
-        return Result<void>::Success();
-    }
-
-    bool EditorViewportRendererOpenGL::IsResidentMeshReady(const ResidentMesh &resident) const {
-        if (!resident.mesh.IsValid())
-            return false;
-        const auto state = frontend_->ResourceState(resident.mesh);
-        return state.HasValue() && state.Value() == Render::RenderResourceState::Ready;
-    }
-
-    void EditorViewportRendererOpenGL::RetireMissingMeshes(const std::span<const EditorViewportMeshResourceView> resources) noexcept {
-        for (auto mesh = meshes_.begin(); mesh != meshes_.end();) {
-            const bool present = std::ranges::any_of(resources, [&](const EditorViewportMeshResourceView &resource) {
-                return resource.handle.id.value == mesh->first;
-            });
-            if (!present) {
-                ReleaseMesh(mesh->second);
-                if (auto pending = pendingMeshes_.find(mesh->first); pending != pendingMeshes_.end()) {
-                    ReleaseMesh(pending->second);
-                    pendingMeshes_.erase(pending);
-                }
-                mesh = meshes_.erase(mesh);
-            } else {
-                ++mesh;
-            }
-        }
-    }
-
-    Result<void> EditorViewportRendererOpenGL::SynchronizeTarget(const EditorViewportExtent extent) {
-        if (allocatedExtent_ == extent) {
-            if (pendingViewportTarget_.extent.IsValid())
-                ReleaseViewportTarget(pendingViewportTarget_);
-            return Result<void>::Success();
-        }
-        if (pendingViewportTarget_.extent.IsValid() && pendingViewportTarget_.extent != extent)
-            ReleaseViewportTarget(pendingViewportTarget_);
-        pendingViewportTarget_.extent = extent;
-        const auto targetReady = AdvanceViewportTarget(pendingViewportTarget_);
-        if (targetReady.HasError())
-            return Result<void>::Failure(targetReady.ErrorValue());
-        if (!targetReady.Value())
-            return Result<void>::Success();
-        auto image = resourceBridge_.EditorImageIdentity(*frontend_, pendingViewportTarget_.colorView);
-        if (image.HasError())
-            return Result<void>::Failure(image.ErrorValue());
-        pendingViewportTarget_.imageIdentity = image.Value();
-        ReleaseViewportTarget(viewportTarget_);
-        viewportTarget_ = std::exchange(pendingViewportTarget_, {});
-        allocatedExtent_ = extent;
-        return Result<void>::Success();
-    }
-
-    Result<bool> EditorViewportRendererOpenGL::AdvanceViewportTarget(ViewportTargetResources &resources) {
-        const auto texturesReady = AdvanceViewportTextures(resources);
-        if (texturesReady.HasError() || !texturesReady.Value())
-            return texturesReady;
-        const auto viewsReady = AdvanceViewportViews(resources);
-        if (viewsReady.HasError() || !viewsReady.Value())
-            return viewsReady;
-        const Render::FramebufferExtent extent{resources.extent.width, resources.extent.height};
-        return AdvanceRenderTarget(*frontend_,
-                                   {.colorAttachment = resources.colorView, .depthAttachment = resources.depthView, .extent = extent},
-                                   resources.target, resources.targetOperation);
-    }
-
-    Result<bool> EditorViewportRendererOpenGL::AdvanceViewportTextures(ViewportTargetResources &resources) {
-        const Render::FramebufferExtent extent{resources.extent.width, resources.extent.height};
-        const auto color = AdvanceTexture(*frontend_,
-                                          {.extent = extent,
-                                           .format = Render::RenderTextureFormat::Rgba8Unorm,
-                                           .usage = Render::RenderTextureUsage::Sampled | Render::RenderTextureUsage::RenderAttachment},
-                                          resources.colorTexture, resources.colorTextureOperation);
-        if (color.HasError())
-            return Result<bool>::Failure(color.ErrorValue());
-        const auto depth = AdvanceTexture(*frontend_,
-                                          {.extent = extent,
-                                           .format = Render::RenderTextureFormat::Depth24Stencil8,
-                                           .usage = Render::RenderTextureUsage::RenderAttachment},
-                                          resources.depthTexture, resources.depthTextureOperation);
-        if (depth.HasError())
-            return Result<bool>::Failure(depth.ErrorValue());
-        return Result<bool>::Success(color.Value() && depth.Value());
-    }
-
-    Result<bool> EditorViewportRendererOpenGL::AdvanceViewportViews(ViewportTargetResources &resources) {
-        const auto color = AdvanceTextureView(*frontend_,
-                                              {.texture = resources.colorTexture,
-                                               .format = Render::RenderTextureFormat::Rgba8Unorm,
-                                               .aspect = Render::RenderTextureAspect::Color},
-                                              resources.colorView, resources.colorViewOperation);
-        if (color.HasError())
-            return Result<bool>::Failure(color.ErrorValue());
-        const auto depth = AdvanceTextureView(*frontend_,
-                                              {.texture = resources.depthTexture,
-                                               .format = Render::RenderTextureFormat::Depth24Stencil8,
-                                               .aspect = Render::RenderTextureAspect::DepthStencil},
-                                              resources.depthView, resources.depthViewOperation);
-        if (depth.HasError())
-            return Result<bool>::Failure(depth.ErrorValue());
-        return Result<bool>::Success(color.Value() && depth.Value());
-    }
-
-    Result<void> EditorViewportRendererOpenGL::SynchronizeShadowResources() {
-        const auto targetReady = AdvanceShadowTarget();
-        if (targetReady.HasError())
-            return Result<void>::Failure(targetReady.ErrorValue());
-        meshesReady_ = meshesReady_ && targetReady.Value();
-        return Result<void>::Success();
-    }
-
-    Result<bool> EditorViewportRendererOpenGL::AdvanceShadowTarget() {
-        constexpr Render::FramebufferExtent shadowExtent{EditorViewportDirectionalShadowMapResolution,
-                                                         EditorViewportDirectionalShadowMapResolution};
-        const auto textureReady =
-            AdvanceTexture(*frontend_,
-                           {.extent = shadowExtent,
-                            .format = Render::RenderTextureFormat::Depth32Float,
-                            .usage = Render::RenderTextureUsage::Sampled | Render::RenderTextureUsage::RenderAttachment},
-                           shadowDepthTexture_, shadowDepthTextureOperation_);
-        if (textureReady.HasError() || !textureReady.Value())
-            return textureReady;
-        const auto viewReady = AdvanceTextureView(*frontend_,
-                                                  {.texture = shadowDepthTexture_,
-                                                   .format = Render::RenderTextureFormat::Depth32Float,
-                                                   .aspect = Render::RenderTextureAspect::Depth},
-                                                  shadowDepthTextureView_, shadowDepthTextureViewOperation_);
-        if (viewReady.HasError() || !viewReady.Value())
-            return viewReady;
-        return AdvanceRenderTarget(*frontend_, {.depthAttachment = shadowDepthTextureView_, .extent = shadowExtent}, shadowTarget_,
-                                   shadowTargetOperation_);
-    }
-
-    void EditorViewportRendererOpenGL::ReleaseMesh(ResidentMesh &mesh) noexcept {
-        if (frontend_ != nullptr) {
-            if (mesh.mesh.IsValid())
-                static_cast<void>(frontend_->ReleaseMesh(mesh.mesh));
-            if (mesh.indexBuffer.IsValid())
-                static_cast<void>(frontend_->ReleaseBuffer(mesh.indexBuffer));
-            if (mesh.vertexBuffer.IsValid())
-                static_cast<void>(frontend_->ReleaseBuffer(mesh.vertexBuffer));
-        }
-        mesh = {};
-    }
-
-    void EditorViewportRendererOpenGL::ReleaseTarget() noexcept {
-        ReleaseShadowResources();
-        ReleaseViewportTarget(pendingViewportTarget_);
-        ReleaseViewportTarget(viewportTarget_);
-        allocatedExtent_ = {};
-    }
-
-    void EditorViewportRendererOpenGL::ReleaseShadowResources() noexcept {
-        if (frontend_ != nullptr) {
-            if (shadowTarget_.IsValid())
-                static_cast<void>(frontend_->ReleaseRenderTarget(shadowTarget_));
-            if (shadowDepthTextureView_.IsValid())
-                static_cast<void>(frontend_->ReleaseTextureView(shadowDepthTextureView_));
-            if (shadowDepthTexture_.IsValid())
-                static_cast<void>(frontend_->ReleaseTexture(shadowDepthTexture_));
-        }
-        shadowDepthTexture_ = {};
-        shadowDepthTextureView_ = {};
-        shadowTarget_ = {};
-        shadowDepthTextureOperation_ = {};
-        shadowDepthTextureViewOperation_ = {};
-        shadowTargetOperation_ = {};
-    }
-
-    void EditorViewportRendererOpenGL::ReleaseViewportTarget(ViewportTargetResources &resources) noexcept {
-        if (frontend_ != nullptr) {
-            if (resources.target.IsValid())
-                static_cast<void>(frontend_->ReleaseRenderTarget(resources.target));
-            if (resources.depthView.IsValid())
-                static_cast<void>(frontend_->ReleaseTextureView(resources.depthView));
-            if (resources.colorView.IsValid())
-                static_cast<void>(frontend_->ReleaseTextureView(resources.colorView));
-            if (resources.depthTexture.IsValid())
-                static_cast<void>(frontend_->ReleaseTexture(resources.depthTexture));
-            if (resources.colorTexture.IsValid())
-                static_cast<void>(frontend_->ReleaseTexture(resources.colorTexture));
-        }
-        resources = {};
-    }
 }  // namespace Horo::Editor

--- a/src/editor/renderer/opengl/EditorViewportRendererOpenGL.cpp
+++ b/src/editor/renderer/opengl/EditorViewportRendererOpenGL.cpp
@@ -1,15 +1,16 @@
 #include "EditorViewportRendererOpenGL.h"
 
+#include "OpenGLViewportShaders.h"
 #include "editor/renderer/EditorRendererErrors.h"
 #include "editor/renderer/grid/EditorViewportGridGeometry.h"
 #include "editor/screens/workspace/panels/viewport/visualizers/light/LightVisualizerGeometry.h"
 
-#include <SDL3/SDL_video.h>
 #include <algorithm>
 #include <array>
 #include <bit>
 #include <cmath>
 #include <glad/gl.h>
+#include <limits>
 #include <string>
 #include <utility>
 
@@ -19,6 +20,63 @@ namespace Horo::Editor {
 
         [[nodiscard]] Error MakeViewportError(const ErrorCodeDescriptor &descriptor, std::string message) {
             return MakeError(descriptor, std::move(message));
+        }
+
+        template <typename Handle>
+        [[nodiscard]] Result<bool> ResourceReady(const Render::RenderFrontend &frontend, const Handle handle,
+                                                 const Render::ResourceOperationId operation) {
+            if (!handle.IsValid())
+                return Result<bool>::Success(false);
+            const auto state = frontend.ResourceState(handle);
+            if (state.HasValue())
+                return Result<bool>::Success(state.Value() == Render::RenderResourceState::Ready);
+            if (operation.IsValid()) {
+                const Result<void> completion = frontend.ResourceOperationResult(operation);
+                if (completion.HasError() && completion.ErrorValue().code.Value() != "render.frontend.resource.operation_pending")
+                    return Result<bool>::Failure(completion.ErrorValue());
+            }
+            return Result<bool>::Failure(state.ErrorValue());
+        }
+
+        [[nodiscard]] Result<bool> AdvanceTexture(Render::RenderFrontend &frontend, const Render::RenderTextureDescriptor &descriptor,
+                                                  Render::RenderTextureHandle &handle, Render::ResourceOperationId &operation) {
+            if (!handle.IsValid()) {
+                auto created = frontend.CreateTexture(descriptor);
+                if (created.HasError())
+                    return Result<bool>::Failure(created.ErrorValue());
+                handle = created.Value().handle;
+                operation = created.Value().operation;
+            }
+            return ResourceReady(frontend, handle, operation);
+        }
+
+        [[nodiscard]] Result<bool> AdvanceTextureView(Render::RenderFrontend &frontend,
+                                                      const Render::RenderTextureViewDescriptor &descriptor,
+                                                      Render::RenderTextureViewHandle &handle, Render::ResourceOperationId &operation) {
+            if (!handle.IsValid()) {
+                auto created = frontend.CreateTextureView(descriptor);
+                if (created.HasError())
+                    return Result<bool>::Failure(created.ErrorValue());
+                handle = created.Value().handle;
+                operation = created.Value().operation;
+            }
+            return ResourceReady(frontend, handle, operation);
+        }
+
+        [[nodiscard]] Result<bool> AdvanceRenderTarget(Render::RenderFrontend &frontend, const Render::RenderTargetDescriptor &descriptor,
+                                                       Render::RenderTargetHandle &handle, Render::ResourceOperationId &operation) {
+            if (!handle.IsValid()) {
+                auto created = frontend.CreateRenderTarget(descriptor);
+                if (created.HasError())
+                    return Result<bool>::Failure(created.ErrorValue());
+                handle = created.Value().handle;
+                operation = created.Value().operation;
+            }
+            return ResourceReady(frontend, handle, operation);
+        }
+
+        [[nodiscard]] bool ExtentChanged(const EditorViewportExtent allocated, const EditorViewportExtent requested) noexcept {
+            return allocated.IsValid() && allocated != requested;
         }
 
         [[nodiscard]] Result<std::uint32_t> CompileShader(const std::uint32_t type, const char *source) {
@@ -40,7 +98,85 @@ namespace Horo::Editor {
             return Result<std::uint32_t>::Failure(
                 MakeViewportError(RendererErrors::ViewportShaderCompileFailed, "Viewport shader compilation failed: " + log));
         }
+
+        void RestoreCapability(const GLenum capability, const GLboolean enabled) noexcept {
+            if (enabled == GL_TRUE)
+                glEnable(capability);
+            else
+                glDisable(capability);
+        }
+
+        /** @brief Restores host-owned OpenGL bindings and fixed-function state on every pass exit. */
+        class OpenGLStateSnapshot final {
+        public:
+            OpenGLStateSnapshot() noexcept {
+                depthTestEnabled_ = glIsEnabled(GL_DEPTH_TEST);
+                scissorTestEnabled_ = glIsEnabled(GL_SCISSOR_TEST);
+                blendEnabled_ = glIsEnabled(GL_BLEND);
+                cullFaceEnabled_ = glIsEnabled(GL_CULL_FACE);
+                glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &drawFramebuffer_);
+                glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &readFramebuffer_);
+                glGetIntegerv(GL_CURRENT_PROGRAM, &program_);
+                glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &vertexArray_);
+                glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &arrayBuffer_);
+                glGetIntegerv(GL_DEPTH_FUNC, &depthFunction_);
+                glGetIntegerv(GL_CULL_FACE_MODE, &cullFaceMode_);
+                glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTexture_);
+                glActiveTexture(GL_TEXTURE7);
+                glGetIntegerv(GL_TEXTURE_BINDING_2D, &shadowTexture_);
+                glGetIntegerv(GL_VIEWPORT, viewport_.data());
+                glGetFloatv(GL_COLOR_CLEAR_VALUE, clearColor_.data());
+                glGetBooleanv(GL_COLOR_WRITEMASK, colorMask_.data());
+                glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMask_);
+            }
+
+            ~OpenGLStateSnapshot() {
+                glBindVertexArray(static_cast<GLuint>(vertexArray_));
+                glBindBuffer(GL_ARRAY_BUFFER, static_cast<GLuint>(arrayBuffer_));
+                glUseProgram(static_cast<GLuint>(program_));
+                glDepthFunc(static_cast<GLenum>(depthFunction_));
+                RestoreCapability(GL_DEPTH_TEST, depthTestEnabled_);
+                RestoreCapability(GL_SCISSOR_TEST, scissorTestEnabled_);
+                RestoreCapability(GL_BLEND, blendEnabled_);
+                RestoreCapability(GL_CULL_FACE, cullFaceEnabled_);
+                glCullFace(static_cast<GLenum>(cullFaceMode_));
+                glColorMask(colorMask_[0], colorMask_[1], colorMask_[2], colorMask_[3]);
+                glDepthMask(depthMask_);
+                glClearColor(clearColor_[0], clearColor_[1], clearColor_[2], clearColor_[3]);
+                glBindFramebuffer(GL_DRAW_FRAMEBUFFER, static_cast<GLuint>(drawFramebuffer_));
+                glBindFramebuffer(GL_READ_FRAMEBUFFER, static_cast<GLuint>(readFramebuffer_));
+                glViewport(viewport_[0], viewport_[1], viewport_[2], viewport_[3]);
+                glActiveTexture(GL_TEXTURE7);
+                glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(shadowTexture_));
+                glActiveTexture(static_cast<GLenum>(activeTexture_));
+            }
+
+            OpenGLStateSnapshot(const OpenGLStateSnapshot &) = delete;
+            OpenGLStateSnapshot &operator=(const OpenGLStateSnapshot &) = delete;
+
+        private:
+            GLint drawFramebuffer_{0};
+            GLint readFramebuffer_{0};
+            GLint program_{0};
+            GLint vertexArray_{0};
+            GLint arrayBuffer_{0};
+            GLint depthFunction_{0};
+            GLint cullFaceMode_{0};
+            GLint activeTexture_{0};
+            GLint shadowTexture_{0};
+            std::array<GLint, 4> viewport_{};
+            std::array<GLfloat, 4> clearColor_{};
+            std::array<GLboolean, 4> colorMask_{};
+            GLboolean depthMask_{GL_TRUE};
+            GLboolean depthTestEnabled_{GL_FALSE};
+            GLboolean scissorTestEnabled_{GL_FALSE};
+            GLboolean blendEnabled_{GL_FALSE};
+            GLboolean cullFaceEnabled_{GL_FALSE};
+        };
     }  // namespace
+
+    /** @copydoc EditorViewportRendererOpenGL::EditorViewportRendererOpenGL */
+    EditorViewportRendererOpenGL::EditorViewportRendererOpenGL(Render::RenderFrontend &frontend) noexcept : frontend_(&frontend) {}
 
     /** @copydoc EditorViewportRendererOpenGL::~EditorViewportRendererOpenGL */
     EditorViewportRendererOpenGL::~EditorViewportRendererOpenGL() {
@@ -49,19 +185,15 @@ namespace Horo::Editor {
 
     /** @copydoc EditorViewportRendererOpenGL::Initialize */
     Result<void> EditorViewportRendererOpenGL::Initialize() {
-        if (initialized_) {
+        if (initialized_ || frontend_ == nullptr) {
             return Result<void>::Failure(
                 MakeViewportError(RendererErrors::ViewportAlreadyInitialized, "Editor viewport renderer is already initialized."));
-        }
-        if (gladLoadGL(SDL_GL_GetProcAddress) == 0) {
-            return Result<void>::Failure(
-                MakeViewportError(RendererErrors::ViewportOpenGLDispatchFailed, "Failed to load OpenGL entry points."));
         }
         if (const Result<void> program = CreateProgram(); program.HasError()) {
             Shutdown();
             return program;
         }
-        if (const Result<void> shadowResources = CreateShadowResources(); shadowResources.HasError()) {
+        if (const Result<void> shadowResources = CreateShadowProgram(); shadowResources.HasError()) {
             Shutdown();
             return shadowResources;
         }
@@ -91,9 +223,9 @@ namespace Horo::Editor {
 
     /** @copydoc EditorViewportRendererOpenGL::Shutdown */
     void EditorViewportRendererOpenGL::Shutdown() noexcept {
-        DestroyTarget();
+        ReleaseTarget();
         for (auto &[id, mesh] : meshes_)
-            DestroyMesh(mesh);
+            ReleaseMesh(mesh);
         meshes_.clear();
         if (gridVertexBuffer_ != 0) {
             glDeleteBuffers(1, &gridVertexBuffer_);
@@ -111,19 +243,13 @@ namespace Horo::Editor {
             glDeleteProgram(shadowProgram_);
             shadowProgram_ = 0;
         }
-        if (shadowDepthTexture_ != 0) {
-            glDeleteTextures(1, &shadowDepthTexture_);
-            shadowDepthTexture_ = 0;
-        }
-        if (shadowFramebuffer_ != 0) {
-            glDeleteFramebuffers(1, &shadowFramebuffer_);
-            shadowFramebuffer_ = 0;
-        }
         uniforms_ = {};
         requestedExtent_ = {};
         gridOptions_ = {};
         lightVisualizerOptions_ = {};
         targetHandle_ = {};
+        editorImageIdentity_ = 0;
+        meshesReady_ = false;
         initialized_ = false;
     }
 
@@ -131,6 +257,29 @@ namespace Horo::Editor {
     void EditorViewportRendererOpenGL::RequestExtent(const EditorViewportExtent extent) noexcept {
         requestedExtent_.width = std::min(extent.width, maxViewportDimension);
         requestedExtent_.height = std::min(extent.height, maxViewportDimension);
+    }
+
+    /** @copydoc EditorViewportRendererOpenGL::PrepareResources */
+    Result<std::optional<Render::RenderTargetHandle>> EditorViewportRendererOpenGL::PrepareResources(Render::RenderFrontend &frontend,
+                                                                                                     const Render::RenderSceneView &scene) {
+        if (!initialized_ || frontend_ != &frontend) {
+            return Result<std::optional<Render::RenderTargetHandle>>::Failure(
+                MakeViewportError(RendererErrors::ViewportNotInitialized, "Viewport resource owner is not initialized."));
+        }
+        if (const Result<void> meshes = SynchronizeMeshes(scene.meshResources); meshes.HasError())
+            return Result<std::optional<Render::RenderTargetHandle>>::Failure(meshes.ErrorValue());
+        if (const Result<void> shadow = SynchronizeShadowResources(); shadow.HasError())
+            return Result<std::optional<Render::RenderTargetHandle>>::Failure(shadow.ErrorValue());
+        if (requestedExtent_.IsValid()) {
+            if (const Result<void> target = SynchronizeTarget(requestedExtent_); target.HasError())
+                return Result<std::optional<Render::RenderTargetHandle>>::Failure(target.ErrorValue());
+        }
+        if (targetHandle_.IsValid()) {
+            const auto ready = frontend_->ResourceState(targetHandle_);
+            if (ready.HasValue() && ready.Value() == Render::RenderResourceState::Ready)
+                return Result<std::optional<Render::RenderTargetHandle>>::Success(targetHandle_);
+        }
+        return Result<std::optional<Render::RenderTargetHandle>>::Success(std::nullopt);
     }
 
     /** @copydoc EditorViewportRendererOpenGL::RequestGrid */
@@ -156,8 +305,7 @@ namespace Horo::Editor {
     }
 
     /** @copydoc EditorViewportRendererOpenGL::ExecuteStaticMeshPass */
-    Result<void> EditorViewportRendererOpenGL::ExecuteStaticMeshPass(  // NOSONAR(cpp:S3776)
-        const Render::StaticMeshPassDescriptor &descriptor) {
+    Result<void> EditorViewportRendererOpenGL::ExecuteStaticMeshPass(const Render::StaticMeshPassDescriptor &descriptor) {
         if (!initialized_) {
             return Result<void>::Failure(
                 MakeViewportError(RendererErrors::ViewportNotInitialized, "Viewport renderer is not initialized."));
@@ -165,9 +313,21 @@ namespace Horo::Editor {
         // A panel must request an extent every UI frame. Consuming the request keeps
         // hidden/inactive viewport tabs from spending GPU time in the background.
         const EditorViewportExtent requestedExtent = std::exchange(requestedExtent_, {});
-        if (!requestedExtent.IsValid()) {
+        if (!requestedExtent.IsValid())
             return Result<void>::Success();
-        }
+        if (const Result<void> valid = ValidatePassRequest(descriptor, requestedExtent); valid.HasError())
+            return valid;
+        targetHandle_ = descriptor.target;
+        const auto shadow = BuildEditorViewportDirectionalShadowView(descriptor.scene, Math::ClipDepthRange::NegativeOneToOne);
+        if (shadow.HasError())
+            return Result<void>::Failure(shadow.ErrorValue());
+        const float aspect = static_cast<float>(allocatedExtent_.width) / static_cast<float>(allocatedExtent_.height);
+        const OpenGLStateSnapshot stateSnapshot;
+        return RenderViewportPass(descriptor, shadow.Value(), aspect);
+    }
+
+    Result<void> EditorViewportRendererOpenGL::ValidatePassRequest(const Render::StaticMeshPassDescriptor &descriptor,
+                                                                   const EditorViewportExtent requestedExtent) const {
         if (!descriptor.IsValid() || descriptor.extent.width != requestedExtent.width ||
             descriptor.extent.height != requestedExtent.height) {
             return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportInvalidScene, "Editor viewport scene data is invalid."));
@@ -176,60 +336,21 @@ namespace Horo::Editor {
             return Result<void>::Failure(
                 MakeViewportError(RendererErrors::ViewportStaleTarget, "Viewport pass references a stale render target."));
         }
-        targetHandle_ = descriptor.target;
-        if (requestedExtent.width != allocatedExtent_.width || requestedExtent.height != allocatedExtent_.height) {
-            if (const Result<void> recreated = RecreateTarget(requestedExtent); recreated.HasError()) {
-                return recreated;
-            }
-        }
-        if (const Result<void> synchronized = SynchronizeMeshes(descriptor.scene.meshResources); synchronized.HasError())
-            return synchronized;
-        const Result<std::optional<EditorViewportDirectionalShadowView>> shadow =
-            BuildEditorViewportDirectionalShadowView(descriptor.scene, Math::ClipDepthRange::NegativeOneToOne);
-        if (shadow.HasError())
-            return Result<void>::Failure(shadow.ErrorValue());
+        if (requestedExtent.width != allocatedExtent_.width || requestedExtent.height != allocatedExtent_.height)
+            return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportStaleTarget, "Viewport target extent is not ready."));
+        return Result<void>::Success();
+    }
 
-        const float aspect = static_cast<float>(allocatedExtent_.width) / static_cast<float>(allocatedExtent_.height);
-
-        GLint previousDrawFramebuffer = 0;
-        GLint previousReadFramebuffer = 0;
-        GLint previousProgram = 0;
-        GLint previousVertexArray = 0;
-        GLint previousArrayBuffer = 0;
-        GLint previousDepthFunction = 0;
-        GLint previousCullFaceMode = 0;
-        GLint previousActiveTexture = 0;
-        GLint previousShadowTexture = 0;
-        std::array<GLint, 4> previousViewport{};
-        std::array<GLfloat, 4> previousClearColor{};
-        const GLboolean depthTestWasEnabled = glIsEnabled(GL_DEPTH_TEST);
-        const GLboolean scissorTestWasEnabled = glIsEnabled(GL_SCISSOR_TEST);
-        const GLboolean blendWasEnabled = glIsEnabled(GL_BLEND);
-        const GLboolean cullFaceWasEnabled = glIsEnabled(GL_CULL_FACE);
-        std::array<GLboolean, 4> previousColorMask{};
-        GLboolean previousDepthMask = GL_TRUE;
-        glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &previousDrawFramebuffer);
-        glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &previousReadFramebuffer);
-        glGetIntegerv(GL_CURRENT_PROGRAM, &previousProgram);
-        glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &previousVertexArray);
-        glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &previousArrayBuffer);
-        glGetIntegerv(GL_DEPTH_FUNC, &previousDepthFunction);
-        glGetIntegerv(GL_CULL_FACE_MODE, &previousCullFaceMode);
-        glGetIntegerv(GL_ACTIVE_TEXTURE, &previousActiveTexture);
-        glActiveTexture(GL_TEXTURE7);
-        glGetIntegerv(GL_TEXTURE_BINDING_2D, &previousShadowTexture);
-        glGetIntegerv(GL_VIEWPORT, previousViewport.data());
-        glGetFloatv(GL_COLOR_CLEAR_VALUE, previousClearColor.data());
-        glGetBooleanv(GL_COLOR_WRITEMASK, previousColorMask.data());
-        glGetBooleanv(GL_DEPTH_WRITEMASK, &previousDepthMask);
-
-        if (shadow.Value().has_value()) {
-            if (const Result<void> renderedShadow = DrawDirectionalShadowMap(descriptor.scene, *shadow.Value());
-                renderedShadow.HasError()) {
+    Result<void> EditorViewportRendererOpenGL::RenderViewportPass(const Render::StaticMeshPassDescriptor &descriptor,
+                                                                  const std::optional<EditorViewportDirectionalShadowView> &shadow,
+                                                                  const float aspect) {
+        if (shadow.has_value()) {
+            if (const Result<void> renderedShadow = DrawDirectionalShadowMap(descriptor.scene, *shadow); renderedShadow.HasError()) {
                 return renderedShadow;
             }
         }
-        glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_);
+        if (const Result<void> bound = resourceBridge_.BindRenderTarget(*frontend_, targetHandle_); bound.HasError())
+            return bound;
         glViewport(0, 0, static_cast<GLsizei>(allocatedExtent_.width), static_cast<GLsizei>(allocatedExtent_.height));
         glDisable(GL_SCISSOR_TEST);
         glDisable(GL_BLEND);
@@ -241,66 +362,39 @@ namespace Horo::Editor {
         glClearColor(descriptor.clearColor.red, descriptor.clearColor.green, descriptor.clearColor.blue, descriptor.clearColor.alpha);
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         glUseProgram(program_);
-        glActiveTexture(GL_TEXTURE7);
-        glBindTexture(GL_TEXTURE_2D, shadowDepthTexture_);
-        UploadLighting(descriptor.scene, shadow.Value());
+        if (const Result<void> boundShadow = resourceBridge_.BindTexture(*frontend_, shadowDepthTextureView_, 7); boundShadow.HasError())
+            return boundShadow;
+        UploadLighting(descriptor.scene, shadow);
         if (const Result<void> grid = DrawGrid(descriptor.scene.camera, aspect, static_cast<float>(allocatedExtent_.height));
             grid.HasError()) {
             return grid;
         }
-        for (const Render::RenderStaticMeshInstance &instance : descriptor.scene.instances) {
+        if (const Result<void> meshes = DrawSceneMeshes(descriptor.scene, aspect); meshes.HasError())
+            return meshes;
+        if (const Result<void> visualizer = DrawLightVisualizer(descriptor.scene.camera, aspect); visualizer.HasError())
+            return visualizer;
+        return Result<void>::Success();
+    }
+
+    Result<void> EditorViewportRendererOpenGL::DrawSceneMeshes(const Render::RenderSceneView &scene, const float aspect) {
+        for (const Render::RenderStaticMeshInstance &instance : scene.instances) {
             const auto mesh = meshes_.find(instance.mesh.id.value);
-            if (mesh == meshes_.end())
+            if (mesh == meshes_.end()) {
                 return Result<void>::Failure(
                     MakeViewportError(RendererErrors::ViewportStaleMeshResource, "Viewport instance references a stale mesh resource."));
-            glBindVertexArray(mesh->second.vertexArray);
+            }
+            if (const Result<void> bound = resourceBridge_.BindMesh(*frontend_, mesh->second.mesh); bound.HasError())
+                return bound;
             const Result<Math::Mat4> mvp =
-                BuildRenderMvp(descriptor.scene.camera, instance.localToWorld, aspect, Math::ClipDepthRange::NegativeOneToOne);
+                BuildRenderMvp(scene.camera, instance.localToWorld, aspect, Math::ClipDepthRange::NegativeOneToOne);
             if (mvp.HasError())
                 return Result<void>::Failure(mvp.ErrorValue());
             glUniformMatrix4fv(uniforms_.mvp, 1, GL_FALSE, mvp.Value().values.data());
             glUniformMatrix4fv(uniforms_.model, 1, GL_FALSE, instance.localToWorld.values.data());
             glUniform3f(uniforms_.selectionColor, instance.presentation.tint.x, instance.presentation.tint.y, instance.presentation.tint.z);
             glUniform1f(uniforms_.selectionStrength, instance.presentation.tintStrength);
-
             glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(mesh->second.indexCount), GL_UNSIGNED_INT, nullptr);
         }
-        if (const Result<void> visualizer = DrawLightVisualizer(descriptor.scene.camera, aspect); visualizer.HasError())
-            return visualizer;
-        glBindVertexArray(static_cast<GLuint>(previousVertexArray));
-        glBindBuffer(GL_ARRAY_BUFFER, static_cast<GLuint>(previousArrayBuffer));
-        glUseProgram(static_cast<GLuint>(previousProgram));
-        glDepthFunc(static_cast<GLenum>(previousDepthFunction));
-        if (depthTestWasEnabled == GL_TRUE) {
-            glEnable(GL_DEPTH_TEST);
-        } else {
-            glDisable(GL_DEPTH_TEST);
-        }
-        if (scissorTestWasEnabled == GL_TRUE) {
-            glEnable(GL_SCISSOR_TEST);
-        } else {
-            glDisable(GL_SCISSOR_TEST);
-        }
-        if (blendWasEnabled == GL_TRUE) {
-            glEnable(GL_BLEND);
-        } else {
-            glDisable(GL_BLEND);
-        }
-        if (cullFaceWasEnabled == GL_TRUE) {
-            glEnable(GL_CULL_FACE);
-        } else {
-            glDisable(GL_CULL_FACE);
-        }
-        glCullFace(static_cast<GLenum>(previousCullFaceMode));
-        glColorMask(previousColorMask[0], previousColorMask[1], previousColorMask[2], previousColorMask[3]);
-        glDepthMask(previousDepthMask);
-        glClearColor(previousClearColor[0], previousClearColor[1], previousClearColor[2], previousClearColor[3]);
-        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, static_cast<GLuint>(previousDrawFramebuffer));
-        glBindFramebuffer(GL_READ_FRAMEBUFFER, static_cast<GLuint>(previousReadFramebuffer));
-        glViewport(previousViewport[0], previousViewport[1], previousViewport[2], previousViewport[3]);
-        glActiveTexture(GL_TEXTURE7);
-        glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(previousShadowTexture));
-        glActiveTexture(static_cast<GLenum>(previousActiveTexture));
         return Result<void>::Success();
     }
 
@@ -383,7 +477,7 @@ namespace Horo::Editor {
     /** @copydoc EditorViewportRendererOpenGL::TextureView */
     EditorViewportTextureView EditorViewportRendererOpenGL::TextureView() const noexcept {
         return EditorViewportTextureView{
-            .textureId = static_cast<std::uintptr_t>(colorTexture_),
+            .textureId = editorImageIdentity_,
             .u0 = 0.0F,
             .v0 = 1.0F,
             .u1 = 1.0F,
@@ -393,124 +487,15 @@ namespace Horo::Editor {
 
     /** @copydoc EditorViewportRendererOpenGL::IsReady */
     bool EditorViewportRendererOpenGL::IsReady() const noexcept {
-        return initialized_ && colorTexture_ != 0 && allocatedExtent_.IsValid();
+        return initialized_ && meshesReady_ && editorImageIdentity_ != 0 && targetHandle_.IsValid() && allocatedExtent_.IsValid();
     }
 
     Result<void> EditorViewportRendererOpenGL::CreateProgram() {
-        static constexpr const char *vertexSource = R"glsl(#version 150 core
-in vec3 aPosition;
-in vec3 aNormal;
-in vec2 aUv;
-out vec3 vWorldPosition;
-out vec3 vWorldNormal;
-out vec4 vShadowPosition;
-uniform mat4 uMvp;
-uniform mat4 uModel;
-uniform mat4 uShadowViewProjection;
-void main()
-{
-    vec4 worldPosition = uModel * vec4(aPosition, 1.0);
-    vWorldPosition = worldPosition.xyz;
-    mat3 modelBasis = mat3(uModel);
-    vec3 inverseRow0 = cross(modelBasis[1], modelBasis[2]);
-    vec3 inverseRow1 = cross(modelBasis[2], modelBasis[0]);
-    vec3 inverseRow2 = cross(modelBasis[0], modelBasis[1]);
-    float determinant = dot(modelBasis[0], inverseRow0);
-    float inverseDeterminant = abs(determinant) > 0.0000001 ? 1.0 / determinant : 1.0;
-    mat3 normalMatrix = mat3(inverseRow0 * inverseDeterminant,
-                             inverseRow1 * inverseDeterminant,
-                             inverseRow2 * inverseDeterminant);
-    vWorldNormal = normalize(normalMatrix * aNormal);
-    vShadowPosition = uShadowViewProjection * worldPosition;
-    gl_Position = uMvp * vec4(aPosition, 1.0);
-}
-)glsl";
-        static constexpr const char *fragmentSource = R"glsl(#version 150 core
-const int MaxLights = 16;
-in vec3 vWorldPosition;
-in vec3 vWorldNormal;
-in vec4 vShadowPosition;
-out vec4 outColor;
-uniform vec3 uCameraPosition;
-uniform int uLightCount;
-uniform vec4 uLightPositionKind[MaxLights];
-uniform vec4 uLightDirectionRange[MaxLights];
-uniform vec4 uLightColorIntensity[MaxLights];
-uniform vec2 uLightCone[MaxLights];
-uniform sampler2D uShadowMap;
-uniform int uShadowEnabled;
-uniform int uShadowLightIndex;
-uniform vec3 uSelectionColor;
-uniform float uSelectionStrength;
-float directionalShadow(vec3 normal, vec3 lightDirection)
-{
-    if (uShadowEnabled == 0)
-        return 1.0;
-    vec3 projected = vShadowPosition.xyz / vShadowPosition.w;
-    vec3 shadowCoordinate = projected * 0.5 + 0.5;
-    if (shadowCoordinate.x <= 0.0 || shadowCoordinate.x >= 1.0 ||
-        shadowCoordinate.y <= 0.0 || shadowCoordinate.y >= 1.0 ||
-        shadowCoordinate.z <= 0.0 || shadowCoordinate.z >= 1.0)
-        return 1.0;
-    vec2 texel = 1.0 / vec2(textureSize(uShadowMap, 0));
-    float bias = max(0.0025 * (1.0 - dot(normal, lightDirection)), 0.00045);
-    float visibility = 0.0;
-    for (int y = -1; y <= 1; ++y)
-        for (int x = -1; x <= 1; ++x)
-        {
-            float closestDepth = texture(uShadowMap, shadowCoordinate.xy + vec2(x, y) * texel).r;
-            visibility += shadowCoordinate.z - bias <= closestDepth ? 1.0 : 0.0;
-        }
-    return visibility / 9.0;
-}
-void main()
-{
-    vec3 normal = normalize(vWorldNormal);
-    vec3 viewDirection = normalize(uCameraPosition - vWorldPosition);
-    vec3 baseColor = vec3(0.68, 0.70, 0.74);
-    vec3 lighting = baseColor * 0.08;
-    for (int index = 0; index < uLightCount; ++index)
-    {
-        int kind = int(uLightPositionKind[index].w + 0.5);
-        vec3 lightDirection;
-        float attenuation = 1.0;
-        if (kind == 0)
-        {
-            lightDirection = normalize(-uLightDirectionRange[index].xyz);
-        }
-        else
-        {
-            vec3 toLight = uLightPositionKind[index].xyz - vWorldPosition;
-            float distanceToLight = length(toLight);
-            lightDirection = distanceToLight > 0.0001 ? toLight / distanceToLight : normal;
-            float range = max(uLightDirectionRange[index].w, 0.0001);
-            float normalizedDistance = distanceToLight / range;
-            float rangeFade = max(1.0 - normalizedDistance * normalizedDistance, 0.0);
-            attenuation = rangeFade * rangeFade;
-            if (kind == 2)
-            {
-                float coneCosine = dot(normalize(uLightDirectionRange[index].xyz), -lightDirection);
-                attenuation *= smoothstep(uLightCone[index].y, uLightCone[index].x, coneCosine);
-            }
-        }
-        float diffuse = max(dot(normal, lightDirection), 0.0);
-        vec3 halfDirection = normalize(lightDirection + viewDirection);
-        float specular = pow(max(dot(normal, halfDirection), 0.0), 48.0) * 0.18;
-        vec3 radiance = uLightColorIntensity[index].rgb * uLightColorIntensity[index].a * attenuation;
-        float visibility = index == uShadowLightIndex ? directionalShadow(normal, lightDirection) : 1.0;
-        lighting += radiance * (baseColor * diffuse + specular) * visibility;
-    }
-    vec3 mapped = lighting / (lighting + vec3(1.0));
-    vec3 displayColor = pow(max(mapped, vec3(0.0)), vec3(1.0 / 2.2));
-    outColor = vec4(mix(displayColor, uSelectionColor, uSelectionStrength), 1.0);
-}
-)glsl";
-
-        auto vertex = CompileShader(GL_VERTEX_SHADER, vertexSource);
+        auto vertex = CompileShader(GL_VERTEX_SHADER, Detail::ViewportVertexShader);
         if (vertex.HasError()) {
             return Result<void>::Failure(vertex.ErrorValue());
         }
-        auto fragment = CompileShader(GL_FRAGMENT_SHADER, fragmentSource);
+        auto fragment = CompileShader(GL_FRAGMENT_SHADER, Detail::ViewportFragmentShader);
         if (fragment.HasError()) {
             glDeleteShader(vertex.Value());
             return Result<void>::Failure(fragment.ErrorValue());
@@ -537,6 +522,10 @@ void main()
             return Result<void>::Failure(
                 MakeViewportError(RendererErrors::ViewportShaderLinkFailed, "Viewport shader linking failed: " + log));
         }
+        return LoadUniformLocations();
+    }
+
+    Result<void> EditorViewportRendererOpenGL::LoadUniformLocations() {
         uniforms_.mvp = glGetUniformLocation(program_, "uMvp");
         uniforms_.model = glGetUniformLocation(program_, "uModel");
         uniforms_.cameraPosition = glGetUniformLocation(program_, "uCameraPosition");
@@ -551,34 +540,36 @@ void main()
         uniforms_.shadowLightIndex = glGetUniformLocation(program_, "uShadowLightIndex");
         uniforms_.selectionColor = glGetUniformLocation(program_, "uSelectionColor");
         uniforms_.selectionStrength = glGetUniformLocation(program_, "uSelectionStrength");
-        if (uniforms_.mvp < 0 || uniforms_.model < 0 || uniforms_.cameraPosition < 0 || uniforms_.lightCount < 0 ||
-            uniforms_.lightPositionKind < 0 || uniforms_.lightDirectionRange < 0 || uniforms_.lightColorIntensity < 0 ||
-            uniforms_.lightCone < 0 || uniforms_.shadowViewProjection < 0 || uniforms_.shadowMap < 0 || uniforms_.shadowEnabled < 0 ||
-            uniforms_.shadowLightIndex < 0 || uniforms_.selectionColor < 0 || uniforms_.selectionStrength < 0) {
+        const std::array locations{
+            uniforms_.mvp,
+            uniforms_.model,
+            uniforms_.cameraPosition,
+            uniforms_.lightCount,
+            uniforms_.lightPositionKind,
+            uniforms_.lightDirectionRange,
+            uniforms_.lightColorIntensity,
+            uniforms_.lightCone,
+            uniforms_.shadowViewProjection,
+            uniforms_.shadowMap,
+            uniforms_.shadowEnabled,
+            uniforms_.shadowLightIndex,
+            uniforms_.selectionColor,
+            uniforms_.selectionStrength,
+        };
+        if (!std::ranges::all_of(locations, [](const std::int32_t location) {
+            return location >= 0;
+        })) {
             return Result<void>::Failure(
                 MakeViewportError(RendererErrors::ViewportShaderContractInvalid, "Viewport shader is missing a required frame uniform."));
         }
-
         return Result<void>::Success();
     }
 
-    Result<void> EditorViewportRendererOpenGL::CreateShadowResources() {
-        static constexpr const char *shadowVertexSource = R"glsl(#version 150 core
-in vec3 aPosition;
-uniform mat4 uShadowMvp;
-void main()
-{
-    gl_Position = uShadowMvp * vec4(aPosition, 1.0);
-}
-)glsl";
-        static constexpr const char *shadowFragmentSource = R"glsl(#version 150 core
-void main() {}
-)glsl";
-
-        auto vertex = CompileShader(GL_VERTEX_SHADER, shadowVertexSource);
+    Result<void> EditorViewportRendererOpenGL::CreateShadowProgram() {
+        auto vertex = CompileShader(GL_VERTEX_SHADER, Detail::ShadowVertexShader);
         if (vertex.HasError())
             return Result<void>::Failure(vertex.ErrorValue());
-        auto fragment = CompileShader(GL_FRAGMENT_SHADER, shadowFragmentSource);
+        auto fragment = CompileShader(GL_FRAGMENT_SHADER, Detail::ShadowFragmentShader);
         if (fragment.HasError()) {
             glDeleteShader(vertex.Value());
             return Result<void>::Failure(fragment.ErrorValue());
@@ -607,43 +598,14 @@ void main() {}
                 MakeViewportError(RendererErrors::ViewportShaderContractInvalid, "Viewport shadow shader is missing its matrix uniform."));
         }
 
-        constexpr auto shadowMapResolution = static_cast<GLsizei>(EditorViewportDirectionalShadowMapResolution);
-        GLint previousDrawFramebuffer = 0;
-        GLint previousReadFramebuffer = 0;
-        GLint previousTexture = 0;
-        glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &previousDrawFramebuffer);
-        glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &previousReadFramebuffer);
-        glGetIntegerv(GL_TEXTURE_BINDING_2D, &previousTexture);
-        glGenFramebuffers(1, &shadowFramebuffer_);
-        glGenTextures(1, &shadowDepthTexture_);
-        glBindTexture(GL_TEXTURE_2D, shadowDepthTexture_);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, shadowMapResolution, shadowMapResolution, 0, GL_DEPTH_COMPONENT, GL_FLOAT,
-                     nullptr);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
-        constexpr std::array<GLfloat, 4> borderColor{1.0F, 1.0F, 1.0F, 1.0F};
-        glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, borderColor.data());
-        glBindFramebuffer(GL_FRAMEBUFFER, shadowFramebuffer_);
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, shadowDepthTexture_, 0);
-        glDrawBuffer(GL_NONE);
-        glReadBuffer(GL_NONE);
-        const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-        glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(previousTexture));
-        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, static_cast<GLuint>(previousDrawFramebuffer));
-        glBindFramebuffer(GL_READ_FRAMEBUFFER, static_cast<GLuint>(previousReadFramebuffer));
-        if (shadowFramebuffer_ == 0 || shadowDepthTexture_ == 0 || status != GL_FRAMEBUFFER_COMPLETE) {
-            return Result<void>::Failure(
-                MakeViewportError(RendererErrors::ViewportFramebufferIncomplete, "OpenGL directional shadow framebuffer is incomplete."));
-        }
         return Result<void>::Success();
     }
 
     Result<void> EditorViewportRendererOpenGL::DrawDirectionalShadowMap(const Render::RenderSceneView &scene,
                                                                         const EditorViewportDirectionalShadowView &shadow) {
         constexpr auto shadowMapResolution = static_cast<GLsizei>(EditorViewportDirectionalShadowMapResolution);
-        glBindFramebuffer(GL_FRAMEBUFFER, shadowFramebuffer_);
+        if (const Result<void> bound = resourceBridge_.BindRenderTarget(*frontend_, shadowTarget_); bound.HasError())
+            return bound;
         glViewport(0, 0, shadowMapResolution, shadowMapResolution);
         glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
         glDepthMask(GL_TRUE);
@@ -661,7 +623,8 @@ void main() {}
             }
             const Math::Mat4 shadowMvp = Math::Multiply(shadow.viewProjection, instance.localToWorld);
             glUniformMatrix4fv(uniforms_.shadowMvp, 1, GL_FALSE, shadowMvp.values.data());
-            glBindVertexArray(mesh->second.vertexArray);
+            if (const Result<void> bound = resourceBridge_.BindMesh(*frontend_, mesh->second.mesh); bound.HasError())
+                return bound;
             glDrawElements(GL_TRIANGLES, static_cast<GLsizei>(mesh->second.indexCount), GL_UNSIGNED_INT, nullptr);
         }
         glCullFace(GL_BACK);
@@ -707,135 +670,249 @@ void main() {}
     }
 
     Result<void> EditorViewportRendererOpenGL::SynchronizeMeshes(const std::span<const EditorViewportMeshResourceView> resources) {
-        GLint previousVertexArray = 0;
-        GLint previousArrayBuffer = 0;
-        glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &previousVertexArray);
-        glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &previousArrayBuffer);
+        meshesReady_ = true;
 
         for (const EditorViewportMeshResourceView &resource : resources) {
-            if (auto existing = meshes_.find(resource.handle.id.value); existing != meshes_.end()) {
-                if (existing->second.generation == resource.handle.generation)
-                    continue;
-                DestroyMesh(existing->second);
-                meshes_.erase(existing);
-            }
-            GpuMesh mesh{.indexCount = static_cast<std::uint32_t>(resource.indices.size()), .generation = resource.handle.generation};
-            glGenVertexArrays(1, &mesh.vertexArray);
-            glBindVertexArray(mesh.vertexArray);
-            glGenBuffers(1, &mesh.vertexBuffer);
-            glBindBuffer(GL_ARRAY_BUFFER, mesh.vertexBuffer);
-            glBufferData(GL_ARRAY_BUFFER, static_cast<GLsizeiptr>(resource.vertices.size_bytes()), resource.vertices.data(),
-                         GL_STATIC_DRAW);
-            glGenBuffers(1, &mesh.indexBuffer);
-            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.indexBuffer);
-            glBufferData(GL_ELEMENT_ARRAY_BUFFER, static_cast<GLsizeiptr>(resource.indices.size_bytes()), resource.indices.data(),
-                         GL_STATIC_DRAW);
-            glEnableVertexAttribArray(0);
-            glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, static_cast<GLsizei>(sizeof(Render::MeshVertex)), nullptr);
-            glEnableVertexAttribArray(1);
-            glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, static_cast<GLsizei>(sizeof(Render::MeshVertex)),
-                                  std::bit_cast<const void *>(static_cast<std::uintptr_t>(offsetof(Render::MeshVertex, normal))));
-            glEnableVertexAttribArray(2);
-            glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, static_cast<GLsizei>(sizeof(Render::MeshVertex)),
-                                  std::bit_cast<const void *>(static_cast<std::uintptr_t>(offsetof(Render::MeshVertex, uv))));
-            if (mesh.vertexArray == 0 || mesh.vertexBuffer == 0 || mesh.indexBuffer == 0) {
-                DestroyMesh(mesh);
-                glBindVertexArray(static_cast<GLuint>(previousVertexArray));
-                glBindBuffer(GL_ARRAY_BUFFER, static_cast<GLuint>(previousArrayBuffer));
-                return Result<void>::Failure(
-                    MakeViewportError(RendererErrors::ViewportGeometryCreationFailed, "Failed to upload a viewport mesh resource."));
-            }
-            meshes_.try_emplace(resource.handle.id.value, mesh);
+            auto [position, inserted] = meshes_.try_emplace(resource.handle.id.value);
+            ResidentMesh &resident = position->second;
+            if (!inserted && resident.sourceGeneration != resource.handle.generation)
+                ReleaseMesh(resident);
+            const auto ready = AdvanceResidentMesh(resource, resident);
+            if (ready.HasError())
+                return Result<void>::Failure(ready.ErrorValue());
+            meshesReady_ = meshesReady_ && ready.Value();
         }
-        for (auto mesh = meshes_.begin(); mesh != meshes_.end();) {
-            const bool present = std::ranges::any_of(resources, [&](const EditorViewportMeshResourceView &resource) {
-                return resource.handle.id.value == mesh->first && resource.handle.generation == mesh->second.generation;
-            });
-            if (!present) {
-                DestroyMesh(mesh->second);
-                mesh = meshes_.erase(mesh);
-            } else
-                ++mesh;
-        }
-        glBindVertexArray(static_cast<GLuint>(previousVertexArray));
-        glBindBuffer(GL_ARRAY_BUFFER, static_cast<GLuint>(previousArrayBuffer));
+
+        RetireMissingMeshes(resources);
         return Result<void>::Success();
     }
 
-    void EditorViewportRendererOpenGL::DestroyMesh(GpuMesh &mesh) noexcept {
-        if (mesh.indexBuffer != 0)
-            glDeleteBuffers(1, &mesh.indexBuffer);
-        if (mesh.vertexBuffer != 0)
-            glDeleteBuffers(1, &mesh.vertexBuffer);
-        if (mesh.vertexArray != 0)
-            glDeleteVertexArrays(1, &mesh.vertexArray);
+    Result<bool> EditorViewportRendererOpenGL::AdvanceResidentMesh(const EditorViewportMeshResourceView &resource, ResidentMesh &resident) {
+        if (resident.sourceGeneration == 0) {
+            const Result<void> created = CreateResidentMeshBuffers(resource, resident);
+            if (created.HasError())
+                return Result<bool>::Failure(created.ErrorValue());
+        }
+        const auto vertexReady = ResourceReady(*frontend_, resident.vertexBuffer, resident.vertexOperation);
+        if (vertexReady.HasError())
+            return Result<bool>::Failure(vertexReady.ErrorValue());
+        const auto indexReady = ResourceReady(*frontend_, resident.indexBuffer, resident.indexOperation);
+        if (indexReady.HasError())
+            return Result<bool>::Failure(indexReady.ErrorValue());
+        if (!resident.mesh.IsValid() && vertexReady.Value() && indexReady.Value()) {
+            auto mesh = frontend_->CreateMesh({.vertexBuffer = resident.vertexBuffer,
+                                               .indexBuffer = resident.indexBuffer,
+                                               .vertexStride = sizeof(Render::MeshVertex),
+                                               .vertexCount = static_cast<std::uint32_t>(resource.vertices.size()),
+                                               .indexFormat = Render::RenderIndexFormat::UInt32,
+                                               .indexCount = resident.indexCount,
+                                               .topology = Render::RenderPrimitiveTopology::Triangles,
+                                               .localBounds = resource.localBounds});
+            if (mesh.HasError())
+                return Result<bool>::Failure(mesh.ErrorValue());
+            resident.mesh = mesh.Value().handle;
+            resident.meshOperation = mesh.Value().operation;
+        }
+        return ResourceReady(*frontend_, resident.mesh, resident.meshOperation);
+    }
+
+    Result<void> EditorViewportRendererOpenGL::CreateResidentMeshBuffers(const EditorViewportMeshResourceView &resource,
+                                                                         ResidentMesh &resident) {
+        if (resource.vertices.size() > std::numeric_limits<std::uint32_t>::max() ||
+            resource.indices.size() > std::numeric_limits<std::uint32_t>::max()) {
+            return Result<void>::Failure(
+                MakeViewportError(RendererErrors::ViewportGeometryCreationFailed, "Viewport mesh exceeds generic resource count limits."));
+        }
+        auto vertex = frontend_->CreateBuffer({.byteSize = resource.vertices.size_bytes(),
+                                               .usage = Render::RenderBufferUsage::Vertex,
+                                               .access = Render::RenderBufferAccess::DeviceLocal},
+                                              std::as_bytes(resource.vertices));
+        if (vertex.HasError())
+            return Result<void>::Failure(vertex.ErrorValue());
+        resident.vertexBuffer = vertex.Value().handle;
+        resident.vertexOperation = vertex.Value().operation;
+        auto index = frontend_->CreateBuffer({.byteSize = resource.indices.size_bytes(),
+                                              .usage = Render::RenderBufferUsage::Index,
+                                              .access = Render::RenderBufferAccess::DeviceLocal},
+                                             std::as_bytes(resource.indices));
+        if (index.HasError()) {
+            ReleaseMesh(resident);
+            return Result<void>::Failure(index.ErrorValue());
+        }
+        resident.indexBuffer = index.Value().handle;
+        resident.indexOperation = index.Value().operation;
+        resident.indexCount = static_cast<std::uint32_t>(resource.indices.size());
+        resident.sourceGeneration = resource.handle.generation;
+        return Result<void>::Success();
+    }
+
+    void EditorViewportRendererOpenGL::RetireMissingMeshes(const std::span<const EditorViewportMeshResourceView> resources) noexcept {
+        for (auto mesh = meshes_.begin(); mesh != meshes_.end();) {
+            const bool present = std::ranges::any_of(resources, [&](const EditorViewportMeshResourceView &resource) {
+                return resource.handle.id.value == mesh->first && resource.handle.generation == mesh->second.sourceGeneration;
+            });
+            if (!present) {
+                ReleaseMesh(mesh->second);
+                mesh = meshes_.erase(mesh);
+            } else {
+                ++mesh;
+            }
+        }
+    }
+
+    Result<void> EditorViewportRendererOpenGL::SynchronizeTarget(const EditorViewportExtent extent) {
+        if (ExtentChanged(allocatedExtent_, extent))
+            ReleaseViewportTarget();
+        allocatedExtent_ = extent;
+        const Render::FramebufferExtent framebufferExtent{extent.width, extent.height};
+        const auto targetReady = AdvanceViewportTarget(framebufferExtent);
+        if (targetReady.HasError())
+            return Result<void>::Failure(targetReady.ErrorValue());
+        if (!targetReady.Value())
+            return Result<void>::Success();
+        auto image = resourceBridge_.EditorImageIdentity(*frontend_, colorTextureView_);
+        if (image.HasError())
+            return Result<void>::Failure(image.ErrorValue());
+        editorImageIdentity_ = image.Value();
+        return Result<void>::Success();
+    }
+
+    Result<bool> EditorViewportRendererOpenGL::AdvanceViewportTarget(const Render::FramebufferExtent extent) {
+        const auto texturesReady = AdvanceViewportTextures(extent);
+        if (texturesReady.HasError() || !texturesReady.Value())
+            return texturesReady;
+        const auto viewsReady = AdvanceViewportViews();
+        if (viewsReady.HasError() || !viewsReady.Value())
+            return viewsReady;
+        return AdvanceRenderTarget(*frontend_,
+                                   {.colorAttachment = colorTextureView_, .depthAttachment = depthTextureView_, .extent = extent},
+                                   targetHandle_, targetOperation_);
+    }
+
+    Result<bool> EditorViewportRendererOpenGL::AdvanceViewportTextures(const Render::FramebufferExtent extent) {
+        const auto color = AdvanceTexture(*frontend_,
+                                          {.extent = extent,
+                                           .format = Render::RenderTextureFormat::Rgba8Unorm,
+                                           .usage = Render::RenderTextureUsage::Sampled | Render::RenderTextureUsage::RenderAttachment},
+                                          colorTexture_, colorTextureOperation_);
+        if (color.HasError())
+            return Result<bool>::Failure(color.ErrorValue());
+        const auto depth = AdvanceTexture(*frontend_,
+                                          {.extent = extent,
+                                           .format = Render::RenderTextureFormat::Depth24Stencil8,
+                                           .usage = Render::RenderTextureUsage::RenderAttachment},
+                                          depthTexture_, depthTextureOperation_);
+        if (depth.HasError())
+            return Result<bool>::Failure(depth.ErrorValue());
+        return Result<bool>::Success(color.Value() && depth.Value());
+    }
+
+    Result<bool> EditorViewportRendererOpenGL::AdvanceViewportViews() {
+        const auto color = AdvanceTextureView(*frontend_,
+                                              {.texture = colorTexture_,
+                                               .format = Render::RenderTextureFormat::Rgba8Unorm,
+                                               .aspect = Render::RenderTextureAspect::Color},
+                                              colorTextureView_, colorTextureViewOperation_);
+        if (color.HasError())
+            return Result<bool>::Failure(color.ErrorValue());
+        const auto depth = AdvanceTextureView(*frontend_,
+                                              {.texture = depthTexture_,
+                                               .format = Render::RenderTextureFormat::Depth24Stencil8,
+                                               .aspect = Render::RenderTextureAspect::DepthStencil},
+                                              depthTextureView_, depthTextureViewOperation_);
+        if (depth.HasError())
+            return Result<bool>::Failure(depth.ErrorValue());
+        return Result<bool>::Success(color.Value() && depth.Value());
+    }
+
+    Result<void> EditorViewportRendererOpenGL::SynchronizeShadowResources() {
+        const auto targetReady = AdvanceShadowTarget();
+        if (targetReady.HasError())
+            return Result<void>::Failure(targetReady.ErrorValue());
+        meshesReady_ = meshesReady_ && targetReady.Value();
+        return Result<void>::Success();
+    }
+
+    Result<bool> EditorViewportRendererOpenGL::AdvanceShadowTarget() {
+        constexpr Render::FramebufferExtent shadowExtent{EditorViewportDirectionalShadowMapResolution,
+                                                         EditorViewportDirectionalShadowMapResolution};
+        const auto textureReady =
+            AdvanceTexture(*frontend_,
+                           {.extent = shadowExtent,
+                            .format = Render::RenderTextureFormat::Depth32Float,
+                            .usage = Render::RenderTextureUsage::Sampled | Render::RenderTextureUsage::RenderAttachment},
+                           shadowDepthTexture_, shadowDepthTextureOperation_);
+        if (textureReady.HasError() || !textureReady.Value())
+            return textureReady;
+        const auto viewReady = AdvanceTextureView(*frontend_,
+                                                  {.texture = shadowDepthTexture_,
+                                                   .format = Render::RenderTextureFormat::Depth32Float,
+                                                   .aspect = Render::RenderTextureAspect::Depth},
+                                                  shadowDepthTextureView_, shadowDepthTextureViewOperation_);
+        if (viewReady.HasError() || !viewReady.Value())
+            return viewReady;
+        return AdvanceRenderTarget(*frontend_, {.depthAttachment = shadowDepthTextureView_, .extent = shadowExtent}, shadowTarget_,
+                                   shadowTargetOperation_);
+    }
+
+    void EditorViewportRendererOpenGL::ReleaseMesh(ResidentMesh &mesh) noexcept {
+        if (frontend_ != nullptr) {
+            if (mesh.mesh.IsValid())
+                static_cast<void>(frontend_->ReleaseMesh(mesh.mesh));
+            if (mesh.indexBuffer.IsValid())
+                static_cast<void>(frontend_->ReleaseBuffer(mesh.indexBuffer));
+            if (mesh.vertexBuffer.IsValid())
+                static_cast<void>(frontend_->ReleaseBuffer(mesh.vertexBuffer));
+        }
         mesh = {};
     }
 
-    Result<void> EditorViewportRendererOpenGL::RecreateTarget(const EditorViewportExtent extent) {
-        GLint previousDrawFramebuffer = 0;
-        GLint previousReadFramebuffer = 0;
-        GLint previousTexture = 0;
-        GLint previousRenderbuffer = 0;
-        glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &previousDrawFramebuffer);
-        glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &previousReadFramebuffer);
-        glGetIntegerv(GL_TEXTURE_BINDING_2D, &previousTexture);
-        glGetIntegerv(GL_RENDERBUFFER_BINDING, &previousRenderbuffer);
-
-        if (framebuffer_ == 0) {
-            glGenFramebuffers(1, &framebuffer_);
-        }
-        if (colorTexture_ == 0) {
-            glGenTextures(1, &colorTexture_);
-        }
-        if (depthBuffer_ == 0) {
-            glGenRenderbuffers(1, &depthBuffer_);
-        }
-
-        // Keep object identities stable across resize. ImGui records the texture ID
-        // before the viewport render pass executes later in the same frame.
-        glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_);
-        glBindTexture(GL_TEXTURE_2D, colorTexture_);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, static_cast<GLsizei>(extent.width), static_cast<GLsizei>(extent.height), 0, GL_RGBA,
-                     GL_UNSIGNED_BYTE, nullptr);
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, colorTexture_, 0);
-
-        glBindRenderbuffer(GL_RENDERBUFFER, depthBuffer_);
-        glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, static_cast<GLsizei>(extent.width),
-                              static_cast<GLsizei>(extent.height));
-        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthBuffer_);
-
-        const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-        glBindRenderbuffer(GL_RENDERBUFFER, static_cast<GLuint>(previousRenderbuffer));
-        glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(previousTexture));
-        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, static_cast<GLuint>(previousDrawFramebuffer));
-        glBindFramebuffer(GL_READ_FRAMEBUFFER, static_cast<GLuint>(previousReadFramebuffer));
-        if (status != GL_FRAMEBUFFER_COMPLETE) {
-            DestroyTarget();
-            return Result<void>::Failure(
-                MakeViewportError(RendererErrors::ViewportFramebufferIncomplete, "OpenGL viewport framebuffer is incomplete."));
-        }
-        allocatedExtent_ = extent;
-        return Result<void>::Success();
+    void EditorViewportRendererOpenGL::ReleaseTarget() noexcept {
+        ReleaseShadowResources();
+        ReleaseViewportTarget();
     }
 
-    void EditorViewportRendererOpenGL::DestroyTarget() noexcept {
-        if (depthBuffer_ != 0) {
-            glDeleteRenderbuffers(1, &depthBuffer_);
-            depthBuffer_ = 0;
+    void EditorViewportRendererOpenGL::ReleaseShadowResources() noexcept {
+        if (frontend_ != nullptr) {
+            if (shadowTarget_.IsValid())
+                static_cast<void>(frontend_->ReleaseRenderTarget(shadowTarget_));
+            if (shadowDepthTextureView_.IsValid())
+                static_cast<void>(frontend_->ReleaseTextureView(shadowDepthTextureView_));
+            if (shadowDepthTexture_.IsValid())
+                static_cast<void>(frontend_->ReleaseTexture(shadowDepthTexture_));
         }
-        if (colorTexture_ != 0) {
-            glDeleteTextures(1, &colorTexture_);
-            colorTexture_ = 0;
+        shadowDepthTexture_ = {};
+        shadowDepthTextureView_ = {};
+        shadowTarget_ = {};
+        shadowDepthTextureOperation_ = {};
+        shadowDepthTextureViewOperation_ = {};
+        shadowTargetOperation_ = {};
+    }
+
+    void EditorViewportRendererOpenGL::ReleaseViewportTarget() noexcept {
+        if (frontend_ != nullptr) {
+            if (targetHandle_.IsValid())
+                static_cast<void>(frontend_->ReleaseRenderTarget(targetHandle_));
+            if (depthTextureView_.IsValid())
+                static_cast<void>(frontend_->ReleaseTextureView(depthTextureView_));
+            if (colorTextureView_.IsValid())
+                static_cast<void>(frontend_->ReleaseTextureView(colorTextureView_));
+            if (depthTexture_.IsValid())
+                static_cast<void>(frontend_->ReleaseTexture(depthTexture_));
+            if (colorTexture_.IsValid())
+                static_cast<void>(frontend_->ReleaseTexture(colorTexture_));
         }
-        if (framebuffer_ != 0) {
-            glDeleteFramebuffers(1, &framebuffer_);
-            framebuffer_ = 0;
-        }
+        colorTexture_ = {};
+        depthTexture_ = {};
+        colorTextureView_ = {};
+        depthTextureView_ = {};
+        colorTextureOperation_ = {};
+        depthTextureOperation_ = {};
+        colorTextureViewOperation_ = {};
+        depthTextureViewOperation_ = {};
+        targetOperation_ = {};
+        targetHandle_ = {};
+        editorImageIdentity_ = 0;
         allocatedExtent_ = {};
     }
 }  // namespace Horo::Editor

--- a/src/editor/renderer/opengl/EditorViewportRendererOpenGL.cpp
+++ b/src/editor/renderer/opengl/EditorViewportRendererOpenGL.cpp
@@ -75,10 +75,6 @@ namespace Horo::Editor {
             return ResourceReady(frontend, handle, operation);
         }
 
-        [[nodiscard]] bool ExtentChanged(const EditorViewportExtent allocated, const EditorViewportExtent requested) noexcept {
-            return allocated.IsValid() && allocated != requested;
-        }
-
         [[nodiscard]] Result<std::uint32_t> CompileShader(const std::uint32_t type, const char *source) {
             const std::uint32_t shader = glCreateShader(type);
             glShaderSource(shader, 1, &source, nullptr);
@@ -226,7 +222,10 @@ namespace Horo::Editor {
         ReleaseTarget();
         for (auto &[id, mesh] : meshes_)
             ReleaseMesh(mesh);
+        for (auto &[id, mesh] : pendingMeshes_)
+            ReleaseMesh(mesh);
         meshes_.clear();
+        pendingMeshes_.clear();
         if (gridVertexBuffer_ != 0) {
             glDeleteBuffers(1, &gridVertexBuffer_);
             gridVertexBuffer_ = 0;
@@ -247,8 +246,6 @@ namespace Horo::Editor {
         requestedExtent_ = {};
         gridOptions_ = {};
         lightVisualizerOptions_ = {};
-        targetHandle_ = {};
-        editorImageIdentity_ = 0;
         meshesReady_ = false;
         initialized_ = false;
     }
@@ -274,10 +271,10 @@ namespace Horo::Editor {
             if (const Result<void> target = SynchronizeTarget(requestedExtent_); target.HasError())
                 return Result<std::optional<Render::RenderTargetHandle>>::Failure(target.ErrorValue());
         }
-        if (targetHandle_.IsValid()) {
-            const auto ready = frontend_->ResourceState(targetHandle_);
+        if (viewportTarget_.target.IsValid()) {
+            const auto ready = frontend_->ResourceState(viewportTarget_.target);
             if (ready.HasValue() && ready.Value() == Render::RenderResourceState::Ready)
-                return Result<std::optional<Render::RenderTargetHandle>>::Success(targetHandle_);
+                return Result<std::optional<Render::RenderTargetHandle>>::Success(viewportTarget_.target);
         }
         return Result<std::optional<Render::RenderTargetHandle>>::Success(std::nullopt);
     }
@@ -296,7 +293,7 @@ namespace Horo::Editor {
 
     /** @copydoc EditorViewportRendererOpenGL::RequestedExtent */
     EditorViewportExtent EditorViewportRendererOpenGL::RequestedExtent() const noexcept {
-        return requestedExtent_;
+        return requestedExtent_.IsValid() && allocatedExtent_.IsValid() ? allocatedExtent_ : requestedExtent_;
     }
 
     /** @copydoc EditorViewportRendererOpenGL::ClipDepthRange */
@@ -312,12 +309,13 @@ namespace Horo::Editor {
         }
         // A panel must request an extent every UI frame. Consuming the request keeps
         // hidden/inactive viewport tabs from spending GPU time in the background.
-        const EditorViewportExtent requestedExtent = std::exchange(requestedExtent_, {});
-        if (!requestedExtent.IsValid())
+        const EditorViewportExtent extentRequest = std::exchange(requestedExtent_, {});
+        if (!extentRequest.IsValid())
             return Result<void>::Success();
-        if (const Result<void> valid = ValidatePassRequest(descriptor, requestedExtent); valid.HasError())
+        const EditorViewportExtent renderExtent = allocatedExtent_.IsValid() ? allocatedExtent_ : extentRequest;
+        if (const Result<void> valid = ValidatePassRequest(descriptor, renderExtent); valid.HasError())
             return valid;
-        targetHandle_ = descriptor.target;
+        viewportTarget_.target = descriptor.target;
         const auto shadow = BuildEditorViewportDirectionalShadowView(descriptor.scene, Math::ClipDepthRange::NegativeOneToOne);
         if (shadow.HasError())
             return Result<void>::Failure(shadow.ErrorValue());
@@ -332,7 +330,7 @@ namespace Horo::Editor {
             descriptor.extent.height != requestedExtent.height) {
             return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportInvalidScene, "Editor viewport scene data is invalid."));
         }
-        if (targetHandle_.IsValid() && targetHandle_ != descriptor.target) {
+        if (viewportTarget_.target.IsValid() && viewportTarget_.target != descriptor.target) {
             return Result<void>::Failure(
                 MakeViewportError(RendererErrors::ViewportStaleTarget, "Viewport pass references a stale render target."));
         }
@@ -349,7 +347,7 @@ namespace Horo::Editor {
                 return renderedShadow;
             }
         }
-        if (const Result<void> bound = resourceBridge_.BindRenderTarget(*frontend_, targetHandle_); bound.HasError())
+        if (const Result<void> bound = resourceBridge_.BindRenderTarget(*frontend_, viewportTarget_.target); bound.HasError())
             return bound;
         glViewport(0, 0, static_cast<GLsizei>(allocatedExtent_.width), static_cast<GLsizei>(allocatedExtent_.height));
         glDisable(GL_SCISSOR_TEST);
@@ -477,7 +475,7 @@ namespace Horo::Editor {
     /** @copydoc EditorViewportRendererOpenGL::TextureView */
     EditorViewportTextureView EditorViewportRendererOpenGL::TextureView() const noexcept {
         return EditorViewportTextureView{
-            .textureId = editorImageIdentity_,
+            .textureId = viewportTarget_.imageIdentity,
             .u0 = 0.0F,
             .v0 = 1.0F,
             .u1 = 1.0F,
@@ -487,7 +485,8 @@ namespace Horo::Editor {
 
     /** @copydoc EditorViewportRendererOpenGL::IsReady */
     bool EditorViewportRendererOpenGL::IsReady() const noexcept {
-        return initialized_ && meshesReady_ && editorImageIdentity_ != 0 && targetHandle_.IsValid() && allocatedExtent_.IsValid();
+        return initialized_ && meshesReady_ && viewportTarget_.imageIdentity != 0 && viewportTarget_.target.IsValid() &&
+               allocatedExtent_.IsValid();
     }
 
     Result<void> EditorViewportRendererOpenGL::CreateProgram() {
@@ -673,11 +672,7 @@ namespace Horo::Editor {
         meshesReady_ = true;
 
         for (const EditorViewportMeshResourceView &resource : resources) {
-            auto [position, inserted] = meshes_.try_emplace(resource.handle.id.value);
-            ResidentMesh &resident = position->second;
-            if (!inserted && resident.sourceGeneration != resource.handle.generation)
-                ReleaseMesh(resident);
-            const auto ready = AdvanceResidentMesh(resource, resident);
+            const auto ready = SynchronizeMesh(resource);
             if (ready.HasError())
                 return Result<void>::Failure(ready.ErrorValue());
             meshesReady_ = meshesReady_ && ready.Value();
@@ -685,6 +680,39 @@ namespace Horo::Editor {
 
         RetireMissingMeshes(resources);
         return Result<void>::Success();
+    }
+
+    Result<bool> EditorViewportRendererOpenGL::SynchronizeMesh(const EditorViewportMeshResourceView &resource) {
+        const std::uint64_t id = resource.handle.id.value;
+        auto [activePosition, inserted] = meshes_.try_emplace(id);
+        ResidentMesh &active = activePosition->second;
+        if (inserted)
+            return AdvanceResidentMesh(resource, active);
+        if (active.sourceGeneration == resource.handle.generation) {
+            if (auto pending = pendingMeshes_.find(id); pending != pendingMeshes_.end()) {
+                ReleaseMesh(pending->second);
+                pendingMeshes_.erase(pending);
+            }
+            return AdvanceResidentMesh(resource, active);
+        }
+
+        if (!IsResidentMeshReady(active)) {
+            ReleaseMesh(active);
+            return AdvanceResidentMesh(resource, active);
+        }
+
+        ResidentMesh &pending = pendingMeshes_[id];
+        if (pending.sourceGeneration != 0 && pending.sourceGeneration != resource.handle.generation)
+            ReleaseMesh(pending);
+        const auto ready = AdvanceResidentMesh(resource, pending);
+        if (ready.HasError())
+            return Result<bool>::Failure(ready.ErrorValue());
+        if (ready.Value()) {
+            ReleaseMesh(active);
+            active = std::exchange(pending, {});
+            pendingMeshes_.erase(id);
+        }
+        return Result<bool>::Success(true);
     }
 
     Result<bool> EditorViewportRendererOpenGL::AdvanceResidentMesh(const EditorViewportMeshResourceView &resource, ResidentMesh &resident) {
@@ -746,13 +774,24 @@ namespace Horo::Editor {
         return Result<void>::Success();
     }
 
+    bool EditorViewportRendererOpenGL::IsResidentMeshReady(const ResidentMesh &resident) const {
+        if (!resident.mesh.IsValid())
+            return false;
+        const auto state = frontend_->ResourceState(resident.mesh);
+        return state.HasValue() && state.Value() == Render::RenderResourceState::Ready;
+    }
+
     void EditorViewportRendererOpenGL::RetireMissingMeshes(const std::span<const EditorViewportMeshResourceView> resources) noexcept {
         for (auto mesh = meshes_.begin(); mesh != meshes_.end();) {
             const bool present = std::ranges::any_of(resources, [&](const EditorViewportMeshResourceView &resource) {
-                return resource.handle.id.value == mesh->first && resource.handle.generation == mesh->second.sourceGeneration;
+                return resource.handle.id.value == mesh->first;
             });
             if (!present) {
                 ReleaseMesh(mesh->second);
+                if (auto pending = pendingMeshes_.find(mesh->first); pending != pendingMeshes_.end()) {
+                    ReleaseMesh(pending->second);
+                    pendingMeshes_.erase(pending);
+                }
                 mesh = meshes_.erase(mesh);
             } else {
                 ++mesh;
@@ -761,65 +800,74 @@ namespace Horo::Editor {
     }
 
     Result<void> EditorViewportRendererOpenGL::SynchronizeTarget(const EditorViewportExtent extent) {
-        if (ExtentChanged(allocatedExtent_, extent))
-            ReleaseViewportTarget();
-        allocatedExtent_ = extent;
-        const Render::FramebufferExtent framebufferExtent{extent.width, extent.height};
-        const auto targetReady = AdvanceViewportTarget(framebufferExtent);
+        if (allocatedExtent_ == extent) {
+            if (pendingViewportTarget_.extent.IsValid())
+                ReleaseViewportTarget(pendingViewportTarget_);
+            return Result<void>::Success();
+        }
+        if (pendingViewportTarget_.extent.IsValid() && pendingViewportTarget_.extent != extent)
+            ReleaseViewportTarget(pendingViewportTarget_);
+        pendingViewportTarget_.extent = extent;
+        const auto targetReady = AdvanceViewportTarget(pendingViewportTarget_);
         if (targetReady.HasError())
             return Result<void>::Failure(targetReady.ErrorValue());
         if (!targetReady.Value())
             return Result<void>::Success();
-        auto image = resourceBridge_.EditorImageIdentity(*frontend_, colorTextureView_);
+        auto image = resourceBridge_.EditorImageIdentity(*frontend_, pendingViewportTarget_.colorView);
         if (image.HasError())
             return Result<void>::Failure(image.ErrorValue());
-        editorImageIdentity_ = image.Value();
+        pendingViewportTarget_.imageIdentity = image.Value();
+        ReleaseViewportTarget(viewportTarget_);
+        viewportTarget_ = std::exchange(pendingViewportTarget_, {});
+        allocatedExtent_ = extent;
         return Result<void>::Success();
     }
 
-    Result<bool> EditorViewportRendererOpenGL::AdvanceViewportTarget(const Render::FramebufferExtent extent) {
-        const auto texturesReady = AdvanceViewportTextures(extent);
+    Result<bool> EditorViewportRendererOpenGL::AdvanceViewportTarget(ViewportTargetResources &resources) {
+        const auto texturesReady = AdvanceViewportTextures(resources);
         if (texturesReady.HasError() || !texturesReady.Value())
             return texturesReady;
-        const auto viewsReady = AdvanceViewportViews();
+        const auto viewsReady = AdvanceViewportViews(resources);
         if (viewsReady.HasError() || !viewsReady.Value())
             return viewsReady;
+        const Render::FramebufferExtent extent{resources.extent.width, resources.extent.height};
         return AdvanceRenderTarget(*frontend_,
-                                   {.colorAttachment = colorTextureView_, .depthAttachment = depthTextureView_, .extent = extent},
-                                   targetHandle_, targetOperation_);
+                                   {.colorAttachment = resources.colorView, .depthAttachment = resources.depthView, .extent = extent},
+                                   resources.target, resources.targetOperation);
     }
 
-    Result<bool> EditorViewportRendererOpenGL::AdvanceViewportTextures(const Render::FramebufferExtent extent) {
+    Result<bool> EditorViewportRendererOpenGL::AdvanceViewportTextures(ViewportTargetResources &resources) {
+        const Render::FramebufferExtent extent{resources.extent.width, resources.extent.height};
         const auto color = AdvanceTexture(*frontend_,
                                           {.extent = extent,
                                            .format = Render::RenderTextureFormat::Rgba8Unorm,
                                            .usage = Render::RenderTextureUsage::Sampled | Render::RenderTextureUsage::RenderAttachment},
-                                          colorTexture_, colorTextureOperation_);
+                                          resources.colorTexture, resources.colorTextureOperation);
         if (color.HasError())
             return Result<bool>::Failure(color.ErrorValue());
         const auto depth = AdvanceTexture(*frontend_,
                                           {.extent = extent,
                                            .format = Render::RenderTextureFormat::Depth24Stencil8,
                                            .usage = Render::RenderTextureUsage::RenderAttachment},
-                                          depthTexture_, depthTextureOperation_);
+                                          resources.depthTexture, resources.depthTextureOperation);
         if (depth.HasError())
             return Result<bool>::Failure(depth.ErrorValue());
         return Result<bool>::Success(color.Value() && depth.Value());
     }
 
-    Result<bool> EditorViewportRendererOpenGL::AdvanceViewportViews() {
+    Result<bool> EditorViewportRendererOpenGL::AdvanceViewportViews(ViewportTargetResources &resources) {
         const auto color = AdvanceTextureView(*frontend_,
-                                              {.texture = colorTexture_,
+                                              {.texture = resources.colorTexture,
                                                .format = Render::RenderTextureFormat::Rgba8Unorm,
                                                .aspect = Render::RenderTextureAspect::Color},
-                                              colorTextureView_, colorTextureViewOperation_);
+                                              resources.colorView, resources.colorViewOperation);
         if (color.HasError())
             return Result<bool>::Failure(color.ErrorValue());
         const auto depth = AdvanceTextureView(*frontend_,
-                                              {.texture = depthTexture_,
+                                              {.texture = resources.depthTexture,
                                                .format = Render::RenderTextureFormat::Depth24Stencil8,
                                                .aspect = Render::RenderTextureAspect::DepthStencil},
-                                              depthTextureView_, depthTextureViewOperation_);
+                                              resources.depthView, resources.depthViewOperation);
         if (depth.HasError())
             return Result<bool>::Failure(depth.ErrorValue());
         return Result<bool>::Success(color.Value() && depth.Value());
@@ -869,7 +917,9 @@ namespace Horo::Editor {
 
     void EditorViewportRendererOpenGL::ReleaseTarget() noexcept {
         ReleaseShadowResources();
-        ReleaseViewportTarget();
+        ReleaseViewportTarget(pendingViewportTarget_);
+        ReleaseViewportTarget(viewportTarget_);
+        allocatedExtent_ = {};
     }
 
     void EditorViewportRendererOpenGL::ReleaseShadowResources() noexcept {
@@ -889,30 +939,19 @@ namespace Horo::Editor {
         shadowTargetOperation_ = {};
     }
 
-    void EditorViewportRendererOpenGL::ReleaseViewportTarget() noexcept {
+    void EditorViewportRendererOpenGL::ReleaseViewportTarget(ViewportTargetResources &resources) noexcept {
         if (frontend_ != nullptr) {
-            if (targetHandle_.IsValid())
-                static_cast<void>(frontend_->ReleaseRenderTarget(targetHandle_));
-            if (depthTextureView_.IsValid())
-                static_cast<void>(frontend_->ReleaseTextureView(depthTextureView_));
-            if (colorTextureView_.IsValid())
-                static_cast<void>(frontend_->ReleaseTextureView(colorTextureView_));
-            if (depthTexture_.IsValid())
-                static_cast<void>(frontend_->ReleaseTexture(depthTexture_));
-            if (colorTexture_.IsValid())
-                static_cast<void>(frontend_->ReleaseTexture(colorTexture_));
+            if (resources.target.IsValid())
+                static_cast<void>(frontend_->ReleaseRenderTarget(resources.target));
+            if (resources.depthView.IsValid())
+                static_cast<void>(frontend_->ReleaseTextureView(resources.depthView));
+            if (resources.colorView.IsValid())
+                static_cast<void>(frontend_->ReleaseTextureView(resources.colorView));
+            if (resources.depthTexture.IsValid())
+                static_cast<void>(frontend_->ReleaseTexture(resources.depthTexture));
+            if (resources.colorTexture.IsValid())
+                static_cast<void>(frontend_->ReleaseTexture(resources.colorTexture));
         }
-        colorTexture_ = {};
-        depthTexture_ = {};
-        colorTextureView_ = {};
-        depthTextureView_ = {};
-        colorTextureOperation_ = {};
-        depthTextureOperation_ = {};
-        colorTextureViewOperation_ = {};
-        depthTextureViewOperation_ = {};
-        targetOperation_ = {};
-        targetHandle_ = {};
-        editorImageIdentity_ = 0;
-        allocatedExtent_ = {};
+        resources = {};
     }
 }  // namespace Horo::Editor

--- a/src/editor/renderer/opengl/EditorViewportRendererOpenGL.h
+++ b/src/editor/renderer/opengl/EditorViewportRendererOpenGL.h
@@ -61,6 +61,21 @@ namespace Horo::Editor {
             std::uint32_t sourceGeneration{0};
         };
 
+        struct ViewportTargetResources {
+            Render::RenderTextureHandle colorTexture;
+            Render::RenderTextureHandle depthTexture;
+            Render::RenderTextureViewHandle colorView;
+            Render::RenderTextureViewHandle depthView;
+            Render::RenderTargetHandle target;
+            Render::ResourceOperationId colorTextureOperation;
+            Render::ResourceOperationId depthTextureOperation;
+            Render::ResourceOperationId colorViewOperation;
+            Render::ResourceOperationId depthViewOperation;
+            Render::ResourceOperationId targetOperation;
+            EditorViewportExtent extent;
+            std::uintptr_t imageIdentity{0};
+        };
+
         struct UniformLocations {
             std::int32_t mvp{-1};
             std::int32_t model{-1};
@@ -81,17 +96,19 @@ namespace Horo::Editor {
 
         [[nodiscard]] Result<void> LoadUniformLocations();
         [[nodiscard]] Result<void> SynchronizeMeshes(std::span<const EditorViewportMeshResourceView> resources);
+        [[nodiscard]] Result<bool> SynchronizeMesh(const EditorViewportMeshResourceView &resource);
         [[nodiscard]] Result<bool> AdvanceResidentMesh(const EditorViewportMeshResourceView &resource, ResidentMesh &resident);
         [[nodiscard]] Result<void> CreateResidentMeshBuffers(const EditorViewportMeshResourceView &resource, ResidentMesh &resident);
+        [[nodiscard]] bool IsResidentMeshReady(const ResidentMesh &resident) const;
         void RetireMissingMeshes(std::span<const EditorViewportMeshResourceView> resources) noexcept;
         [[nodiscard]] Result<void> SynchronizeTarget(EditorViewportExtent extent);
-        [[nodiscard]] Result<bool> AdvanceViewportTarget(Render::FramebufferExtent extent);
-        [[nodiscard]] Result<bool> AdvanceViewportTextures(Render::FramebufferExtent extent);
-        [[nodiscard]] Result<bool> AdvanceViewportViews();
+        [[nodiscard]] Result<bool> AdvanceViewportTarget(ViewportTargetResources &resources);
+        [[nodiscard]] Result<bool> AdvanceViewportTextures(ViewportTargetResources &resources);
+        [[nodiscard]] Result<bool> AdvanceViewportViews(ViewportTargetResources &resources);
         void ReleaseMesh(ResidentMesh &mesh) noexcept;
         void ReleaseTarget() noexcept;
         void ReleaseShadowResources() noexcept;
-        void ReleaseViewportTarget() noexcept;
+        void ReleaseViewportTarget(ViewportTargetResources &resources) noexcept;
 
         std::uint32_t program_{0};
         std::uint32_t shadowProgram_{0};
@@ -104,24 +121,16 @@ namespace Horo::Editor {
         std::uint32_t gridVertexArray_{0};
         std::uint32_t gridVertexBuffer_{0};
         std::unordered_map<std::uint64_t, ResidentMesh> meshes_;
+        std::unordered_map<std::uint64_t, ResidentMesh> pendingMeshes_;
         Render::RenderFrontend *frontend_{nullptr};
         OpenGLViewportResourceBridge resourceBridge_;
-        Render::RenderTextureHandle colorTexture_;
-        Render::RenderTextureHandle depthTexture_;
-        Render::RenderTextureViewHandle colorTextureView_;
-        Render::RenderTextureViewHandle depthTextureView_;
-        Render::ResourceOperationId colorTextureOperation_;
-        Render::ResourceOperationId depthTextureOperation_;
-        Render::ResourceOperationId colorTextureViewOperation_;
-        Render::ResourceOperationId depthTextureViewOperation_;
-        Render::ResourceOperationId targetOperation_;
-        std::uintptr_t editorImageIdentity_{0};
+        ViewportTargetResources viewportTarget_;
+        ViewportTargetResources pendingViewportTarget_;
         UniformLocations uniforms_{};
         EditorViewportExtent requestedExtent_{};
         EditorViewportExtent allocatedExtent_{};
         EditorViewportGridOptions gridOptions_{};
         EditorViewportLightVisualizerOptions lightVisualizerOptions_{};
-        Render::RenderTargetHandle targetHandle_{};
         bool initialized_{false};
         bool meshesReady_{false};
     };

--- a/src/editor/renderer/opengl/EditorViewportRendererOpenGL.h
+++ b/src/editor/renderer/opengl/EditorViewportRendererOpenGL.h
@@ -42,8 +42,8 @@ namespace Horo::Editor {
         [[nodiscard]] Result<void> RenderViewportPass(const Render::StaticMeshPassDescriptor &descriptor,
                                                       const std::optional<EditorViewportDirectionalShadowView> &shadow, float aspect);
         [[nodiscard]] Result<void> DrawDirectionalShadowMap(const Render::RenderSceneView &scene,
-                                                            const EditorViewportDirectionalShadowView &shadow);
-        [[nodiscard]] Result<void> DrawSceneMeshes(const Render::RenderSceneView &scene, float aspect);
+                                                            const EditorViewportDirectionalShadowView &shadow) const;
+        [[nodiscard]] Result<void> DrawSceneMeshes(const Render::RenderSceneView &scene, float aspect) const;
         [[nodiscard]] Result<void> DrawGrid(const Render::RenderCameraView &camera, float aspect, float viewportHeightPixels) const;
         [[nodiscard]] Result<void> DrawLightVisualizer(const Render::RenderCameraView &camera, float aspect);
         void UploadLighting(const Render::RenderSceneView &scene, const std::optional<EditorViewportDirectionalShadowView> &shadow) const;

--- a/src/editor/renderer/opengl/EditorViewportRendererOpenGL.h
+++ b/src/editor/renderer/opengl/EditorViewportRendererOpenGL.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "editor/renderer/EditorViewportRenderer.h"
+#include "editor/renderer/opengl/OpenGLViewportResourceBridge.h"
 
 #include <optional>
 #include <unordered_map>
@@ -9,7 +10,8 @@ namespace Horo::Editor {
     /** @brief OpenGL editor adapter that renders backend-neutral editor scene instances into an offscreen target. */
     class EditorViewportRendererOpenGL final : public IEditorViewportRenderer {
     public:
-        EditorViewportRendererOpenGL() = default;
+        /** @brief Borrows the frontend that owns every generic viewport resource. */
+        explicit EditorViewportRendererOpenGL(Render::RenderFrontend &frontend) noexcept;
         ~EditorViewportRendererOpenGL() override;
 
         EditorViewportRendererOpenGL(const EditorViewportRendererOpenGL &) = delete;
@@ -27,24 +29,36 @@ namespace Horo::Editor {
         [[nodiscard]] EditorViewportExtent RequestedExtent() const noexcept override;
         [[nodiscard]] Math::ClipDepthRange ClipDepthRange() const noexcept override;
         [[nodiscard]] Result<void> ExecuteStaticMeshPass(const Render::StaticMeshPassDescriptor &descriptor) override;
+        [[nodiscard]] Result<std::optional<Render::RenderTargetHandle>> PrepareResources(Render::RenderFrontend &frontend,
+                                                                                         const Render::RenderSceneView &scene) override;
         [[nodiscard]] EditorViewportTextureView TextureView() const noexcept override;
         [[nodiscard]] bool IsReady() const noexcept override;
 
     private:
         [[nodiscard]] Result<void> CreateProgram();
-        [[nodiscard]] Result<void> CreateShadowResources();
+        [[nodiscard]] Result<void> CreateShadowProgram();
+        [[nodiscard]] Result<void> ValidatePassRequest(const Render::StaticMeshPassDescriptor &descriptor,
+                                                       EditorViewportExtent requestedExtent) const;
+        [[nodiscard]] Result<void> RenderViewportPass(const Render::StaticMeshPassDescriptor &descriptor,
+                                                      const std::optional<EditorViewportDirectionalShadowView> &shadow, float aspect);
+        [[nodiscard]] Result<void> SynchronizeShadowResources();
+        [[nodiscard]] Result<bool> AdvanceShadowTarget();
         [[nodiscard]] Result<void> DrawDirectionalShadowMap(const Render::RenderSceneView &scene,
                                                             const EditorViewportDirectionalShadowView &shadow);
+        [[nodiscard]] Result<void> DrawSceneMeshes(const Render::RenderSceneView &scene, float aspect);
         [[nodiscard]] Result<void> DrawGrid(const Render::RenderCameraView &camera, float aspect, float viewportHeightPixels) const;
         [[nodiscard]] Result<void> DrawLightVisualizer(const Render::RenderCameraView &camera, float aspect);
         void UploadLighting(const Render::RenderSceneView &scene, const std::optional<EditorViewportDirectionalShadowView> &shadow) const;
 
-        struct GpuMesh {
-            std::uint32_t vertexArray{0};
-            std::uint32_t vertexBuffer{0};
-            std::uint32_t indexBuffer{0};
+        struct ResidentMesh {
+            Render::RenderBufferHandle vertexBuffer;
+            Render::RenderBufferHandle indexBuffer;
+            Render::RenderMeshHandle mesh;
+            Render::ResourceOperationId vertexOperation;
+            Render::ResourceOperationId indexOperation;
+            Render::ResourceOperationId meshOperation;
             std::uint32_t indexCount{0};
-            std::uint32_t generation{0};
+            std::uint32_t sourceGeneration{0};
         };
 
         struct UniformLocations {
@@ -65,21 +79,43 @@ namespace Horo::Editor {
             std::int32_t selectionStrength{-1};
         };
 
+        [[nodiscard]] Result<void> LoadUniformLocations();
         [[nodiscard]] Result<void> SynchronizeMeshes(std::span<const EditorViewportMeshResourceView> resources);
-        static void DestroyMesh(GpuMesh &mesh) noexcept;
-        [[nodiscard]] Result<void> RecreateTarget(EditorViewportExtent extent);
-        void DestroyTarget() noexcept;
+        [[nodiscard]] Result<bool> AdvanceResidentMesh(const EditorViewportMeshResourceView &resource, ResidentMesh &resident);
+        [[nodiscard]] Result<void> CreateResidentMeshBuffers(const EditorViewportMeshResourceView &resource, ResidentMesh &resident);
+        void RetireMissingMeshes(std::span<const EditorViewportMeshResourceView> resources) noexcept;
+        [[nodiscard]] Result<void> SynchronizeTarget(EditorViewportExtent extent);
+        [[nodiscard]] Result<bool> AdvanceViewportTarget(Render::FramebufferExtent extent);
+        [[nodiscard]] Result<bool> AdvanceViewportTextures(Render::FramebufferExtent extent);
+        [[nodiscard]] Result<bool> AdvanceViewportViews();
+        void ReleaseMesh(ResidentMesh &mesh) noexcept;
+        void ReleaseTarget() noexcept;
+        void ReleaseShadowResources() noexcept;
+        void ReleaseViewportTarget() noexcept;
 
         std::uint32_t program_{0};
         std::uint32_t shadowProgram_{0};
-        std::uint32_t shadowFramebuffer_{0};
-        std::uint32_t shadowDepthTexture_{0};
+        Render::RenderTextureHandle shadowDepthTexture_;
+        Render::RenderTextureViewHandle shadowDepthTextureView_;
+        Render::RenderTargetHandle shadowTarget_;
+        Render::ResourceOperationId shadowDepthTextureOperation_;
+        Render::ResourceOperationId shadowDepthTextureViewOperation_;
+        Render::ResourceOperationId shadowTargetOperation_;
         std::uint32_t gridVertexArray_{0};
         std::uint32_t gridVertexBuffer_{0};
-        std::unordered_map<std::uint64_t, GpuMesh> meshes_;
-        std::uint32_t framebuffer_{0};
-        std::uint32_t colorTexture_{0};
-        std::uint32_t depthBuffer_{0};
+        std::unordered_map<std::uint64_t, ResidentMesh> meshes_;
+        Render::RenderFrontend *frontend_{nullptr};
+        OpenGLViewportResourceBridge resourceBridge_;
+        Render::RenderTextureHandle colorTexture_;
+        Render::RenderTextureHandle depthTexture_;
+        Render::RenderTextureViewHandle colorTextureView_;
+        Render::RenderTextureViewHandle depthTextureView_;
+        Render::ResourceOperationId colorTextureOperation_;
+        Render::ResourceOperationId depthTextureOperation_;
+        Render::ResourceOperationId colorTextureViewOperation_;
+        Render::ResourceOperationId depthTextureViewOperation_;
+        Render::ResourceOperationId targetOperation_;
+        std::uintptr_t editorImageIdentity_{0};
         UniformLocations uniforms_{};
         EditorViewportExtent requestedExtent_{};
         EditorViewportExtent allocatedExtent_{};
@@ -87,6 +123,7 @@ namespace Horo::Editor {
         EditorViewportLightVisualizerOptions lightVisualizerOptions_{};
         Render::RenderTargetHandle targetHandle_{};
         bool initialized_{false};
+        bool meshesReady_{false};
     };
 
 }  // namespace Horo::Editor

--- a/src/editor/renderer/opengl/EditorViewportRendererOpenGL.h
+++ b/src/editor/renderer/opengl/EditorViewportRendererOpenGL.h
@@ -2,9 +2,9 @@
 
 #include "editor/renderer/EditorViewportRenderer.h"
 #include "editor/renderer/opengl/OpenGLViewportResourceBridge.h"
+#include "editor/renderer/opengl/OpenGLViewportResources.h"
 
 #include <optional>
-#include <unordered_map>
 
 namespace Horo::Editor {
     /** @brief OpenGL editor adapter that renders backend-neutral editor scene instances into an offscreen target. */
@@ -41,40 +41,12 @@ namespace Horo::Editor {
                                                        EditorViewportExtent requestedExtent) const;
         [[nodiscard]] Result<void> RenderViewportPass(const Render::StaticMeshPassDescriptor &descriptor,
                                                       const std::optional<EditorViewportDirectionalShadowView> &shadow, float aspect);
-        [[nodiscard]] Result<void> SynchronizeShadowResources();
-        [[nodiscard]] Result<bool> AdvanceShadowTarget();
         [[nodiscard]] Result<void> DrawDirectionalShadowMap(const Render::RenderSceneView &scene,
                                                             const EditorViewportDirectionalShadowView &shadow);
         [[nodiscard]] Result<void> DrawSceneMeshes(const Render::RenderSceneView &scene, float aspect);
         [[nodiscard]] Result<void> DrawGrid(const Render::RenderCameraView &camera, float aspect, float viewportHeightPixels) const;
         [[nodiscard]] Result<void> DrawLightVisualizer(const Render::RenderCameraView &camera, float aspect);
         void UploadLighting(const Render::RenderSceneView &scene, const std::optional<EditorViewportDirectionalShadowView> &shadow) const;
-
-        struct ResidentMesh {
-            Render::RenderBufferHandle vertexBuffer;
-            Render::RenderBufferHandle indexBuffer;
-            Render::RenderMeshHandle mesh;
-            Render::ResourceOperationId vertexOperation;
-            Render::ResourceOperationId indexOperation;
-            Render::ResourceOperationId meshOperation;
-            std::uint32_t indexCount{0};
-            std::uint32_t sourceGeneration{0};
-        };
-
-        struct ViewportTargetResources {
-            Render::RenderTextureHandle colorTexture;
-            Render::RenderTextureHandle depthTexture;
-            Render::RenderTextureViewHandle colorView;
-            Render::RenderTextureViewHandle depthView;
-            Render::RenderTargetHandle target;
-            Render::ResourceOperationId colorTextureOperation;
-            Render::ResourceOperationId depthTextureOperation;
-            Render::ResourceOperationId colorViewOperation;
-            Render::ResourceOperationId depthViewOperation;
-            Render::ResourceOperationId targetOperation;
-            EditorViewportExtent extent;
-            std::uintptr_t imageIdentity{0};
-        };
 
         struct UniformLocations {
             std::int32_t mvp{-1};
@@ -95,44 +67,18 @@ namespace Horo::Editor {
         };
 
         [[nodiscard]] Result<void> LoadUniformLocations();
-        [[nodiscard]] Result<void> SynchronizeMeshes(std::span<const EditorViewportMeshResourceView> resources);
-        [[nodiscard]] Result<bool> SynchronizeMesh(const EditorViewportMeshResourceView &resource);
-        [[nodiscard]] Result<bool> AdvanceResidentMesh(const EditorViewportMeshResourceView &resource, ResidentMesh &resident);
-        [[nodiscard]] Result<void> CreateResidentMeshBuffers(const EditorViewportMeshResourceView &resource, ResidentMesh &resident);
-        [[nodiscard]] bool IsResidentMeshReady(const ResidentMesh &resident) const;
-        void RetireMissingMeshes(std::span<const EditorViewportMeshResourceView> resources) noexcept;
-        [[nodiscard]] Result<void> SynchronizeTarget(EditorViewportExtent extent);
-        [[nodiscard]] Result<bool> AdvanceViewportTarget(ViewportTargetResources &resources);
-        [[nodiscard]] Result<bool> AdvanceViewportTextures(ViewportTargetResources &resources);
-        [[nodiscard]] Result<bool> AdvanceViewportViews(ViewportTargetResources &resources);
-        void ReleaseMesh(ResidentMesh &mesh) noexcept;
-        void ReleaseTarget() noexcept;
-        void ReleaseShadowResources() noexcept;
-        void ReleaseViewportTarget(ViewportTargetResources &resources) noexcept;
 
         std::uint32_t program_{0};
         std::uint32_t shadowProgram_{0};
-        Render::RenderTextureHandle shadowDepthTexture_;
-        Render::RenderTextureViewHandle shadowDepthTextureView_;
-        Render::RenderTargetHandle shadowTarget_;
-        Render::ResourceOperationId shadowDepthTextureOperation_;
-        Render::ResourceOperationId shadowDepthTextureViewOperation_;
-        Render::ResourceOperationId shadowTargetOperation_;
         std::uint32_t gridVertexArray_{0};
         std::uint32_t gridVertexBuffer_{0};
-        std::unordered_map<std::uint64_t, ResidentMesh> meshes_;
-        std::unordered_map<std::uint64_t, ResidentMesh> pendingMeshes_;
         Render::RenderFrontend *frontend_{nullptr};
-        OpenGLViewportResourceBridge resourceBridge_;
-        ViewportTargetResources viewportTarget_;
-        ViewportTargetResources pendingViewportTarget_;
+        OpenGLViewportResources resources_;
         UniformLocations uniforms_{};
         EditorViewportExtent requestedExtent_{};
-        EditorViewportExtent allocatedExtent_{};
         EditorViewportGridOptions gridOptions_{};
         EditorViewportLightVisualizerOptions lightVisualizerOptions_{};
         bool initialized_{false};
-        bool meshesReady_{false};
     };
 
 }  // namespace Horo::Editor

--- a/src/editor/renderer/opengl/OpenGLStateSnapshot.cpp
+++ b/src/editor/renderer/opengl/OpenGLStateSnapshot.cpp
@@ -1,0 +1,56 @@
+#include "OpenGLStateSnapshot.h"
+
+namespace Horo::Editor {
+    namespace {
+        void RestoreCapability(const GLenum capability, const GLboolean enabled) noexcept {
+            if (enabled == GL_TRUE)
+                glEnable(capability);
+            else
+                glDisable(capability);
+        }
+    }  // namespace
+
+    /** @copydoc OpenGLStateSnapshot::OpenGLStateSnapshot */
+    OpenGLStateSnapshot::OpenGLStateSnapshot() noexcept {
+        depthTestEnabled_ = glIsEnabled(GL_DEPTH_TEST);
+        scissorTestEnabled_ = glIsEnabled(GL_SCISSOR_TEST);
+        blendEnabled_ = glIsEnabled(GL_BLEND);
+        cullFaceEnabled_ = glIsEnabled(GL_CULL_FACE);
+        glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &drawFramebuffer_);
+        glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &readFramebuffer_);
+        glGetIntegerv(GL_CURRENT_PROGRAM, &program_);
+        glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &vertexArray_);
+        glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &arrayBuffer_);
+        glGetIntegerv(GL_DEPTH_FUNC, &depthFunction_);
+        glGetIntegerv(GL_CULL_FACE_MODE, &cullFaceMode_);
+        glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTexture_);
+        glActiveTexture(GL_TEXTURE7);
+        glGetIntegerv(GL_TEXTURE_BINDING_2D, &shadowTexture_);
+        glGetIntegerv(GL_VIEWPORT, viewport_.data());
+        glGetFloatv(GL_COLOR_CLEAR_VALUE, clearColor_.data());
+        glGetBooleanv(GL_COLOR_WRITEMASK, colorMask_.data());
+        glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMask_);
+    }
+
+    /** @copydoc OpenGLStateSnapshot::~OpenGLStateSnapshot */
+    OpenGLStateSnapshot::~OpenGLStateSnapshot() {
+        glBindVertexArray(static_cast<GLuint>(vertexArray_));
+        glBindBuffer(GL_ARRAY_BUFFER, static_cast<GLuint>(arrayBuffer_));
+        glUseProgram(static_cast<GLuint>(program_));
+        glDepthFunc(static_cast<GLenum>(depthFunction_));
+        RestoreCapability(GL_DEPTH_TEST, depthTestEnabled_);
+        RestoreCapability(GL_SCISSOR_TEST, scissorTestEnabled_);
+        RestoreCapability(GL_BLEND, blendEnabled_);
+        RestoreCapability(GL_CULL_FACE, cullFaceEnabled_);
+        glCullFace(static_cast<GLenum>(cullFaceMode_));
+        glColorMask(colorMask_[0], colorMask_[1], colorMask_[2], colorMask_[3]);
+        glDepthMask(depthMask_);
+        glClearColor(clearColor_[0], clearColor_[1], clearColor_[2], clearColor_[3]);
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, static_cast<GLuint>(drawFramebuffer_));
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, static_cast<GLuint>(readFramebuffer_));
+        glViewport(viewport_[0], viewport_[1], viewport_[2], viewport_[3]);
+        glActiveTexture(GL_TEXTURE7);
+        glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(shadowTexture_));
+        glActiveTexture(static_cast<GLenum>(activeTexture_));
+    }
+}  // namespace Horo::Editor

--- a/src/editor/renderer/opengl/OpenGLStateSnapshot.h
+++ b/src/editor/renderer/opengl/OpenGLStateSnapshot.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <array>
+#include <glad/gl.h>
+
+namespace Horo::Editor {
+    /** @brief Restores host-owned OpenGL bindings and fixed-function state on scope exit. */
+    class OpenGLStateSnapshot final {
+    public:
+        /** @brief Captures the OpenGL state mutated by an editor viewport pass. */
+        OpenGLStateSnapshot() noexcept;
+
+        /** @brief Restores the captured OpenGL state. */
+        ~OpenGLStateSnapshot();
+
+        OpenGLStateSnapshot(const OpenGLStateSnapshot &) = delete;
+        OpenGLStateSnapshot &operator=(const OpenGLStateSnapshot &) = delete;
+
+    private:
+        GLint drawFramebuffer_{0};
+        GLint readFramebuffer_{0};
+        GLint program_{0};
+        GLint vertexArray_{0};
+        GLint arrayBuffer_{0};
+        GLint depthFunction_{0};
+        GLint cullFaceMode_{0};
+        GLint activeTexture_{0};
+        GLint shadowTexture_{0};
+        std::array<GLint, 4> viewport_{};
+        std::array<GLfloat, 4> clearColor_{};
+        std::array<GLboolean, 4> colorMask_{};
+        GLboolean depthMask_{GL_TRUE};
+        GLboolean depthTestEnabled_{GL_FALSE};
+        GLboolean scissorTestEnabled_{GL_FALSE};
+        GLboolean blendEnabled_{GL_FALSE};
+        GLboolean cullFaceEnabled_{GL_FALSE};
+    };
+}  // namespace Horo::Editor

--- a/src/editor/renderer/opengl/OpenGLViewportResourceBridge.cpp
+++ b/src/editor/renderer/opengl/OpenGLViewportResourceBridge.cpp
@@ -25,7 +25,7 @@ namespace Horo::Editor {
     }  // namespace
 
     /** @copydoc OpenGLViewportResourceBridge::BindMesh */
-    Result<void> OpenGLViewportResourceBridge::BindMesh(const Render::RenderFrontend &frontend, const Render::RenderMeshHandle mesh) const {
+    Result<void> OpenGLViewportResourceBridge::BindMesh(const Render::RenderFrontend &frontend, const Render::RenderMeshHandle mesh) {
         const auto object = ResolveOpenGLObject(frontend, Render::Detail::RenderFrontendResourceAccess::BackendInstance(frontend, mesh));
         if (object.HasError())
             return Result<void>::Failure(object.ErrorValue());
@@ -35,7 +35,7 @@ namespace Horo::Editor {
 
     /** @copydoc OpenGLViewportResourceBridge::BindRenderTarget */
     Result<void> OpenGLViewportResourceBridge::BindRenderTarget(const Render::RenderFrontend &frontend,
-                                                                const Render::RenderTargetHandle target) const {
+                                                                const Render::RenderTargetHandle target) {
         const auto object = ResolveOpenGLObject(frontend, Render::Detail::RenderFrontendResourceAccess::BackendInstance(frontend, target));
         if (object.HasError())
             return Result<void>::Failure(object.ErrorValue());
@@ -45,7 +45,7 @@ namespace Horo::Editor {
 
     /** @copydoc OpenGLViewportResourceBridge::BindTexture */
     Result<void> OpenGLViewportResourceBridge::BindTexture(const Render::RenderFrontend &frontend,
-                                                           const Render::RenderTextureViewHandle view, const std::uint32_t unit) const {
+                                                           const Render::RenderTextureViewHandle view, const std::uint32_t unit) {
         if (unit >= 32)
             return Result<void>::Failure(MakeError(Render::OpenGLBackendErrors::UnsupportedResourceOperation,
                                                    "OpenGL editor texture unit is outside the supported bridge range."));
@@ -59,7 +59,7 @@ namespace Horo::Editor {
 
     /** @copydoc OpenGLViewportResourceBridge::EditorImageIdentity */
     Result<std::uintptr_t> OpenGLViewportResourceBridge::EditorImageIdentity(const Render::RenderFrontend &frontend,
-                                                                             const Render::RenderTextureViewHandle view) const {
+                                                                             const Render::RenderTextureViewHandle view) {
         const auto object = ResolveOpenGLObject(frontend, Render::Detail::RenderFrontendResourceAccess::BackendInstance(frontend, view));
         if (object.HasError())
             return Result<std::uintptr_t>::Failure(object.ErrorValue());

--- a/src/editor/renderer/opengl/OpenGLViewportResourceBridge.cpp
+++ b/src/editor/renderer/opengl/OpenGLViewportResourceBridge.cpp
@@ -1,0 +1,73 @@
+#include "OpenGLViewportResourceBridge.h"
+
+#include "runtime/renderer/frontend/RenderFrontendResourceAccess.h"
+#include "runtime/renderer/modules/opengl/OpenGLRenderBackendErrors.h"
+
+#if defined(__APPLE__)
+#include <OpenGL/gl3.h>
+#else
+#include <SDL3/SDL_opengl.h>
+#endif
+
+#include <limits>
+
+namespace Horo::Editor {
+    namespace {
+        [[nodiscard]] Result<std::uint32_t> ResolveOpenGLObject(const Render::RenderFrontend &frontend,
+                                                                const Result<std::uint64_t> &resolved) {
+            if (frontend.Capabilities().backend != Render::RenderBackendId{"opengl"}) {
+                return Result<std::uint32_t>::Failure(MakeError(Render::OpenGLBackendErrors::UnsupportedResourceOperation,
+                                                                "OpenGL editor bridge received a non-OpenGL frontend."));
+            }
+            if (resolved.HasError())
+                return Result<std::uint32_t>::Failure(resolved.ErrorValue());
+            if (resolved.Value() == 0 || resolved.Value() > std::numeric_limits<std::uint32_t>::max()) {
+                return Result<std::uint32_t>::Failure(MakeError(Render::OpenGLBackendErrors::UnsupportedResourceOperation,
+                                                                "OpenGL resource identity is outside the native object range."));
+            }
+            return Result<std::uint32_t>::Success(static_cast<std::uint32_t>(resolved.Value()));
+        }
+    }  // namespace
+
+    /** @copydoc OpenGLViewportResourceBridge::BindMesh */
+    Result<void> OpenGLViewportResourceBridge::BindMesh(const Render::RenderFrontend &frontend, const Render::RenderMeshHandle mesh) const {
+        const auto object = ResolveOpenGLObject(frontend, Render::Detail::RenderFrontendResourceAccess::BackendInstance(frontend, mesh));
+        if (object.HasError())
+            return Result<void>::Failure(object.ErrorValue());
+        glBindVertexArray(object.Value());
+        return Result<void>::Success();
+    }
+
+    /** @copydoc OpenGLViewportResourceBridge::BindRenderTarget */
+    Result<void> OpenGLViewportResourceBridge::BindRenderTarget(const Render::RenderFrontend &frontend,
+                                                                const Render::RenderTargetHandle target) const {
+        const auto object = ResolveOpenGLObject(frontend, Render::Detail::RenderFrontendResourceAccess::BackendInstance(frontend, target));
+        if (object.HasError())
+            return Result<void>::Failure(object.ErrorValue());
+        glBindFramebuffer(GL_FRAMEBUFFER, object.Value());
+        return Result<void>::Success();
+    }
+
+    /** @copydoc OpenGLViewportResourceBridge::BindTexture */
+    Result<void> OpenGLViewportResourceBridge::BindTexture(const Render::RenderFrontend &frontend,
+                                                           const Render::RenderTextureViewHandle view, const std::uint32_t unit) const {
+        if (unit >= 32)
+            return Result<void>::Failure(MakeError(Render::OpenGLBackendErrors::UnsupportedResourceOperation,
+                                                   "OpenGL editor texture unit is outside the supported bridge range."));
+        const auto object = ResolveOpenGLObject(frontend, Render::Detail::RenderFrontendResourceAccess::BackendInstance(frontend, view));
+        if (object.HasError())
+            return Result<void>::Failure(object.ErrorValue());
+        glActiveTexture(GL_TEXTURE0 + unit);
+        glBindTexture(GL_TEXTURE_2D, object.Value());
+        return Result<void>::Success();
+    }
+
+    /** @copydoc OpenGLViewportResourceBridge::EditorImageIdentity */
+    Result<std::uintptr_t> OpenGLViewportResourceBridge::EditorImageIdentity(const Render::RenderFrontend &frontend,
+                                                                             const Render::RenderTextureViewHandle view) const {
+        const auto object = ResolveOpenGLObject(frontend, Render::Detail::RenderFrontendResourceAccess::BackendInstance(frontend, view));
+        if (object.HasError())
+            return Result<std::uintptr_t>::Failure(object.ErrorValue());
+        return Result<std::uintptr_t>::Success(object.Value());
+    }
+}  // namespace Horo::Editor

--- a/src/editor/renderer/opengl/OpenGLViewportResourceBridge.cpp
+++ b/src/editor/renderer/opengl/OpenGLViewportResourceBridge.cpp
@@ -3,12 +3,7 @@
 #include "runtime/renderer/frontend/RenderFrontendResourceAccess.h"
 #include "runtime/renderer/modules/opengl/OpenGLRenderBackendErrors.h"
 
-#if defined(__APPLE__)
-#include <OpenGL/gl3.h>
-#else
-#include <SDL3/SDL_opengl.h>
-#endif
-
+#include <glad/gl.h>
 #include <limits>
 
 namespace Horo::Editor {

--- a/src/editor/renderer/opengl/OpenGLViewportResourceBridge.h
+++ b/src/editor/renderer/opengl/OpenGLViewportResourceBridge.h
@@ -7,17 +7,17 @@ namespace Horo::Editor {
     class OpenGLViewportResourceBridge final {
     public:
         /** @brief Binds a ready generic mesh's backend-private vertex input object. */
-        [[nodiscard]] Result<void> BindMesh(const Render::RenderFrontend &frontend, Render::RenderMeshHandle mesh) const;
+        [[nodiscard]] static Result<void> BindMesh(const Render::RenderFrontend &frontend, Render::RenderMeshHandle mesh);
 
         /** @brief Binds a ready generic offscreen render target. */
-        [[nodiscard]] Result<void> BindRenderTarget(const Render::RenderFrontend &frontend, Render::RenderTargetHandle target) const;
+        [[nodiscard]] static Result<void> BindRenderTarget(const Render::RenderFrontend &frontend, Render::RenderTargetHandle target);
 
         /** @brief Binds a ready generic texture view to an OpenGL texture unit slot. */
-        [[nodiscard]] Result<void> BindTexture(const Render::RenderFrontend &frontend, Render::RenderTextureViewHandle view,
-                                               std::uint32_t unit) const;
+        [[nodiscard]] static Result<void> BindTexture(const Render::RenderFrontend &frontend, Render::RenderTextureViewHandle view,
+                                                      std::uint32_t unit);
 
         /** @brief Returns the opaque GUI identity derived from a ready generic texture view. */
-        [[nodiscard]] Result<std::uintptr_t> EditorImageIdentity(const Render::RenderFrontend &frontend,
-                                                                 Render::RenderTextureViewHandle view) const;
+        [[nodiscard]] static Result<std::uintptr_t> EditorImageIdentity(const Render::RenderFrontend &frontend,
+                                                                        Render::RenderTextureViewHandle view);
     };
 }  // namespace Horo::Editor

--- a/src/editor/renderer/opengl/OpenGLViewportResourceBridge.h
+++ b/src/editor/renderer/opengl/OpenGLViewportResourceBridge.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Horo/Runtime/Render/RenderFrontend.h"
+
+namespace Horo::Editor {
+    /** @brief Matching editor integration that consumes generic handles without exposing native objects. */
+    class OpenGLViewportResourceBridge final {
+    public:
+        /** @brief Binds a ready generic mesh's backend-private vertex input object. */
+        [[nodiscard]] Result<void> BindMesh(const Render::RenderFrontend &frontend, Render::RenderMeshHandle mesh) const;
+
+        /** @brief Binds a ready generic offscreen render target. */
+        [[nodiscard]] Result<void> BindRenderTarget(const Render::RenderFrontend &frontend, Render::RenderTargetHandle target) const;
+
+        /** @brief Binds a ready generic texture view to an OpenGL texture unit slot. */
+        [[nodiscard]] Result<void> BindTexture(const Render::RenderFrontend &frontend, Render::RenderTextureViewHandle view,
+                                               std::uint32_t unit) const;
+
+        /** @brief Returns the opaque GUI identity derived from a ready generic texture view. */
+        [[nodiscard]] Result<std::uintptr_t> EditorImageIdentity(const Render::RenderFrontend &frontend,
+                                                                 Render::RenderTextureViewHandle view) const;
+    };
+}  // namespace Horo::Editor

--- a/src/editor/renderer/opengl/OpenGLViewportResources.cpp
+++ b/src/editor/renderer/opengl/OpenGLViewportResources.cpp
@@ -1,0 +1,400 @@
+#include "OpenGLViewportResources.h"
+
+#include "OpenGLViewportResourceBridge.h"
+#include "editor/renderer/EditorRendererErrors.h"
+
+#include <limits>
+#include <ranges>
+#include <string>
+#include <utility>
+
+namespace Horo::Editor {
+    namespace {
+        [[nodiscard]] Error MakeViewportError(const ErrorCodeDescriptor &descriptor, std::string message) {
+            return MakeError(descriptor, std::move(message));
+        }
+
+        template <typename Handle>
+        [[nodiscard]] Result<bool> ResourceReady(const Render::RenderFrontend &frontend, const Handle handle,
+                                                 const Render::ResourceOperationId operation) {
+            if (!handle.IsValid())
+                return Result<bool>::Success(false);
+            const auto state = frontend.ResourceState(handle);
+            if (state.HasValue())
+                return Result<bool>::Success(state.Value() == Render::RenderResourceState::Ready);
+            if (operation.IsValid()) {
+                if (const Result<void> completion = frontend.ResourceOperationResult(operation);
+                    completion.HasError() && completion.ErrorValue().code.Value() != "render.frontend.resource.operation_pending")
+                    return Result<bool>::Failure(completion.ErrorValue());
+            }
+            return Result<bool>::Failure(state.ErrorValue());
+        }
+
+        [[nodiscard]] Result<bool> AdvanceTexture(Render::RenderFrontend &frontend, const Render::RenderTextureDescriptor &descriptor,
+                                                  Render::RenderTextureHandle &handle, Render::ResourceOperationId &operation) {
+            if (!handle.IsValid()) {
+                auto created = frontend.CreateTexture(descriptor);
+                if (created.HasError())
+                    return Result<bool>::Failure(created.ErrorValue());
+                handle = created.Value().handle;
+                operation = created.Value().operation;
+            }
+            return ResourceReady(frontend, handle, operation);
+        }
+
+        [[nodiscard]] Result<bool> AdvanceTextureView(Render::RenderFrontend &frontend,
+                                                      const Render::RenderTextureViewDescriptor &descriptor,
+                                                      Render::RenderTextureViewHandle &handle, Render::ResourceOperationId &operation) {
+            if (!handle.IsValid()) {
+                auto created = frontend.CreateTextureView(descriptor);
+                if (created.HasError())
+                    return Result<bool>::Failure(created.ErrorValue());
+                handle = created.Value().handle;
+                operation = created.Value().operation;
+            }
+            return ResourceReady(frontend, handle, operation);
+        }
+
+        [[nodiscard]] Result<bool> AdvanceRenderTarget(Render::RenderFrontend &frontend, const Render::RenderTargetDescriptor &descriptor,
+                                                       Render::RenderTargetHandle &handle, Render::ResourceOperationId &operation) {
+            if (!handle.IsValid()) {
+                auto created = frontend.CreateRenderTarget(descriptor);
+                if (created.HasError())
+                    return Result<bool>::Failure(created.ErrorValue());
+                handle = created.Value().handle;
+                operation = created.Value().operation;
+            }
+            return ResourceReady(frontend, handle, operation);
+        }
+    }  // namespace
+
+    OpenGLViewportResources::OpenGLViewportResources(Render::RenderFrontend &frontend) noexcept : frontend_(&frontend) {}
+
+    Result<std::optional<Render::RenderTargetHandle>> OpenGLViewportResources::Prepare(const Render::RenderSceneView &scene,
+                                                                                       const EditorViewportExtent requestedExtent) {
+        if (const Result<void> meshes = SynchronizeMeshes(scene.meshResources); meshes.HasError())
+            return Result<std::optional<Render::RenderTargetHandle>>::Failure(meshes.ErrorValue());
+        if (const Result<void> shadow = SynchronizeShadowResources(); shadow.HasError())
+            return Result<std::optional<Render::RenderTargetHandle>>::Failure(shadow.ErrorValue());
+        const Result<void> target = requestedExtent.IsValid() ? SynchronizeTarget(requestedExtent) : Result<void>::Success();
+        if (target.HasError())
+            return Result<std::optional<Render::RenderTargetHandle>>::Failure(target.ErrorValue());
+        if (viewportTarget_.target.IsValid()) {
+            if (const auto ready = frontend_->ResourceState(viewportTarget_.target);
+                ready.HasValue() && ready.Value() == Render::RenderResourceState::Ready)
+                return Result<std::optional<Render::RenderTargetHandle>>::Success(viewportTarget_.target);
+        }
+        return Result<std::optional<Render::RenderTargetHandle>>::Success(std::nullopt);
+    }
+
+    void OpenGLViewportResources::Shutdown() noexcept {
+        ReleaseShadowResources();
+        ReleaseViewportTarget(pendingViewportTarget_);
+        ReleaseViewportTarget(viewportTarget_);
+        for (auto &entry : meshes_)
+            ReleaseMesh(entry.second);
+        for (auto &entry : pendingMeshes_)
+            ReleaseMesh(entry.second);
+        meshes_.clear();
+        pendingMeshes_.clear();
+        allocatedExtent_ = {};
+        meshesReady_ = false;
+    }
+
+    std::optional<OpenGLViewportResources::MeshBinding> OpenGLViewportResources::FindMesh(const std::uint64_t sourceId) const noexcept {
+        if (const auto mesh = meshes_.find(sourceId); mesh != meshes_.end())
+            return MeshBinding{mesh->second.mesh, mesh->second.indexCount};
+        return std::nullopt;
+    }
+
+    Render::RenderTargetHandle OpenGLViewportResources::Target() const noexcept {
+        return viewportTarget_.target;
+    }
+
+    Render::RenderTargetHandle OpenGLViewportResources::ShadowTarget() const noexcept {
+        return shadowTarget_;
+    }
+
+    Render::RenderTextureViewHandle OpenGLViewportResources::ShadowTextureView() const noexcept {
+        return shadowDepthTextureView_;
+    }
+
+    EditorViewportExtent OpenGLViewportResources::AllocatedExtent() const noexcept {
+        return allocatedExtent_;
+    }
+
+    std::uintptr_t OpenGLViewportResources::ImageIdentity() const noexcept {
+        return viewportTarget_.imageIdentity;
+    }
+
+    bool OpenGLViewportResources::IsReady() const noexcept {
+        return meshesReady_ && viewportTarget_.imageIdentity != 0 && viewportTarget_.target.IsValid() && allocatedExtent_.IsValid();
+    }
+
+    Result<void> OpenGLViewportResources::SynchronizeMeshes(const std::span<const EditorViewportMeshResourceView> resources) {
+        meshesReady_ = true;
+        for (const EditorViewportMeshResourceView &resource : resources) {
+            const auto ready = SynchronizeMesh(resource);
+            if (ready.HasError())
+                return Result<void>::Failure(ready.ErrorValue());
+            meshesReady_ = meshesReady_ && ready.Value();
+        }
+        RetireMissingMeshes(resources);
+        return Result<void>::Success();
+    }
+
+    Result<bool> OpenGLViewportResources::SynchronizeMesh(const EditorViewportMeshResourceView &resource) {
+        const std::uint64_t id = resource.handle.id.value;
+        auto [activePosition, inserted] = meshes_.try_emplace(id);
+        ResidentMesh &active = activePosition->second;
+        if (inserted)
+            return AdvanceResidentMesh(resource, active);
+        if (active.sourceGeneration == resource.handle.generation) {
+            if (auto pending = pendingMeshes_.find(id); pending != pendingMeshes_.end()) {
+                ReleaseMesh(pending->second);
+                pendingMeshes_.erase(pending);
+            }
+            return AdvanceResidentMesh(resource, active);
+        }
+        if (!IsResidentMeshReady(active)) {
+            ReleaseMesh(active);
+            return AdvanceResidentMesh(resource, active);
+        }
+        ResidentMesh &pending = pendingMeshes_[id];
+        if (pending.sourceGeneration != 0 && pending.sourceGeneration != resource.handle.generation)
+            ReleaseMesh(pending);
+        const auto ready = AdvanceResidentMesh(resource, pending);
+        if (ready.HasError())
+            return Result<bool>::Failure(ready.ErrorValue());
+        if (ready.Value()) {
+            ReleaseMesh(active);
+            active = std::exchange(pending, {});
+            pendingMeshes_.erase(id);
+        }
+        return Result<bool>::Success(true);
+    }
+
+    Result<bool> OpenGLViewportResources::AdvanceResidentMesh(const EditorViewportMeshResourceView &resource, ResidentMesh &resident) {
+        if (resident.sourceGeneration == 0) {
+            if (const Result<void> created = CreateResidentMeshBuffers(resource, resident); created.HasError())
+                return Result<bool>::Failure(created.ErrorValue());
+        }
+        const auto vertexReady = ResourceReady(*frontend_, resident.vertexBuffer, resident.vertexOperation);
+        if (vertexReady.HasError())
+            return Result<bool>::Failure(vertexReady.ErrorValue());
+        const auto indexReady = ResourceReady(*frontend_, resident.indexBuffer, resident.indexOperation);
+        if (indexReady.HasError())
+            return Result<bool>::Failure(indexReady.ErrorValue());
+        if (!resident.mesh.IsValid() && vertexReady.Value() && indexReady.Value()) {
+            auto mesh = frontend_->CreateMesh({.vertexBuffer = resident.vertexBuffer,
+                                               .indexBuffer = resident.indexBuffer,
+                                               .vertexStride = sizeof(Render::MeshVertex),
+                                               .vertexCount = static_cast<std::uint32_t>(resource.vertices.size()),
+                                               .indexFormat = Render::RenderIndexFormat::UInt32,
+                                               .indexCount = resident.indexCount,
+                                               .topology = Render::RenderPrimitiveTopology::Triangles,
+                                               .localBounds = resource.localBounds});
+            if (mesh.HasError())
+                return Result<bool>::Failure(mesh.ErrorValue());
+            resident.mesh = mesh.Value().handle;
+            resident.meshOperation = mesh.Value().operation;
+        }
+        return ResourceReady(*frontend_, resident.mesh, resident.meshOperation);
+    }
+
+    Result<void> OpenGLViewportResources::CreateResidentMeshBuffers(const EditorViewportMeshResourceView &resource,
+                                                                    ResidentMesh &resident) {
+        if (resource.vertices.size() > std::numeric_limits<std::uint32_t>::max() ||
+            resource.indices.size() > std::numeric_limits<std::uint32_t>::max()) {
+            return Result<void>::Failure(
+                MakeViewportError(RendererErrors::ViewportGeometryCreationFailed, "Viewport mesh exceeds generic resource count limits."));
+        }
+        auto vertex = frontend_->CreateBuffer({.byteSize = resource.vertices.size_bytes(),
+                                               .usage = Render::RenderBufferUsage::Vertex,
+                                               .access = Render::RenderBufferAccess::DeviceLocal},
+                                              std::as_bytes(resource.vertices));
+        if (vertex.HasError())
+            return Result<void>::Failure(vertex.ErrorValue());
+        resident.vertexBuffer = vertex.Value().handle;
+        resident.vertexOperation = vertex.Value().operation;
+        auto index = frontend_->CreateBuffer({.byteSize = resource.indices.size_bytes(),
+                                              .usage = Render::RenderBufferUsage::Index,
+                                              .access = Render::RenderBufferAccess::DeviceLocal},
+                                             std::as_bytes(resource.indices));
+        if (index.HasError()) {
+            ReleaseMesh(resident);
+            return Result<void>::Failure(index.ErrorValue());
+        }
+        resident.indexBuffer = index.Value().handle;
+        resident.indexOperation = index.Value().operation;
+        resident.indexCount = static_cast<std::uint32_t>(resource.indices.size());
+        resident.sourceGeneration = resource.handle.generation;
+        return Result<void>::Success();
+    }
+
+    bool OpenGLViewportResources::IsResidentMeshReady(const ResidentMesh &resident) const {
+        if (!resident.mesh.IsValid())
+            return false;
+        if (const auto state = frontend_->ResourceState(resident.mesh); state.HasValue())
+            return state.Value() == Render::RenderResourceState::Ready;
+        return false;
+    }
+
+    void OpenGLViewportResources::RetireMissingMeshes(const std::span<const EditorViewportMeshResourceView> resources) noexcept {
+        for (auto mesh = meshes_.begin(); mesh != meshes_.end();) {
+            const bool present = std::ranges::any_of(resources, [&](const EditorViewportMeshResourceView &resource) {
+                return resource.handle.id.value == mesh->first;
+            });
+            if (!present) {
+                ReleaseMesh(mesh->second);
+                if (auto pending = pendingMeshes_.find(mesh->first); pending != pendingMeshes_.end()) {
+                    ReleaseMesh(pending->second);
+                    pendingMeshes_.erase(pending);
+                }
+                mesh = meshes_.erase(mesh);
+            } else {
+                ++mesh;
+            }
+        }
+    }
+
+    Result<void> OpenGLViewportResources::SynchronizeTarget(const EditorViewportExtent extent) {
+        if (allocatedExtent_ == extent) {
+            if (pendingViewportTarget_.extent.IsValid())
+                ReleaseViewportTarget(pendingViewportTarget_);
+            return Result<void>::Success();
+        }
+        if (pendingViewportTarget_.extent.IsValid() && pendingViewportTarget_.extent != extent)
+            ReleaseViewportTarget(pendingViewportTarget_);
+        pendingViewportTarget_.extent = extent;
+        const auto targetReady = AdvanceViewportTarget(pendingViewportTarget_);
+        if (targetReady.HasError())
+            return Result<void>::Failure(targetReady.ErrorValue());
+        if (!targetReady.Value())
+            return Result<void>::Success();
+        auto image = OpenGLViewportResourceBridge::EditorImageIdentity(*frontend_, pendingViewportTarget_.colorView);
+        if (image.HasError())
+            return Result<void>::Failure(image.ErrorValue());
+        pendingViewportTarget_.imageIdentity = image.Value();
+        ReleaseViewportTarget(viewportTarget_);
+        viewportTarget_ = std::exchange(pendingViewportTarget_, {});
+        allocatedExtent_ = extent;
+        return Result<void>::Success();
+    }
+
+    Result<bool> OpenGLViewportResources::AdvanceViewportTarget(ViewportTargetResources &resources) {
+        if (const auto texturesReady = AdvanceViewportTextures(resources); texturesReady.HasError() || !texturesReady.Value())
+            return texturesReady;
+        if (const auto viewsReady = AdvanceViewportViews(resources); viewsReady.HasError() || !viewsReady.Value())
+            return viewsReady;
+        const Render::FramebufferExtent extent{resources.extent.width, resources.extent.height};
+        return AdvanceRenderTarget(*frontend_,
+                                   {.colorAttachment = resources.colorView, .depthAttachment = resources.depthView, .extent = extent},
+                                   resources.target, resources.targetOperation);
+    }
+
+    Result<bool> OpenGLViewportResources::AdvanceViewportTextures(ViewportTargetResources &resources) {
+        using enum Render::RenderTextureUsage;
+        const Render::FramebufferExtent extent{resources.extent.width, resources.extent.height};
+        const auto color =
+            AdvanceTexture(*frontend_,
+                           {.extent = extent, .format = Render::RenderTextureFormat::Rgba8Unorm, .usage = Sampled | RenderAttachment},
+                           resources.colorTexture, resources.colorTextureOperation);
+        if (color.HasError())
+            return Result<bool>::Failure(color.ErrorValue());
+        const auto depth =
+            AdvanceTexture(*frontend_,
+                           {.extent = extent, .format = Render::RenderTextureFormat::Depth24Stencil8, .usage = RenderAttachment},
+                           resources.depthTexture, resources.depthTextureOperation);
+        if (depth.HasError())
+            return Result<bool>::Failure(depth.ErrorValue());
+        return Result<bool>::Success(color.Value() && depth.Value());
+    }
+
+    Result<bool> OpenGLViewportResources::AdvanceViewportViews(ViewportTargetResources &resources) {
+        const auto color = AdvanceTextureView(*frontend_,
+                                              {.texture = resources.colorTexture,
+                                               .format = Render::RenderTextureFormat::Rgba8Unorm,
+                                               .aspect = Render::RenderTextureAspect::Color},
+                                              resources.colorView, resources.colorViewOperation);
+        if (color.HasError())
+            return Result<bool>::Failure(color.ErrorValue());
+        const auto depth = AdvanceTextureView(*frontend_,
+                                              {.texture = resources.depthTexture,
+                                               .format = Render::RenderTextureFormat::Depth24Stencil8,
+                                               .aspect = Render::RenderTextureAspect::DepthStencil},
+                                              resources.depthView, resources.depthViewOperation);
+        if (depth.HasError())
+            return Result<bool>::Failure(depth.ErrorValue());
+        return Result<bool>::Success(color.Value() && depth.Value());
+    }
+
+    Result<void> OpenGLViewportResources::SynchronizeShadowResources() {
+        const auto targetReady = AdvanceShadowTarget();
+        if (targetReady.HasError())
+            return Result<void>::Failure(targetReady.ErrorValue());
+        meshesReady_ = meshesReady_ && targetReady.Value();
+        return Result<void>::Success();
+    }
+
+    Result<bool> OpenGLViewportResources::AdvanceShadowTarget() {
+        using enum Render::RenderTextureUsage;
+        constexpr Render::FramebufferExtent shadowExtent{EditorViewportDirectionalShadowMapResolution,
+                                                         EditorViewportDirectionalShadowMapResolution};
+        if (const auto textureReady = AdvanceTexture(*frontend_,
+                                                     {.extent = shadowExtent,
+                                                      .format = Render::RenderTextureFormat::Depth32Float,
+                                                      .usage = Sampled | RenderAttachment},
+                                                     shadowDepthTexture_, shadowDepthTextureOperation_);
+            textureReady.HasError() || !textureReady.Value())
+            return textureReady;
+        if (const auto viewReady = AdvanceTextureView(*frontend_,
+                                                      {.texture = shadowDepthTexture_,
+                                                       .format = Render::RenderTextureFormat::Depth32Float,
+                                                       .aspect = Render::RenderTextureAspect::Depth},
+                                                      shadowDepthTextureView_, shadowDepthTextureViewOperation_);
+            viewReady.HasError() || !viewReady.Value())
+            return viewReady;
+        return AdvanceRenderTarget(*frontend_, {.depthAttachment = shadowDepthTextureView_, .extent = shadowExtent}, shadowTarget_,
+                                   shadowTargetOperation_);
+    }
+
+    void OpenGLViewportResources::ReleaseMesh(ResidentMesh &mesh) noexcept {
+        if (mesh.mesh.IsValid())
+            static_cast<void>(frontend_->ReleaseMesh(mesh.mesh));
+        if (mesh.indexBuffer.IsValid())
+            static_cast<void>(frontend_->ReleaseBuffer(mesh.indexBuffer));
+        if (mesh.vertexBuffer.IsValid())
+            static_cast<void>(frontend_->ReleaseBuffer(mesh.vertexBuffer));
+        mesh = {};
+    }
+
+    void OpenGLViewportResources::ReleaseShadowResources() noexcept {
+        if (shadowTarget_.IsValid())
+            static_cast<void>(frontend_->ReleaseRenderTarget(shadowTarget_));
+        if (shadowDepthTextureView_.IsValid())
+            static_cast<void>(frontend_->ReleaseTextureView(shadowDepthTextureView_));
+        if (shadowDepthTexture_.IsValid())
+            static_cast<void>(frontend_->ReleaseTexture(shadowDepthTexture_));
+        shadowDepthTexture_ = {};
+        shadowDepthTextureView_ = {};
+        shadowTarget_ = {};
+        shadowDepthTextureOperation_ = {};
+        shadowDepthTextureViewOperation_ = {};
+        shadowTargetOperation_ = {};
+    }
+
+    void OpenGLViewportResources::ReleaseViewportTarget(ViewportTargetResources &resources) noexcept {
+        if (resources.target.IsValid())
+            static_cast<void>(frontend_->ReleaseRenderTarget(resources.target));
+        if (resources.depthView.IsValid())
+            static_cast<void>(frontend_->ReleaseTextureView(resources.depthView));
+        if (resources.colorView.IsValid())
+            static_cast<void>(frontend_->ReleaseTextureView(resources.colorView));
+        if (resources.depthTexture.IsValid())
+            static_cast<void>(frontend_->ReleaseTexture(resources.depthTexture));
+        if (resources.colorTexture.IsValid())
+            static_cast<void>(frontend_->ReleaseTexture(resources.colorTexture));
+        resources = {};
+    }
+}  // namespace Horo::Editor

--- a/src/editor/renderer/opengl/OpenGLViewportResources.cpp
+++ b/src/editor/renderer/opengl/OpenGLViewportResources.cpp
@@ -2,6 +2,7 @@
 
 #include "OpenGLViewportResourceBridge.h"
 #include "editor/renderer/EditorRendererErrors.h"
+#include "runtime/renderer/frontend/RenderFrontendErrors.h"
 
 #include <limits>
 #include <ranges>
@@ -24,7 +25,8 @@ namespace Horo::Editor {
                 return Result<bool>::Success(state.Value() == Render::RenderResourceState::Ready);
             if (operation.IsValid()) {
                 if (const Result<void> completion = frontend.ResourceOperationResult(operation);
-                    completion.HasError() && completion.ErrorValue().code.Value() != "render.frontend.resource.operation_pending")
+                    completion.HasError() &&
+                    completion.ErrorValue().code.Value() != Render::FrontendErrors::ResourceOperationPending.code.Value())
                     return Result<bool>::Failure(completion.ErrorValue());
             }
             return Result<bool>::Failure(state.ErrorValue());
@@ -76,8 +78,8 @@ namespace Horo::Editor {
             return Result<std::optional<Render::RenderTargetHandle>>::Failure(meshes.ErrorValue());
         if (const Result<void> shadow = SynchronizeShadowResources(); shadow.HasError())
             return Result<std::optional<Render::RenderTargetHandle>>::Failure(shadow.ErrorValue());
-        const Result<void> target = requestedExtent.IsValid() ? SynchronizeTarget(requestedExtent) : Result<void>::Success();
-        if (target.HasError())
+        if (const Result<void> target = requestedExtent.IsValid() ? SynchronizeTarget(requestedExtent) : Result<void>::Success();
+            target.HasError())
             return Result<std::optional<Render::RenderTargetHandle>>::Failure(target.ErrorValue());
         if (viewportTarget_.target.IsValid()) {
             if (const auto ready = frontend_->ResourceState(viewportTarget_.target);
@@ -91,10 +93,10 @@ namespace Horo::Editor {
         ReleaseShadowResources();
         ReleaseViewportTarget(pendingViewportTarget_);
         ReleaseViewportTarget(viewportTarget_);
-        for (auto &entry : meshes_)
-            ReleaseMesh(entry.second);
-        for (auto &entry : pendingMeshes_)
-            ReleaseMesh(entry.second);
+        for (auto &mesh : meshes_ | std::views::values)
+            ReleaseMesh(mesh);
+        for (auto &mesh : pendingMeshes_ | std::views::values)
+            ReleaseMesh(mesh);
         meshes_.clear();
         pendingMeshes_.clear();
         allocatedExtent_ = {};

--- a/src/editor/renderer/opengl/OpenGLViewportResources.h
+++ b/src/editor/renderer/opengl/OpenGLViewportResources.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "editor/renderer/EditorViewportRenderer.h"
+
+#include <optional>
+#include <unordered_map>
+
+namespace Horo::Editor {
+    /** @brief Owns frontend-backed OpenGL viewport resources and atomic replacement state. */
+    class OpenGLViewportResources final {
+    public:
+        struct MeshBinding {
+            Render::RenderMeshHandle mesh;
+            std::uint32_t indexCount{0};
+        };
+
+        explicit OpenGLViewportResources(Render::RenderFrontend &frontend) noexcept;
+
+        [[nodiscard]] Result<std::optional<Render::RenderTargetHandle>> Prepare(const Render::RenderSceneView &scene,
+                                                                                EditorViewportExtent requestedExtent);
+        void Shutdown() noexcept;
+
+        [[nodiscard]] std::optional<MeshBinding> FindMesh(std::uint64_t sourceId) const noexcept;
+        [[nodiscard]] Render::RenderTargetHandle Target() const noexcept;
+        [[nodiscard]] Render::RenderTargetHandle ShadowTarget() const noexcept;
+        [[nodiscard]] Render::RenderTextureViewHandle ShadowTextureView() const noexcept;
+        [[nodiscard]] EditorViewportExtent AllocatedExtent() const noexcept;
+        [[nodiscard]] std::uintptr_t ImageIdentity() const noexcept;
+        [[nodiscard]] bool IsReady() const noexcept;
+
+    private:
+        struct ResidentMesh {
+            Render::RenderBufferHandle vertexBuffer;
+            Render::RenderBufferHandle indexBuffer;
+            Render::RenderMeshHandle mesh;
+            Render::ResourceOperationId vertexOperation;
+            Render::ResourceOperationId indexOperation;
+            Render::ResourceOperationId meshOperation;
+            std::uint32_t indexCount{0};
+            std::uint32_t sourceGeneration{0};
+        };
+
+        struct ViewportTargetResources {
+            Render::RenderTextureHandle colorTexture;
+            Render::RenderTextureHandle depthTexture;
+            Render::RenderTextureViewHandle colorView;
+            Render::RenderTextureViewHandle depthView;
+            Render::RenderTargetHandle target;
+            Render::ResourceOperationId colorTextureOperation;
+            Render::ResourceOperationId depthTextureOperation;
+            Render::ResourceOperationId colorViewOperation;
+            Render::ResourceOperationId depthViewOperation;
+            Render::ResourceOperationId targetOperation;
+            EditorViewportExtent extent;
+            std::uintptr_t imageIdentity{0};
+        };
+
+        [[nodiscard]] Result<void> SynchronizeMeshes(std::span<const EditorViewportMeshResourceView> resources);
+        [[nodiscard]] Result<bool> SynchronizeMesh(const EditorViewportMeshResourceView &resource);
+        [[nodiscard]] Result<bool> AdvanceResidentMesh(const EditorViewportMeshResourceView &resource, ResidentMesh &resident);
+        [[nodiscard]] Result<void> CreateResidentMeshBuffers(const EditorViewportMeshResourceView &resource, ResidentMesh &resident);
+        [[nodiscard]] bool IsResidentMeshReady(const ResidentMesh &resident) const;
+        void RetireMissingMeshes(std::span<const EditorViewportMeshResourceView> resources) noexcept;
+        [[nodiscard]] Result<void> SynchronizeTarget(EditorViewportExtent extent);
+        [[nodiscard]] Result<bool> AdvanceViewportTarget(ViewportTargetResources &resources);
+        [[nodiscard]] Result<bool> AdvanceViewportTextures(ViewportTargetResources &resources);
+        [[nodiscard]] Result<bool> AdvanceViewportViews(ViewportTargetResources &resources);
+        [[nodiscard]] Result<void> SynchronizeShadowResources();
+        [[nodiscard]] Result<bool> AdvanceShadowTarget();
+        void ReleaseMesh(ResidentMesh &mesh) noexcept;
+        void ReleaseShadowResources() noexcept;
+        void ReleaseViewportTarget(ViewportTargetResources &resources) noexcept;
+
+        Render::RenderFrontend *frontend_{nullptr};
+        std::unordered_map<std::uint64_t, ResidentMesh> meshes_;
+        std::unordered_map<std::uint64_t, ResidentMesh> pendingMeshes_;
+        ViewportTargetResources viewportTarget_;
+        ViewportTargetResources pendingViewportTarget_;
+        Render::RenderTextureHandle shadowDepthTexture_;
+        Render::RenderTextureViewHandle shadowDepthTextureView_;
+        Render::RenderTargetHandle shadowTarget_;
+        Render::ResourceOperationId shadowDepthTextureOperation_;
+        Render::ResourceOperationId shadowDepthTextureViewOperation_;
+        Render::ResourceOperationId shadowTargetOperation_;
+        EditorViewportExtent allocatedExtent_;
+        bool meshesReady_{false};
+    };
+}  // namespace Horo::Editor

--- a/src/editor/renderer/opengl/OpenGLViewportShaders.h
+++ b/src/editor/renderer/opengl/OpenGLViewportShaders.h
@@ -1,0 +1,126 @@
+#pragma once
+
+namespace Horo::Editor::Detail {
+    inline constexpr char ViewportVertexShader[] = R"glsl(#version 150 core
+in vec3 aPosition;
+in vec3 aNormal;
+in vec2 aUv;
+out vec3 vWorldPosition;
+out vec3 vWorldNormal;
+out vec4 vShadowPosition;
+uniform mat4 uMvp;
+uniform mat4 uModel;
+uniform mat4 uShadowViewProjection;
+void main()
+{
+    vec4 worldPosition = uModel * vec4(aPosition, 1.0);
+    vWorldPosition = worldPosition.xyz;
+    mat3 modelBasis = mat3(uModel);
+    vec3 inverseRow0 = cross(modelBasis[1], modelBasis[2]);
+    vec3 inverseRow1 = cross(modelBasis[2], modelBasis[0]);
+    vec3 inverseRow2 = cross(modelBasis[0], modelBasis[1]);
+    float determinant = dot(modelBasis[0], inverseRow0);
+    float inverseDeterminant = abs(determinant) > 0.0000001 ? 1.0 / determinant : 1.0;
+    mat3 normalMatrix = mat3(inverseRow0 * inverseDeterminant,
+                             inverseRow1 * inverseDeterminant,
+                             inverseRow2 * inverseDeterminant);
+    vWorldNormal = normalize(normalMatrix * aNormal);
+    vShadowPosition = uShadowViewProjection * worldPosition;
+    gl_Position = uMvp * vec4(aPosition, 1.0);
+}
+)glsl";
+
+    inline constexpr char ViewportFragmentShader[] = R"glsl(#version 150 core
+const int MaxLights = 16;
+in vec3 vWorldPosition;
+in vec3 vWorldNormal;
+in vec4 vShadowPosition;
+out vec4 outColor;
+uniform vec3 uCameraPosition;
+uniform int uLightCount;
+uniform vec4 uLightPositionKind[MaxLights];
+uniform vec4 uLightDirectionRange[MaxLights];
+uniform vec4 uLightColorIntensity[MaxLights];
+uniform vec2 uLightCone[MaxLights];
+uniform sampler2D uShadowMap;
+uniform int uShadowEnabled;
+uniform int uShadowLightIndex;
+uniform vec3 uSelectionColor;
+uniform float uSelectionStrength;
+float directionalShadow(vec3 normal, vec3 lightDirection)
+{
+    if (uShadowEnabled == 0)
+        return 1.0;
+    vec3 projected = vShadowPosition.xyz / vShadowPosition.w;
+    vec3 shadowCoordinate = projected * 0.5 + 0.5;
+    if (shadowCoordinate.x <= 0.0 || shadowCoordinate.x >= 1.0 ||
+        shadowCoordinate.y <= 0.0 || shadowCoordinate.y >= 1.0 ||
+        shadowCoordinate.z <= 0.0 || shadowCoordinate.z >= 1.0)
+        return 1.0;
+    vec2 texel = 1.0 / vec2(textureSize(uShadowMap, 0));
+    float bias = max(0.0025 * (1.0 - dot(normal, lightDirection)), 0.00045);
+    float visibility = 0.0;
+    for (int y = -1; y <= 1; ++y)
+        for (int x = -1; x <= 1; ++x)
+        {
+            float closestDepth = texture(uShadowMap, shadowCoordinate.xy + vec2(x, y) * texel).r;
+            visibility += shadowCoordinate.z - bias <= closestDepth ? 1.0 : 0.0;
+        }
+    return visibility / 9.0;
+}
+void main()
+{
+    vec3 normal = normalize(vWorldNormal);
+    vec3 viewDirection = normalize(uCameraPosition - vWorldPosition);
+    vec3 baseColor = vec3(0.68, 0.70, 0.74);
+    vec3 lighting = baseColor * 0.08;
+    for (int index = 0; index < uLightCount; ++index)
+    {
+        int kind = int(uLightPositionKind[index].w + 0.5);
+        vec3 lightDirection;
+        float attenuation = 1.0;
+        if (kind == 0)
+        {
+            lightDirection = normalize(-uLightDirectionRange[index].xyz);
+        }
+        else
+        {
+            vec3 toLight = uLightPositionKind[index].xyz - vWorldPosition;
+            float distanceToLight = length(toLight);
+            lightDirection = distanceToLight > 0.0001 ? toLight / distanceToLight : normal;
+            float range = max(uLightDirectionRange[index].w, 0.0001);
+            float normalizedDistance = distanceToLight / range;
+            float rangeFade = max(1.0 - normalizedDistance * normalizedDistance, 0.0);
+            attenuation = rangeFade * rangeFade;
+            if (kind == 2)
+            {
+                float coneCosine = dot(normalize(uLightDirectionRange[index].xyz), -lightDirection);
+                attenuation *= smoothstep(uLightCone[index].y, uLightCone[index].x, coneCosine);
+            }
+        }
+        float diffuse = max(dot(normal, lightDirection), 0.0);
+        vec3 halfDirection = normalize(lightDirection + viewDirection);
+        float specular = pow(max(dot(normal, halfDirection), 0.0), 48.0) * 0.18;
+        vec3 radiance = uLightColorIntensity[index].rgb * uLightColorIntensity[index].a * attenuation;
+        float visibility = index == uShadowLightIndex ? directionalShadow(normal, lightDirection) : 1.0;
+        lighting += radiance * (baseColor * diffuse + specular) * visibility;
+    }
+    vec3 mapped = lighting / (lighting + vec3(1.0));
+    vec3 displayColor = pow(max(mapped, vec3(0.0)), vec3(1.0 / 2.2));
+    outColor = vec4(mix(displayColor, uSelectionColor, uSelectionStrength), 1.0);
+}
+)glsl";
+
+    inline constexpr char ShadowVertexShader[] = R"glsl(#version 150 core
+in vec3 aPosition;
+uniform mat4 uShadowMvp;
+void main()
+{
+    gl_Position = uShadowMvp * vec4(aPosition, 1.0);
+}
+)glsl";
+
+    inline constexpr char ShadowFragmentShader[] = R"glsl(#version 150 core
+void main() {}
+)glsl";
+}  // namespace Horo::Editor::Detail

--- a/src/editor/renderer/opengl/SdlOpenGLPresentationPort.cpp
+++ b/src/editor/renderer/opengl/SdlOpenGLPresentationPort.cpp
@@ -2,6 +2,7 @@
 
 #include "editor/renderer/EditorRendererErrors.h"
 
+#include <glad/gl.h>
 #include <string>
 
 namespace Horo::Editor {
@@ -39,6 +40,15 @@ namespace Horo::Editor {
     Result<void> SdlOpenGLPresentationPort::MakeCurrent() {
         if (context_ == nullptr || !SDL_GL_MakeCurrent(window_, context_)) {
             return Result<void>::Failure(MakeSdlRenderError(RendererErrors::SdlMakeCurrentFailed, "SDL_GL_MakeCurrent failed"));
+        }
+        return Result<void>::Success();
+    }
+
+    /** @copydoc SdlOpenGLPresentationPort::LoadCommandDispatch */
+    Result<void> SdlOpenGLPresentationPort::LoadCommandDispatch() {
+        if (context_ == nullptr || gladLoadGL(SDL_GL_GetProcAddress) == 0) {
+            return Result<void>::Failure(
+                MakeSdlRenderError(RendererErrors::ViewportOpenGLDispatchFailed, "OpenGL command dispatch loading failed"));
         }
         return Result<void>::Success();
     }

--- a/src/editor/renderer/opengl/SdlOpenGLPresentationPort.h
+++ b/src/editor/renderer/opengl/SdlOpenGLPresentationPort.h
@@ -13,6 +13,7 @@ namespace Horo::Editor {
 
         [[nodiscard]] Result<void> CreateContext(const Render::OpenGLContextDescriptor &descriptor) override;
         [[nodiscard]] Result<void> MakeCurrent() override;
+        [[nodiscard]] Result<void> LoadCommandDispatch() override;
         [[nodiscard]] Result<void> SetPresentMode(Render::PresentMode mode) override;
         [[nodiscard]] Result<void> SwapBuffers() override;
         void DestroyContext() noexcept override;

--- a/src/runtime/renderer/frontend/RenderFrontend.cpp
+++ b/src/runtime/renderer/frontend/RenderFrontend.cpp
@@ -5,7 +5,6 @@
 #include "RenderResourceRegistry.h"
 #include "RenderResourceUploadQueue.h"
 
-#include <array>
 #include <optional>
 #include <string>
 #include <utility>
@@ -190,16 +189,22 @@ namespace Horo::Render {
     RenderFrontend::RenderFrontend(std::unique_ptr<IRenderBackend> backend, const RenderResourceOwnerId resourceOwner,
                                    const RenderResourceUploadLimits uploadLimits, ConstructionKey)
         : backend_(std::move(backend)),
-          resourceRegistry_(std::make_unique<Detail::RenderResourceRegistry>(resourceOwner, Detail::RenderResourceRegistryLimits{},
-                                                                             [this](const Detail::RenderResourceClass resourceClass,
-                                                                                    const std::uint64_t backendInstance) {
-                                                                                 if (resourceClass == Detail::RenderResourceClass::Buffer) {
-                                                                                     backend_->DestroyBuffer(backendInstance);
-                                                                                 } else if (resourceClass ==
-                                                                                            Detail::RenderResourceClass::Mesh) {
-                                                                                     backend_->DestroyMesh(backendInstance);
-                                                                                 }
-                                                                             })),
+          resourceRegistry_(
+              std::make_unique<Detail::RenderResourceRegistry>(resourceOwner, Detail::RenderResourceRegistryLimits{},
+                                                               [this](const Detail::RenderResourceClass resourceClass,
+                                                                      const std::uint64_t backendInstance) {
+                                                                   if (resourceClass == Detail::RenderResourceClass::Buffer) {
+                                                                       backend_->DestroyBuffer(backendInstance);
+                                                                   } else if (resourceClass == Detail::RenderResourceClass::Mesh) {
+                                                                       backend_->DestroyMesh(backendInstance);
+                                                                   } else if (resourceClass == Detail::RenderResourceClass::Texture) {
+                                                                       backend_->DestroyTexture(backendInstance);
+                                                                   } else if (resourceClass == Detail::RenderResourceClass::TextureView) {
+                                                                       backend_->DestroyTextureView(backendInstance);
+                                                                   } else if (resourceClass == Detail::RenderResourceClass::RenderTarget) {
+                                                                       backend_->DestroyRenderTarget(backendInstance);
+                                                                   }
+                                                               })),
           resourceUploadQueue_(std::make_unique<Detail::RenderResourceUploadQueue>(uploadLimits)) {}
 
     /** @copydoc RenderFrontend::~RenderFrontend */
@@ -298,252 +303,4 @@ namespace Horo::Render {
         }
     }
 
-    /** @copydoc RenderFrontend::CreateOffscreenTarget */
-    Result<RenderTargetHandle> RenderFrontend::CreateOffscreenTarget(const FramebufferExtent extent) {
-        if (!extent.IsValid())
-            return Result<RenderTargetHandle>::Failure(
-                MakeFrontendError(FrontendErrors::InvalidTargetExtent, "Offscreen target extent is invalid."));
-        auto reservation = resourceRegistry_->Reserve(Detail::RenderResourceClass::RenderTarget);
-        if (reservation.HasError()) {
-            return Result<RenderTargetHandle>::Failure(reservation.ErrorValue());
-        }
-        const Detail::RenderResourceIdentity identity = reservation.Value().identity;
-        if (identity.slot >= targets_.size()) {
-            targets_.resize(static_cast<std::size_t>(identity.slot) + 1);
-        }
-        targets_[identity.slot].extent = extent;
-        if (const Result<void> published = resourceRegistry_->Publish(Detail::RenderResourceClass::RenderTarget, identity, identity.slot);
-            published.HasError()) {
-            const Error publicationError = published.ErrorValue();
-            static_cast<void>(resourceRegistry_->Fail(Detail::RenderResourceClass::RenderTarget, identity, publicationError));
-            static_cast<void>(resourceRegistry_->DrainRetirements());
-            targets_[identity.slot] = {};
-            return Result<RenderTargetHandle>::Failure(publicationError);
-        }
-        return Result<RenderTargetHandle>::Success(RenderTargetHandle{identity.owner, identity.slot, identity.generation});
-    }
-
-    /** @copydoc RenderFrontend::ResizeOffscreenTarget */
-    Result<void> RenderFrontend::ResizeOffscreenTarget(const RenderTargetHandle target, const FramebufferExtent extent) {
-        if (!extent.IsValid()) {
-            return Result<void>::Failure(MakeFrontendError(FrontendErrors::InvalidTargetExtent, "Offscreen target extent is invalid."));
-        }
-        const Detail::RenderResourceIdentity identity{target.owner, target.slot, target.generation};
-        const auto state = resourceRegistry_->State(Detail::RenderResourceClass::RenderTarget, identity);
-        if (state.HasError()) {
-            return Result<void>::Failure(state.ErrorValue());
-        }
-        if (state.Value() != RenderResourceState::Ready) {
-            return Result<void>::Failure(MakeFrontendError(FrontendErrors::ResourceNotReady, "Offscreen target is not ready for resize."));
-        }
-        targets_[target.slot].extent = extent;
-        return Result<void>::Success();
-    }
-
-    /** @copydoc RenderFrontend::ReleaseOffscreenTarget */
-    Result<void> RenderFrontend::ReleaseOffscreenTarget(const RenderTargetHandle target) {
-        if (activeFrameScope_ != nullptr)
-            return Result<void>::Failure(
-                MakeFrontendError(FrontendErrors::TargetReleaseDuringFrame, "Offscreen target cannot be released during a frame."));
-        const Detail::RenderResourceIdentity identity{target.owner, target.slot, target.generation};
-        if (const Result<void> released = resourceRegistry_->Release(Detail::RenderResourceClass::RenderTarget, identity);
-            released.HasError()) {
-            return Result<void>::Failure(released.ErrorValue());
-        }
-        targets_[target.slot] = {};
-        static_cast<void>(resourceRegistry_->DrainRetirements());
-        return Result<void>::Success();
-    }
-
-    /** @copydoc RenderFrontend::CreateBuffer */
-    Result<ResourceCreation<RenderBufferHandle>> RenderFrontend::CreateBuffer(const RenderBufferDescriptor &descriptor,
-                                                                              const std::span<const std::byte> initialData) {
-        if (activeFrameScope_ != nullptr) {
-            return Result<ResourceCreation<RenderBufferHandle>>::Failure(
-                MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A buffer cannot be created during an active frame."));
-        }
-        if (!descriptor.IsValid()) {
-            return Result<ResourceCreation<RenderBufferHandle>>::Failure(
-                MakeFrontendError(FrontendErrors::InvalidBufferDescriptor, "The buffer descriptor is structurally invalid."));
-        }
-        if (!backend_->Capabilities().supportsBufferResources) {
-            return Result<ResourceCreation<RenderBufferHandle>>::Failure(
-                MakeFrontendError(FrontendErrors::ResourceUnsupported, "The active renderer backend does not support generic buffers."));
-        }
-        if (initialData.size() != descriptor.byteSize) {
-            return Result<ResourceCreation<RenderBufferHandle>>::Failure(
-                MakeFrontendError(FrontendErrors::ResourceBufferUploadSizeMismatch,
-                                  "The initial-data byte count must equal the buffer descriptor size."));
-        }
-        if (!resourceUploadQueue_->CanEnqueue(initialData.size())) {
-            return Result<ResourceCreation<RenderBufferHandle>>::Failure(
-                MakeFrontendError(FrontendErrors::ResourceUploadCapacityExceeded,
-                                  "The bounded initial-upload byte queue has insufficient capacity."));
-        }
-
-        auto reserved = resourceRegistry_->Reserve(Detail::RenderResourceClass::Buffer);
-        if (reserved.HasError()) {
-            return Result<ResourceCreation<RenderBufferHandle>>::Failure(reserved.ErrorValue());
-        }
-        const Detail::ResourceReservation reservation = reserved.Value();
-        if (reservation.identity.slot >= buffers_.size()) {
-            buffers_.resize(static_cast<std::size_t>(reservation.identity.slot) + 1);
-        }
-        buffers_[reservation.identity.slot] = {.generation = reservation.identity.generation, .descriptor = descriptor};
-        resourceUploadQueue_->EnqueueBuffer(reservation.identity, descriptor, initialData);
-        return Result<ResourceCreation<RenderBufferHandle>>::Success(
-            {.handle = BufferHandle(reservation.identity), .operation = reservation.operation});
-    }
-
-    /** @copydoc RenderFrontend::CreateMesh */
-    Result<ResourceCreation<RenderMeshHandle>> RenderFrontend::CreateMesh(const RenderMeshDescriptor &descriptor) {
-        if (activeFrameScope_ != nullptr) {
-            return Result<ResourceCreation<RenderMeshHandle>>::Failure(
-                MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A mesh cannot be created during an active frame."));
-        }
-        if (!descriptor.IsValid()) {
-            return Result<ResourceCreation<RenderMeshHandle>>::Failure(
-                MakeFrontendError(FrontendErrors::InvalidMeshDescriptor, "The mesh descriptor is structurally invalid."));
-        }
-        if (!backend_->Capabilities().supportsMeshResources) {
-            return Result<ResourceCreation<RenderMeshHandle>>::Failure(
-                MakeFrontendError(FrontendErrors::ResourceUnsupported, "The active renderer backend does not support generic meshes."));
-        }
-
-        if (const Result<void> dependencies = ValidateMeshDependencies(descriptor); dependencies.HasError()) {
-            return Result<ResourceCreation<RenderMeshHandle>>::Failure(dependencies.ErrorValue());
-        }
-        if (!IsMeshBufferLayoutCompatible(descriptor)) {
-            return Result<ResourceCreation<RenderMeshHandle>>::Failure(
-                MakeFrontendError(FrontendErrors::InvalidMeshDescriptor,
-                                  "Mesh layout or counts are incompatible with the referenced buffers."));
-        }
-
-        const std::array dependencies{Identity(descriptor.vertexBuffer), Identity(descriptor.indexBuffer)};
-        auto reserved = resourceRegistry_->Reserve(Detail::RenderResourceClass::Mesh, dependencies);
-        if (reserved.HasError()) {
-            return Result<ResourceCreation<RenderMeshHandle>>::Failure(reserved.ErrorValue());
-        }
-        const Detail::ResourceReservation reservation = reserved.Value();
-        resourceUploadQueue_->EnqueueMesh(reservation.identity, descriptor, std::nullopt);
-        return Result<ResourceCreation<RenderMeshHandle>>::Success(
-            {.handle = MeshHandle(reservation.identity), .operation = reservation.operation});
-    }
-
-    /** @copydoc RenderFrontend::ReplaceMesh */
-    Result<ResourceCreation<RenderMeshHandle>> RenderFrontend::ReplaceMesh(const RenderMeshHandle current,
-                                                                           const RenderMeshDescriptor &descriptor) {
-        const auto state = ResourceState(current);
-        if (state.HasError()) {
-            return Result<ResourceCreation<RenderMeshHandle>>::Failure(state.ErrorValue());
-        }
-        if (state.Value() != RenderResourceState::Ready) {
-            return Result<ResourceCreation<RenderMeshHandle>>::Failure(
-                MakeFrontendError(FrontendErrors::ResourceNotReady, "Only a ready mesh generation can be replaced."));
-        }
-        auto replacement = CreateMesh(descriptor);
-        if (replacement.HasValue()) {
-            resourceUploadQueue_->MarkBackAsReplacement(Identity(current));
-        }
-        return replacement;
-    }
-
-    /** @copydoc RenderFrontend::ProcessResourceRequests */
-    Result<std::size_t> RenderFrontend::ProcessResourceRequests() {
-        if (activeFrameScope_ != nullptr) {
-            return Result<std::size_t>::Failure(MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame,
-                                                                  "Resource requests can only be processed at a frame boundary."));
-        }
-
-        std::size_t completedRequests = 0;
-        std::size_t completedBytes = 0;
-        while (!resourceUploadQueue_->Empty() && !resourceUploadQueue_->DrainLimitReached(completedRequests, completedBytes)) {
-            Detail::RenderResourceUploadQueue::Request request = resourceUploadQueue_->Pop();
-            completedBytes += request.initialData.size();
-            const Result<std::uint64_t> created = RealizeResourceRequest(*backend_, *resourceRegistry_, request);
-            CompleteResourceRequest(*backend_, *resourceRegistry_, request, created);
-            ++completedRequests;
-        }
-        static_cast<void>(resourceRegistry_->DrainRetirements());
-        return Result<std::size_t>::Success(completedRequests);
-    }
-
-    /** @copydoc RenderFrontend::ResourceState(RenderBufferHandle) */
-    Result<RenderResourceState> RenderFrontend::ResourceState(const RenderBufferHandle buffer) const {
-        return resourceRegistry_->State(Detail::RenderResourceClass::Buffer, Identity(buffer));
-    }
-
-    /** @copydoc RenderFrontend::ResourceState(RenderMeshHandle) */
-    Result<RenderResourceState> RenderFrontend::ResourceState(const RenderMeshHandle mesh) const {
-        return resourceRegistry_->State(Detail::RenderResourceClass::Mesh, Identity(mesh));
-    }
-
-    /** @copydoc RenderFrontend::ResourceOperationResult */
-    Result<void> RenderFrontend::ResourceOperationResult(const ResourceOperationId operation) const {
-        return resourceRegistry_->OperationResult(operation);
-    }
-
-    /** @copydoc RenderFrontend::ReleaseBuffer */
-    Result<void> RenderFrontend::ReleaseBuffer(const RenderBufferHandle buffer) {
-        if (activeFrameScope_ != nullptr) {
-            return Result<void>::Failure(
-                MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A buffer cannot be released during an active frame."));
-        }
-        const Result<void> released = resourceRegistry_->Release(Detail::RenderResourceClass::Buffer, Identity(buffer));
-        if (released.HasValue()) {
-            static_cast<void>(resourceRegistry_->DrainRetirements());
-        }
-        return released;
-    }
-
-    /** @copydoc RenderFrontend::ReleaseMesh */
-    Result<void> RenderFrontend::ReleaseMesh(const RenderMeshHandle mesh) {
-        if (activeFrameScope_ != nullptr) {
-            return Result<void>::Failure(
-                MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A mesh cannot be released during an active frame."));
-        }
-        const Result<void> released = resourceRegistry_->Release(Detail::RenderResourceClass::Mesh, Identity(mesh));
-        if (released.HasValue()) {
-            static_cast<void>(resourceRegistry_->DrainRetirements());
-        }
-        return released;
-    }
-
-    Result<void> RenderFrontend::ValidateMeshDependencies(const RenderMeshDescriptor &descriptor) const {
-        const auto vertex = resourceRegistry_->State(Detail::RenderResourceClass::Buffer, Identity(descriptor.vertexBuffer));
-        if (vertex.HasError()) {
-            return Result<void>::Failure(vertex.ErrorValue());
-        }
-        const auto index = resourceRegistry_->State(Detail::RenderResourceClass::Buffer, Identity(descriptor.indexBuffer));
-        if (index.HasError()) {
-            return Result<void>::Failure(index.ErrorValue());
-        }
-        if (vertex.Value() != RenderResourceState::Ready || index.Value() != RenderResourceState::Ready) {
-            return Result<void>::Failure(
-                MakeFrontendError(FrontendErrors::ResourceDependencyNotReady, "Mesh creation requires ready vertex and index buffers."));
-        }
-        return Result<void>::Success();
-    }
-
-    bool RenderFrontend::IsMeshBufferLayoutCompatible(const RenderMeshDescriptor &descriptor) const noexcept {
-        if (descriptor.vertexBuffer.slot >= buffers_.size() || descriptor.indexBuffer.slot >= buffers_.size()) {
-            return false;
-        }
-        const BufferRecord &vertex = buffers_[descriptor.vertexBuffer.slot];
-        const BufferRecord &index = buffers_[descriptor.indexBuffer.slot];
-        const std::uint32_t indexSize = descriptor.indexFormat == RenderIndexFormat::UInt16 ? 2U : 4U;
-        const bool recordsMatch =
-            vertex.generation == descriptor.vertexBuffer.generation && index.generation == descriptor.indexBuffer.generation;
-        return recordsMatch && HasBufferUsage(vertex.descriptor.usage, RenderBufferUsage::Vertex) &&
-               HasBufferUsage(index.descriptor.usage, RenderBufferUsage::Index) &&
-               FitsBuffer(descriptor.vertexStride, descriptor.vertexCount, vertex.descriptor.byteSize) &&
-               FitsBuffer(indexSize, descriptor.indexCount, index.descriptor.byteSize);
-    }
-
-    bool RenderFrontend::IsLiveTarget(const RenderTargetHandle target, const FramebufferExtent extent) const noexcept {
-        const auto state =
-            resourceRegistry_->State(Detail::RenderResourceClass::RenderTarget, {target.owner, target.slot, target.generation});
-        return state.HasValue() && state.Value() == RenderResourceState::Ready && target.slot < targets_.size() &&
-               targets_[target.slot].extent.width == extent.width && targets_[target.slot].extent.height == extent.height;
-    }
 }  // namespace Horo::Render

--- a/src/runtime/renderer/frontend/RenderFrontend.cpp
+++ b/src/runtime/renderer/frontend/RenderFrontend.cpp
@@ -189,22 +189,22 @@ namespace Horo::Render {
     RenderFrontend::RenderFrontend(std::unique_ptr<IRenderBackend> backend, const RenderResourceOwnerId resourceOwner,
                                    const RenderResourceUploadLimits uploadLimits, ConstructionKey)
         : backend_(std::move(backend)),
-          resourceRegistry_(
-              std::make_unique<Detail::RenderResourceRegistry>(resourceOwner, Detail::RenderResourceRegistryLimits{},
-                                                               [this](const Detail::RenderResourceClass resourceClass,
-                                                                      const std::uint64_t backendInstance) {
-                                                                   if (resourceClass == Detail::RenderResourceClass::Buffer) {
-                                                                       backend_->DestroyBuffer(backendInstance);
-                                                                   } else if (resourceClass == Detail::RenderResourceClass::Mesh) {
-                                                                       backend_->DestroyMesh(backendInstance);
-                                                                   } else if (resourceClass == Detail::RenderResourceClass::Texture) {
-                                                                       backend_->DestroyTexture(backendInstance);
-                                                                   } else if (resourceClass == Detail::RenderResourceClass::TextureView) {
-                                                                       backend_->DestroyTextureView(backendInstance);
-                                                                   } else if (resourceClass == Detail::RenderResourceClass::RenderTarget) {
-                                                                       backend_->DestroyRenderTarget(backendInstance);
-                                                                   }
-                                                               })),
+          resourceRegistry_(std::make_unique<Detail::RenderResourceRegistry>(resourceOwner, Detail::RenderResourceRegistryLimits{},
+                                                                             [this](const Detail::RenderResourceClass resourceClass,
+                                                                                    const std::uint64_t backendInstance) {
+                                                                                 using enum Detail::RenderResourceClass;
+                                                                                 if (resourceClass == Buffer) {
+                                                                                     backend_->DestroyBuffer(backendInstance);
+                                                                                 } else if (resourceClass == Mesh) {
+                                                                                     backend_->DestroyMesh(backendInstance);
+                                                                                 } else if (resourceClass == Texture) {
+                                                                                     backend_->DestroyTexture(backendInstance);
+                                                                                 } else if (resourceClass == TextureView) {
+                                                                                     backend_->DestroyTextureView(backendInstance);
+                                                                                 } else if (resourceClass == RenderTarget) {
+                                                                                     backend_->DestroyRenderTarget(backendInstance);
+                                                                                 }
+                                                                             })),
           resourceUploadQueue_(std::make_unique<Detail::RenderResourceUploadQueue>(uploadLimits)) {}
 
     /** @copydoc RenderFrontend::~RenderFrontend */

--- a/src/runtime/renderer/frontend/RenderFrontendErrors.cpp
+++ b/src/runtime/renderer/frontend/RenderFrontendErrors.cpp
@@ -94,6 +94,15 @@ namespace Horo::Render::FrontendErrors {
                                                     .retryable = false,
                                                     .userActionable = false};
 
+    const ErrorCodeDescriptor InvalidRenderTargetDescriptor{.domain = Domain,
+                                                            .code = ErrorCode{"render.frontend.resource.invalid_render_target_descriptor"},
+                                                            .defaultSeverity = ErrorSeverity::Error,
+                                                            .summary = "Render target descriptor is invalid.",
+                                                            .remediationHint =
+                                                                "Provide compatible ready color and depth texture-view generations.",
+                                                            .retryable = false,
+                                                            .userActionable = false};
+
     const ErrorCodeDescriptor InvalidResourceUploadLimits{.domain = Domain,
                                                           .code = ErrorCode{"render.frontend.resource.invalid_upload_limits"},
                                                           .defaultSeverity = ErrorSeverity::Error,
@@ -117,6 +126,23 @@ namespace Horo::Render::FrontendErrors {
                                                   .remediationHint = "Use a non-zero extent supported by the active backend.",
                                                   .retryable = false,
                                                   .userActionable = false};
+
+    const ErrorCodeDescriptor InvalidTextureDescriptor{.domain = Domain,
+                                                       .code = ErrorCode{"render.frontend.resource.invalid_texture_descriptor"},
+                                                       .defaultSeverity = ErrorSeverity::Error,
+                                                       .summary = "Render texture descriptor is invalid.",
+                                                       .remediationHint = "Provide a supported format, extent, and typed usage policy.",
+                                                       .retryable = false,
+                                                       .userActionable = false};
+
+    const ErrorCodeDescriptor InvalidTextureViewDescriptor{.domain = Domain,
+                                                           .code = ErrorCode{"render.frontend.resource.invalid_texture_view_descriptor"},
+                                                           .defaultSeverity = ErrorSeverity::Error,
+                                                           .summary = "Render texture-view descriptor is invalid.",
+                                                           .remediationHint =
+                                                               "Provide a compatible ready texture generation, format, range, and aspect.",
+                                                           .retryable = false,
+                                                           .userActionable = false};
 
     const ErrorCodeDescriptor ResizeDuringFrame{.domain = Domain,
                                                 .code = ErrorCode{"render.frontend.resize_during_frame"},
@@ -221,6 +247,14 @@ namespace Horo::Render::FrontendErrors {
                                                        .remediationHint = "Poll after the frontend processes the queued request.",
                                                        .retryable = true,
                                                        .userActionable = false};
+
+    const ErrorCodeDescriptor ResourceOperationCancelled{.domain = Domain,
+                                                         .code = ErrorCode{"render.frontend.resource.operation_cancelled"},
+                                                         .defaultSeverity = ErrorSeverity::Warning,
+                                                         .summary = "Render resource operation was cancelled.",
+                                                         .remediationHint = "Submit a new generation if the resource is still required.",
+                                                         .retryable = true,
+                                                         .userActionable = false};
 
     const ErrorCodeDescriptor ResourceOperationUnknown{.domain = Domain,
                                                        .code = ErrorCode{"render.frontend.resource.operation_unknown"},

--- a/src/runtime/renderer/frontend/RenderFrontendErrors.h
+++ b/src/runtime/renderer/frontend/RenderFrontendErrors.h
@@ -14,9 +14,12 @@ namespace Horo::Render::FrontendErrors {
     extern const ErrorCodeDescriptor InvalidFrameToken;
     extern const ErrorCodeDescriptor InvalidBufferDescriptor;
     extern const ErrorCodeDescriptor InvalidMeshDescriptor;
+    extern const ErrorCodeDescriptor InvalidRenderTargetDescriptor;
     extern const ErrorCodeDescriptor InvalidResourceUploadLimits;
     extern const ErrorCodeDescriptor InvalidStaticMeshPass;
     extern const ErrorCodeDescriptor InvalidTargetExtent;
+    extern const ErrorCodeDescriptor InvalidTextureDescriptor;
+    extern const ErrorCodeDescriptor InvalidTextureViewDescriptor;
     extern const ErrorCodeDescriptor ResizeDuringFrame;
     extern const ErrorCodeDescriptor ResizeException;
     extern const ErrorCodeDescriptor ResourceAlreadyRetiring;
@@ -30,6 +33,7 @@ namespace Horo::Render::FrontendErrors {
     extern const ErrorCodeDescriptor ResourceNotPending;
     extern const ErrorCodeDescriptor ResourceNotReady;
     extern const ErrorCodeDescriptor ResourceOperationPending;
+    extern const ErrorCodeDescriptor ResourceOperationCancelled;
     extern const ErrorCodeDescriptor ResourceOperationUnknown;
     extern const ErrorCodeDescriptor ResourceOwnerExhausted;
     extern const ErrorCodeDescriptor ResourceQueueFull;

--- a/src/runtime/renderer/frontend/RenderFrontendResourceAccess.h
+++ b/src/runtime/renderer/frontend/RenderFrontendResourceAccess.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Horo/Runtime/Render/RenderFrontend.h"
+
+namespace Horo::Render::Detail {
+    /** @brief Internal adapter used by matching integrations without publishing native resource identity. */
+    class RenderFrontendResourceAccess final {
+    public:
+        [[nodiscard]] static Result<std::uint64_t> BackendInstance(const RenderFrontend &frontend, RenderMeshHandle mesh);
+        [[nodiscard]] static Result<std::uint64_t> BackendInstance(const RenderFrontend &frontend, RenderTextureViewHandle view);
+        [[nodiscard]] static Result<std::uint64_t> BackendInstance(const RenderFrontend &frontend, RenderTargetHandle target);
+    };
+}  // namespace Horo::Render::Detail

--- a/src/runtime/renderer/frontend/RenderFrontendResources.cpp
+++ b/src/runtime/renderer/frontend/RenderFrontendResources.cpp
@@ -1,0 +1,514 @@
+#include "Horo/Runtime/Render/RenderFrontend.h"
+#include "RenderFrontendErrors.h"
+#include "RenderFrontendResourceAccess.h"
+#include "RenderResourceOperations.h"
+#include "RenderResourceRegistry.h"
+#include "RenderResourceUploadQueue.h"
+
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <string>
+#include <utility>
+
+namespace Horo::Render {
+    namespace {
+        [[nodiscard]] Error MakeFrontendError(const ErrorCodeDescriptor &descriptor, std::string message) {
+            return MakeError(descriptor, std::move(message));
+        }
+
+        [[nodiscard]] Result<void> ReleaseOrCancelResource(Detail::RenderResourceRegistry &registry,
+                                                           const Detail::RenderResourceClass resourceClass,
+                                                           const Detail::RenderResourceIdentity identity) {
+            const auto state = registry.State(resourceClass, identity);
+            if (state.HasError())
+                return Result<void>::Failure(state.ErrorValue());
+            Result<void> released = state.Value() == RenderResourceState::Pending ? registry.CancelPending(resourceClass, identity)
+                                                                                  : registry.Release(resourceClass, identity);
+            if (released.HasValue())
+                static_cast<void>(registry.DrainRetirements());
+            return released;
+        }
+    }  // namespace
+
+    /** @copydoc RenderFrontend::CreateOffscreenTarget */
+    Result<RenderTargetHandle> RenderFrontend::CreateOffscreenTarget(const FramebufferExtent extent) {
+        if (!extent.IsValid())
+            return Result<RenderTargetHandle>::Failure(
+                MakeFrontendError(FrontendErrors::InvalidTargetExtent, "Offscreen target extent is invalid."));
+        auto reservation = resourceRegistry_->Reserve(Detail::RenderResourceClass::RenderTarget);
+        if (reservation.HasError()) {
+            return Result<RenderTargetHandle>::Failure(reservation.ErrorValue());
+        }
+        const Detail::RenderResourceIdentity identity = reservation.Value().identity;
+        if (identity.slot >= targets_.size()) {
+            targets_.resize(static_cast<std::size_t>(identity.slot) + 1);
+        }
+        targets_[identity.slot].extent = extent;
+        if (const Result<void> published = resourceRegistry_->Publish(Detail::RenderResourceClass::RenderTarget, identity, identity.slot);
+            published.HasError()) {
+            const Error publicationError = published.ErrorValue();
+            static_cast<void>(resourceRegistry_->Fail(Detail::RenderResourceClass::RenderTarget, identity, publicationError));
+            static_cast<void>(resourceRegistry_->DrainRetirements());
+            targets_[identity.slot] = {};
+            return Result<RenderTargetHandle>::Failure(publicationError);
+        }
+        return Result<RenderTargetHandle>::Success(RenderTargetHandle{identity.owner, identity.slot, identity.generation});
+    }
+
+    /** @copydoc RenderFrontend::ResizeOffscreenTarget */
+    Result<void> RenderFrontend::ResizeOffscreenTarget(const RenderTargetHandle target, const FramebufferExtent extent) {
+        if (!extent.IsValid()) {
+            return Result<void>::Failure(MakeFrontendError(FrontendErrors::InvalidTargetExtent, "Offscreen target extent is invalid."));
+        }
+        const Detail::RenderResourceIdentity identity{target.owner, target.slot, target.generation};
+        const auto state = resourceRegistry_->State(Detail::RenderResourceClass::RenderTarget, identity);
+        if (state.HasError()) {
+            return Result<void>::Failure(state.ErrorValue());
+        }
+        if (state.Value() != RenderResourceState::Ready) {
+            return Result<void>::Failure(MakeFrontendError(FrontendErrors::ResourceNotReady, "Offscreen target is not ready for resize."));
+        }
+        targets_[target.slot].extent = extent;
+        return Result<void>::Success();
+    }
+
+    /** @copydoc RenderFrontend::ReleaseOffscreenTarget */
+    Result<void> RenderFrontend::ReleaseOffscreenTarget(const RenderTargetHandle target) {
+        if (activeFrameScope_ != nullptr)
+            return Result<void>::Failure(
+                MakeFrontendError(FrontendErrors::TargetReleaseDuringFrame, "Offscreen target cannot be released during a frame."));
+        const Detail::RenderResourceIdentity identity{target.owner, target.slot, target.generation};
+        if (const Result<void> released = resourceRegistry_->Release(Detail::RenderResourceClass::RenderTarget, identity);
+            released.HasError()) {
+            return Result<void>::Failure(released.ErrorValue());
+        }
+        targets_[target.slot] = {};
+        static_cast<void>(resourceRegistry_->DrainRetirements());
+        return Result<void>::Success();
+    }
+
+    /** @copydoc RenderFrontend::CreateBuffer */
+    Result<ResourceCreation<RenderBufferHandle>> RenderFrontend::CreateBuffer(const RenderBufferDescriptor &descriptor,
+                                                                              const std::span<const std::byte> initialData) {
+        if (activeFrameScope_ != nullptr) {
+            return Result<ResourceCreation<RenderBufferHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A buffer cannot be created during an active frame."));
+        }
+        if (!descriptor.IsValid()) {
+            return Result<ResourceCreation<RenderBufferHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::InvalidBufferDescriptor, "The buffer descriptor is structurally invalid."));
+        }
+        if (!backend_->Capabilities().supportsBufferResources) {
+            return Result<ResourceCreation<RenderBufferHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceUnsupported, "The active renderer backend does not support generic buffers."));
+        }
+        if (initialData.size() != descriptor.byteSize) {
+            return Result<ResourceCreation<RenderBufferHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceBufferUploadSizeMismatch,
+                                  "The initial-data byte count must equal the buffer descriptor size."));
+        }
+        if (!resourceUploadQueue_->CanEnqueue(initialData.size())) {
+            return Result<ResourceCreation<RenderBufferHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceUploadCapacityExceeded,
+                                  "The bounded initial-upload byte queue has insufficient capacity."));
+        }
+
+        auto reserved = resourceRegistry_->Reserve(Detail::RenderResourceClass::Buffer);
+        if (reserved.HasError()) {
+            return Result<ResourceCreation<RenderBufferHandle>>::Failure(reserved.ErrorValue());
+        }
+        const Detail::ResourceReservation reservation = reserved.Value();
+        if (reservation.identity.slot >= buffers_.size()) {
+            buffers_.resize(static_cast<std::size_t>(reservation.identity.slot) + 1);
+        }
+        buffers_[reservation.identity.slot] = {.generation = reservation.identity.generation, .descriptor = descriptor};
+        resourceUploadQueue_->EnqueueBuffer(reservation.identity, descriptor, initialData);
+        return Result<ResourceCreation<RenderBufferHandle>>::Success(
+            {.handle = BufferHandle(reservation.identity), .operation = reservation.operation});
+    }
+
+    /** @copydoc RenderFrontend::CreateMesh */
+    Result<ResourceCreation<RenderMeshHandle>> RenderFrontend::CreateMesh(const RenderMeshDescriptor &descriptor) {
+        if (activeFrameScope_ != nullptr) {
+            return Result<ResourceCreation<RenderMeshHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A mesh cannot be created during an active frame."));
+        }
+        if (!descriptor.IsValid()) {
+            return Result<ResourceCreation<RenderMeshHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::InvalidMeshDescriptor, "The mesh descriptor is structurally invalid."));
+        }
+        if (!backend_->Capabilities().supportsMeshResources) {
+            return Result<ResourceCreation<RenderMeshHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceUnsupported, "The active renderer backend does not support generic meshes."));
+        }
+
+        if (const Result<void> dependencies = ValidateMeshDependencies(descriptor); dependencies.HasError()) {
+            return Result<ResourceCreation<RenderMeshHandle>>::Failure(dependencies.ErrorValue());
+        }
+        if (!IsMeshBufferLayoutCompatible(descriptor)) {
+            return Result<ResourceCreation<RenderMeshHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::InvalidMeshDescriptor,
+                                  "Mesh layout or counts are incompatible with the referenced buffers."));
+        }
+
+        const std::array dependencies{Identity(descriptor.vertexBuffer), Identity(descriptor.indexBuffer)};
+        auto reserved = resourceRegistry_->Reserve(Detail::RenderResourceClass::Mesh, dependencies);
+        if (reserved.HasError()) {
+            return Result<ResourceCreation<RenderMeshHandle>>::Failure(reserved.ErrorValue());
+        }
+        const Detail::ResourceReservation reservation = reserved.Value();
+        resourceUploadQueue_->EnqueueMesh(reservation.identity, descriptor, std::nullopt);
+        return Result<ResourceCreation<RenderMeshHandle>>::Success(
+            {.handle = MeshHandle(reservation.identity), .operation = reservation.operation});
+    }
+
+    /** @copydoc RenderFrontend::CreateTexture */
+    Result<ResourceCreation<RenderTextureHandle>> RenderFrontend::CreateTexture(const RenderTextureDescriptor &descriptor) {
+        if (activeFrameScope_ != nullptr) {
+            return Result<ResourceCreation<RenderTextureHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A texture cannot be created during an active frame."));
+        }
+        if (!descriptor.IsValid()) {
+            return Result<ResourceCreation<RenderTextureHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::InvalidTextureDescriptor, "The texture descriptor is structurally invalid."));
+        }
+        if (!backend_->Capabilities().supportsTextureResources) {
+            return Result<ResourceCreation<RenderTextureHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceUnsupported, "The active renderer backend does not support generic textures."));
+        }
+        auto reserved = resourceRegistry_->Reserve(Detail::RenderResourceClass::Texture);
+        if (reserved.HasError())
+            return Result<ResourceCreation<RenderTextureHandle>>::Failure(reserved.ErrorValue());
+        const Detail::ResourceReservation reservation = reserved.Value();
+        if (reservation.identity.slot >= textures_.size())
+            textures_.resize(static_cast<std::size_t>(reservation.identity.slot) + 1);
+        textures_[reservation.identity.slot] = {.generation = reservation.identity.generation, .descriptor = descriptor};
+        resourceUploadQueue_->EnqueueTexture(reservation.identity, descriptor);
+        return Result<ResourceCreation<RenderTextureHandle>>::Success(
+            {.handle = TextureHandle(reservation.identity), .operation = reservation.operation});
+    }
+
+    /** @copydoc RenderFrontend::CreateTextureView */
+    Result<ResourceCreation<RenderTextureViewHandle>> RenderFrontend::CreateTextureView(const RenderTextureViewDescriptor &descriptor) {
+        if (activeFrameScope_ != nullptr) {
+            return Result<ResourceCreation<RenderTextureViewHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A texture view cannot be created during an active frame."));
+        }
+        if (!descriptor.IsValid()) {
+            return Result<ResourceCreation<RenderTextureViewHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::InvalidTextureViewDescriptor, "The texture-view descriptor is structurally invalid."));
+        }
+        if (!backend_->Capabilities().supportsTextureResources) {
+            return Result<ResourceCreation<RenderTextureViewHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceUnsupported,
+                                  "The active renderer backend does not support generic texture views."));
+        }
+        if (const Result<void> dependency = ValidateTextureViewDependency(descriptor); dependency.HasError())
+            return Result<ResourceCreation<RenderTextureViewHandle>>::Failure(dependency.ErrorValue());
+        const std::array dependencies{Identity(descriptor.texture)};
+        auto reserved = resourceRegistry_->Reserve(Detail::RenderResourceClass::TextureView, dependencies);
+        if (reserved.HasError())
+            return Result<ResourceCreation<RenderTextureViewHandle>>::Failure(reserved.ErrorValue());
+        const Detail::ResourceReservation reservation = reserved.Value();
+        if (reservation.identity.slot >= textureViews_.size())
+            textureViews_.resize(static_cast<std::size_t>(reservation.identity.slot) + 1);
+        textureViews_[reservation.identity.slot] = {.generation = reservation.identity.generation, .descriptor = descriptor};
+        resourceUploadQueue_->EnqueueTextureView(reservation.identity, descriptor);
+        return Result<ResourceCreation<RenderTextureViewHandle>>::Success(
+            {.handle = TextureViewHandle(reservation.identity), .operation = reservation.operation});
+    }
+
+    /** @copydoc RenderFrontend::CreateRenderTarget */
+    Result<ResourceCreation<RenderTargetHandle>> RenderFrontend::CreateRenderTarget(const RenderTargetDescriptor &descriptor) {
+        if (activeFrameScope_ != nullptr) {
+            return Result<ResourceCreation<RenderTargetHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A render target cannot be created during an active frame."));
+        }
+        if (!descriptor.IsValid()) {
+            return Result<ResourceCreation<RenderTargetHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::InvalidRenderTargetDescriptor, "The render-target descriptor is structurally invalid."));
+        }
+        if (!backend_->Capabilities().supportsRenderTargetResources) {
+            return Result<ResourceCreation<RenderTargetHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceUnsupported,
+                                  "The active renderer backend does not support generic render targets."));
+        }
+        if (const Result<void> dependencies = ValidateRenderTargetDependencies(descriptor); dependencies.HasError())
+            return Result<ResourceCreation<RenderTargetHandle>>::Failure(dependencies.ErrorValue());
+        std::array<Detail::RenderResourceIdentity, 2> dependencies{};
+        std::size_t dependencyCount = 0;
+        if (descriptor.colorAttachment.IsValid())
+            dependencies[dependencyCount++] = Identity(descriptor.colorAttachment);
+        if (descriptor.depthAttachment.IsValid())
+            dependencies[dependencyCount++] = Identity(descriptor.depthAttachment);
+        auto reserved =
+            resourceRegistry_->Reserve(Detail::RenderResourceClass::RenderTarget, std::span{dependencies}.first(dependencyCount));
+        if (reserved.HasError())
+            return Result<ResourceCreation<RenderTargetHandle>>::Failure(reserved.ErrorValue());
+        const Detail::ResourceReservation reservation = reserved.Value();
+        if (reservation.identity.slot >= targets_.size())
+            targets_.resize(static_cast<std::size_t>(reservation.identity.slot) + 1);
+        targets_[reservation.identity.slot].extent = descriptor.extent;
+        resourceUploadQueue_->EnqueueRenderTarget(reservation.identity, descriptor);
+        return Result<ResourceCreation<RenderTargetHandle>>::Success(
+            {.handle = TargetHandle(reservation.identity), .operation = reservation.operation});
+    }
+
+    /** @copydoc RenderFrontend::ReplaceMesh */
+    Result<ResourceCreation<RenderMeshHandle>> RenderFrontend::ReplaceMesh(const RenderMeshHandle current,
+                                                                           const RenderMeshDescriptor &descriptor) {
+        const auto state = ResourceState(current);
+        if (state.HasError()) {
+            return Result<ResourceCreation<RenderMeshHandle>>::Failure(state.ErrorValue());
+        }
+        if (state.Value() != RenderResourceState::Ready) {
+            return Result<ResourceCreation<RenderMeshHandle>>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceNotReady, "Only a ready mesh generation can be replaced."));
+        }
+        auto replacement = CreateMesh(descriptor);
+        if (replacement.HasValue()) {
+            resourceUploadQueue_->MarkBackAsReplacement(Identity(current));
+        }
+        return replacement;
+    }
+
+    /** @copydoc RenderFrontend::ProcessResourceRequests */
+    Result<std::size_t> RenderFrontend::ProcessResourceRequests() {
+        if (activeFrameScope_ != nullptr) {
+            return Result<std::size_t>::Failure(MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame,
+                                                                  "Resource requests can only be processed at a frame boundary."));
+        }
+
+        std::size_t completedRequests = 0;
+        std::size_t completedBytes = 0;
+        while (!resourceUploadQueue_->Empty() && !resourceUploadQueue_->DrainLimitReached(completedRequests, completedBytes)) {
+            Detail::RenderResourceUploadQueue::Request request = resourceUploadQueue_->Pop();
+            completedBytes += request.initialData.size();
+            const Result<std::uint64_t> created = RealizeResourceRequest(*backend_, *resourceRegistry_, request);
+            CompleteResourceRequest(*backend_, *resourceRegistry_, request, created);
+            ++completedRequests;
+        }
+        static_cast<void>(resourceRegistry_->DrainRetirements());
+        return Result<std::size_t>::Success(completedRequests);
+    }
+
+    /** @copydoc RenderFrontend::ResourceState(RenderBufferHandle) */
+    Result<RenderResourceState> RenderFrontend::ResourceState(const RenderBufferHandle buffer) const {
+        return resourceRegistry_->State(Detail::RenderResourceClass::Buffer, Identity(buffer));
+    }
+
+    /** @copydoc RenderFrontend::ResourceState(RenderMeshHandle) */
+    Result<RenderResourceState> RenderFrontend::ResourceState(const RenderMeshHandle mesh) const {
+        return resourceRegistry_->State(Detail::RenderResourceClass::Mesh, Identity(mesh));
+    }
+
+    /** @copydoc RenderFrontend::ResourceState(RenderTextureHandle) */
+    Result<RenderResourceState> RenderFrontend::ResourceState(const RenderTextureHandle texture) const {
+        return resourceRegistry_->State(Detail::RenderResourceClass::Texture, Identity(texture));
+    }
+
+    /** @copydoc RenderFrontend::ResourceState(RenderTextureViewHandle) */
+    Result<RenderResourceState> RenderFrontend::ResourceState(const RenderTextureViewHandle view) const {
+        return resourceRegistry_->State(Detail::RenderResourceClass::TextureView, Identity(view));
+    }
+
+    /** @copydoc RenderFrontend::ResourceState(RenderTargetHandle) */
+    Result<RenderResourceState> RenderFrontend::ResourceState(const RenderTargetHandle target) const {
+        return resourceRegistry_->State(Detail::RenderResourceClass::RenderTarget, Identity(target));
+    }
+
+    /** @copydoc RenderFrontend::ResourceOperationResult */
+    Result<void> RenderFrontend::ResourceOperationResult(const ResourceOperationId operation) const {
+        return resourceRegistry_->OperationResult(operation);
+    }
+
+    /** @copydoc RenderFrontend::ReleaseBuffer */
+    Result<void> RenderFrontend::ReleaseBuffer(const RenderBufferHandle buffer) {
+        if (activeFrameScope_ != nullptr) {
+            return Result<void>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A buffer cannot be released during an active frame."));
+        }
+        return ReleaseOrCancelResource(*resourceRegistry_, Detail::RenderResourceClass::Buffer, Identity(buffer));
+    }
+
+    /** @copydoc RenderFrontend::ReleaseMesh */
+    Result<void> RenderFrontend::ReleaseMesh(const RenderMeshHandle mesh) {
+        if (activeFrameScope_ != nullptr) {
+            return Result<void>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A mesh cannot be released during an active frame."));
+        }
+        return ReleaseOrCancelResource(*resourceRegistry_, Detail::RenderResourceClass::Mesh, Identity(mesh));
+    }
+
+    /** @copydoc RenderFrontend::ReleaseTexture */
+    Result<void> RenderFrontend::ReleaseTexture(const RenderTextureHandle texture) {
+        if (activeFrameScope_ != nullptr)
+            return Result<void>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A texture cannot be released during an active frame."));
+        return ReleaseOrCancelResource(*resourceRegistry_, Detail::RenderResourceClass::Texture, Identity(texture));
+    }
+
+    /** @copydoc RenderFrontend::ReleaseTextureView */
+    Result<void> RenderFrontend::ReleaseTextureView(const RenderTextureViewHandle view) {
+        if (activeFrameScope_ != nullptr)
+            return Result<void>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A texture view cannot be released during an active frame."));
+        return ReleaseOrCancelResource(*resourceRegistry_, Detail::RenderResourceClass::TextureView, Identity(view));
+    }
+
+    /** @copydoc RenderFrontend::ReleaseRenderTarget */
+    Result<void> RenderFrontend::ReleaseRenderTarget(const RenderTargetHandle target) {
+        if (activeFrameScope_ != nullptr)
+            return Result<void>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A render target cannot be released during an active frame."));
+        const Result<void> released =
+            ReleaseOrCancelResource(*resourceRegistry_, Detail::RenderResourceClass::RenderTarget, Identity(target));
+        if (released.HasValue()) {
+            if (target.slot < targets_.size())
+                targets_[target.slot] = {};
+        }
+        return released;
+    }
+
+    Result<void> RenderFrontend::ValidateMeshDependencies(const RenderMeshDescriptor &descriptor) const {
+        const auto vertex = resourceRegistry_->State(Detail::RenderResourceClass::Buffer, Identity(descriptor.vertexBuffer));
+        if (vertex.HasError()) {
+            return Result<void>::Failure(vertex.ErrorValue());
+        }
+        const auto index = resourceRegistry_->State(Detail::RenderResourceClass::Buffer, Identity(descriptor.indexBuffer));
+        if (index.HasError()) {
+            return Result<void>::Failure(index.ErrorValue());
+        }
+        if (vertex.Value() != RenderResourceState::Ready || index.Value() != RenderResourceState::Ready) {
+            return Result<void>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceDependencyNotReady, "Mesh creation requires ready vertex and index buffers."));
+        }
+        return Result<void>::Success();
+    }
+
+    bool RenderFrontend::IsMeshBufferLayoutCompatible(const RenderMeshDescriptor &descriptor) const noexcept {
+        if (descriptor.vertexBuffer.slot >= buffers_.size() || descriptor.indexBuffer.slot >= buffers_.size()) {
+            return false;
+        }
+        const BufferRecord &vertex = buffers_[descriptor.vertexBuffer.slot];
+        const BufferRecord &index = buffers_[descriptor.indexBuffer.slot];
+        const std::uint32_t indexSize = descriptor.indexFormat == RenderIndexFormat::UInt16 ? 2U : 4U;
+        const bool recordsMatch =
+            vertex.generation == descriptor.vertexBuffer.generation && index.generation == descriptor.indexBuffer.generation;
+        return recordsMatch && HasBufferUsage(vertex.descriptor.usage, RenderBufferUsage::Vertex) &&
+               HasBufferUsage(index.descriptor.usage, RenderBufferUsage::Index) &&
+               FitsBuffer(descriptor.vertexStride, descriptor.vertexCount, vertex.descriptor.byteSize) &&
+               FitsBuffer(indexSize, descriptor.indexCount, index.descriptor.byteSize);
+    }
+
+    Result<void> RenderFrontend::ValidateTextureViewDependency(const RenderTextureViewDescriptor &descriptor) const {
+        const auto textureState = resourceRegistry_->State(Detail::RenderResourceClass::Texture, Identity(descriptor.texture));
+        if (textureState.HasError())
+            return Result<void>::Failure(textureState.ErrorValue());
+        if (textureState.Value() != RenderResourceState::Ready) {
+            return Result<void>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceDependencyNotReady, "Texture-view creation requires a ready texture."));
+        }
+        if (descriptor.texture.slot >= textures_.size()) {
+            return Result<void>::Failure(
+                MakeFrontendError(FrontendErrors::InvalidTextureViewDescriptor, "Texture-view source metadata is unavailable."));
+        }
+        const TextureRecord &texture = textures_[descriptor.texture.slot];
+        const bool colorFormat = texture.descriptor.format == RenderTextureFormat::Rgba8Unorm;
+        const bool aspectCompatible =
+            colorFormat ? descriptor.aspect == RenderTextureAspect::Color : descriptor.aspect != RenderTextureAspect::Color;
+        const std::array compatible{
+            texture.generation == descriptor.texture.generation,
+            descriptor.format == texture.descriptor.format,
+            descriptor.baseMip == 0,
+            descriptor.mipCount == texture.descriptor.mipCount,
+            descriptor.baseLayer == 0,
+            descriptor.layerCount == texture.descriptor.layerCount,
+            aspectCompatible,
+        };
+        if (!std::ranges::all_of(compatible, std::identity{})) {
+            return Result<void>::Failure(MakeFrontendError(FrontendErrors::InvalidTextureViewDescriptor,
+                                                           "Texture-view format, range, or aspect is incompatible with its texture."));
+        }
+        return Result<void>::Success();
+    }
+
+    Result<void> RenderFrontend::ValidateRenderTargetDependencies(const RenderTargetDescriptor &descriptor) const {
+        if (const Result<void> color = ValidateRenderTargetAttachment(descriptor.colorAttachment, RenderTextureAspect::Color,
+                                                                      descriptor.extent, descriptor.sampleCount);
+            color.HasError())
+            return color;
+        if (const Result<void> depth = ValidateRenderTargetAttachment(descriptor.depthAttachment, RenderTextureAspect::Depth,
+                                                                      descriptor.extent, descriptor.sampleCount);
+            depth.HasError())
+            return depth;
+        return Result<void>::Success();
+    }
+
+    Result<void> RenderFrontend::ValidateRenderTargetAttachment(const RenderTextureViewHandle handle,
+                                                                const RenderTextureAspect requiredAspect, const FramebufferExtent extent,
+                                                                const std::uint32_t sampleCount) const {
+        if (!handle.IsValid())
+            return Result<void>::Success();
+        const auto state = resourceRegistry_->State(Detail::RenderResourceClass::TextureView, Identity(handle));
+        if (state.HasError())
+            return Result<void>::Failure(state.ErrorValue());
+        if (state.Value() != RenderResourceState::Ready)
+            return Result<void>::Failure(
+                MakeFrontendError(FrontendErrors::ResourceDependencyNotReady, "Render-target creation requires ready attachment views."));
+        if (handle.slot >= textureViews_.size())
+            return Result<void>::Failure(
+                MakeFrontendError(FrontendErrors::InvalidRenderTargetDescriptor, "Render-target attachment metadata is unavailable."));
+        const TextureViewRecord &view = textureViews_[handle.slot];
+        const bool aspectCompatible = requiredAspect == RenderTextureAspect::Color ? view.descriptor.aspect == RenderTextureAspect::Color
+                                                                                   : view.descriptor.aspect != RenderTextureAspect::Color;
+        if (view.generation != handle.generation || !aspectCompatible || view.descriptor.texture.slot >= textures_.size())
+            return Result<void>::Failure(
+                MakeFrontendError(FrontendErrors::InvalidRenderTargetDescriptor, "Render-target attachment aspect is incompatible."));
+        const TextureRecord &texture = textures_[view.descriptor.texture.slot];
+        const std::array compatible{
+            texture.descriptor.extent == extent,
+            texture.descriptor.sampleCount == sampleCount,
+            HasTextureUsage(texture.descriptor.usage, RenderTextureUsage::RenderAttachment),
+        };
+        if (!std::ranges::all_of(compatible, std::identity{}))
+            return Result<void>::Failure(MakeFrontendError(FrontendErrors::InvalidRenderTargetDescriptor,
+                                                           "Render-target attachment extent, samples, or usage is incompatible."));
+        return Result<void>::Success();
+    }
+
+    bool RenderFrontend::IsLiveTarget(const RenderTargetHandle target, const FramebufferExtent extent) const noexcept {
+        const auto state =
+            resourceRegistry_->State(Detail::RenderResourceClass::RenderTarget, {target.owner, target.slot, target.generation});
+        return state.HasValue() && state.Value() == RenderResourceState::Ready && target.slot < targets_.size() &&
+               targets_[target.slot].extent.width == extent.width && targets_[target.slot].extent.height == extent.height;
+    }
+
+    Result<std::uint64_t> RenderFrontend::BackendInstance(const RenderMeshHandle mesh) const {
+        return resourceRegistry_->BackendInstance(Detail::RenderResourceClass::Mesh, Identity(mesh));
+    }
+
+    Result<std::uint64_t> RenderFrontend::BackendInstance(const RenderTextureViewHandle view) const {
+        return resourceRegistry_->BackendInstance(Detail::RenderResourceClass::TextureView, Identity(view));
+    }
+
+    Result<std::uint64_t> RenderFrontend::BackendInstance(const RenderTargetHandle target) const {
+        return resourceRegistry_->BackendInstance(Detail::RenderResourceClass::RenderTarget, Identity(target));
+    }
+
+    Result<std::uint64_t> Detail::RenderFrontendResourceAccess::BackendInstance(const RenderFrontend &frontend,
+                                                                                const RenderMeshHandle mesh) {
+        return frontend.BackendInstance(mesh);
+    }
+
+    Result<std::uint64_t> Detail::RenderFrontendResourceAccess::BackendInstance(const RenderFrontend &frontend,
+                                                                                const RenderTextureViewHandle view) {
+        return frontend.BackendInstance(view);
+    }
+
+    Result<std::uint64_t> Detail::RenderFrontendResourceAccess::BackendInstance(const RenderFrontend &frontend,
+                                                                                const RenderTargetHandle target) {
+        return frontend.BackendInstance(target);
+    }
+}  // namespace Horo::Render

--- a/src/runtime/renderer/frontend/RenderFrontendResources.cpp
+++ b/src/runtime/renderer/frontend/RenderFrontendResources.cpp
@@ -364,10 +364,8 @@ namespace Horo::Render {
                 MakeFrontendError(FrontendErrors::ResourceChangeDuringFrame, "A render target cannot be released during an active frame."));
         const Result<void> released =
             ReleaseOrCancelResource(*resourceRegistry_, Detail::RenderResourceClass::RenderTarget, Identity(target));
-        if (released.HasValue()) {
-            if (target.slot < targets_.size())
-                targets_[target.slot] = {};
-        }
+        if (released.HasValue() && target.slot < targets_.size())
+            targets_[target.slot] = {};
         return released;
     }
 
@@ -418,16 +416,16 @@ namespace Horo::Render {
         const bool colorFormat = texture.descriptor.format == RenderTextureFormat::Rgba8Unorm;
         const bool aspectCompatible =
             colorFormat ? descriptor.aspect == RenderTextureAspect::Color : descriptor.aspect != RenderTextureAspect::Color;
-        const std::array compatible{
-            texture.generation == descriptor.texture.generation,
-            descriptor.format == texture.descriptor.format,
-            descriptor.baseMip == 0,
-            descriptor.mipCount == texture.descriptor.mipCount,
-            descriptor.baseLayer == 0,
-            descriptor.layerCount == texture.descriptor.layerCount,
-            aspectCompatible,
-        };
-        if (!std::ranges::all_of(compatible, std::identity{})) {
+        if (const std::array compatible{
+                texture.generation == descriptor.texture.generation,
+                descriptor.format == texture.descriptor.format,
+                descriptor.baseMip == 0,
+                descriptor.mipCount == texture.descriptor.mipCount,
+                descriptor.baseLayer == 0,
+                descriptor.layerCount == texture.descriptor.layerCount,
+                aspectCompatible,
+            };
+            !std::ranges::all_of(compatible, std::identity{})) {
             return Result<void>::Failure(MakeFrontendError(FrontendErrors::InvalidTextureViewDescriptor,
                                                            "Texture-view format, range, or aspect is incompatible with its texture."));
         }
@@ -461,18 +459,19 @@ namespace Horo::Render {
             return Result<void>::Failure(
                 MakeFrontendError(FrontendErrors::InvalidRenderTargetDescriptor, "Render-target attachment metadata is unavailable."));
         const TextureViewRecord &view = textureViews_[handle.slot];
-        const bool aspectCompatible = requiredAspect == RenderTextureAspect::Color ? view.descriptor.aspect == RenderTextureAspect::Color
-                                                                                   : view.descriptor.aspect != RenderTextureAspect::Color;
-        if (view.generation != handle.generation || !aspectCompatible || view.descriptor.texture.slot >= textures_.size())
+        if (const bool aspectCompatible = requiredAspect == RenderTextureAspect::Color
+                                              ? view.descriptor.aspect == RenderTextureAspect::Color
+                                              : view.descriptor.aspect != RenderTextureAspect::Color;
+            view.generation != handle.generation || !aspectCompatible || view.descriptor.texture.slot >= textures_.size())
             return Result<void>::Failure(
                 MakeFrontendError(FrontendErrors::InvalidRenderTargetDescriptor, "Render-target attachment aspect is incompatible."));
         const TextureRecord &texture = textures_[view.descriptor.texture.slot];
-        const std::array compatible{
-            texture.descriptor.extent == extent,
-            texture.descriptor.sampleCount == sampleCount,
-            HasTextureUsage(texture.descriptor.usage, RenderTextureUsage::RenderAttachment),
-        };
-        if (!std::ranges::all_of(compatible, std::identity{}))
+        if (const std::array compatible{
+                texture.descriptor.extent == extent,
+                texture.descriptor.sampleCount == sampleCount,
+                HasTextureUsage(texture.descriptor.usage, RenderTextureUsage::RenderAttachment),
+            };
+            !std::ranges::all_of(compatible, std::identity{}))
             return Result<void>::Failure(MakeFrontendError(FrontendErrors::InvalidRenderTargetDescriptor,
                                                            "Render-target attachment extent, samples, or usage is incompatible."));
         return Result<void>::Success();

--- a/src/runtime/renderer/frontend/RenderResourceOperations.cpp
+++ b/src/runtime/renderer/frontend/RenderResourceOperations.cpp
@@ -12,7 +12,19 @@ namespace Horo::Render {
         using UploadRequestKind = Detail::RenderResourceUploadQueue::RequestKind;
 
         [[nodiscard]] Detail::RenderResourceClass ResourceClassFor(const UploadRequestKind kind) noexcept {
-            return kind == UploadRequestKind::Buffer ? Detail::RenderResourceClass::Buffer : Detail::RenderResourceClass::Mesh;
+            switch (kind) {
+                case UploadRequestKind::Buffer:
+                    return Detail::RenderResourceClass::Buffer;
+                case UploadRequestKind::Mesh:
+                    return Detail::RenderResourceClass::Mesh;
+                case UploadRequestKind::Texture:
+                    return Detail::RenderResourceClass::Texture;
+                case UploadRequestKind::TextureView:
+                    return Detail::RenderResourceClass::TextureView;
+                case UploadRequestKind::RenderTarget:
+                    return Detail::RenderResourceClass::RenderTarget;
+            }
+            return Detail::RenderResourceClass::Buffer;
         }
 
         [[nodiscard]] Result<std::uint64_t> RealizeMeshRequest(IRenderBackend &backend, const Detail::RenderResourceRegistry &registry,
@@ -28,13 +40,54 @@ namespace Horo::Render {
             return backend.CreateMesh(descriptor, vertex.Value(), index.Value());
         }
 
+        [[nodiscard]] Result<std::uint64_t> RealizeTextureViewRequest(IRenderBackend &backend,
+                                                                      const Detail::RenderResourceRegistry &registry,
+                                                                      const RenderTextureViewDescriptor &descriptor) {
+            const auto texture = registry.BackendInstance(Detail::RenderResourceClass::Texture, Identity(descriptor.texture));
+            if (texture.HasError())
+                return Result<std::uint64_t>::Failure(texture.ErrorValue());
+            return backend.CreateTextureView(descriptor, texture.Value());
+        }
+
+        [[nodiscard]] Result<std::uint64_t> RealizeRenderTargetRequest(IRenderBackend &backend,
+                                                                       const Detail::RenderResourceRegistry &registry,
+                                                                       const RenderTargetDescriptor &descriptor) {
+            std::uint64_t colorInstance = 0;
+            if (descriptor.colorAttachment.IsValid()) {
+                const auto color = registry.BackendInstance(Detail::RenderResourceClass::TextureView, Identity(descriptor.colorAttachment));
+                if (color.HasError())
+                    return Result<std::uint64_t>::Failure(color.ErrorValue());
+                colorInstance = color.Value();
+            }
+            std::uint64_t depthInstance = 0;
+            if (descriptor.depthAttachment.IsValid()) {
+                const auto depth = registry.BackendInstance(Detail::RenderResourceClass::TextureView, Identity(descriptor.depthAttachment));
+                if (depth.HasError())
+                    return Result<std::uint64_t>::Failure(depth.ErrorValue());
+                depthInstance = depth.Value();
+            }
+            return backend.CreateRenderTarget(descriptor, colorInstance, depthInstance);
+        }
+
         void DestroyResourceInstance(IRenderBackend &backend, const Detail::RenderResourceClass resourceClass,
                                      const std::uint64_t backendInstance) noexcept {
             if (resourceClass == Detail::RenderResourceClass::Buffer) {
                 backend.DestroyBuffer(backendInstance);
                 return;
             }
-            backend.DestroyMesh(backendInstance);
+            if (resourceClass == Detail::RenderResourceClass::Mesh) {
+                backend.DestroyMesh(backendInstance);
+                return;
+            }
+            if (resourceClass == Detail::RenderResourceClass::Texture) {
+                backend.DestroyTexture(backendInstance);
+                return;
+            }
+            if (resourceClass == Detail::RenderResourceClass::TextureView) {
+                backend.DestroyTextureView(backendInstance);
+                return;
+            }
+            backend.DestroyRenderTarget(backendInstance);
         }
     }  // namespace
 
@@ -46,11 +99,35 @@ namespace Horo::Render {
         return {handle.owner, handle.slot, handle.generation};
     }
 
+    Detail::RenderResourceIdentity Identity(const RenderTextureHandle handle) noexcept {
+        return {handle.owner, handle.slot, handle.generation};
+    }
+
+    Detail::RenderResourceIdentity Identity(const RenderTextureViewHandle handle) noexcept {
+        return {handle.owner, handle.slot, handle.generation};
+    }
+
+    Detail::RenderResourceIdentity Identity(const RenderTargetHandle handle) noexcept {
+        return {handle.owner, handle.slot, handle.generation};
+    }
+
     RenderBufferHandle BufferHandle(const Detail::RenderResourceIdentity identity) noexcept {
         return {identity.owner, identity.slot, identity.generation};
     }
 
     RenderMeshHandle MeshHandle(const Detail::RenderResourceIdentity identity) noexcept {
+        return {identity.owner, identity.slot, identity.generation};
+    }
+
+    RenderTextureHandle TextureHandle(const Detail::RenderResourceIdentity identity) noexcept {
+        return {identity.owner, identity.slot, identity.generation};
+    }
+
+    RenderTextureViewHandle TextureViewHandle(const Detail::RenderResourceIdentity identity) noexcept {
+        return {identity.owner, identity.slot, identity.generation};
+    }
+
+    RenderTargetHandle TargetHandle(const Detail::RenderResourceIdentity identity) noexcept {
         return {identity.owner, identity.slot, identity.generation};
     }
 
@@ -62,10 +139,20 @@ namespace Horo::Render {
     Result<std::uint64_t> RealizeResourceRequest(IRenderBackend &backend, const Detail::RenderResourceRegistry &registry,
                                                  const UploadRequest &request) {
         try {
-            if (request.kind == UploadRequestKind::Buffer) {
-                return backend.CreateBuffer(request.buffer, request.initialData);
+            switch (request.kind) {
+                case UploadRequestKind::Buffer:
+                    return backend.CreateBuffer(request.buffer, request.initialData);
+                case UploadRequestKind::Mesh:
+                    return RealizeMeshRequest(backend, registry, request.mesh);
+                case UploadRequestKind::Texture:
+                    return backend.CreateTexture(request.texture);
+                case UploadRequestKind::TextureView:
+                    return RealizeTextureViewRequest(backend, registry, request.textureView);
+                case UploadRequestKind::RenderTarget:
+                    return RealizeRenderTargetRequest(backend, registry, request.renderTarget);
             }
-            return RealizeMeshRequest(backend, registry, request.mesh);
+            return Result<std::uint64_t>::Failure(
+                MakeError(FrontendErrors::ResourceBackendException, "Renderer resource request kind is invalid."));
         } catch (...) {  // NOSONAR(cpp:S2738)
             return Result<std::uint64_t>::Failure(
                 MakeError(FrontendErrors::ResourceBackendException, "Renderer backend resource realization threw an exception."));

--- a/src/runtime/renderer/frontend/RenderResourceOperations.cpp
+++ b/src/runtime/renderer/frontend/RenderResourceOperations.cpp
@@ -71,19 +71,20 @@ namespace Horo::Render {
 
         void DestroyResourceInstance(IRenderBackend &backend, const Detail::RenderResourceClass resourceClass,
                                      const std::uint64_t backendInstance) noexcept {
-            if (resourceClass == Detail::RenderResourceClass::Buffer) {
+            using enum Detail::RenderResourceClass;
+            if (resourceClass == Buffer) {
                 backend.DestroyBuffer(backendInstance);
                 return;
             }
-            if (resourceClass == Detail::RenderResourceClass::Mesh) {
+            if (resourceClass == Mesh) {
                 backend.DestroyMesh(backendInstance);
                 return;
             }
-            if (resourceClass == Detail::RenderResourceClass::Texture) {
+            if (resourceClass == Texture) {
                 backend.DestroyTexture(backendInstance);
                 return;
             }
-            if (resourceClass == Detail::RenderResourceClass::TextureView) {
+            if (resourceClass == TextureView) {
                 backend.DestroyTextureView(backendInstance);
                 return;
             }
@@ -139,16 +140,17 @@ namespace Horo::Render {
     Result<std::uint64_t> RealizeResourceRequest(IRenderBackend &backend, const Detail::RenderResourceRegistry &registry,
                                                  const UploadRequest &request) {
         try {
+            using enum UploadRequestKind;
             switch (request.kind) {
-                case UploadRequestKind::Buffer:
+                case Buffer:
                     return backend.CreateBuffer(request.buffer, request.initialData);
-                case UploadRequestKind::Mesh:
+                case Mesh:
                     return RealizeMeshRequest(backend, registry, request.mesh);
-                case UploadRequestKind::Texture:
+                case Texture:
                     return backend.CreateTexture(request.texture);
-                case UploadRequestKind::TextureView:
+                case TextureView:
                     return RealizeTextureViewRequest(backend, registry, request.textureView);
-                case UploadRequestKind::RenderTarget:
+                case RenderTarget:
                     return RealizeRenderTargetRequest(backend, registry, request.renderTarget);
             }
             return Result<std::uint64_t>::Failure(

--- a/src/runtime/renderer/frontend/RenderResourceOperations.h
+++ b/src/runtime/renderer/frontend/RenderResourceOperations.h
@@ -7,8 +7,14 @@
 namespace Horo::Render {
     [[nodiscard]] Detail::RenderResourceIdentity Identity(RenderBufferHandle handle) noexcept;
     [[nodiscard]] Detail::RenderResourceIdentity Identity(RenderMeshHandle handle) noexcept;
+    [[nodiscard]] Detail::RenderResourceIdentity Identity(RenderTextureHandle handle) noexcept;
+    [[nodiscard]] Detail::RenderResourceIdentity Identity(RenderTextureViewHandle handle) noexcept;
+    [[nodiscard]] Detail::RenderResourceIdentity Identity(RenderTargetHandle handle) noexcept;
     [[nodiscard]] RenderBufferHandle BufferHandle(Detail::RenderResourceIdentity identity) noexcept;
     [[nodiscard]] RenderMeshHandle MeshHandle(Detail::RenderResourceIdentity identity) noexcept;
+    [[nodiscard]] RenderTextureHandle TextureHandle(Detail::RenderResourceIdentity identity) noexcept;
+    [[nodiscard]] RenderTextureViewHandle TextureViewHandle(Detail::RenderResourceIdentity identity) noexcept;
+    [[nodiscard]] RenderTargetHandle TargetHandle(Detail::RenderResourceIdentity identity) noexcept;
     [[nodiscard]] bool FitsBuffer(std::uint32_t elementSize, std::uint32_t elementCount, std::size_t bufferSize) noexcept;
     [[nodiscard]] Result<std::uint64_t> RealizeResourceRequest(IRenderBackend &backend, const Detail::RenderResourceRegistry &registry,
                                                                const Detail::RenderResourceUploadQueue::Request &request);

--- a/src/runtime/renderer/frontend/RenderResourceRegistry.cpp
+++ b/src/runtime/renderer/frontend/RenderResourceRegistry.cpp
@@ -195,6 +195,22 @@ namespace Horo::Render::Detail {
         return Result<void>::Success();
     }
 
+    Result<void> RenderResourceRegistry::CancelPending(const RenderResourceClass resourceClass, const RenderResourceIdentity identity) {
+        auto validated = Validate(resourceClass, identity);
+        if (validated.HasError())
+            return Result<void>::Failure(validated.ErrorValue());
+        Entry &entry = entries_[validated.Value()];
+        if (entry.state != RenderResourceState::Pending)
+            return Result<void>::Failure(
+                RegistryError(FrontendErrors::ResourceNotPending, "Only a pending resource operation can be cancelled."));
+        --pendingRequests_;
+        CompleteOperation(entry.operation, RegistryError(FrontendErrors::ResourceOperationCancelled,
+                                                         "The pending resource operation was cancelled before realization."));
+        entry.state = RenderResourceState::Retiring;
+        QueueRetirementIfEligible(identity.slot);
+        return Result<void>::Success();
+    }
+
     Result<RenderResourceState> RenderResourceRegistry::State(const RenderResourceClass resourceClass,
                                                               const RenderResourceIdentity identity) const {
         auto validated = Validate(resourceClass, identity);

--- a/src/runtime/renderer/frontend/RenderResourceRegistry.h
+++ b/src/runtime/renderer/frontend/RenderResourceRegistry.h
@@ -65,6 +65,7 @@ namespace Horo::Render::Detail {
                                            std::uint64_t backendInstance);
         [[nodiscard]] Result<void> Fail(RenderResourceClass resourceClass, RenderResourceIdentity identity, Error error);
         [[nodiscard]] Result<void> Release(RenderResourceClass resourceClass, RenderResourceIdentity identity);
+        [[nodiscard]] Result<void> CancelPending(RenderResourceClass resourceClass, RenderResourceIdentity identity);
         [[nodiscard]] Result<RenderResourceState> State(RenderResourceClass resourceClass, RenderResourceIdentity identity) const;
         [[nodiscard]] Result<void> OperationResult(ResourceOperationId operation) const;
         [[nodiscard]] Result<std::uint64_t> BackendInstance(RenderResourceClass resourceClass, RenderResourceIdentity identity) const;

--- a/src/runtime/renderer/frontend/RenderResourceUploadQueue.h
+++ b/src/runtime/renderer/frontend/RenderResourceUploadQueue.h
@@ -2,6 +2,7 @@
 
 #include "Horo/Runtime/Render/Mesh.h"
 #include "Horo/Runtime/Render/RenderFrontend.h"
+#include "Horo/Runtime/Render/Texture.h"
 #include "RenderResourceRegistry.h"
 
 #include <deque>
@@ -14,6 +15,9 @@ namespace Horo::Render::Detail {
         enum class RequestKind : std::uint8_t {
             Buffer,
             Mesh,
+            Texture,
+            TextureView,
+            RenderTarget,
         };
 
         struct Request {
@@ -21,6 +25,9 @@ namespace Horo::Render::Detail {
             RenderResourceIdentity identity;
             RenderBufferDescriptor buffer;
             RenderMeshDescriptor mesh;
+            RenderTextureDescriptor texture;
+            RenderTextureViewDescriptor textureView;
+            RenderTargetDescriptor renderTarget;
             std::vector<std::byte> initialData;
             std::optional<RenderResourceIdentity> replacedMesh;
         };
@@ -42,6 +49,18 @@ namespace Horo::Render::Detail {
         void EnqueueMesh(const RenderResourceIdentity identity, const RenderMeshDescriptor &descriptor,
                          const std::optional<RenderResourceIdentity> replacedMesh) {
             requests_.push_back(Request{.kind = RequestKind::Mesh, .identity = identity, .mesh = descriptor, .replacedMesh = replacedMesh});
+        }
+
+        void EnqueueTexture(const RenderResourceIdentity identity, const RenderTextureDescriptor &descriptor) {
+            requests_.push_back(Request{.kind = RequestKind::Texture, .identity = identity, .texture = descriptor});
+        }
+
+        void EnqueueTextureView(const RenderResourceIdentity identity, const RenderTextureViewDescriptor &descriptor) {
+            requests_.push_back(Request{.kind = RequestKind::TextureView, .identity = identity, .textureView = descriptor});
+        }
+
+        void EnqueueRenderTarget(const RenderResourceIdentity identity, const RenderTargetDescriptor &descriptor) {
+            requests_.push_back(Request{.kind = RequestKind::RenderTarget, .identity = identity, .renderTarget = descriptor});
         }
 
         void MarkBackAsReplacement(const RenderResourceIdentity replacedMesh) noexcept {

--- a/src/runtime/renderer/modules/metal/MetalRenderBackend.cpp
+++ b/src/runtime/renderer/modules/metal/MetalRenderBackend.cpp
@@ -83,6 +83,21 @@ namespace Horo::Render {
                                                                      "Metal generic mesh migration is owned by RND-001.5."));
             }
 
+            Result<std::uint64_t> CreateTexture(const RenderTextureDescriptor &) override {
+                return Result<std::uint64_t>::Failure(MakeMetalError(MetalBackendErrors::UnsupportedResourceOperation,
+                                                                     "Metal generic texture migration is owned by RND-001.5."));
+            }
+
+            Result<std::uint64_t> CreateTextureView(const RenderTextureViewDescriptor &, std::uint64_t) override {
+                return Result<std::uint64_t>::Failure(MakeMetalError(MetalBackendErrors::UnsupportedResourceOperation,
+                                                                     "Metal generic texture-view migration is owned by RND-001.5."));
+            }
+
+            Result<std::uint64_t> CreateRenderTarget(const RenderTargetDescriptor &, std::uint64_t, std::uint64_t) override {
+                return Result<std::uint64_t>::Failure(MakeMetalError(MetalBackendErrors::UnsupportedResourceOperation,
+                                                                     "Metal generic render-target migration is owned by RND-001.5."));
+            }
+
             /** @copydoc IRenderBackend::DestroyBuffer */
             void DestroyBuffer(std::uint64_t) noexcept override {
                 // Generic Metal buffers cannot exist until the focused RND-001.5 migration.
@@ -92,6 +107,12 @@ namespace Horo::Render {
             void DestroyMesh(std::uint64_t) noexcept override {
                 // Generic Metal meshes cannot exist until the focused RND-001.5 migration.
             }
+
+            void DestroyTexture(std::uint64_t) noexcept override {}
+
+            void DestroyTextureView(std::uint64_t) noexcept override {}
+
+            void DestroyRenderTarget(std::uint64_t) noexcept override {}
 
             /** @copydoc IRenderBackend::BeginFrame */
             Result<FrameToken> BeginFrame(const FrameDescriptor &descriptor) override {

--- a/src/runtime/renderer/modules/null/NullRenderBackend.cpp
+++ b/src/runtime/renderer/modules/null/NullRenderBackend.cpp
@@ -111,11 +111,17 @@ namespace Horo::Render {
                 // Null resources are opaque monotonic identities with no native allocation to release.
             }
 
-            void DestroyTexture(std::uint64_t) noexcept override {}
+            void DestroyTexture(std::uint64_t) noexcept override {
+                // Null resources are opaque monotonic identities with no native allocation to release.
+            }
 
-            void DestroyTextureView(std::uint64_t) noexcept override {}
+            void DestroyTextureView(std::uint64_t) noexcept override {
+                // Null resources are opaque monotonic identities with no native allocation to release.
+            }
 
-            void DestroyRenderTarget(std::uint64_t) noexcept override {}
+            void DestroyRenderTarget(std::uint64_t) noexcept override {
+                // Null resources are opaque monotonic identities with no native allocation to release.
+            }
 
             /** @copydoc IRenderBackend::BeginFrame */
             Result<FrameToken> BeginFrame(const FrameDescriptor &descriptor) override {

--- a/src/runtime/renderer/modules/null/NullRenderBackend.cpp
+++ b/src/runtime/renderer/modules/null/NullRenderBackend.cpp
@@ -79,6 +79,28 @@ namespace Horo::Render {
                 return NextResourceInstance();
             }
 
+            Result<std::uint64_t> CreateTexture(const RenderTextureDescriptor &descriptor) override {
+                if (!initialized_ || !descriptor.IsValid())
+                    return Result<std::uint64_t>::Failure(
+                        MakeBackendError(NullBackendErrors::InvalidConfig, "Null texture realization request is invalid."));
+                return NextResourceInstance();
+            }
+
+            Result<std::uint64_t> CreateTextureView(const RenderTextureViewDescriptor &descriptor, const std::uint64_t texture) override {
+                if (!initialized_ || !descriptor.IsValid() || texture == 0)
+                    return Result<std::uint64_t>::Failure(
+                        MakeBackendError(NullBackendErrors::InvalidConfig, "Null texture-view realization request is invalid."));
+                return NextResourceInstance();
+            }
+
+            Result<std::uint64_t> CreateRenderTarget(const RenderTargetDescriptor &descriptor, const std::uint64_t colorAttachment,
+                                                     const std::uint64_t depthAttachment) override {
+                if (!initialized_ || !descriptor.IsValid() || (colorAttachment == 0 && depthAttachment == 0))
+                    return Result<std::uint64_t>::Failure(
+                        MakeBackendError(NullBackendErrors::InvalidConfig, "Null render-target realization request is invalid."));
+                return NextResourceInstance();
+            }
+
             /** @copydoc IRenderBackend::DestroyBuffer */
             void DestroyBuffer(std::uint64_t) noexcept override {
                 // Null resources are opaque monotonic identities with no native allocation to release.
@@ -88,6 +110,12 @@ namespace Horo::Render {
             void DestroyMesh(std::uint64_t) noexcept override {
                 // Null resources are opaque monotonic identities with no native allocation to release.
             }
+
+            void DestroyTexture(std::uint64_t) noexcept override {}
+
+            void DestroyTextureView(std::uint64_t) noexcept override {}
+
+            void DestroyRenderTarget(std::uint64_t) noexcept override {}
 
             /** @copydoc IRenderBackend::BeginFrame */
             Result<FrameToken> BeginFrame(const FrameDescriptor &descriptor) override {
@@ -243,6 +271,8 @@ namespace Horo::Render {
                 .backend = RenderBackendId{"null"},
                 .supportsBufferResources = true,
                 .supportsMeshResources = true,
+                .supportsTextureResources = true,
+                .supportsRenderTargetResources = true,
             };
             RenderBackendConfig config_{};
             FramebufferExtent extent_{};

--- a/src/runtime/renderer/modules/opengl/OpenGLBackendInternal.h
+++ b/src/runtime/renderer/modules/opengl/OpenGLBackendInternal.h
@@ -2,23 +2,102 @@
 
 #include "OpenGLBackendModule.h"
 
+#include <algorithm>
+#include <array>
+#include <cstddef>
 #include <cstdint>
+#include <functional>
 
 namespace Horo::Render::Detail {
     using OpenGLViewportFunction = void (*)(std::int32_t x, std::int32_t y, std::int32_t width, std::int32_t height);
     using OpenGLClearColorFunction = void (*)(float red, float green, float blue, float alpha);
     using OpenGLClearFunction = void (*)(std::uint32_t mask);
+    using OpenGLGenerateObjectsFunction = void (*)(std::int32_t count, std::uint32_t *objects);
+    using OpenGLDeleteObjectsFunction = void (*)(std::int32_t count, const std::uint32_t *objects);
+    using OpenGLBindObjectFunction = void (*)(std::uint32_t target, std::uint32_t object);
+    using OpenGLBufferDataFunction = void (*)(std::uint32_t target, std::ptrdiff_t size, const void *data, std::uint32_t usage);
+    using OpenGLVertexAttributePointerFunction = void (*)(std::uint32_t index, std::int32_t size, std::uint32_t type,
+                                                          std::uint8_t normalized, std::int32_t stride, const void *offset);
+    using OpenGLEnableVertexAttributeFunction = void (*)(std::uint32_t index);
+    using OpenGLTextureParameterFunction = void (*)(std::uint32_t target, std::uint32_t parameter, std::int32_t value);
+
+    struct OpenGLTextureImageDescriptor {
+        std::uint32_t target{0};
+        std::int32_t level{0};
+        std::int32_t internalFormat{0};
+        std::int32_t width{0};
+        std::int32_t height{0};
+        std::int32_t border{0};
+        std::uint32_t format{0};
+        std::uint32_t type{0};
+        const void *pixels{nullptr};
+    };
+
+    using OpenGLTextureImageFunction = void (*)(const OpenGLTextureImageDescriptor &descriptor);
+    using OpenGLFramebufferTextureFunction = void (*)(std::uint32_t target, std::uint32_t attachment, std::uint32_t texture,
+                                                      std::int32_t level);
+    using OpenGLCheckFramebufferFunction = std::uint32_t (*)(std::uint32_t target);
+    using OpenGLDrawReadBufferFunction = void (*)(std::uint32_t mode);
 
     struct OpenGLCommandFunctions {
         OpenGLViewportFunction viewport{nullptr};
         OpenGLClearColorFunction clearColor{nullptr};
         OpenGLClearFunction clear{nullptr};
+        OpenGLGenerateObjectsFunction generateBuffers{nullptr};
+        OpenGLDeleteObjectsFunction deleteBuffers{nullptr};
+        OpenGLBindObjectFunction bindBuffer{nullptr};
+        OpenGLBufferDataFunction bufferData{nullptr};
+        OpenGLGenerateObjectsFunction generateVertexArrays{nullptr};
+        OpenGLDeleteObjectsFunction deleteVertexArrays{nullptr};
+        OpenGLBindObjectFunction bindVertexArray{nullptr};
+        OpenGLVertexAttributePointerFunction vertexAttributePointer{nullptr};
+        OpenGLEnableVertexAttributeFunction enableVertexAttribute{nullptr};
+        OpenGLGenerateObjectsFunction generateTextures{nullptr};
+        OpenGLDeleteObjectsFunction deleteTextures{nullptr};
+        OpenGLBindObjectFunction bindTexture{nullptr};
+        OpenGLTextureParameterFunction textureParameter{nullptr};
+        OpenGLTextureImageFunction textureImage{nullptr};
+        OpenGLGenerateObjectsFunction generateFramebuffers{nullptr};
+        OpenGLDeleteObjectsFunction deleteFramebuffers{nullptr};
+        OpenGLBindObjectFunction bindFramebuffer{nullptr};
+        OpenGLFramebufferTextureFunction framebufferTexture{nullptr};
+        OpenGLCheckFramebufferFunction checkFramebuffer{nullptr};
+        OpenGLDrawReadBufferFunction drawBuffer{nullptr};
+        OpenGLDrawReadBufferFunction readBuffer{nullptr};
 
         [[nodiscard]] bool IsValid() const noexcept {
             return viewport != nullptr && clearColor != nullptr && clear != nullptr;
         }
+
+        [[nodiscard]] bool HasResourceFunctions() const noexcept {
+            const std::array available{
+                generateBuffers != nullptr,
+                deleteBuffers != nullptr,
+                bindBuffer != nullptr,
+                bufferData != nullptr,
+                generateVertexArrays != nullptr,
+                deleteVertexArrays != nullptr,
+                bindVertexArray != nullptr,
+                vertexAttributePointer != nullptr,
+                enableVertexAttribute != nullptr,
+                generateTextures != nullptr,
+                deleteTextures != nullptr,
+                bindTexture != nullptr,
+                textureParameter != nullptr,
+                textureImage != nullptr,
+                generateFramebuffers != nullptr,
+                deleteFramebuffers != nullptr,
+                bindFramebuffer != nullptr,
+                framebufferTexture != nullptr,
+                checkFramebuffer != nullptr,
+                drawBuffer != nullptr,
+                readBuffer != nullptr,
+            };
+            return std::ranges::all_of(available, std::identity{});
+        }
     };
 
+    [[nodiscard]] OpenGLCommandFunctions ProductionOpenGLCommandFunctions() noexcept;
     [[nodiscard]] Result<void> RegisterOpenGLRenderBackendWithFunctions(RenderBackendRegistry &registry,
                                                                         IOpenGLPresentationPort &presentationPort,
                                                                         OpenGLBackendOptions options, OpenGLCommandFunctions functions);

--- a/src/runtime/renderer/modules/opengl/OpenGLBackendInternal.h
+++ b/src/runtime/renderer/modules/opengl/OpenGLBackendInternal.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <span>
 
 namespace Horo::Render::Detail {
     using OpenGLViewportFunction = void (*)(std::int32_t x, std::int32_t y, std::int32_t width, std::int32_t height);
@@ -15,9 +16,9 @@ namespace Horo::Render::Detail {
     using OpenGLGenerateObjectsFunction = void (*)(std::int32_t count, std::uint32_t *objects);
     using OpenGLDeleteObjectsFunction = void (*)(std::int32_t count, const std::uint32_t *objects);
     using OpenGLBindObjectFunction = void (*)(std::uint32_t target, std::uint32_t object);
-    using OpenGLBufferDataFunction = void (*)(std::uint32_t target, std::ptrdiff_t size, const void *data, std::uint32_t usage);
+    using OpenGLBufferDataFunction = void (*)(std::uint32_t target, std::span<const std::byte> data, std::uint32_t usage);
     using OpenGLVertexAttributePointerFunction = void (*)(std::uint32_t index, std::int32_t size, std::uint32_t type,
-                                                          std::uint8_t normalized, std::int32_t stride, const void *offset);
+                                                          std::uint8_t normalized, std::int32_t stride, std::uintptr_t offset);
     using OpenGLEnableVertexAttributeFunction = void (*)(std::uint32_t index);
     using OpenGLTextureParameterFunction = void (*)(std::uint32_t target, std::uint32_t parameter, std::int32_t value);
 
@@ -30,7 +31,6 @@ namespace Horo::Render::Detail {
         std::int32_t border{0};
         std::uint32_t format{0};
         std::uint32_t type{0};
-        const void *pixels{nullptr};
     };
 
     using OpenGLTextureImageFunction = void (*)(const OpenGLTextureImageDescriptor &descriptor);
@@ -39,24 +39,30 @@ namespace Horo::Render::Detail {
     using OpenGLCheckFramebufferFunction = std::uint32_t (*)(std::uint32_t target);
     using OpenGLDrawReadBufferFunction = void (*)(std::uint32_t mode);
 
-    struct OpenGLCommandFunctions {
-        OpenGLViewportFunction viewport{nullptr};
-        OpenGLClearColorFunction clearColor{nullptr};
-        OpenGLClearFunction clear{nullptr};
+    struct OpenGLBufferFunctions {
         OpenGLGenerateObjectsFunction generateBuffers{nullptr};
         OpenGLDeleteObjectsFunction deleteBuffers{nullptr};
         OpenGLBindObjectFunction bindBuffer{nullptr};
         OpenGLBufferDataFunction bufferData{nullptr};
+    };
+
+    struct OpenGLVertexArrayFunctions {
         OpenGLGenerateObjectsFunction generateVertexArrays{nullptr};
         OpenGLDeleteObjectsFunction deleteVertexArrays{nullptr};
         OpenGLBindObjectFunction bindVertexArray{nullptr};
         OpenGLVertexAttributePointerFunction vertexAttributePointer{nullptr};
         OpenGLEnableVertexAttributeFunction enableVertexAttribute{nullptr};
+    };
+
+    struct OpenGLTextureFunctions {
         OpenGLGenerateObjectsFunction generateTextures{nullptr};
         OpenGLDeleteObjectsFunction deleteTextures{nullptr};
         OpenGLBindObjectFunction bindTexture{nullptr};
         OpenGLTextureParameterFunction textureParameter{nullptr};
         OpenGLTextureImageFunction textureImage{nullptr};
+    };
+
+    struct OpenGLFramebufferFunctions {
         OpenGLGenerateObjectsFunction generateFramebuffers{nullptr};
         OpenGLDeleteObjectsFunction deleteFramebuffers{nullptr};
         OpenGLBindObjectFunction bindFramebuffer{nullptr};
@@ -64,6 +70,16 @@ namespace Horo::Render::Detail {
         OpenGLCheckFramebufferFunction checkFramebuffer{nullptr};
         OpenGLDrawReadBufferFunction drawBuffer{nullptr};
         OpenGLDrawReadBufferFunction readBuffer{nullptr};
+    };
+
+    struct OpenGLCommandFunctions {
+        OpenGLViewportFunction viewport{nullptr};
+        OpenGLClearColorFunction clearColor{nullptr};
+        OpenGLClearFunction clear{nullptr};
+        OpenGLBufferFunctions buffers;
+        OpenGLVertexArrayFunctions vertexArrays;
+        OpenGLTextureFunctions textures;
+        OpenGLFramebufferFunctions framebuffers;
 
         [[nodiscard]] bool IsValid() const noexcept {
             return viewport != nullptr && clearColor != nullptr && clear != nullptr;
@@ -71,27 +87,27 @@ namespace Horo::Render::Detail {
 
         [[nodiscard]] bool HasResourceFunctions() const noexcept {
             const std::array available{
-                generateBuffers != nullptr,
-                deleteBuffers != nullptr,
-                bindBuffer != nullptr,
-                bufferData != nullptr,
-                generateVertexArrays != nullptr,
-                deleteVertexArrays != nullptr,
-                bindVertexArray != nullptr,
-                vertexAttributePointer != nullptr,
-                enableVertexAttribute != nullptr,
-                generateTextures != nullptr,
-                deleteTextures != nullptr,
-                bindTexture != nullptr,
-                textureParameter != nullptr,
-                textureImage != nullptr,
-                generateFramebuffers != nullptr,
-                deleteFramebuffers != nullptr,
-                bindFramebuffer != nullptr,
-                framebufferTexture != nullptr,
-                checkFramebuffer != nullptr,
-                drawBuffer != nullptr,
-                readBuffer != nullptr,
+                buffers.generateBuffers != nullptr,
+                buffers.deleteBuffers != nullptr,
+                buffers.bindBuffer != nullptr,
+                buffers.bufferData != nullptr,
+                vertexArrays.generateVertexArrays != nullptr,
+                vertexArrays.deleteVertexArrays != nullptr,
+                vertexArrays.bindVertexArray != nullptr,
+                vertexArrays.vertexAttributePointer != nullptr,
+                vertexArrays.enableVertexAttribute != nullptr,
+                textures.generateTextures != nullptr,
+                textures.deleteTextures != nullptr,
+                textures.bindTexture != nullptr,
+                textures.textureParameter != nullptr,
+                textures.textureImage != nullptr,
+                framebuffers.generateFramebuffers != nullptr,
+                framebuffers.deleteFramebuffers != nullptr,
+                framebuffers.bindFramebuffer != nullptr,
+                framebuffers.framebufferTexture != nullptr,
+                framebuffers.checkFramebuffer != nullptr,
+                framebuffers.drawBuffer != nullptr,
+                framebuffers.readBuffer != nullptr,
             };
             return std::ranges::all_of(available, std::identity{});
         }
@@ -100,5 +116,6 @@ namespace Horo::Render::Detail {
     [[nodiscard]] OpenGLCommandFunctions ProductionOpenGLCommandFunctions() noexcept;
     [[nodiscard]] Result<void> RegisterOpenGLRenderBackendWithFunctions(RenderBackendRegistry &registry,
                                                                         IOpenGLPresentationPort &presentationPort,
-                                                                        OpenGLBackendOptions options, OpenGLCommandFunctions functions);
+                                                                        OpenGLBackendOptions options,
+                                                                        const OpenGLCommandFunctions &functions);
 }  // namespace Horo::Render::Detail

--- a/src/runtime/renderer/modules/opengl/OpenGLBackendModule.cpp
+++ b/src/runtime/renderer/modules/opengl/OpenGLBackendModule.cpp
@@ -1,0 +1,26 @@
+#include "OpenGLBackendInternal.h"
+
+namespace Horo::Render {
+    /** @copydoc GetOpenGLRenderBackendModuleInfo */
+    const RenderBackendModuleInfo &GetOpenGLRenderBackendModuleInfo() noexcept {
+        static const RenderBackendModuleInfo info{
+            .id = RenderBackendId{"opengl"},
+            .displayName = "OpenGL",
+            .windowRequirements =
+                RenderHostWindowRequirements{
+                    .presentation = RenderPresentationKind::OpenGL,
+                    .resizable = true,
+                    .highPixelDensity = true,
+                },
+            .supportsInteractivePresentation = true,
+        };
+        return info;
+    }
+
+    /** @copydoc RegisterOpenGLRenderBackend */
+    Result<void> RegisterOpenGLRenderBackend(RenderBackendRegistry &registry, IOpenGLPresentationPort &presentationPort,
+                                             const OpenGLBackendOptions options) {
+        return Detail::RegisterOpenGLRenderBackendWithFunctions(registry, presentationPort, options,
+                                                                Detail::ProductionOpenGLCommandFunctions());
+    }
+}  // namespace Horo::Render

--- a/src/runtime/renderer/modules/opengl/OpenGLBackendModule.h
+++ b/src/runtime/renderer/modules/opengl/OpenGLBackendModule.h
@@ -52,6 +52,9 @@ namespace Horo::Render {
         /** @brief Makes the retained graphics context current on the calling render-capable thread. */
         [[nodiscard]] virtual Result<void> MakeCurrent() = 0;
 
+        /** @brief Loads the linked OpenGL command dispatch after the retained context becomes current. */
+        [[nodiscard]] virtual Result<void> LoadCommandDispatch() = 0;
+
         /**
          * @brief Applies backend-neutral presentation pacing to the retained context.
          * @param mode Requested presentation pacing policy.

--- a/src/runtime/renderer/modules/opengl/OpenGLCommandFunctions.cpp
+++ b/src/runtime/renderer/modules/opengl/OpenGLCommandFunctions.cpp
@@ -1,0 +1,135 @@
+#include "OpenGLBackendInternal.h"
+
+#include <glad/gl.h>
+
+namespace Horo::Render::Detail {
+    namespace {
+        void ProductionViewport(const std::int32_t x, const std::int32_t y, const std::int32_t width, const std::int32_t height) {
+            glViewport(x, y, width, height);
+        }
+
+        void ProductionClearColor(const float red, const float green, const float blue, const float alpha) {
+            glClearColor(red, green, blue, alpha);
+        }
+
+        void ProductionClear(const std::uint32_t mask) {
+            glClear(mask);
+        }
+
+        void ProductionGenerateBuffers(const std::int32_t count, std::uint32_t *objects) {
+            glGenBuffers(count, objects);
+        }
+
+        void ProductionDeleteBuffers(const std::int32_t count, const std::uint32_t *objects) {
+            glDeleteBuffers(count, objects);
+        }
+
+        void ProductionBindBuffer(const std::uint32_t target, const std::uint32_t object) {
+            glBindBuffer(target, object);
+        }
+
+        void ProductionBufferData(const std::uint32_t target, const std::ptrdiff_t size, const void *data, const std::uint32_t usage) {
+            glBufferData(target, size, data, usage);
+        }
+
+        void ProductionGenerateVertexArrays(const std::int32_t count, std::uint32_t *objects) {
+            glGenVertexArrays(count, objects);
+        }
+
+        void ProductionDeleteVertexArrays(const std::int32_t count, const std::uint32_t *objects) {
+            glDeleteVertexArrays(count, objects);
+        }
+
+        void ProductionBindVertexArray(const std::uint32_t, const std::uint32_t object) {
+            glBindVertexArray(object);
+        }
+
+        void ProductionVertexAttributePointer(const std::uint32_t index, const std::int32_t size, const std::uint32_t type,
+                                              const std::uint8_t normalized, const std::int32_t stride, const void *offset) {
+            glVertexAttribPointer(index, size, type, normalized, stride, offset);
+        }
+
+        void ProductionEnableVertexAttribute(const std::uint32_t index) {
+            glEnableVertexAttribArray(index);
+        }
+
+        void ProductionGenerateTextures(const std::int32_t count, std::uint32_t *objects) {
+            glGenTextures(count, objects);
+        }
+
+        void ProductionDeleteTextures(const std::int32_t count, const std::uint32_t *objects) {
+            glDeleteTextures(count, objects);
+        }
+
+        void ProductionBindTexture(const std::uint32_t target, const std::uint32_t object) {
+            glBindTexture(target, object);
+        }
+
+        void ProductionTextureParameter(const std::uint32_t target, const std::uint32_t parameter, const std::int32_t value) {
+            glTexParameteri(target, parameter, value);
+        }
+
+        void ProductionTextureImage(const OpenGLTextureImageDescriptor &descriptor) {
+            glTexImage2D(descriptor.target, descriptor.level, descriptor.internalFormat, descriptor.width, descriptor.height,
+                         descriptor.border, descriptor.format, descriptor.type, descriptor.pixels);
+        }
+
+        void ProductionGenerateFramebuffers(const std::int32_t count, std::uint32_t *objects) {
+            glGenFramebuffers(count, objects);
+        }
+
+        void ProductionDeleteFramebuffers(const std::int32_t count, const std::uint32_t *objects) {
+            glDeleteFramebuffers(count, objects);
+        }
+
+        void ProductionBindFramebuffer(const std::uint32_t target, const std::uint32_t object) {
+            glBindFramebuffer(target, object);
+        }
+
+        void ProductionFramebufferTexture(const std::uint32_t target, const std::uint32_t attachment, const std::uint32_t texture,
+                                          const std::int32_t level) {
+            glFramebufferTexture2D(target, attachment, GL_TEXTURE_2D, texture, level);
+        }
+
+        std::uint32_t ProductionCheckFramebuffer(const std::uint32_t target) {
+            return glCheckFramebufferStatus(target);
+        }
+
+        void ProductionDrawBuffer(const std::uint32_t mode) {
+            glDrawBuffer(mode);
+        }
+
+        void ProductionReadBuffer(const std::uint32_t mode) {
+            glReadBuffer(mode);
+        }
+    }  // namespace
+
+    OpenGLCommandFunctions ProductionOpenGLCommandFunctions() noexcept {
+        return OpenGLCommandFunctions{
+            .viewport = &ProductionViewport,
+            .clearColor = &ProductionClearColor,
+            .clear = &ProductionClear,
+            .generateBuffers = &ProductionGenerateBuffers,
+            .deleteBuffers = &ProductionDeleteBuffers,
+            .bindBuffer = &ProductionBindBuffer,
+            .bufferData = &ProductionBufferData,
+            .generateVertexArrays = &ProductionGenerateVertexArrays,
+            .deleteVertexArrays = &ProductionDeleteVertexArrays,
+            .bindVertexArray = &ProductionBindVertexArray,
+            .vertexAttributePointer = &ProductionVertexAttributePointer,
+            .enableVertexAttribute = &ProductionEnableVertexAttribute,
+            .generateTextures = &ProductionGenerateTextures,
+            .deleteTextures = &ProductionDeleteTextures,
+            .bindTexture = &ProductionBindTexture,
+            .textureParameter = &ProductionTextureParameter,
+            .textureImage = &ProductionTextureImage,
+            .generateFramebuffers = &ProductionGenerateFramebuffers,
+            .deleteFramebuffers = &ProductionDeleteFramebuffers,
+            .bindFramebuffer = &ProductionBindFramebuffer,
+            .framebufferTexture = &ProductionFramebufferTexture,
+            .checkFramebuffer = &ProductionCheckFramebuffer,
+            .drawBuffer = &ProductionDrawBuffer,
+            .readBuffer = &ProductionReadBuffer,
+        };
+    }
+}  // namespace Horo::Render::Detail

--- a/src/runtime/renderer/modules/opengl/OpenGLCommandFunctions.cpp
+++ b/src/runtime/renderer/modules/opengl/OpenGLCommandFunctions.cpp
@@ -1,5 +1,6 @@
 #include "OpenGLBackendInternal.h"
 
+#include <bit>
 #include <glad/gl.h>
 
 namespace Horo::Render::Detail {
@@ -28,8 +29,8 @@ namespace Horo::Render::Detail {
             glBindBuffer(target, object);
         }
 
-        void ProductionBufferData(const std::uint32_t target, const std::ptrdiff_t size, const void *data, const std::uint32_t usage) {
-            glBufferData(target, size, data, usage);
+        void ProductionBufferData(const std::uint32_t target, const std::span<const std::byte> data, const std::uint32_t usage) {
+            glBufferData(target, static_cast<GLsizeiptr>(data.size()), data.data(), usage);
         }
 
         void ProductionGenerateVertexArrays(const std::int32_t count, std::uint32_t *objects) {
@@ -45,8 +46,9 @@ namespace Horo::Render::Detail {
         }
 
         void ProductionVertexAttributePointer(const std::uint32_t index, const std::int32_t size, const std::uint32_t type,
-                                              const std::uint8_t normalized, const std::int32_t stride, const void *offset) {
-            glVertexAttribPointer(index, size, type, normalized, stride, offset);
+                                              const std::uint8_t normalized, const std::int32_t stride, const std::uintptr_t offset) {
+            glVertexAttribPointer(index, size, type, normalized, stride,
+                                  std::bit_cast<const void *>(offset));  // NOSONAR: OpenGL models byte offsets as pointers.
         }
 
         void ProductionEnableVertexAttribute(const std::uint32_t index) {
@@ -71,7 +73,7 @@ namespace Horo::Render::Detail {
 
         void ProductionTextureImage(const OpenGLTextureImageDescriptor &descriptor) {
             glTexImage2D(descriptor.target, descriptor.level, descriptor.internalFormat, descriptor.width, descriptor.height,
-                         descriptor.border, descriptor.format, descriptor.type, descriptor.pixels);
+                         descriptor.border, descriptor.format, descriptor.type, nullptr);
         }
 
         void ProductionGenerateFramebuffers(const std::int32_t count, std::uint32_t *objects) {
@@ -109,27 +111,27 @@ namespace Horo::Render::Detail {
             .viewport = &ProductionViewport,
             .clearColor = &ProductionClearColor,
             .clear = &ProductionClear,
-            .generateBuffers = &ProductionGenerateBuffers,
-            .deleteBuffers = &ProductionDeleteBuffers,
-            .bindBuffer = &ProductionBindBuffer,
-            .bufferData = &ProductionBufferData,
-            .generateVertexArrays = &ProductionGenerateVertexArrays,
-            .deleteVertexArrays = &ProductionDeleteVertexArrays,
-            .bindVertexArray = &ProductionBindVertexArray,
-            .vertexAttributePointer = &ProductionVertexAttributePointer,
-            .enableVertexAttribute = &ProductionEnableVertexAttribute,
-            .generateTextures = &ProductionGenerateTextures,
-            .deleteTextures = &ProductionDeleteTextures,
-            .bindTexture = &ProductionBindTexture,
-            .textureParameter = &ProductionTextureParameter,
-            .textureImage = &ProductionTextureImage,
-            .generateFramebuffers = &ProductionGenerateFramebuffers,
-            .deleteFramebuffers = &ProductionDeleteFramebuffers,
-            .bindFramebuffer = &ProductionBindFramebuffer,
-            .framebufferTexture = &ProductionFramebufferTexture,
-            .checkFramebuffer = &ProductionCheckFramebuffer,
-            .drawBuffer = &ProductionDrawBuffer,
-            .readBuffer = &ProductionReadBuffer,
+            .buffers = {.generateBuffers = &ProductionGenerateBuffers,
+                        .deleteBuffers = &ProductionDeleteBuffers,
+                        .bindBuffer = &ProductionBindBuffer,
+                        .bufferData = &ProductionBufferData},
+            .vertexArrays = {.generateVertexArrays = &ProductionGenerateVertexArrays,
+                             .deleteVertexArrays = &ProductionDeleteVertexArrays,
+                             .bindVertexArray = &ProductionBindVertexArray,
+                             .vertexAttributePointer = &ProductionVertexAttributePointer,
+                             .enableVertexAttribute = &ProductionEnableVertexAttribute},
+            .textures = {.generateTextures = &ProductionGenerateTextures,
+                         .deleteTextures = &ProductionDeleteTextures,
+                         .bindTexture = &ProductionBindTexture,
+                         .textureParameter = &ProductionTextureParameter,
+                         .textureImage = &ProductionTextureImage},
+            .framebuffers = {.generateFramebuffers = &ProductionGenerateFramebuffers,
+                             .deleteFramebuffers = &ProductionDeleteFramebuffers,
+                             .bindFramebuffer = &ProductionBindFramebuffer,
+                             .framebufferTexture = &ProductionFramebufferTexture,
+                             .checkFramebuffer = &ProductionCheckFramebuffer,
+                             .drawBuffer = &ProductionDrawBuffer,
+                             .readBuffer = &ProductionReadBuffer},
         };
     }
 }  // namespace Horo::Render::Detail

--- a/src/runtime/renderer/modules/opengl/OpenGLRenderBackend.cpp
+++ b/src/runtime/renderer/modules/opengl/OpenGLRenderBackend.cpp
@@ -1,26 +1,15 @@
 #include "OpenGLBackendInternal.h"
 #include "OpenGLRenderBackendErrors.h"
 
-#if defined(__APPLE__)
-#include <OpenGL/gl3.h>
-#elif defined(_WIN32)
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-// clang-format off
-#include <windows.h>
-#include <GL/gl.h>
-// clang-format on
-#else
-#include <GL/gl.h>
-#endif
-
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <glad/gl.h>
 #include <limits>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 namespace Horo::Render {
@@ -31,41 +20,54 @@ namespace Horo::Render {
             return MakeError(descriptor, std::move(message));
         }
 
-        /** @brief Dispatches a viewport update through the linked production OpenGL API. */
-        void ProductionViewport(const std::int32_t x, const std::int32_t y, const std::int32_t width, const std::int32_t height) {
-            glViewport(x, y, width, height);
-        }
-
-        /** @brief Dispatches a clear-color update through the linked production OpenGL API. */
-        void ProductionClearColor(const float red, const float green, const float blue, const float alpha) {
-            glClearColor(red, green, blue, alpha);
-        }
-
-        /** @brief Clears selected buffers through the linked production OpenGL API. */
-        void ProductionClear(const std::uint32_t mask) {
-            glClear(mask);
-        }
-
-        /** @brief Returns the complete production OpenGL command dispatch. */
-        [[nodiscard]] Detail::OpenGLCommandFunctions ProductionFunctions() noexcept {
-            return Detail::OpenGLCommandFunctions{
-                .viewport = &ProductionViewport,
-                .clearColor = &ProductionClearColor,
-                .clear = &ProductionClear,
-            };
-        }
-
         /** @brief Serializes ownership of the single context retained by one presentation port. */
         struct OpenGLContextLease {
             bool claimed{false};
         };
+
+        struct OpenGLTextureFormat {
+            std::int32_t internal;
+            std::uint32_t external;
+            std::uint32_t type;
+        };
+
+        [[nodiscard]] OpenGLTextureFormat TextureFormat(const RenderTextureFormat format) noexcept {
+            switch (format) {
+                case RenderTextureFormat::Rgba8Unorm:
+                    return {GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE};
+                case RenderTextureFormat::Depth24Stencil8:
+                    return {GL_DEPTH24_STENCIL8, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8};
+                case RenderTextureFormat::Depth32Float:
+                    return {GL_DEPTH_COMPONENT32F, GL_DEPTH_COMPONENT, GL_FLOAT};
+            }
+            return {};
+        }
+
+        [[nodiscard]] bool IsValidRenderTargetRequest(const RenderTargetDescriptor &descriptor, const std::uint64_t colorAttachment,
+                                                      const std::uint64_t depthAttachment) noexcept {
+            constexpr auto maximumObject = static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max());
+            const std::array valid{
+                descriptor.IsValid(),
+                colorAttachment != 0 || depthAttachment != 0,
+                colorAttachment <= maximumObject,
+                depthAttachment <= maximumObject,
+            };
+            return std::ranges::all_of(valid, std::identity{});
+        }
 
         /** @brief OpenGL backend owning one presentation-port context lifecycle. */
         class OpenGLRenderBackend final : public IRenderBackend {
         public:
             OpenGLRenderBackend(IOpenGLPresentationPort &presentationPort, const OpenGLBackendOptions options,
                                 const Detail::OpenGLCommandFunctions functions, std::shared_ptr<OpenGLContextLease> contextLease) noexcept
-                : presentationPort_(&presentationPort), options_(options), functions_(functions), contextLease_(std::move(contextLease)) {}
+                : presentationPort_(&presentationPort), options_(options), functions_(functions), contextLease_(std::move(contextLease)) {
+                const bool resourcesAvailable = functions_.HasResourceFunctions();
+                capabilities_.supportsOffscreenTargets = resourcesAvailable;
+                capabilities_.supportsBufferResources = resourcesAvailable;
+                capabilities_.supportsMeshResources = resourcesAvailable;
+                capabilities_.supportsTextureResources = resourcesAvailable;
+                capabilities_.supportsRenderTargetResources = resourcesAvailable;
+            }
 
             /** @brief Releases a remaining OpenGL context as a lifecycle fallback. */
             ~OpenGLRenderBackend() override {
@@ -113,6 +115,10 @@ namespace Horo::Render {
                     DestroyContext();
                     return Result<void>::Failure(current.ErrorValue());
                 }
+                if (const Result<void> loaded = presentationPort_->LoadCommandDispatch(); loaded.HasError()) {
+                    DestroyContext();
+                    return Result<void>::Failure(loaded.ErrorValue());
+                }
                 if (const Result<void> presentMode = presentationPort_->SetPresentMode(config.presentMode); presentMode.HasError()) {
                     DestroyContext();
                     return Result<void>::Failure(presentMode.ErrorValue());
@@ -128,25 +134,169 @@ namespace Horo::Render {
             }
 
             /** @copydoc IRenderBackend::CreateBuffer */
-            Result<std::uint64_t> CreateBuffer(const RenderBufferDescriptor &, std::span<const std::byte>) override {
-                return Result<std::uint64_t>::Failure(MakeOpenGLError(OpenGLBackendErrors::UnsupportedResourceOperation,
-                                                                      "OpenGL generic buffer migration is owned by RND-001.4."));
+            Result<std::uint64_t> CreateBuffer(const RenderBufferDescriptor &descriptor,
+                                               const std::span<const std::byte> initialData) override {
+                if (!initialized_ || !functions_.HasResourceFunctions())
+                    return ResourceUnavailable("OpenGL buffer creation is unavailable in the current backend state.");
+                if (!descriptor.IsValid() || initialData.size() != descriptor.byteSize ||
+                    descriptor.byteSize > static_cast<std::size_t>(std::numeric_limits<std::ptrdiff_t>::max()))
+                    return Result<std::uint64_t>::Failure(
+                        MakeOpenGLError(OpenGLBackendErrors::InvalidConfig, "OpenGL buffer creation request is invalid."));
+                std::uint32_t buffer = 0;
+                functions_.generateBuffers(1, &buffer);
+                if (buffer == 0)
+                    return ResourceUnavailable("OpenGL failed to allocate a buffer object.");
+                constexpr std::uint32_t target = GL_ARRAY_BUFFER;
+                functions_.bindBuffer(target, buffer);
+                functions_.bufferData(target, static_cast<std::ptrdiff_t>(initialData.size()), initialData.data(), GL_STATIC_DRAW);
+                functions_.bindBuffer(target, 0);
+                buffers_.insert(buffer);
+                return Result<std::uint64_t>::Success(buffer);
             }
 
             /** @copydoc IRenderBackend::CreateMesh */
-            Result<std::uint64_t> CreateMesh(const RenderMeshDescriptor &, std::uint64_t, std::uint64_t) override {
-                return Result<std::uint64_t>::Failure(MakeOpenGLError(OpenGLBackendErrors::UnsupportedResourceOperation,
-                                                                      "OpenGL generic mesh migration is owned by RND-001.4."));
+            Result<std::uint64_t> CreateMesh(const RenderMeshDescriptor &descriptor, const std::uint64_t vertexBuffer,
+                                             const std::uint64_t indexBuffer) override {
+                if (!initialized_ || !functions_.HasResourceFunctions())
+                    return ResourceUnavailable("OpenGL mesh creation is unavailable in the current backend state.");
+                if (!descriptor.IsValid() || vertexBuffer == 0 || indexBuffer == 0 ||
+                    vertexBuffer > std::numeric_limits<std::uint32_t>::max() || indexBuffer > std::numeric_limits<std::uint32_t>::max())
+                    return Result<std::uint64_t>::Failure(
+                        MakeOpenGLError(OpenGLBackendErrors::InvalidConfig, "OpenGL mesh creation request is invalid."));
+                std::uint32_t vertexArray = 0;
+                functions_.generateVertexArrays(1, &vertexArray);
+                if (vertexArray == 0)
+                    return ResourceUnavailable("OpenGL failed to allocate a mesh vertex array.");
+                functions_.bindVertexArray(0, vertexArray);
+                functions_.bindBuffer(GL_ARRAY_BUFFER, static_cast<std::uint32_t>(vertexBuffer));
+                functions_.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, static_cast<std::uint32_t>(indexBuffer));
+                functions_.vertexAttributePointer(0, 3, GL_FLOAT, GL_FALSE, static_cast<std::int32_t>(descriptor.vertexStride),
+                                                  reinterpret_cast<const void *>(offsetof(MeshVertex, position)));
+                functions_.enableVertexAttribute(0);
+                functions_.vertexAttributePointer(1, 3, GL_FLOAT, GL_FALSE, static_cast<std::int32_t>(descriptor.vertexStride),
+                                                  reinterpret_cast<const void *>(offsetof(MeshVertex, normal)));
+                functions_.enableVertexAttribute(1);
+                functions_.vertexAttributePointer(2, 2, GL_FLOAT, GL_FALSE, static_cast<std::int32_t>(descriptor.vertexStride),
+                                                  reinterpret_cast<const void *>(offsetof(MeshVertex, uv)));
+                functions_.enableVertexAttribute(2);
+                functions_.bindVertexArray(0, 0);
+                functions_.bindBuffer(GL_ARRAY_BUFFER, 0);
+                meshes_.insert(vertexArray);
+                return Result<std::uint64_t>::Success(vertexArray);
+            }
+
+            Result<std::uint64_t> CreateTexture(const RenderTextureDescriptor &descriptor) override {
+                if (!initialized_ || !functions_.HasResourceFunctions())
+                    return ResourceUnavailable("OpenGL texture creation is unavailable in the current backend state.");
+                constexpr auto maximumExtent = static_cast<std::uint32_t>(std::numeric_limits<std::int32_t>::max());
+                if (!descriptor.IsValid() || descriptor.extent.width > maximumExtent || descriptor.extent.height > maximumExtent)
+                    return Result<std::uint64_t>::Failure(
+                        MakeOpenGLError(OpenGLBackendErrors::InvalidConfig, "OpenGL texture creation request is invalid."));
+                std::uint32_t texture = 0;
+                functions_.generateTextures(1, &texture);
+                if (texture == 0)
+                    return ResourceUnavailable("OpenGL failed to allocate a texture object.");
+                functions_.bindTexture(GL_TEXTURE_2D, texture);
+                functions_.textureParameter(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+                functions_.textureParameter(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+                functions_.textureParameter(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+                functions_.textureParameter(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+                const auto format = TextureFormat(descriptor.format);
+                functions_.textureImage({
+                    .target = GL_TEXTURE_2D,
+                    .internalFormat = format.internal,
+                    .width = static_cast<std::int32_t>(descriptor.extent.width),
+                    .height = static_cast<std::int32_t>(descriptor.extent.height),
+                    .format = format.external,
+                    .type = format.type,
+                });
+                functions_.bindTexture(GL_TEXTURE_2D, 0);
+                textureFormats_.insert_or_assign(texture, descriptor.format);
+                textures_.insert(texture);
+                return Result<std::uint64_t>::Success(texture);
+            }
+
+            Result<std::uint64_t> CreateTextureView(const RenderTextureViewDescriptor &descriptor, const std::uint64_t texture) override {
+                if (!initialized_ || !functions_.HasResourceFunctions())
+                    return ResourceUnavailable("OpenGL texture-view creation is unavailable in the current backend state.");
+                if (!descriptor.IsValid() || texture == 0 || texture > std::numeric_limits<std::uint32_t>::max())
+                    return Result<std::uint64_t>::Failure(
+                        MakeOpenGLError(OpenGLBackendErrors::InvalidConfig, "OpenGL texture-view creation request is invalid."));
+                const auto source = textureFormats_.find(static_cast<std::uint32_t>(texture));
+                if (source == textureFormats_.end() || source->second != descriptor.format)
+                    return Result<std::uint64_t>::Failure(
+                        MakeOpenGLError(OpenGLBackendErrors::InvalidConfig, "OpenGL texture-view format does not match its texture."));
+                textureViewFormats_.insert_or_assign(static_cast<std::uint32_t>(texture), descriptor.format);
+                return Result<std::uint64_t>::Success(texture);
+            }
+
+            Result<std::uint64_t> CreateRenderTarget(const RenderTargetDescriptor &descriptor, const std::uint64_t colorAttachment,
+                                                     const std::uint64_t depthAttachment) override {
+                if (!initialized_ || !functions_.HasResourceFunctions())
+                    return ResourceUnavailable("OpenGL render-target creation is unavailable in the current backend state.");
+                if (!IsValidRenderTargetRequest(descriptor, colorAttachment, depthAttachment))
+                    return Result<std::uint64_t>::Failure(
+                        MakeOpenGLError(OpenGLBackendErrors::InvalidConfig, "OpenGL render-target creation request is invalid."));
+                std::uint32_t framebuffer = 0;
+                functions_.generateFramebuffers(1, &framebuffer);
+                if (framebuffer == 0)
+                    return ResourceUnavailable("OpenGL failed to allocate a framebuffer object.");
+                functions_.bindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+                if (colorAttachment != 0)
+                    functions_.framebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, static_cast<std::uint32_t>(colorAttachment), 0);
+                else {
+                    functions_.drawBuffer(GL_NONE);
+                    functions_.readBuffer(GL_NONE);
+                }
+                if (const Result<void> depth = AttachDepthView(depthAttachment); depth.HasError()) {
+                    functions_.bindFramebuffer(GL_FRAMEBUFFER, 0);
+                    functions_.deleteFramebuffers(1, &framebuffer);
+                    return Result<std::uint64_t>::Failure(depth.ErrorValue());
+                }
+                const bool complete = functions_.checkFramebuffer(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
+                functions_.bindFramebuffer(GL_FRAMEBUFFER, 0);
+                if (!complete) {
+                    functions_.deleteFramebuffers(1, &framebuffer);
+                    return ResourceUnavailable("OpenGL framebuffer attachments are incomplete.");
+                }
+                renderTargets_.insert(framebuffer);
+                return Result<std::uint64_t>::Success(framebuffer);
+            }
+
+            [[nodiscard]] Result<void> AttachDepthView(const std::uint64_t depthAttachment) const {
+                if (depthAttachment == 0)
+                    return Result<void>::Success();
+                const auto format = textureViewFormats_.find(static_cast<std::uint32_t>(depthAttachment));
+                if (format == textureViewFormats_.end())
+                    return Result<void>::Failure(
+                        MakeOpenGLError(OpenGLBackendErrors::InvalidConfig, "OpenGL render-target depth view metadata is unavailable."));
+                const std::uint32_t attachment =
+                    format->second == RenderTextureFormat::Depth24Stencil8 ? GL_DEPTH_STENCIL_ATTACHMENT : GL_DEPTH_ATTACHMENT;
+                functions_.framebufferTexture(GL_FRAMEBUFFER, attachment, static_cast<std::uint32_t>(depthAttachment), 0);
+                return Result<void>::Success();
             }
 
             /** @copydoc IRenderBackend::DestroyBuffer */
-            void DestroyBuffer(std::uint64_t) noexcept override {
-                // Generic OpenGL buffers cannot exist until the focused RND-001.4 migration.
+            void DestroyBuffer(const std::uint64_t backendInstance) noexcept override {
+                DeleteTrackedObject(functions_.deleteBuffers, buffers_, backendInstance);
             }
 
             /** @copydoc IRenderBackend::DestroyMesh */
-            void DestroyMesh(std::uint64_t) noexcept override {
-                // Generic OpenGL meshes cannot exist until the focused RND-001.4 migration.
+            void DestroyMesh(const std::uint64_t backendInstance) noexcept override {
+                DeleteTrackedObject(functions_.deleteVertexArrays, meshes_, backendInstance);
+            }
+
+            void DestroyTexture(const std::uint64_t backendInstance) noexcept override {
+                textureFormats_.erase(static_cast<std::uint32_t>(backendInstance));
+                DeleteTrackedObject(functions_.deleteTextures, textures_, backendInstance);
+            }
+
+            void DestroyTextureView(const std::uint64_t backendInstance) noexcept override {
+                textureViewFormats_.erase(static_cast<std::uint32_t>(backendInstance));
+            }
+
+            void DestroyRenderTarget(const std::uint64_t backendInstance) noexcept override {
+                DeleteTrackedObject(functions_.deleteFramebuffers, renderTargets_, backendInstance);
             }
 
             /** @copydoc IRenderBackend::BeginFrame */
@@ -250,11 +400,47 @@ namespace Horo::Render {
             /** @copydoc IRenderBackend::Shutdown */
             void Shutdown() noexcept override {
                 AbortActiveFrame();
+                DestroyRemainingResources();
                 initialized_ = false;
                 DestroyContext();
             }
 
         private:
+            [[nodiscard]] Result<std::uint64_t> ResourceUnavailable(std::string message) const {
+                return Result<std::uint64_t>::Failure(
+                    MakeOpenGLError(OpenGLBackendErrors::UnsupportedResourceOperation, std::move(message)));
+            }
+
+            static void DeleteObject(const Detail::OpenGLDeleteObjectsFunction destroy, const std::uint64_t backendInstance) noexcept {
+                if (destroy != nullptr && backendInstance != 0 && backendInstance <= std::numeric_limits<std::uint32_t>::max()) {
+                    const std::uint32_t object = static_cast<std::uint32_t>(backendInstance);
+                    destroy(1, &object);
+                }
+            }
+
+            static void DeleteTrackedObject(const Detail::OpenGLDeleteObjectsFunction destroy, std::unordered_set<std::uint32_t> &objects,
+                                            const std::uint64_t backendInstance) noexcept {
+                if (backendInstance <= std::numeric_limits<std::uint32_t>::max() &&
+                    objects.erase(static_cast<std::uint32_t>(backendInstance)) > 0)
+                    DeleteObject(destroy, backendInstance);
+            }
+
+            void DestroyRemainingResources() noexcept {
+                const auto destroyAll = [](const Detail::OpenGLDeleteObjectsFunction destroy, std::unordered_set<std::uint32_t> &objects) {
+                    for (const std::uint32_t object : objects)
+                        destroy(1, &object);
+                    objects.clear();
+                };
+                if (functions_.HasResourceFunctions()) {
+                    destroyAll(functions_.deleteFramebuffers, renderTargets_);
+                    destroyAll(functions_.deleteVertexArrays, meshes_);
+                    destroyAll(functions_.deleteTextures, textures_);
+                    destroyAll(functions_.deleteBuffers, buffers_);
+                }
+                textureViewFormats_.clear();
+                textureFormats_.clear();
+            }
+
             [[nodiscard]] Result<void> ValidateActiveFrame(const FrameToken frame) const {
                 if (!initialized_) {
                     return Result<void>::Failure(
@@ -322,6 +508,12 @@ namespace Horo::Render {
             OpenGLBackendOptions options_{};
             Detail::OpenGLCommandFunctions functions_{};
             std::shared_ptr<OpenGLContextLease> contextLease_;
+            std::unordered_map<std::uint32_t, RenderTextureFormat> textureFormats_;
+            std::unordered_map<std::uint32_t, RenderTextureFormat> textureViewFormats_;
+            std::unordered_set<std::uint32_t> buffers_;
+            std::unordered_set<std::uint32_t> meshes_;
+            std::unordered_set<std::uint32_t> textures_;
+            std::unordered_set<std::uint32_t> renderTargets_;
             RenderBackendCapabilities capabilities_{
                 .backend = RenderBackendId{"opengl"},
                 .presentsToWindow = true,
@@ -375,25 +567,4 @@ namespace Horo::Render {
         }
     }  // namespace Detail
 
-    /** @copydoc GetOpenGLRenderBackendModuleInfo */
-    const RenderBackendModuleInfo &GetOpenGLRenderBackendModuleInfo() noexcept {
-        static const RenderBackendModuleInfo info{
-            .id = RenderBackendId{"opengl"},
-            .displayName = "OpenGL",
-            .windowRequirements =
-                RenderHostWindowRequirements{
-                    .presentation = RenderPresentationKind::OpenGL,
-                    .resizable = true,
-                    .highPixelDensity = true,
-                },
-            .supportsInteractivePresentation = true,
-        };
-        return info;
-    }
-
-    /** @copydoc RegisterOpenGLRenderBackend */
-    Result<void> RegisterOpenGLRenderBackend(RenderBackendRegistry &registry, IOpenGLPresentationPort &presentationPort,
-                                             const OpenGLBackendOptions options) {
-        return Detail::RegisterOpenGLRenderBackendWithFunctions(registry, presentationPort, options, ProductionFunctions());
-    }
 }  // namespace Horo::Render

--- a/src/runtime/renderer/modules/opengl/OpenGLRenderBackend.cpp
+++ b/src/runtime/renderer/modules/opengl/OpenGLRenderBackend.cpp
@@ -32,12 +32,13 @@ namespace Horo::Render {
         };
 
         [[nodiscard]] OpenGLTextureFormat TextureFormat(const RenderTextureFormat format) noexcept {
+            using enum RenderTextureFormat;
             switch (format) {
-                case RenderTextureFormat::Rgba8Unorm:
+                case Rgba8Unorm:
                     return {GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE};
-                case RenderTextureFormat::Depth24Stencil8:
+                case Depth24Stencil8:
                     return {GL_DEPTH24_STENCIL8, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8};
-                case RenderTextureFormat::Depth32Float:
+                case Depth32Float:
                     return {GL_DEPTH_COMPONENT32F, GL_DEPTH_COMPONENT, GL_FLOAT};
             }
             return {};
@@ -59,7 +60,7 @@ namespace Horo::Render {
         class OpenGLRenderBackend final : public IRenderBackend {
         public:
             OpenGLRenderBackend(IOpenGLPresentationPort &presentationPort, const OpenGLBackendOptions options,
-                                const Detail::OpenGLCommandFunctions functions, std::shared_ptr<OpenGLContextLease> contextLease) noexcept
+                                const Detail::OpenGLCommandFunctions &functions, std::shared_ptr<OpenGLContextLease> contextLease) noexcept
                 : presentationPort_(&presentationPort), options_(options), functions_(functions), contextLease_(std::move(contextLease)) {
                 const bool resourcesAvailable = functions_.HasResourceFunctions();
                 capabilities_.supportsOffscreenTargets = resourcesAvailable;
@@ -143,13 +144,13 @@ namespace Horo::Render {
                     return Result<std::uint64_t>::Failure(
                         MakeOpenGLError(OpenGLBackendErrors::InvalidConfig, "OpenGL buffer creation request is invalid."));
                 std::uint32_t buffer = 0;
-                functions_.generateBuffers(1, &buffer);
+                functions_.buffers.generateBuffers(1, &buffer);
                 if (buffer == 0)
                     return ResourceUnavailable("OpenGL failed to allocate a buffer object.");
                 constexpr std::uint32_t target = GL_ARRAY_BUFFER;
-                functions_.bindBuffer(target, buffer);
-                functions_.bufferData(target, static_cast<std::ptrdiff_t>(initialData.size()), initialData.data(), GL_STATIC_DRAW);
-                functions_.bindBuffer(target, 0);
+                functions_.buffers.bindBuffer(target, buffer);
+                functions_.buffers.bufferData(target, initialData, GL_STATIC_DRAW);
+                functions_.buffers.bindBuffer(target, 0);
                 buffers_.insert(buffer);
                 return Result<std::uint64_t>::Success(buffer);
             }
@@ -164,23 +165,23 @@ namespace Horo::Render {
                     return Result<std::uint64_t>::Failure(
                         MakeOpenGLError(OpenGLBackendErrors::InvalidConfig, "OpenGL mesh creation request is invalid."));
                 std::uint32_t vertexArray = 0;
-                functions_.generateVertexArrays(1, &vertexArray);
+                functions_.vertexArrays.generateVertexArrays(1, &vertexArray);
                 if (vertexArray == 0)
                     return ResourceUnavailable("OpenGL failed to allocate a mesh vertex array.");
-                functions_.bindVertexArray(0, vertexArray);
-                functions_.bindBuffer(GL_ARRAY_BUFFER, static_cast<std::uint32_t>(vertexBuffer));
-                functions_.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, static_cast<std::uint32_t>(indexBuffer));
-                functions_.vertexAttributePointer(0, 3, GL_FLOAT, GL_FALSE, static_cast<std::int32_t>(descriptor.vertexStride),
-                                                  reinterpret_cast<const void *>(offsetof(MeshVertex, position)));
-                functions_.enableVertexAttribute(0);
-                functions_.vertexAttributePointer(1, 3, GL_FLOAT, GL_FALSE, static_cast<std::int32_t>(descriptor.vertexStride),
-                                                  reinterpret_cast<const void *>(offsetof(MeshVertex, normal)));
-                functions_.enableVertexAttribute(1);
-                functions_.vertexAttributePointer(2, 2, GL_FLOAT, GL_FALSE, static_cast<std::int32_t>(descriptor.vertexStride),
-                                                  reinterpret_cast<const void *>(offsetof(MeshVertex, uv)));
-                functions_.enableVertexAttribute(2);
-                functions_.bindVertexArray(0, 0);
-                functions_.bindBuffer(GL_ARRAY_BUFFER, 0);
+                functions_.vertexArrays.bindVertexArray(0, vertexArray);
+                functions_.buffers.bindBuffer(GL_ARRAY_BUFFER, static_cast<std::uint32_t>(vertexBuffer));
+                functions_.buffers.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, static_cast<std::uint32_t>(indexBuffer));
+                functions_.vertexArrays.vertexAttributePointer(0, 3, GL_FLOAT, GL_FALSE, static_cast<std::int32_t>(descriptor.vertexStride),
+                                                               offsetof(MeshVertex, position));
+                functions_.vertexArrays.enableVertexAttribute(0);
+                functions_.vertexArrays.vertexAttributePointer(1, 3, GL_FLOAT, GL_FALSE, static_cast<std::int32_t>(descriptor.vertexStride),
+                                                               offsetof(MeshVertex, normal));
+                functions_.vertexArrays.enableVertexAttribute(1);
+                functions_.vertexArrays.vertexAttributePointer(2, 2, GL_FLOAT, GL_FALSE, static_cast<std::int32_t>(descriptor.vertexStride),
+                                                               offsetof(MeshVertex, uv));
+                functions_.vertexArrays.enableVertexAttribute(2);
+                functions_.vertexArrays.bindVertexArray(0, 0);
+                functions_.buffers.bindBuffer(GL_ARRAY_BUFFER, 0);
                 meshes_.insert(vertexArray);
                 return Result<std::uint64_t>::Success(vertexArray);
             }
@@ -188,21 +189,21 @@ namespace Horo::Render {
             Result<std::uint64_t> CreateTexture(const RenderTextureDescriptor &descriptor) override {
                 if (!initialized_ || !functions_.HasResourceFunctions())
                     return ResourceUnavailable("OpenGL texture creation is unavailable in the current backend state.");
-                constexpr auto maximumExtent = static_cast<std::uint32_t>(std::numeric_limits<std::int32_t>::max());
-                if (!descriptor.IsValid() || descriptor.extent.width > maximumExtent || descriptor.extent.height > maximumExtent)
+                if (constexpr auto maximumExtent = static_cast<std::uint32_t>(std::numeric_limits<std::int32_t>::max());
+                    !descriptor.IsValid() || descriptor.extent.width > maximumExtent || descriptor.extent.height > maximumExtent)
                     return Result<std::uint64_t>::Failure(
                         MakeOpenGLError(OpenGLBackendErrors::InvalidConfig, "OpenGL texture creation request is invalid."));
                 std::uint32_t texture = 0;
-                functions_.generateTextures(1, &texture);
+                functions_.textures.generateTextures(1, &texture);
                 if (texture == 0)
                     return ResourceUnavailable("OpenGL failed to allocate a texture object.");
-                functions_.bindTexture(GL_TEXTURE_2D, texture);
-                functions_.textureParameter(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-                functions_.textureParameter(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-                functions_.textureParameter(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-                functions_.textureParameter(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+                functions_.textures.bindTexture(GL_TEXTURE_2D, texture);
+                functions_.textures.textureParameter(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+                functions_.textures.textureParameter(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+                functions_.textures.textureParameter(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+                functions_.textures.textureParameter(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
                 const auto format = TextureFormat(descriptor.format);
-                functions_.textureImage({
+                functions_.textures.textureImage({
                     .target = GL_TEXTURE_2D,
                     .internalFormat = format.internal,
                     .width = static_cast<std::int32_t>(descriptor.extent.width),
@@ -210,7 +211,7 @@ namespace Horo::Render {
                     .format = format.external,
                     .type = format.type,
                 });
-                functions_.bindTexture(GL_TEXTURE_2D, 0);
+                functions_.textures.bindTexture(GL_TEXTURE_2D, 0);
                 textureFormats_.insert_or_assign(texture, descriptor.format);
                 textures_.insert(texture);
                 return Result<std::uint64_t>::Success(texture);
@@ -222,8 +223,8 @@ namespace Horo::Render {
                 if (!descriptor.IsValid() || texture == 0 || texture > std::numeric_limits<std::uint32_t>::max())
                     return Result<std::uint64_t>::Failure(
                         MakeOpenGLError(OpenGLBackendErrors::InvalidConfig, "OpenGL texture-view creation request is invalid."));
-                const auto source = textureFormats_.find(static_cast<std::uint32_t>(texture));
-                if (source == textureFormats_.end() || source->second != descriptor.format)
+                if (const auto source = textureFormats_.find(static_cast<std::uint32_t>(texture));
+                    source == textureFormats_.end() || source->second != descriptor.format)
                     return Result<std::uint64_t>::Failure(
                         MakeOpenGLError(OpenGLBackendErrors::InvalidConfig, "OpenGL texture-view format does not match its texture."));
                 textureViewFormats_.insert_or_assign(static_cast<std::uint32_t>(texture), descriptor.format);
@@ -238,25 +239,26 @@ namespace Horo::Render {
                     return Result<std::uint64_t>::Failure(
                         MakeOpenGLError(OpenGLBackendErrors::InvalidConfig, "OpenGL render-target creation request is invalid."));
                 std::uint32_t framebuffer = 0;
-                functions_.generateFramebuffers(1, &framebuffer);
+                functions_.framebuffers.generateFramebuffers(1, &framebuffer);
                 if (framebuffer == 0)
                     return ResourceUnavailable("OpenGL failed to allocate a framebuffer object.");
-                functions_.bindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+                functions_.framebuffers.bindFramebuffer(GL_FRAMEBUFFER, framebuffer);
                 if (colorAttachment != 0)
-                    functions_.framebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, static_cast<std::uint32_t>(colorAttachment), 0);
+                    functions_.framebuffers.framebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                                               static_cast<std::uint32_t>(colorAttachment), 0);
                 else {
-                    functions_.drawBuffer(GL_NONE);
-                    functions_.readBuffer(GL_NONE);
+                    functions_.framebuffers.drawBuffer(GL_NONE);
+                    functions_.framebuffers.readBuffer(GL_NONE);
                 }
                 if (const Result<void> depth = AttachDepthView(depthAttachment); depth.HasError()) {
-                    functions_.bindFramebuffer(GL_FRAMEBUFFER, 0);
-                    functions_.deleteFramebuffers(1, &framebuffer);
+                    functions_.framebuffers.bindFramebuffer(GL_FRAMEBUFFER, 0);
+                    functions_.framebuffers.deleteFramebuffers(1, &framebuffer);
                     return Result<std::uint64_t>::Failure(depth.ErrorValue());
                 }
-                const bool complete = functions_.checkFramebuffer(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
-                functions_.bindFramebuffer(GL_FRAMEBUFFER, 0);
+                const bool complete = functions_.framebuffers.checkFramebuffer(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
+                functions_.framebuffers.bindFramebuffer(GL_FRAMEBUFFER, 0);
                 if (!complete) {
-                    functions_.deleteFramebuffers(1, &framebuffer);
+                    functions_.framebuffers.deleteFramebuffers(1, &framebuffer);
                     return ResourceUnavailable("OpenGL framebuffer attachments are incomplete.");
                 }
                 renderTargets_.insert(framebuffer);
@@ -272,23 +274,23 @@ namespace Horo::Render {
                         MakeOpenGLError(OpenGLBackendErrors::InvalidConfig, "OpenGL render-target depth view metadata is unavailable."));
                 const std::uint32_t attachment =
                     format->second == RenderTextureFormat::Depth24Stencil8 ? GL_DEPTH_STENCIL_ATTACHMENT : GL_DEPTH_ATTACHMENT;
-                functions_.framebufferTexture(GL_FRAMEBUFFER, attachment, static_cast<std::uint32_t>(depthAttachment), 0);
+                functions_.framebuffers.framebufferTexture(GL_FRAMEBUFFER, attachment, static_cast<std::uint32_t>(depthAttachment), 0);
                 return Result<void>::Success();
             }
 
             /** @copydoc IRenderBackend::DestroyBuffer */
             void DestroyBuffer(const std::uint64_t backendInstance) noexcept override {
-                DeleteTrackedObject(functions_.deleteBuffers, buffers_, backendInstance);
+                DeleteTrackedObject(functions_.buffers.deleteBuffers, buffers_, backendInstance);
             }
 
             /** @copydoc IRenderBackend::DestroyMesh */
             void DestroyMesh(const std::uint64_t backendInstance) noexcept override {
-                DeleteTrackedObject(functions_.deleteVertexArrays, meshes_, backendInstance);
+                DeleteTrackedObject(functions_.vertexArrays.deleteVertexArrays, meshes_, backendInstance);
             }
 
             void DestroyTexture(const std::uint64_t backendInstance) noexcept override {
                 textureFormats_.erase(static_cast<std::uint32_t>(backendInstance));
-                DeleteTrackedObject(functions_.deleteTextures, textures_, backendInstance);
+                DeleteTrackedObject(functions_.textures.deleteTextures, textures_, backendInstance);
             }
 
             void DestroyTextureView(const std::uint64_t backendInstance) noexcept override {
@@ -296,7 +298,7 @@ namespace Horo::Render {
             }
 
             void DestroyRenderTarget(const std::uint64_t backendInstance) noexcept override {
-                DeleteTrackedObject(functions_.deleteFramebuffers, renderTargets_, backendInstance);
+                DeleteTrackedObject(functions_.framebuffers.deleteFramebuffers, renderTargets_, backendInstance);
             }
 
             /** @copydoc IRenderBackend::BeginFrame */
@@ -411,14 +413,15 @@ namespace Horo::Render {
                     MakeOpenGLError(OpenGLBackendErrors::UnsupportedResourceOperation, std::move(message)));
             }
 
-            static void DeleteObject(const Detail::OpenGLDeleteObjectsFunction destroy, const std::uint64_t backendInstance) noexcept {
+            template <typename Destroy> static void DeleteObject(const Destroy destroy, const std::uint64_t backendInstance) noexcept {
                 if (destroy != nullptr && backendInstance != 0 && backendInstance <= std::numeric_limits<std::uint32_t>::max()) {
-                    const std::uint32_t object = static_cast<std::uint32_t>(backendInstance);
+                    const auto object = static_cast<std::uint32_t>(backendInstance);
                     destroy(1, &object);
                 }
             }
 
-            static void DeleteTrackedObject(const Detail::OpenGLDeleteObjectsFunction destroy, std::unordered_set<std::uint32_t> &objects,
+            template <typename Destroy>
+            static void DeleteTrackedObject(const Destroy destroy, std::unordered_set<std::uint32_t> &objects,
                                             const std::uint64_t backendInstance) noexcept {
                 if (backendInstance <= std::numeric_limits<std::uint32_t>::max() &&
                     objects.erase(static_cast<std::uint32_t>(backendInstance)) > 0)
@@ -426,16 +429,16 @@ namespace Horo::Render {
             }
 
             void DestroyRemainingResources() noexcept {
-                const auto destroyAll = [](const Detail::OpenGLDeleteObjectsFunction destroy, std::unordered_set<std::uint32_t> &objects) {
+                const auto destroyAll = [](const auto destroy, std::unordered_set<std::uint32_t> &objects) {
                     for (const std::uint32_t object : objects)
                         destroy(1, &object);
                     objects.clear();
                 };
                 if (functions_.HasResourceFunctions()) {
-                    destroyAll(functions_.deleteFramebuffers, renderTargets_);
-                    destroyAll(functions_.deleteVertexArrays, meshes_);
-                    destroyAll(functions_.deleteTextures, textures_);
-                    destroyAll(functions_.deleteBuffers, buffers_);
+                    destroyAll(functions_.framebuffers.deleteFramebuffers, renderTargets_);
+                    destroyAll(functions_.vertexArrays.deleteVertexArrays, meshes_);
+                    destroyAll(functions_.textures.deleteTextures, textures_);
+                    destroyAll(functions_.buffers.deleteBuffers, buffers_);
                 }
                 textureViewFormats_.clear();
                 textureFormats_.clear();
@@ -535,7 +538,7 @@ namespace Horo::Render {
         class OpenGLBackendProvider final : public IRenderBackendProvider {
         public:
             OpenGLBackendProvider(IOpenGLPresentationPort &presentationPort, const OpenGLBackendOptions options,
-                                  const Detail::OpenGLCommandFunctions functions)
+                                  const Detail::OpenGLCommandFunctions &functions)
                 : presentationPort_(&presentationPort), options_(options), functions_(functions) {}
 
             /** @copydoc IRenderBackendProvider::Create */
@@ -554,7 +557,7 @@ namespace Horo::Render {
 
     namespace Detail {
         Result<void> RegisterOpenGLRenderBackendWithFunctions(RenderBackendRegistry &registry, IOpenGLPresentationPort &presentationPort,
-                                                              const OpenGLBackendOptions options, const OpenGLCommandFunctions functions) {
+                                                              const OpenGLBackendOptions options, const OpenGLCommandFunctions &functions) {
             if (!functions.IsValid() || options.majorVersion == 0) {
                 return Result<void>::Failure(
                     MakeOpenGLError(OpenGLBackendErrors::InvalidRegistration, "OpenGL backend registration options are invalid."));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -849,6 +849,7 @@ add_test(NAME HoroExtensionManagerTests COMMAND HoroExtensionManagerTests)
 if (HORO_BUILD_RENDER_OPENGL)
     add_executable(HoroRenderOpenGLTests
             unit/runtime/renderer/OpenGLRenderBackendTests.cpp
+            unit/runtime/renderer/OpenGLRenderResourceTests.cpp
     )
 
     target_compile_features(HoroRenderOpenGLTests PRIVATE cxx_std_20)

--- a/tests/helpers/editor_ui/InteractiveEditorUiTestRenderer.cpp
+++ b/tests/helpers/editor_ui/InteractiveEditorUiTestRenderer.cpp
@@ -36,6 +36,16 @@ namespace Horo::Tests {
         if (!outputExtent.IsValid())
             throw std::invalid_argument("Interactive UI-test renderer requires a valid drawable extent.");
 
+        auto prepared =
+            viewportRenderer_->PrepareResources(*frontend_, Render::RenderSceneView{.camera = ToRenderCamera(previousScene_.camera),
+                                                                                    .meshResources = previousScene_.meshResources,
+                                                                                    .instances = previousScene_.instances,
+                                                                                    .lights = previousScene_.lights});
+        if (prepared.HasError())
+            ThrowRendererError(prepared.ErrorValue());
+        if (prepared.Value().has_value())
+            viewportTarget_ = *prepared.Value();
+
         if (outputExtent.width != outputExtent_.width || outputExtent.height != outputExtent_.height) {
             const Result<void> resized = frontend_->Resize(outputExtent);
             if (resized.HasError())
@@ -58,7 +68,8 @@ namespace Horo::Tests {
     }
 
     void InteractiveEditorUiTestRenderer::RenderViewport(const Editor::EditorViewportSceneView scene) {
-        ExecutePasses(scene, viewportRenderer_->RequestedExtent().IsValid());
+        previousScene_ = scene;
+        ExecutePasses(scene, viewportRenderer_->RequestedExtent().IsValid() && viewportTarget_.IsValid() && viewportRenderer_->IsReady());
     }
 
     void InteractiveEditorUiTestRenderer::Present() {
@@ -94,7 +105,8 @@ namespace Horo::Tests {
             executorAttached_ = false;
         }
         if (frontend_ != nullptr && viewportTarget_.IsValid()) {
-            static_cast<void>(frontend_->ReleaseOffscreenTarget(viewportTarget_));
+            if (!frontend_->Capabilities().supportsRenderTargetResources)
+                static_cast<void>(frontend_->ReleaseOffscreenTarget(viewportTarget_));
             viewportTarget_ = {};
         }
         viewportRenderer_.reset();
@@ -124,10 +136,12 @@ namespace Horo::Tests {
             ThrowRendererError(attached.ErrorValue());
         executorAttached_ = true;
 
-        auto target = frontend_->CreateOffscreenTarget({1, 1});
-        if (target.HasError())
-            ThrowRendererError(target.ErrorValue());
-        viewportTarget_ = target.Value();
+        if (!frontend_->Capabilities().supportsRenderTargetResources) {
+            auto target = frontend_->CreateOffscreenTarget({1, 1});
+            if (target.HasError())
+                ThrowRendererError(target.ErrorValue());
+            viewportTarget_ = target.Value();
+        }
     }
 
     void InteractiveEditorUiTestRenderer::ExecutePasses(const Editor::EditorViewportSceneView scene, const bool includeViewport) {

--- a/tests/helpers/editor_ui/InteractiveEditorUiTestRenderer.h
+++ b/tests/helpers/editor_ui/InteractiveEditorUiTestRenderer.h
@@ -47,6 +47,7 @@ namespace Horo::Tests {
         std::unique_ptr<Editor::IEditorViewportRenderer> viewportRenderer_;
         Render::RenderTargetHandle viewportTarget_{};
         Render::FramebufferExtent outputExtent_{};
+        Editor::EditorViewportSceneView previousScene_{};
         std::optional<Render::RenderFrameScope> frame_;
         std::uint64_t frameNumber_{1};
         bool guiInitialized_{false};

--- a/tests/helpers/editor_ui/InteractiveOpenGlEditorUiTestSurface.cpp
+++ b/tests/helpers/editor_ui/InteractiveOpenGlEditorUiTestSurface.cpp
@@ -63,13 +63,14 @@ namespace Horo::Tests {
                 if (frontend.HasError())
                     ThrowRendererError(frontend.ErrorValue());
 
-                auto viewportRenderer = std::make_unique<Editor::EditorViewportRendererOpenGL>();
+                std::unique_ptr<Render::RenderFrontend> frontendOwner = std::move(frontend).Value();
+                auto viewportRenderer = std::make_unique<Editor::EditorViewportRendererOpenGL>(*frontendOwner);
                 const Result<void> viewportInitialized = viewportRenderer->Initialize();
                 if (viewportInitialized.HasError())
                     ThrowRendererError(viewportInitialized.ErrorValue());
                 auto guiRenderer = std::make_unique<Editor::EditorGuiRendererOpenGL>(*window_, presentationPort_->Context());
-                renderer_ = InteractiveEditorUiTestRenderer::Create(std::move(frontend).Value(), std::move(guiRenderer),
-                                                                    std::move(viewportRenderer));
+                renderer_ =
+                    InteractiveEditorUiTestRenderer::Create(std::move(frontendOwner), std::move(guiRenderer), std::move(viewportRenderer));
                 initialized_ = true;
             }
 

--- a/tests/integration/renderer/EditorViewportOpenGLSmoke.cpp
+++ b/tests/integration/renderer/EditorViewportOpenGLSmoke.cpp
@@ -35,6 +35,53 @@ namespace {
         return {};
     }
 
+    /** @brief Verifies that replacements keep the active viewport usable until publication. */
+    void CheckSeamlessResourceTransition(EditorViewportRendererOpenGL &viewport, RenderFrontend &frontend,
+                                         const EditorViewportSceneView &scene, const RenderTargetHandle activeTarget,
+                                         const EditorViewportTextureView activeTexture) {
+        constexpr EditorViewportExtent activeExtent{512, 384};
+        constexpr EditorViewportExtent resizedExtent{384, 256};
+        std::vector<EditorViewportMeshResourceView> replacementMeshes{scene.meshResources.begin(), scene.meshResources.end()};
+        replacementMeshes.front().handle.generation = 2;
+        std::vector<EditorViewportInstance> replacementInstances{scene.instances.begin(), scene.instances.end()};
+        replacementInstances.front().mesh.generation = 2;
+        const EditorViewportSceneView replacementScene{scene.camera, replacementMeshes, replacementInstances, scene.lights};
+        const RenderSceneView renderScene{ToRenderCamera(replacementScene.camera), replacementScene.meshResources,
+                                          replacementScene.instances, replacementScene.lights};
+
+        viewport.RequestExtent(resizedExtent);
+        auto pendingPreparation = viewport.PrepareResources(frontend, renderScene);
+        Check(pendingPreparation.HasValue() && pendingPreparation.Value() == activeTarget);
+        Check(viewport.IsReady());
+        Check(viewport.TextureView().textureId == activeTexture.textureId);
+        Check(viewport.RequestedExtent() == activeExtent);
+
+        auto begun = frontend.BeginFrame(FrameDescriptor{.frameNumber = 2, .outputExtent = {640, 480}});
+        Check(begun.HasValue());
+        RenderFrameScope frame = std::move(begun).Value();
+        const std::array passes{RenderPassDescriptor{
+            .id = RenderPassId{1},
+            .kind = RenderPassKind::Graphics,
+            .staticMesh =
+                StaticMeshPassDescriptor{.target = activeTarget, .extent = {activeExtent.width, activeExtent.height}, .scene = renderScene},
+        }};
+        Check(frame.Execute(passes).HasValue());
+        Check(frame.Present().HasValue());
+
+        RenderTargetHandle resizedTarget;
+        for (std::size_t attempt = 0; attempt < 4 && !resizedTarget.IsValid(); ++attempt) {
+            viewport.RequestExtent(resizedExtent);
+            auto prepared = viewport.PrepareResources(frontend, renderScene);
+            Check(prepared.HasValue());
+            Check(frontend.ProcessResourceRequests().HasValue());
+            if (prepared.Value().has_value() && *prepared.Value() != activeTarget)
+                resizedTarget = *prepared.Value();
+        }
+        Check(resizedTarget.IsValid());
+        Check(viewport.RequestedExtent() == resizedExtent);
+        Check(viewport.TextureView().textureId != activeTexture.textureId);
+    }
+
 }  // namespace
 
 TEST_CASE("Editor Viewport Open GL Smoke", "[integration][renderer][gpu]") {
@@ -209,6 +256,9 @@ TEST_CASE("Editor Viewport Open GL Smoke", "[integration][renderer][gpu]") {
     const std::size_t center = (static_cast<std::size_t>(height / 2) * width + width / 2) * 4;
     Check(pixels[center] < 150 && pixels[center + 1] > 130 && pixels[center + 2] > 150);
     Check(frame.Present().HasValue());
+
+    CheckSeamlessResourceTransition(viewport, *frontend, viewportScene, viewportTarget, firstTextureView);
+
     frontend->DetachStaticMeshPassExecutor(viewport);
     viewport.Shutdown();
     glBindBuffer(GL_ARRAY_BUFFER, 0);

--- a/tests/integration/renderer/EditorViewportOpenGLSmoke.cpp
+++ b/tests/integration/renderer/EditorViewportOpenGLSmoke.cpp
@@ -21,6 +21,39 @@ namespace {
         REQUIRE((condition));
     }
 
+    /** @brief Uses a real SDL OpenGL context while omitting display-server presentation pacing in headless CI. */
+    class HeadlessOpenGLPresentationPort final : public IOpenGLPresentationPort {
+    public:
+        explicit HeadlessOpenGLPresentationPort(SDL_Window &window) noexcept : port_(window) {}
+
+        Result<void> CreateContext(const OpenGLContextDescriptor &descriptor) override {
+            return port_.CreateContext(descriptor);
+        }
+
+        Result<void> MakeCurrent() override {
+            return port_.MakeCurrent();
+        }
+
+        Result<void> LoadCommandDispatch() override {
+            return port_.LoadCommandDispatch();
+        }
+
+        Result<void> SetPresentMode(PresentMode) override {
+            return Result<void>::Success();
+        }
+
+        Result<void> SwapBuffers() override {
+            return port_.SwapBuffers();
+        }
+
+        void DestroyContext() noexcept override {
+            port_.DestroyContext();
+        }
+
+    private:
+        SdlOpenGLPresentationPort port_;
+    };
+
     RenderTargetHandle PrepareViewportTarget(EditorViewportRendererOpenGL &viewport, RenderFrontend &frontend,
                                              const EditorViewportSceneView &scene) {
         for (std::size_t attempt = 0; attempt < 4; ++attempt) {
@@ -93,7 +126,7 @@ TEST_CASE("Editor Viewport Open GL Smoke", "[integration][renderer][gpu]") {
     SDL_Window *window = SDL_CreateWindow("Horo viewport smoke", 640, 480, SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);
     Check(window != nullptr);
 
-    SdlOpenGLPresentationPort presentationPort{*window};
+    HeadlessOpenGLPresentationPort presentationPort{*window};
     RenderBackendRegistry registry;
     Check(RegisterOpenGLRenderBackend(registry, presentationPort).HasValue());
     Check(registry.Seal().HasValue());

--- a/tests/integration/renderer/EditorViewportOpenGLSmoke.cpp
+++ b/tests/integration/renderer/EditorViewportOpenGLSmoke.cpp
@@ -21,6 +21,20 @@ namespace {
         REQUIRE((condition));
     }
 
+    RenderTargetHandle PrepareViewportTarget(EditorViewportRendererOpenGL &viewport, RenderFrontend &frontend,
+                                             const EditorViewportSceneView &scene) {
+        for (std::size_t attempt = 0; attempt < 4; ++attempt) {
+            auto prepared = viewport.PrepareResources(frontend, RenderSceneView{ToRenderCamera(scene.camera), scene.meshResources,
+                                                                                scene.instances, scene.lights});
+            Check(prepared.HasValue());
+            Check(frontend.ProcessResourceRequests().HasValue());
+            if (prepared.Value().has_value())
+                return *prepared.Value();
+        }
+        Check(false);
+        return {};
+    }
+
 }  // namespace
 
 TEST_CASE("Editor Viewport Open GL Smoke", "[integration][renderer][gpu]") {
@@ -56,7 +70,7 @@ TEST_CASE("Editor Viewport Open GL Smoke", "[integration][renderer][gpu]") {
     glBindVertexArray(callerVertexArray);
     glBindBuffer(GL_ARRAY_BUFFER, callerArrayBuffer);
 
-    EditorViewportRendererOpenGL viewport;
+    EditorViewportRendererOpenGL viewport{*frontend};
     Check(viewport.Initialize().HasValue());
     Runtime::PrimitiveMeshCache meshCache;
     constexpr std::array primitiveTypes{Runtime::PrimitiveMeshType::Box,     Runtime::PrimitiveMeshType::Sphere,
@@ -105,31 +119,22 @@ TEST_CASE("Editor Viewport Open GL Smoke", "[integration][renderer][gpu]") {
     Check(initializedArrayBuffer == static_cast<GLint>(callerArrayBuffer));
     viewport.RequestExtent(EditorViewportExtent{width, height});
     Check(frontend->AttachStaticMeshPassExecutor(viewport).HasValue());
-    auto viewportTargetResult = frontend->CreateOffscreenTarget({width, height});
-    Check(viewportTargetResult.HasValue());
-    const RenderTargetHandle viewportTarget = viewportTargetResult.Value();
+    const RenderTargetHandle viewportTarget = PrepareViewportTarget(viewport, *frontend, viewportScene);
 
     auto begun = frontend->BeginFrame(FrameDescriptor{.frameNumber = 1, .outputExtent = {640, 480}});
     Check(begun.HasValue());
     RenderFrameScope frame = std::move(begun).Value();
-    const std::array passes{
-        RenderPassDescriptor{
-            .id = RenderPassId{1},
-            .kind = RenderPassKind::Graphics,
-            .staticMesh =
-                StaticMeshPassDescriptor{
-                    .target = viewportTarget,
-                    .extent = {width, height},
-                    .scene = RenderSceneView{ToRenderCamera(viewportScene.camera), viewportScene.meshResources, viewportScene.instances,
-                                             viewportScene.lights},
-                },
-        },
-        RenderPassDescriptor{
-            .id = RenderPassId{2},
-            .kind = RenderPassKind::Graphics,
-            .primaryOutput = PrimaryOutputAttachment{},
-        },
-    };
+    const std::array passes{RenderPassDescriptor{
+        .id = RenderPassId{1},
+        .kind = RenderPassKind::Graphics,
+        .staticMesh =
+            StaticMeshPassDescriptor{
+                .target = viewportTarget,
+                .extent = {width, height},
+                .scene = RenderSceneView{ToRenderCamera(viewportScene.camera), viewportScene.meshResources, viewportScene.instances,
+                                         viewportScene.lights},
+            },
+    }};
 
     glViewport(7, 9, 111, 113);
     glClearColor(0.2F, 0.3F, 0.4F, 0.5F);
@@ -144,6 +149,7 @@ TEST_CASE("Editor Viewport Open GL Smoke", "[integration][renderer][gpu]") {
     glDepthMask(GL_FALSE);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, callerDrawFramebuffer);
     glBindFramebuffer(GL_READ_FRAMEBUFFER, callerReadFramebuffer);
+    Check(frame.Execute(passes).HasValue());
 
     GLint restoredDrawFramebuffer = 0;
     GLint restoredReadFramebuffer = 0;
@@ -184,9 +190,6 @@ TEST_CASE("Editor Viewport Open GL Smoke", "[integration][renderer][gpu]") {
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
     glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
 
-    // The primary pass executes after external viewport GL work and re-establishes
-    // the swapchain output state before GUI rendering/presentation.
-    Check(frame.Execute(passes).HasValue());
     Check(viewport.IsReady());
     const EditorViewportTextureView firstTextureView = viewport.TextureView();
     Check(firstTextureView.IsValid());
@@ -207,7 +210,6 @@ TEST_CASE("Editor Viewport Open GL Smoke", "[integration][renderer][gpu]") {
     Check(pixels[center] < 150 && pixels[center + 1] > 130 && pixels[center + 2] > 150);
     Check(frame.Present().HasValue());
     frontend->DetachStaticMeshPassExecutor(viewport);
-    Check(frontend->ReleaseOffscreenTarget(viewportTarget).HasValue());
     viewport.Shutdown();
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindVertexArray(0);

--- a/tests/unit/runtime/renderer/OpenGLRenderBackendTests.cpp
+++ b/tests/unit/runtime/renderer/OpenGLRenderBackendTests.cpp
@@ -26,6 +26,7 @@ namespace {
         Create,
         CreateThrowsAfterRetain,
         MakeCurrent,
+        LoadDispatch,
         PresentMode,
         Swap,
     };
@@ -33,6 +34,7 @@ namespace {
     struct PortState {
         int createCount{0};
         int makeCurrentCount{0};
+        int loadDispatchCount{0};
         int presentModeCount{0};
         int swapCount{0};
         int destroyCount{0};
@@ -63,6 +65,14 @@ namespace {
             ++state_->makeCurrentCount;
             if (state_->failure == PortFailure::MakeCurrent) {
                 return Result<void>::Failure(MakePortError("render.test.current_failed", "Injected make-current failure."));
+            }
+            return Result<void>::Success();
+        }
+
+        Result<void> LoadCommandDispatch() override {
+            ++state_->loadDispatchCount;
+            if (state_->failure == PortFailure::LoadDispatch) {
+                return Result<void>::Failure(MakePortError("render.test.dispatch_failed", "Injected command-dispatch load failure."));
             }
             return Result<void>::Success();
         }
@@ -232,7 +242,7 @@ namespace {
     }
 
     TEST_CASE("Initialization Failures Preserve Typed Errors And Rollback Created Context", "[unit][runtime][renderer]") {
-        constexpr std::array failures{PortFailure::Create, PortFailure::MakeCurrent, PortFailure::PresentMode};
+        constexpr std::array failures{PortFailure::Create, PortFailure::MakeCurrent, PortFailure::LoadDispatch, PortFailure::PresentMode};
         for (const PortFailure failure : failures) {
             PortState portState{.failure = failure};
             FakePresentationPort port{portState};
@@ -265,7 +275,7 @@ namespace {
         Check(portState.destroyCount == 1);
     }
 
-    TEST_CASE("Generic Resources Remain Explicitly Unsupported Before OpenGL Migration", "[unit][runtime][renderer][resource]") {
+    TEST_CASE("Incomplete OpenGL Command Dispatch Rejects Generic Resources", "[unit][runtime][renderer][resource]") {
         PortState portState;
         FakePresentationPort port{portState};
         std::unique_ptr<IRenderBackend> backend = CreateBackend(port);

--- a/tests/unit/runtime/renderer/OpenGLRenderResourceTests.cpp
+++ b/tests/unit/runtime/renderer/OpenGLRenderResourceTests.cpp
@@ -103,11 +103,11 @@ namespace {
 
     void ProbeBindObject(std::uint32_t, std::uint32_t) {}
 
-    void ProbeBufferData(std::uint32_t, std::ptrdiff_t, const void *, std::uint32_t) {
+    void ProbeBufferData(std::uint32_t, std::span<const std::byte>, std::uint32_t) {
         ++resourceCommandState.uploads;
     }
 
-    void ProbeVertexAttributePointer(std::uint32_t, std::int32_t, std::uint32_t, std::uint8_t, std::int32_t, const void *) {}
+    void ProbeVertexAttributePointer(std::uint32_t, std::int32_t, std::uint32_t, std::uint8_t, std::int32_t, std::uintptr_t) {}
 
     void ProbeEnableVertexAttribute(std::uint32_t) {}
 
@@ -128,27 +128,27 @@ namespace {
             .viewport = &ProbeViewport,
             .clearColor = &ProbeClearColor,
             .clear = &ProbeNoOp,
-            .generateBuffers = &ProbeGenerateBuffers,
-            .deleteBuffers = &ProbeDeleteBuffers,
-            .bindBuffer = &ProbeBindObject,
-            .bufferData = &ProbeBufferData,
-            .generateVertexArrays = &ProbeGenerateVertexArrays,
-            .deleteVertexArrays = &ProbeDeleteVertexArrays,
-            .bindVertexArray = &ProbeBindObject,
-            .vertexAttributePointer = &ProbeVertexAttributePointer,
-            .enableVertexAttribute = &ProbeEnableVertexAttribute,
-            .generateTextures = &ProbeGenerateTextures,
-            .deleteTextures = &ProbeDeleteTextures,
-            .bindTexture = &ProbeBindObject,
-            .textureParameter = &ProbeTextureParameter,
-            .textureImage = &ProbeTextureImage,
-            .generateFramebuffers = &ProbeGenerateFramebuffers,
-            .deleteFramebuffers = &ProbeDeleteFramebuffers,
-            .bindFramebuffer = &ProbeBindObject,
-            .framebufferTexture = &ProbeFramebufferTexture,
-            .checkFramebuffer = &ProbeCheckFramebuffer,
-            .drawBuffer = &ProbeNoOp,
-            .readBuffer = &ProbeNoOp,
+            .buffers = {.generateBuffers = &ProbeGenerateBuffers,
+                        .deleteBuffers = &ProbeDeleteBuffers,
+                        .bindBuffer = &ProbeBindObject,
+                        .bufferData = &ProbeBufferData},
+            .vertexArrays = {.generateVertexArrays = &ProbeGenerateVertexArrays,
+                             .deleteVertexArrays = &ProbeDeleteVertexArrays,
+                             .bindVertexArray = &ProbeBindObject,
+                             .vertexAttributePointer = &ProbeVertexAttributePointer,
+                             .enableVertexAttribute = &ProbeEnableVertexAttribute},
+            .textures = {.generateTextures = &ProbeGenerateTextures,
+                         .deleteTextures = &ProbeDeleteTextures,
+                         .bindTexture = &ProbeBindObject,
+                         .textureParameter = &ProbeTextureParameter,
+                         .textureImage = &ProbeTextureImage},
+            .framebuffers = {.generateFramebuffers = &ProbeGenerateFramebuffers,
+                             .deleteFramebuffers = &ProbeDeleteFramebuffers,
+                             .bindFramebuffer = &ProbeBindObject,
+                             .framebufferTexture = &ProbeFramebufferTexture,
+                             .checkFramebuffer = &ProbeCheckFramebuffer,
+                             .drawBuffer = &ProbeNoOp,
+                             .readBuffer = &ProbeNoOp},
         };
     }
 

--- a/tests/unit/runtime/renderer/OpenGLRenderResourceTests.cpp
+++ b/tests/unit/runtime/renderer/OpenGLRenderResourceTests.cpp
@@ -1,0 +1,279 @@
+#include "Horo/Runtime/Render/RenderFrontend.h"
+#include "OpenGLBackendInternal.h"
+
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+
+namespace {
+    using namespace Horo;
+    using namespace Horo::Render;
+
+    void Check(const bool condition) {
+        REQUIRE((condition));
+    }
+
+    class ResourcePresentationPort final : public IOpenGLPresentationPort {
+    public:
+        Result<void> CreateContext(const OpenGLContextDescriptor &) override {
+            return Result<void>::Success();
+        }
+
+        Result<void> MakeCurrent() override {
+            return Result<void>::Success();
+        }
+
+        Result<void> LoadCommandDispatch() override {
+            return Result<void>::Success();
+        }
+
+        Result<void> SetPresentMode(PresentMode) override {
+            return Result<void>::Success();
+        }
+
+        Result<void> SwapBuffers() override {
+            return Result<void>::Success();
+        }
+
+        void DestroyContext() noexcept override {}
+    };
+
+    struct ResourceCommandState {
+        std::uint32_t nextObject{10};
+        int generatedBuffers{0};
+        int deletedBuffers{0};
+        int generatedVertexArrays{0};
+        int deletedVertexArrays{0};
+        int generatedTextures{0};
+        int deletedTextures{0};
+        int generatedFramebuffers{0};
+        int deletedFramebuffers{0};
+        int uploads{0};
+        int attachments{0};
+        bool framebufferComplete{true};
+    };
+
+    ResourceCommandState resourceCommandState;
+
+    void ProbeNoOp(std::uint32_t) {}
+
+    void ProbeViewport(std::int32_t, std::int32_t, std::int32_t, std::int32_t) {}
+
+    void ProbeClearColor(float, float, float, float) {}
+
+    void ProbeGenerateBuffers(const std::int32_t count, std::uint32_t *objects) {
+        resourceCommandState.generatedBuffers += count;
+        for (std::int32_t index = 0; index < count; ++index)
+            objects[index] = resourceCommandState.nextObject++;
+    }
+
+    void ProbeDeleteBuffers(const std::int32_t count, const std::uint32_t *) {
+        resourceCommandState.deletedBuffers += count;
+    }
+
+    void ProbeGenerateVertexArrays(const std::int32_t count, std::uint32_t *objects) {
+        resourceCommandState.generatedVertexArrays += count;
+        for (std::int32_t index = 0; index < count; ++index)
+            objects[index] = resourceCommandState.nextObject++;
+    }
+
+    void ProbeDeleteVertexArrays(const std::int32_t count, const std::uint32_t *) {
+        resourceCommandState.deletedVertexArrays += count;
+    }
+
+    void ProbeGenerateTextures(const std::int32_t count, std::uint32_t *objects) {
+        resourceCommandState.generatedTextures += count;
+        for (std::int32_t index = 0; index < count; ++index)
+            objects[index] = resourceCommandState.nextObject++;
+    }
+
+    void ProbeDeleteTextures(const std::int32_t count, const std::uint32_t *) {
+        resourceCommandState.deletedTextures += count;
+    }
+
+    void ProbeGenerateFramebuffers(const std::int32_t count, std::uint32_t *objects) {
+        resourceCommandState.generatedFramebuffers += count;
+        for (std::int32_t index = 0; index < count; ++index)
+            objects[index] = resourceCommandState.nextObject++;
+    }
+
+    void ProbeDeleteFramebuffers(const std::int32_t count, const std::uint32_t *) {
+        resourceCommandState.deletedFramebuffers += count;
+    }
+
+    void ProbeBindObject(std::uint32_t, std::uint32_t) {}
+
+    void ProbeBufferData(std::uint32_t, std::ptrdiff_t, const void *, std::uint32_t) {
+        ++resourceCommandState.uploads;
+    }
+
+    void ProbeVertexAttributePointer(std::uint32_t, std::int32_t, std::uint32_t, std::uint8_t, std::int32_t, const void *) {}
+
+    void ProbeEnableVertexAttribute(std::uint32_t) {}
+
+    void ProbeTextureParameter(std::uint32_t, std::uint32_t, std::int32_t) {}
+
+    void ProbeTextureImage(const Detail::OpenGLTextureImageDescriptor &) {}
+
+    void ProbeFramebufferTexture(std::uint32_t, std::uint32_t, std::uint32_t, std::int32_t) {
+        ++resourceCommandState.attachments;
+    }
+
+    std::uint32_t ProbeCheckFramebuffer(std::uint32_t) {
+        return resourceCommandState.framebufferComplete ? 0x8CD5U : 0;
+    }
+
+    [[nodiscard]] Detail::OpenGLCommandFunctions ResourceProbeFunctions() noexcept {
+        return {
+            .viewport = &ProbeViewport,
+            .clearColor = &ProbeClearColor,
+            .clear = &ProbeNoOp,
+            .generateBuffers = &ProbeGenerateBuffers,
+            .deleteBuffers = &ProbeDeleteBuffers,
+            .bindBuffer = &ProbeBindObject,
+            .bufferData = &ProbeBufferData,
+            .generateVertexArrays = &ProbeGenerateVertexArrays,
+            .deleteVertexArrays = &ProbeDeleteVertexArrays,
+            .bindVertexArray = &ProbeBindObject,
+            .vertexAttributePointer = &ProbeVertexAttributePointer,
+            .enableVertexAttribute = &ProbeEnableVertexAttribute,
+            .generateTextures = &ProbeGenerateTextures,
+            .deleteTextures = &ProbeDeleteTextures,
+            .bindTexture = &ProbeBindObject,
+            .textureParameter = &ProbeTextureParameter,
+            .textureImage = &ProbeTextureImage,
+            .generateFramebuffers = &ProbeGenerateFramebuffers,
+            .deleteFramebuffers = &ProbeDeleteFramebuffers,
+            .bindFramebuffer = &ProbeBindObject,
+            .framebufferTexture = &ProbeFramebufferTexture,
+            .checkFramebuffer = &ProbeCheckFramebuffer,
+            .drawBuffer = &ProbeNoOp,
+            .readBuffer = &ProbeNoOp,
+        };
+    }
+
+    [[nodiscard]] std::unique_ptr<IRenderBackend> CreateResourceBackend(ResourcePresentationPort &port) {
+        RenderBackendRegistry registry;
+        Check(
+            Detail::RegisterOpenGLRenderBackendWithFunctions(registry, port, OpenGLBackendOptions{}, ResourceProbeFunctions()).HasValue());
+        Check(registry.Seal().HasValue());
+        auto created = registry.Create(RenderBackendId{"opengl"});
+        Check(created.HasValue());
+        return std::move(created).Value();
+    }
+
+    struct ResourceInstances {
+        std::uint64_t vertex{0};
+        std::uint64_t index{0};
+        std::uint64_t mesh{0};
+        std::uint64_t color{0};
+        std::uint64_t depth{0};
+        std::uint64_t colorView{0};
+        std::uint64_t depthView{0};
+        std::uint64_t target{0};
+    };
+
+    /** @brief Creates one triangle's generic buffer and mesh resources. */
+    void CreateMeshResources(IRenderBackend &backend, ResourceInstances &resources) {
+        const std::array<std::byte, sizeof(MeshVertex) * 3> vertices{};
+        const std::array<std::byte, sizeof(std::uint32_t) * 3> indices{};
+        auto vertex = backend.CreateBuffer({.byteSize = vertices.size(),
+                                            .usage = RenderBufferUsage::Vertex,
+                                            .access = RenderBufferAccess::DeviceLocal},
+                                           vertices);
+        auto index =
+            backend.CreateBuffer({.byteSize = indices.size(), .usage = RenderBufferUsage::Index, .access = RenderBufferAccess::DeviceLocal},
+                                 indices);
+        Check(vertex.HasValue() && index.HasValue());
+        auto mesh = backend.CreateMesh({.vertexBuffer = {{1}, 1, 1},
+                                        .indexBuffer = {{1}, 2, 1},
+                                        .vertexStride = sizeof(MeshVertex),
+                                        .vertexCount = 3,
+                                        .indexCount = 3,
+                                        .localBounds = {{-1, -1, -1}, {1, 1, 1}}},
+                                       vertex.Value(), index.Value());
+        Check(mesh.HasValue());
+        resources.vertex = vertex.Value();
+        resources.index = index.Value();
+        resources.mesh = mesh.Value();
+    }
+
+    /** @brief Creates a color/depth texture pair, views, and their render target. */
+    [[nodiscard]] RenderTargetDescriptor CreateTargetResources(IRenderBackend &backend, ResourceInstances &resources) {
+        const RenderTextureDescriptor colorDescriptor{.extent = {64, 32},
+                                                      .format = RenderTextureFormat::Rgba8Unorm,
+                                                      .usage = RenderTextureUsage::Sampled | RenderTextureUsage::RenderAttachment};
+        const RenderTextureDescriptor depthDescriptor{.extent = {64, 32},
+                                                      .format = RenderTextureFormat::Depth24Stencil8,
+                                                      .usage = RenderTextureUsage::RenderAttachment};
+        auto color = backend.CreateTexture(colorDescriptor);
+        auto depth = backend.CreateTexture(depthDescriptor);
+        Check(color.HasValue() && depth.HasValue());
+        auto colorView = backend.CreateTextureView({.texture = {{1}, 3, 1},
+                                                    .format = RenderTextureFormat::Rgba8Unorm,
+                                                    .aspect = RenderTextureAspect::Color},
+                                                   color.Value());
+        auto depthView = backend.CreateTextureView({.texture = {{1}, 4, 1},
+                                                    .format = RenderTextureFormat::Depth24Stencil8,
+                                                    .aspect = RenderTextureAspect::DepthStencil},
+                                                   depth.Value());
+        Check(colorView.HasValue() && depthView.HasValue());
+        const RenderTargetDescriptor descriptor{.colorAttachment = {{1}, 5, 1}, .depthAttachment = {{1}, 6, 1}, .extent = {64, 32}};
+        auto target = backend.CreateRenderTarget(descriptor, colorView.Value(), depthView.Value());
+        Check(target.HasValue());
+        resources.color = color.Value();
+        resources.depth = depth.Value();
+        resources.colorView = colorView.Value();
+        resources.depthView = depthView.Value();
+        resources.target = target.Value();
+        return descriptor;
+    }
+
+    /** @brief Verifies creation accounting and incomplete-framebuffer rollback. */
+    void CheckCreationAndRollback(IRenderBackend &backend, const ResourceInstances &resources, const RenderTargetDescriptor &descriptor) {
+        Check(resourceCommandState.generatedBuffers == 2);
+        Check(resourceCommandState.generatedVertexArrays == 1);
+        Check(resourceCommandState.generatedTextures == 2);
+        Check(resourceCommandState.generatedFramebuffers == 1);
+        Check(resourceCommandState.uploads == 2);
+        Check(resourceCommandState.attachments == 2);
+        resourceCommandState.framebufferComplete = false;
+        auto incomplete = backend.CreateRenderTarget(descriptor, resources.colorView, resources.depthView);
+        Check(incomplete.HasError());
+        Check(incomplete.ErrorValue().code.Value() == "render.opengl.unsupported_resource_operation");
+        Check(resourceCommandState.deletedFramebuffers == 1);
+    }
+
+    /** @brief Destroys resources in dependency order and verifies native release accounting. */
+    void DestroyResources(IRenderBackend &backend, const ResourceInstances &resources) {
+        backend.DestroyRenderTarget(resources.target);
+        backend.DestroyTextureView(resources.depthView);
+        backend.DestroyTextureView(resources.colorView);
+        backend.DestroyTexture(resources.depth);
+        backend.DestroyTexture(resources.color);
+        backend.DestroyMesh(resources.mesh);
+        backend.DestroyBuffer(resources.index);
+        backend.DestroyBuffer(resources.vertex);
+        Check(resourceCommandState.deletedFramebuffers == 2);
+        Check(resourceCommandState.deletedTextures == 2);
+        Check(resourceCommandState.deletedVertexArrays == 1);
+        Check(resourceCommandState.deletedBuffers == 2);
+    }
+}  // namespace
+
+TEST_CASE("OpenGL Generic Resources Realize And Roll Back Through Typed Contracts", "[unit][runtime][renderer][resource]") {
+    resourceCommandState = {};
+    ResourcePresentationPort port;
+    std::unique_ptr<IRenderBackend> backend = CreateResourceBackend(port);
+    Check(backend->Initialize(RenderBackendConfig{}).HasValue());
+    Check(backend->Capabilities().supportsBufferResources);
+    Check(backend->Capabilities().supportsMeshResources);
+    Check(backend->Capabilities().supportsTextureResources);
+    Check(backend->Capabilities().supportsRenderTargetResources);
+    ResourceInstances resources;
+    CreateMeshResources(*backend, resources);
+    const RenderTargetDescriptor targetDescriptor = CreateTargetResources(*backend, resources);
+    CheckCreationAndRollback(*backend, resources, targetDescriptor);
+    DestroyResources(*backend, resources);
+    backend->Shutdown();
+}

--- a/tests/unit/runtime/renderer/RenderFrontendTests.cpp
+++ b/tests/unit/runtime/renderer/RenderFrontendTests.cpp
@@ -44,8 +44,14 @@ namespace {
         int resizeCount{0};
         int createBufferCount{0};
         int createMeshCount{0};
+        int createTextureCount{0};
+        int createTextureViewCount{0};
+        int createRenderTargetCount{0};
         int destroyBufferCount{0};
         int destroyMeshCount{0};
+        int destroyTextureCount{0};
+        int destroyTextureViewCount{0};
+        int destroyRenderTargetCount{0};
         bool failPresentation{false};
         bool throwDuringInitialize{false};
         bool throwDuringResize{false};
@@ -60,6 +66,8 @@ namespace {
         bool throwDuringResourceCreation{false};
         bool supportsBufferResources{true};
         bool supportsMeshResources{true};
+        bool supportsTextureResources{true};
+        bool supportsRenderTargetResources{true};
     };
 
     BackendLifecycleState lifecycleState;
@@ -69,7 +77,9 @@ namespace {
         TrackingBackend()
             : capabilities_{.backend = RenderBackendId{"tracking"},
                             .supportsBufferResources = lifecycleState.supportsBufferResources,
-                            .supportsMeshResources = lifecycleState.supportsMeshResources} {}
+                            .supportsMeshResources = lifecycleState.supportsMeshResources,
+                            .supportsTextureResources = lifecycleState.supportsTextureResources,
+                            .supportsRenderTargetResources = lifecycleState.supportsRenderTargetResources} {}
 
         Result<void> Initialize(const RenderBackendConfig &) override {
             ++lifecycleState.initializeCount;
@@ -114,12 +124,39 @@ namespace {
             return Result<std::uint64_t>::Success(lifecycleState.nextResourceInstance++);
         }
 
+        Result<std::uint64_t> CreateTexture(const RenderTextureDescriptor &) override {
+            ++lifecycleState.createTextureCount;
+            return Result<std::uint64_t>::Success(lifecycleState.nextResourceInstance++);
+        }
+
+        Result<std::uint64_t> CreateTextureView(const RenderTextureViewDescriptor &, std::uint64_t) override {
+            ++lifecycleState.createTextureViewCount;
+            return Result<std::uint64_t>::Success(lifecycleState.nextResourceInstance++);
+        }
+
+        Result<std::uint64_t> CreateRenderTarget(const RenderTargetDescriptor &, std::uint64_t, std::uint64_t) override {
+            ++lifecycleState.createRenderTargetCount;
+            return Result<std::uint64_t>::Success(lifecycleState.nextResourceInstance++);
+        }
+
         void DestroyBuffer(std::uint64_t) noexcept override {
             ++lifecycleState.destroyBufferCount;
         }
 
         void DestroyMesh(std::uint64_t) noexcept override {
             ++lifecycleState.destroyMeshCount;
+        }
+
+        void DestroyTexture(std::uint64_t) noexcept override {
+            ++lifecycleState.destroyTextureCount;
+        }
+
+        void DestroyTextureView(std::uint64_t) noexcept override {
+            ++lifecycleState.destroyTextureViewCount;
+        }
+
+        void DestroyRenderTarget(std::uint64_t) noexcept override {
+            ++lifecycleState.destroyRenderTargetCount;
         }
 
         Result<FrameToken> BeginFrame(const FrameDescriptor &descriptor) override {
@@ -315,6 +352,71 @@ namespace {
         Check(frontend->ReleaseMesh(mesh.Value().handle).HasValue());
         Check(lifecycleState.destroyMeshCount == 1);
         Check(lifecycleState.destroyBufferCount == 2);
+    }
+
+    TEST_CASE("Frontend Publishes Texture Views And Targets With Dependency-Pinned Retirement", "[unit][runtime][renderer][resource]") {
+        lifecycleState = {};
+        std::unique_ptr<RenderFrontend> frontend = CreateTrackingFrontend();
+        const RenderTextureDescriptor colorDescriptor{.extent = {320, 180},
+                                                      .format = RenderTextureFormat::Rgba8Unorm,
+                                                      .usage = RenderTextureUsage::Sampled | RenderTextureUsage::RenderAttachment};
+        const RenderTextureDescriptor depthDescriptor{.extent = {320, 180},
+                                                      .format = RenderTextureFormat::Depth24Stencil8,
+                                                      .usage = RenderTextureUsage::RenderAttachment};
+        auto color = frontend->CreateTexture(colorDescriptor);
+        auto depth = frontend->CreateTexture(depthDescriptor);
+        Check(color.HasValue() && depth.HasValue());
+        Check(frontend->CreateTextureView({}).ErrorValue().code.Value() == "render.frontend.resource.invalid_texture_view_descriptor");
+        Check(frontend
+                  ->CreateTextureView(
+                      {.texture = color.Value().handle, .format = RenderTextureFormat::Rgba8Unorm, .aspect = RenderTextureAspect::Color})
+                  .ErrorValue()
+                  .code.Value() == "render.frontend.resource.dependency_not_ready");
+        Check(frontend->ProcessResourceRequests().Value() == 2);
+
+        auto colorView = frontend->CreateTextureView(
+            {.texture = color.Value().handle, .format = RenderTextureFormat::Rgba8Unorm, .aspect = RenderTextureAspect::Color});
+        auto depthView = frontend->CreateTextureView(
+            {.texture = depth.Value().handle, .format = RenderTextureFormat::Depth24Stencil8, .aspect = RenderTextureAspect::DepthStencil});
+        Check(colorView.HasValue() && depthView.HasValue());
+        Check(frontend->ProcessResourceRequests().Value() == 2);
+        auto target = frontend->CreateRenderTarget(
+            {.colorAttachment = colorView.Value().handle, .depthAttachment = depthView.Value().handle, .extent = {320, 180}});
+        Check(target.HasValue());
+        Check(frontend->ProcessResourceRequests().Value() == 1);
+        Check(frontend->ResourceState(target.Value().handle).Value() == RenderResourceState::Ready);
+
+        Check(frontend->ReleaseTexture(color.Value().handle).HasValue());
+        Check(frontend->ReleaseTextureView(colorView.Value().handle).HasValue());
+        Check(lifecycleState.destroyTextureCount == 0);
+        Check(lifecycleState.destroyTextureViewCount == 0);
+        Check(frontend->ReleaseRenderTarget(target.Value().handle).HasValue());
+        Check(lifecycleState.destroyRenderTargetCount == 1);
+        Check(lifecycleState.destroyTextureViewCount == 1);
+        Check(lifecycleState.destroyTextureCount == 1);
+        Check(frontend->ReleaseTextureView(depthView.Value().handle).HasValue());
+        Check(frontend->ReleaseTexture(depth.Value().handle).HasValue());
+        Check(lifecycleState.destroyTextureViewCount == 2);
+        Check(lifecycleState.destroyTextureCount == 2);
+    }
+
+    TEST_CASE("Frontend Cancels Pending Resource Generations Without Leaking Late Realization", "[unit][runtime][renderer][resource]") {
+        lifecycleState = {};
+        std::unique_ptr<RenderFrontend> frontend = CreateTrackingFrontend();
+        const std::array<std::byte, 16> bytes{};
+        auto buffer = frontend->CreateBuffer({.byteSize = bytes.size(),
+                                              .usage = RenderBufferUsage::Vertex,
+                                              .access = RenderBufferAccess::DeviceLocal},
+                                             bytes);
+        Check(buffer.HasValue());
+        Check(frontend->ReleaseBuffer(buffer.Value().handle).HasValue());
+        const Result<void> completion = frontend->ResourceOperationResult(buffer.Value().operation);
+        Check(completion.HasError());
+        Check(completion.ErrorValue().code.Value() == "render.frontend.resource.operation_cancelled");
+        Check(frontend->ProcessResourceRequests().Value() == 1);
+        Check(lifecycleState.createBufferCount == 1);
+        Check(lifecycleState.destroyBufferCount == 1);
+        Check(frontend->ResourceState(buffer.Value().handle).ErrorValue().code.Value() == "render.frontend.resource.stale");
     }
 
     TEST_CASE("Frontend Mesh Replacement Preserves The Old Generation On Failure", "[unit][runtime][renderer][resource]") {


### PR DESCRIPTION
## Summary
- Migrates OpenGL editor viewport meshes, textures, views, and render targets to typed frontend-owned resource handles.
- Adds backend-neutral texture contracts, bounded queued realization, dependency-pinned retirement, OpenGL realization, and explicit Null/Metal capability behavior.
- Preserves OpenGL state across viewport execution and moves backend identities behind a private editor/OpenGL bridge.

## Motivation
- The editor viewport still owned native OpenGL resource lifetimes directly, bypassing the renderer frontend ownership and lifecycle contract.

## Implementation Notes
- Resource creation remains explicit and bounded at frontend frame-safe points.
- Texture views and render targets pin their dependencies until retirement drains.
- OpenGL context creation now loads command dispatch only after the context is current.
- Metal remains explicitly unsupported for the new generic resource capability in this ticket; backend parity work remains separate.
- Error descriptors use the existing designated-field format and typed error codes.

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [x] Manual smoke tested if applicable

Commands run:
```bash
cmake -S . -B build/horo293-skeleton -G Ninja -DBUILD_TESTING=ON -DHORO_ENABLE_GPU_SMOKE_TESTS=ON
cmake --build build/horo293-skeleton --parallel
ctest --test-dir build/horo293-skeleton --output-on-failure
codacy-cli analyze --tool lizard --format sarif --output /tmp/horo-293-codacy-final-2.sarif
sonar analyze --base origin/main --project abdullahbodur_horo-engine --force --format json
```

Result: 669/669 CTest tests passed, including OpenGL and Metal GPU smoke plus both editor first-frame tests. Codacy reported no new resource-test complexity finding after refactoring. Sonar secret analysis reported zero issues; local C++ Vortex analysis is unavailable for the organization and returned 403, so PR analysis remains authoritative.

## Risks
- OpenGL resource realization and editor integration are exercised on macOS; CI remains responsible for Linux and Windows compiler/backend coverage.
- Repository Python tests were skipped by configure because pytest is unavailable in this local environment.

## Issue Links

- Jira: HORO-293
- GitHub: Closes #293

## Reviewer Notes
- Review the public contracts first in `Texture.h`, `RenderBackend.h`, and `RenderFrontend.h`.
- Then review frontend lifetime/retirement logic, OpenGL realization, and finally viewport integration and smoke coverage.