### PR TITLE
feat(extensions): enforce bounded manifest validation HORO-71 #71 [EXT-001.3]

### DIFF
--- a/examples/extensions/asset-importer-basic/extension.json
+++ b/examples/extensions/asset-importer-basic/extension.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": 1,
   "id": "com.horo.examples.asset-importer-basic",
   "displayName": "Basic Asset Importer Example",
   "description": "Minimal external importer and preview provider using Horo's versioned C ABI.",

--- a/include/Horo/Extensions/ExtensionManifest.h
+++ b/include/Horo/Extensions/ExtensionManifest.h
@@ -1,11 +1,32 @@
 #pragma once
 
+/**
+ * @file ExtensionManifest.h
+ * @brief Bounded extension manifest parsing and validated package metadata.
+ */
+
 #include "Horo/Foundation/Result.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace Horo::Extensions {
+    /** @brief Resource limits applied before an untrusted manifest can reach extension resolution. */
+    struct ExtensionManifestLimits {
+        std::size_t maximumDocumentBytes{64U * 1024U}; /**< Maximum encoded JSON document size. */
+        std::size_t maximumNestingDepth{16};           /**< Maximum number of nested JSON containers. */
+        std::size_t maximumObjectMembers{512};         /**< Maximum object members across the document. */
+        std::size_t maximumArrayElements{512};         /**< Maximum array elements across the document. */
+        std::size_t maximumStringBytes{4U * 1024U};    /**< Maximum decoded bytes in one general string. */
+        std::size_t maximumIdentifierBytes{256};       /**< Maximum decoded bytes in one stable identity. */
+        std::size_t maximumModules{64};                /**< Maximum modules declared by one package. */
+        std::size_t maximumContributions{256};         /**< Maximum contributions declared by one package. */
+        std::size_t maximumPlatforms{32};              /**< Maximum compatibility platforms. */
+    };
+
     /** @brief One versioned native or declarative module exported by an extension package. */
     struct ExtensionModuleManifest {
         std::string id;      /**< Stable module identity. */
@@ -23,6 +44,7 @@ namespace Horo::Extensions {
 
     /** @brief Represents a parsed extension.json manifest. */
     struct ExtensionManifest {
+        std::uint32_t schemaVersion{1};
         std::string id;
         std::string version;
         std::string kind;
@@ -43,10 +65,12 @@ namespace Horo::Extensions {
     };
 
     /**
-     * @brief Parses an extension.json file.
-     * @param jsonContent The content of the extension.json file.
-     * @return Result containing the parsed manifest, or an error.
+     * @brief Parses and validates an untrusted extension.json document without loading extension code.
+     * @param jsonContent Encoded JSON content; the returned manifest owns every decoded value.
+     * @param limits Resource limits enforced during syntax and schema decoding.
+     * @return Validated manifest, or an error whose diagnostic message starts with the exact JSON field path.
      */
-    [[nodiscard]] Result<ExtensionManifest> ParseExtensionManifest(const std::string &jsonContent);
+    [[nodiscard]] Result<ExtensionManifest> ParseExtensionManifest(std::string_view jsonContent,
+                                                                   const ExtensionManifestLimits &limits = {});
 
 }  // namespace Horo::Extensions

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -673,6 +673,7 @@ endif ()
 add_library(HoroExtensions STATIC
         extensions/host/ExtensionManager.cpp
         extensions/manifest/ExtensionManifestParser.cpp
+        extensions/manifest/ExtensionManifestJson.cpp
         extensions/registry/ExtensionErrors.cpp
         extensions/registry/ExtensionInventory.cpp
         extensions/marketplace/ExtensionMarketplace.cpp

--- a/src/extensions/host/ExtensionManager.cpp
+++ b/src/extensions/host/ExtensionManager.cpp
@@ -121,10 +121,11 @@ namespace Horo::Extensions {
 
             const fs::path manifestPath = requestedRoot / "extension.json";
             std::error_code fileError;
-            const std::uintmax_t manifestBytes = fs::file_size(manifestPath, fileError);
-            if (fileError || manifestBytes > kManifestLimits.maximumDocumentBytes)
+            if (const std::uintmax_t manifestBytes = fs::file_size(manifestPath, fileError);
+                fileError || manifestBytes > kManifestLimits.maximumDocumentBytes) {
                 return Result<ExtensionManifest>::Failure(
                     MakeError(ExtensionErrors::InvalidManifest, "Extension manifest is unavailable or exceeds the bounded size."));
+            }
             std::ifstream fileStream(manifestPath, std::ios::binary);
             if (!fileStream.is_open())
                 return Result<ExtensionManifest>::Failure(MakeError(ExtensionErrors::InvalidManifest, "Could not open extension.json"));
@@ -144,6 +145,100 @@ namespace Horo::Extensions {
                 return Result<ExtensionManifest>::Failure(
                     MakeError(ExtensionErrors::InvalidManifest, "The current native loader requires exactly one module per package."));
             return Result<ExtensionManifest>::Success(std::move(manifest));
+        }
+
+        /** @brief Invokes an extension entry point while containing exceptions at the ABI boundary. */
+        [[nodiscard]] HoroExtensionStatus InvokeExtensionLoad(const HoroExtensionLoadFunc loadFunc, HoroExtensionHostApi &hostApi,
+                                                              HoroExtensionModuleApi &moduleApi, const std::string &extensionId) {
+            try {
+                return loadFunc(&hostApi, &moduleApi);
+            } catch (const std::runtime_error &exception) {  // NOSONAR(cpp:S1181)
+                LOG_ERROR("extensions", "Extension %s threw runtime error during load: %s", extensionId.c_str(), exception.what());
+            } catch (const std::logic_error &exception) {  // NOSONAR(cpp:S1181)
+                LOG_ERROR("extensions", "Extension %s threw logic error during load: %s", extensionId.c_str(), exception.what());
+            } catch (const std::bad_alloc &exception) {  // NOSONAR(cpp:S1181)
+                LOG_ERROR("extensions", "Extension %s threw bad alloc during load: %s", extensionId.c_str(), exception.what());
+            } catch (const std::exception &exception) {  // NOSONAR(cpp:S1181)
+                LOG_ERROR("extensions", "Extension %s threw during load: %s", extensionId.c_str(), exception.what());
+            } catch (...) {  // NOSONAR(cpp:S1181)
+                LOG_ERROR("extensions", "Extension %s threw unknown exception during load.", extensionId.c_str());
+            }
+            return HORO_EXTENSION_ERROR_INIT_FAILED;
+        }
+
+        /** @brief Checks the loaded module identity against the validated manifest declaration. */
+        [[nodiscard]] bool MatchesDeclaredModule(const HoroExtensionModuleApi &moduleApi, const std::string_view declaredId,
+                                                 const std::string_view declaredVersion) noexcept {
+            return IsValidBoundedText(moduleApi.moduleId) && IsValidBoundedText(moduleApi.moduleVersion) &&
+                   (View(moduleApi.moduleId).empty() || View(moduleApi.moduleId) == declaredId) &&
+                   (View(moduleApi.moduleVersion).empty() || View(moduleApi.moduleVersion) == declaredVersion);
+        }
+
+        /** @brief Owns a validated native module and its staged importer contributions. */
+        struct ActivatedModule {
+            std::shared_ptr<ExtensionModuleLifetime> lifetime;
+            std::vector<Assets::AssetImporterContribution> contributions;
+        };
+
+        /** @brief Loads and validates one native module while retaining rollback ownership. */
+        [[nodiscard]] Result<ActivatedModule> ActivateModule(const std::shared_ptr<Platform::DynamicLibrary> &library,
+                                                             const ExtensionManifest &manifest,
+                                                             const ExtensionModuleManifest &manifestModule) {
+            const auto loadFunc = reinterpret_cast<HoroExtensionLoadFunc>(library->GetSymbol("horo_extension_load"));  // NOSONAR(cpp:S3630)
+            if (loadFunc == nullptr)
+                return Result<ActivatedModule>::Failure(
+                    MakeError(ExtensionErrors::MissingEntryPoint, "Symbol horo_extension_load not found"));
+
+            auto lifetime = std::make_shared<ExtensionModuleLifetime>();
+            lifetime->library = library;
+            lifetime->unload =
+                reinterpret_cast<HoroExtensionUnloadFunc>(library->GetSymbol("horo_extension_unload"));  // NOSONAR(cpp:S3630)
+            AssetImporterRegistrationSession registration{
+                .manifest = &manifest,
+                .extensionModule = &manifestModule,
+                .lifetime = lifetime,
+            };
+            constexpr std::string_view engineVersion = "0.1.0";
+            HoroExtensionHostApi hostApi{
+                .structSize = sizeof(HoroExtensionHostApi),
+                .abiVersion = HORO_EXTENSION_ABI_VERSION,
+                .engineVersion = {engineVersion.data(), static_cast<std::uint32_t>(engineVersion.size())},
+                .hostContext = &registration,
+                .registerAssetImporter = RegisterExternalAssetImporter,
+            };
+            HoroExtensionModuleApi moduleApi{.structSize = sizeof(HoroExtensionModuleApi)};
+            const HoroExtensionStatus status = InvokeExtensionLoad(loadFunc, hostApi, moduleApi, manifest.id);
+            if (status != HORO_EXTENSION_SUCCESS || registration.failed) {
+                SafeUnload(lifetime->unload, moduleApi, "rollback");
+                if (registration.failed)
+                    return Result<ActivatedModule>::Failure(std::move(registration.error));
+                return Result<ActivatedModule>::Failure(
+                    MakeError(ExtensionErrors::LoadFailed, "Extension load function returned an error."));
+            }
+            if (!MatchesDeclaredModule(moduleApi, manifestModule.id, manifestModule.version)) {
+                SafeUnload(lifetime->unload, moduleApi, "validation failure");
+                return Result<ActivatedModule>::Failure(
+                    MakeError(ExtensionErrors::InvalidManifest, "Loaded module identity/version does not match extension.json."));
+            }
+            lifetime->moduleApi = moduleApi;
+            lifetime->loaded = true;
+            return Result<ActivatedModule>::Success(
+                {.lifetime = std::move(lifetime), .contributions = std::move(registration.contributions)});
+        }
+
+        /** @brief Atomically commits staged importer contributions to the host catalog. */
+        [[nodiscard]] Result<void> CommitContributions(std::vector<Assets::AssetImporterContribution> &contributions,
+                                                       Assets::AssetImporterCatalog *importerCatalog) {
+            if (contributions.empty())
+                return Result<void>::Success();
+            if (importerCatalog == nullptr)
+                return Result<void>::Failure(
+                    MakeError(ExtensionErrors::ContributionRejected, "The host did not provide an asset importer catalog."));
+            if (auto registered = importerCatalog->RegisterBatch(std::move(contributions)); registered.HasError()) {
+                return Result<void>::Failure(MakeError(ExtensionErrors::ContributionRejected,
+                                                       "The complete extension contribution batch conflicted with the host catalog."));
+            }
+            return Result<void>::Success();
         }
 
     }  // namespace
@@ -197,83 +292,16 @@ namespace Horo::Extensions {
             return Result<std::string>::Failure(loadResult.ErrorValue());
         std::shared_ptr<Platform::DynamicLibrary> library{std::move(loadResult).Value()};
 
-        const auto loadFunc = reinterpret_cast<HoroExtensionLoadFunc>(library->GetSymbol("horo_extension_load"));  // NOSONAR(cpp:S3630)
-        if (loadFunc == nullptr)
-            return Result<std::string>::Failure(MakeError(ExtensionErrors::MissingEntryPoint, "Symbol horo_extension_load not found"));
-
-        auto lifetime = std::make_shared<ExtensionModuleLifetime>();
-        lifetime->library = library;
-        lifetime->unload = reinterpret_cast<HoroExtensionUnloadFunc>(library->GetSymbol("horo_extension_unload"));  // NOSONAR(cpp:S3630)
-
-        AssetImporterRegistrationSession registration{
-            .manifest = &manifest,
-            .extensionModule = &manifestModule,
-            .lifetime = lifetime,
-        };
-        constexpr std::string_view engineVersion = "0.1.0";
-        HoroExtensionHostApi hostApi{
-            .structSize = sizeof(HoroExtensionHostApi),
-            .abiVersion = HORO_EXTENSION_ABI_VERSION,
-            .engineVersion = {engineVersion.data(), static_cast<std::uint32_t>(engineVersion.size())},
-            .hostContext = &registration,
-            .registerAssetImporter = RegisterExternalAssetImporter,
-        };
-        HoroExtensionModuleApi moduleApi{
-            .structSize = sizeof(HoroExtensionModuleApi),
-        };
-
-        HoroExtensionStatus status = HORO_EXTENSION_ERROR_INIT_FAILED;
-        try {
-            status = loadFunc(&hostApi, &moduleApi);
-        } catch (const std::runtime_error &exception) {  // NOSONAR(cpp:S1181)
-            LOG_ERROR("extensions", "Extension %s threw runtime error during load: %s", manifest.id.c_str(), exception.what());
-            status = HORO_EXTENSION_ERROR_INIT_FAILED;
-        } catch (const std::logic_error &exception) {  // NOSONAR(cpp:S1181)
-            LOG_ERROR("extensions", "Extension %s threw logic error during load: %s", manifest.id.c_str(), exception.what());
-            status = HORO_EXTENSION_ERROR_INIT_FAILED;
-        } catch (const std::bad_alloc &exception) {  // NOSONAR(cpp:S1181)
-            LOG_ERROR("extensions", "Extension %s threw bad alloc during load: %s", manifest.id.c_str(), exception.what());
-            status = HORO_EXTENSION_ERROR_INIT_FAILED;
-        } catch (const std::exception &exception) {  // NOSONAR(cpp:S1181)
-            LOG_ERROR("extensions", "Extension %s threw during load: %s", manifest.id.c_str(), exception.what());
-            status = HORO_EXTENSION_ERROR_INIT_FAILED;
-        } catch (...) {  // NOSONAR(cpp:S1181)
-            LOG_ERROR("extensions", "Extension %s threw unknown exception during load.", manifest.id.c_str());
-            status = HORO_EXTENSION_ERROR_INIT_FAILED;
-        }
-
-        if (status != HORO_EXTENSION_SUCCESS || registration.failed) {
-            SafeUnload(lifetime->unload, moduleApi, "rollback");
-            if (registration.failed)
-                return Result<std::string>::Failure(std::move(registration.error));
-            return Result<std::string>::Failure(MakeError(ExtensionErrors::LoadFailed, "Extension load function returned an error."));
-        }
-
-        if (!IsValidBoundedText(moduleApi.moduleId) || !IsValidBoundedText(moduleApi.moduleVersion) ||
-            (!View(moduleApi.moduleId).empty() && View(moduleApi.moduleId) != declaredModuleId) ||
-            (!View(moduleApi.moduleVersion).empty() && View(moduleApi.moduleVersion) != declaredModuleVersion)) {
-            SafeUnload(lifetime->unload, moduleApi, "validation failure");
-            return Result<std::string>::Failure(
-                MakeError(ExtensionErrors::InvalidManifest, "Loaded module identity/version does not match extension.json."));
-        }
-
-        lifetime->moduleApi = moduleApi;
-        lifetime->loaded = true;
-
-        if (!registration.contributions.empty()) {
-            if (m_importerCatalog == nullptr)
-                return Result<std::string>::Failure(
-                    MakeError(ExtensionErrors::ContributionRejected, "The host did not provide an asset importer catalog."));
-            if (auto registered = m_importerCatalog->RegisterBatch(std::move(registration.contributions)); registered.HasError()) {
-                return Result<std::string>::Failure(
-                    MakeError(ExtensionErrors::ContributionRejected,
-                              "The complete extension contribution batch conflicted with the host catalog."));
-            }
-        }
+        auto activatedResult = ActivateModule(library, manifest, manifestModule);
+        if (activatedResult.HasError())
+            return Result<std::string>::Failure(activatedResult.ErrorValue());
+        ActivatedModule activated = std::move(activatedResult).Value();
+        if (auto committed = CommitContributions(activated.contributions, m_importerCatalog); committed.HasError())
+            return Result<std::string>::Failure(committed.ErrorValue());
 
         auto loadedExtension = std::make_unique<LoadedExtension>();
         loadedExtension->manifest = std::move(manifest);
-        loadedExtension->lifetime = std::move(lifetime);
+        loadedExtension->lifetime = std::move(activated.lifetime);
         loadedExtension->moduleId = declaredModuleId;
         loadedExtension->moduleVersion = declaredModuleVersion;
         const std::string extensionId = loadedExtension->manifest.id;

--- a/src/extensions/host/ExtensionManager.cpp
+++ b/src/extensions/host/ExtensionManager.cpp
@@ -19,6 +19,7 @@ namespace Horo::Extensions {
         namespace fs = std::filesystem;
 
         constexpr std::uint32_t kMaximumModuleIdentityBytes = 256;
+        constexpr ExtensionManifestLimits kManifestLimits{};
 
         [[nodiscard]] std::string_view View(const HoroExtensionStringView value) noexcept {
             return value.data != nullptr ? std::string_view{value.data, value.length} : std::string_view{};
@@ -119,13 +120,18 @@ namespace Horo::Extensions {
                     MakeError(ExtensionErrors::InvalidManifest, "Extension package path must be absolute."));
 
             const fs::path manifestPath = requestedRoot / "extension.json";
-            std::ifstream fileStream(manifestPath);
+            std::error_code fileError;
+            const std::uintmax_t manifestBytes = fs::file_size(manifestPath, fileError);
+            if (fileError || manifestBytes > kManifestLimits.maximumDocumentBytes)
+                return Result<ExtensionManifest>::Failure(
+                    MakeError(ExtensionErrors::InvalidManifest, "Extension manifest is unavailable or exceeds the bounded size."));
+            std::ifstream fileStream(manifestPath, std::ios::binary);
             if (!fileStream.is_open())
                 return Result<ExtensionManifest>::Failure(MakeError(ExtensionErrors::InvalidManifest, "Could not open extension.json"));
 
             std::stringstream buffer;
             buffer << fileStream.rdbuf();
-            auto parseResult = ParseExtensionManifest(buffer.str());
+            auto parseResult = ParseExtensionManifest(buffer.str(), kManifestLimits);
             if (parseResult.HasError())
                 return Result<ExtensionManifest>::Failure(parseResult.ErrorValue());
 

--- a/src/extensions/host/ExtensionManager.cpp
+++ b/src/extensions/host/ExtensionManager.cpp
@@ -94,45 +94,61 @@ namespace Horo::Extensions {
             return Result<fs::path>::Success(libraryPath);
         }
 
-        void SafeUnload(HoroExtensionUnloadFunc unload, HoroExtensionModuleApi &moduleApi,  // NOSONAR(cpp:S5205)
-                        const char *context) {
-            if (unload != nullptr && moduleApi.moduleContext != nullptr) {
-                try {
-                    unload(&moduleApi);
-                } catch (const std::runtime_error &exception) {  // NOSONAR(cpp:S1181)
-                    LOG_WARN("extensions", "Runtime error during %s unload: %s", context, exception.what());
-                } catch (const std::logic_error &exception) {  // NOSONAR(cpp:S1181)
-                    LOG_WARN("extensions", "Logic error during %s unload: %s", context, exception.what());
-                } catch (const std::bad_alloc &exception) {  // NOSONAR(cpp:S1181)
-                    LOG_WARN("extensions", "Bad alloc during %s unload: %s", context, exception.what());
-                } catch (const std::exception &exception) {  // NOSONAR(cpp:S1181) External code is an exception containment boundary.
-                    LOG_WARN("extensions", "Exception during %s unload: %s", context, exception.what());
-                } catch (...) {  // NOSONAR(cpp:S1181)
-                    LOG_WARN("extensions", "Unknown exception during %s unload.", context);
-                }
+        /** @brief Logs the active exception caught while unloading external code. */
+        void LogUnloadException(const char *context) noexcept {
+            try {
+                throw;
+            } catch (const std::runtime_error &exception) {  // NOSONAR(cpp:S1181)
+                LOG_WARN("extensions", "Runtime error during %s unload: %s", context, exception.what());
+            } catch (const std::logic_error &exception) {  // NOSONAR(cpp:S1181)
+                LOG_WARN("extensions", "Logic error during %s unload: %s", context, exception.what());
+            } catch (const std::bad_alloc &exception) {  // NOSONAR(cpp:S1181)
+                LOG_WARN("extensions", "Bad alloc during %s unload: %s", context, exception.what());
+            } catch (const std::exception &exception) {  // NOSONAR(cpp:S1181) External code is an exception containment boundary.
+                LOG_WARN("extensions", "Exception during %s unload: %s", context, exception.what());
+            } catch (...) {  // NOSONAR(cpp:S1181)
+                LOG_WARN("extensions", "Unknown exception during %s unload.", context);
             }
         }
 
-        template <typename LoadedMap>
-        [[nodiscard]] Result<ExtensionManifest> ReadAndValidateManifest(const fs::path &requestedRoot, const LoadedMap &loaded) {
+        void SafeUnload(HoroExtensionUnloadFunc unload, HoroExtensionModuleApi &moduleApi,  // NOSONAR(cpp:S5205)
+                        const char *context) {
+            if (unload == nullptr || moduleApi.moduleContext == nullptr)
+                return;
+            try {
+                unload(&moduleApi);
+            } catch (...) {  // NOSONAR(cpp:S1181) External code is an exception containment boundary.
+                LogUnloadException(context);
+            }
+        }
+
+        /** @brief Reads one bounded manifest file from an absolute package root. */
+        [[nodiscard]] Result<std::string> ReadManifestContent(const fs::path &requestedRoot) {
             if (!requestedRoot.is_absolute())
-                return Result<ExtensionManifest>::Failure(
+                return Result<std::string>::Failure(
                     MakeError(ExtensionErrors::InvalidManifest, "Extension package path must be absolute."));
 
             const fs::path manifestPath = requestedRoot / "extension.json";
             std::error_code fileError;
             if (const std::uintmax_t manifestBytes = fs::file_size(manifestPath, fileError);
                 fileError || manifestBytes > kManifestLimits.maximumDocumentBytes) {
-                return Result<ExtensionManifest>::Failure(
+                return Result<std::string>::Failure(
                     MakeError(ExtensionErrors::InvalidManifest, "Extension manifest is unavailable or exceeds the bounded size."));
             }
             std::ifstream fileStream(manifestPath, std::ios::binary);
             if (!fileStream.is_open())
-                return Result<ExtensionManifest>::Failure(MakeError(ExtensionErrors::InvalidManifest, "Could not open extension.json"));
+                return Result<std::string>::Failure(MakeError(ExtensionErrors::InvalidManifest, "Could not open extension.json"));
 
             std::stringstream buffer;
             buffer << fileStream.rdbuf();
-            auto parseResult = ParseExtensionManifest(buffer.str(), kManifestLimits);
+            return Result<std::string>::Success(std::move(buffer).str());
+        }
+
+        /** @brief Parses a manifest and checks constraints imposed by the native loader. */
+        template <typename LoadedMap>
+        [[nodiscard]] Result<ExtensionManifest> ValidateLoadableManifest(std::string content, const fs::path &requestedRoot,
+                                                                         const LoadedMap &loaded) {
+            auto parseResult = ParseExtensionManifest(content, kManifestLimits);
             if (parseResult.HasError())
                 return Result<ExtensionManifest>::Failure(parseResult.ErrorValue());
 
@@ -145,6 +161,14 @@ namespace Horo::Extensions {
                 return Result<ExtensionManifest>::Failure(
                     MakeError(ExtensionErrors::InvalidManifest, "The current native loader requires exactly one module per package."));
             return Result<ExtensionManifest>::Success(std::move(manifest));
+        }
+
+        template <typename LoadedMap>
+        [[nodiscard]] Result<ExtensionManifest> ReadAndValidateManifest(const fs::path &requestedRoot, const LoadedMap &loaded) {
+            auto content = ReadManifestContent(requestedRoot);
+            if (content.HasError())
+                return Result<ExtensionManifest>::Failure(content.ErrorValue());
+            return ValidateLoadableManifest(std::move(content).Value(), requestedRoot, loaded);
         }
 
         /** @brief Invokes an extension entry point while containing exceptions at the ABI boundary. */

--- a/src/extensions/host/ExtensionManager.cpp
+++ b/src/extensions/host/ExtensionManager.cpp
@@ -148,7 +148,8 @@ namespace Horo::Extensions {
         }
 
         /** @brief Invokes an extension entry point while containing exceptions at the ABI boundary. */
-        [[nodiscard]] HoroExtensionStatus InvokeExtensionLoad(const HoroExtensionLoadFunc loadFunc, HoroExtensionHostApi &hostApi,
+        template <typename LoadFunction>
+        [[nodiscard]] HoroExtensionStatus InvokeExtensionLoad(const LoadFunction loadFunc, const HoroExtensionHostApi &hostApi,
                                                               HoroExtensionModuleApi &moduleApi, const std::string &extensionId) {
             try {
                 return loadFunc(&hostApi, &moduleApi);
@@ -207,8 +208,8 @@ namespace Horo::Extensions {
                 .registerAssetImporter = RegisterExternalAssetImporter,
             };
             HoroExtensionModuleApi moduleApi{.structSize = sizeof(HoroExtensionModuleApi)};
-            const HoroExtensionStatus status = InvokeExtensionLoad(loadFunc, hostApi, moduleApi, manifest.id);
-            if (status != HORO_EXTENSION_SUCCESS || registration.failed) {
+            if (const HoroExtensionStatus status = InvokeExtensionLoad(loadFunc, hostApi, moduleApi, manifest.id);
+                status != HORO_EXTENSION_SUCCESS || registration.failed) {
                 SafeUnload(lifetime->unload, moduleApi, "rollback");
                 if (registration.failed)
                     return Result<ActivatedModule>::Failure(std::move(registration.error));

--- a/src/extensions/host/ExtensionManager.cpp
+++ b/src/extensions/host/ExtensionManager.cpp
@@ -94,31 +94,16 @@ namespace Horo::Extensions {
             return Result<fs::path>::Success(libraryPath);
         }
 
-        /** @brief Logs the active exception caught while unloading external code. */
-        void LogUnloadException(const char *context) noexcept {
-            try {
-                throw;
-            } catch (const std::runtime_error &exception) {  // NOSONAR(cpp:S1181)
-                LOG_WARN("extensions", "Runtime error during %s unload: %s", context, exception.what());
-            } catch (const std::logic_error &exception) {  // NOSONAR(cpp:S1181)
-                LOG_WARN("extensions", "Logic error during %s unload: %s", context, exception.what());
-            } catch (const std::bad_alloc &exception) {  // NOSONAR(cpp:S1181)
-                LOG_WARN("extensions", "Bad alloc during %s unload: %s", context, exception.what());
-            } catch (const std::exception &exception) {  // NOSONAR(cpp:S1181) External code is an exception containment boundary.
-                LOG_WARN("extensions", "Exception during %s unload: %s", context, exception.what());
-            } catch (...) {  // NOSONAR(cpp:S1181)
-                LOG_WARN("extensions", "Unknown exception during %s unload.", context);
-            }
-        }
-
         void SafeUnload(HoroExtensionUnloadFunc unload, HoroExtensionModuleApi &moduleApi,  // NOSONAR(cpp:S5205)
                         const char *context) {
             if (unload == nullptr || moduleApi.moduleContext == nullptr)
                 return;
             try {
                 unload(&moduleApi);
+            } catch (const std::exception &exception) {  // NOSONAR(cpp:S1181) External code is an exception containment boundary.
+                LOG_WARN("extensions", "Exception during %s unload: %s", context, exception.what());
             } catch (...) {  // NOSONAR(cpp:S1181) External code is an exception containment boundary.
-                LogUnloadException(context);
+                LOG_WARN("extensions", "Unknown exception during %s unload.", context);
             }
         }
 
@@ -146,7 +131,7 @@ namespace Horo::Extensions {
 
         /** @brief Parses a manifest and checks constraints imposed by the native loader. */
         template <typename LoadedMap>
-        [[nodiscard]] Result<ExtensionManifest> ValidateLoadableManifest(std::string content, const fs::path &requestedRoot,
+        [[nodiscard]] Result<ExtensionManifest> ValidateLoadableManifest(const std::string &content, const fs::path &requestedRoot,
                                                                          const LoadedMap &loaded) {
             auto parseResult = ParseExtensionManifest(content, kManifestLimits);
             if (parseResult.HasError())
@@ -168,7 +153,7 @@ namespace Horo::Extensions {
             auto content = ReadManifestContent(requestedRoot);
             if (content.HasError())
                 return Result<ExtensionManifest>::Failure(content.ErrorValue());
-            return ValidateLoadableManifest(std::move(content).Value(), requestedRoot, loaded);
+            return ValidateLoadableManifest(content.Value(), requestedRoot, loaded);
         }
 
         /** @brief Invokes an extension entry point while containing exceptions at the ABI boundary. */

--- a/src/extensions/manifest/ExtensionManifestJson.cpp
+++ b/src/extensions/manifest/ExtensionManifestJson.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include <format>
 #include <optional>
-#include <unordered_set>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -51,8 +51,11 @@ namespace Horo::Extensions::ManifestParsing {
             for (const char character : content) {
                 if (ConsumeQuotedCharacter(character, inString, escaped))
                     continue;
-                if (IsOpeningContainer(character) && ++depth > limits.maximumNestingDepth) {
-                    return ManifestError("$", "extension.manifest.nesting_limit", "JSON nesting exceeds the configured limit.");
+                if (IsOpeningContainer(character)) {
+                    ++depth;
+                    if (depth > limits.maximumNestingDepth) {
+                        return ManifestError("$", "extension.manifest.nesting_limit", "JSON nesting exceeds the configured limit.");
+                    }
                 }
                 if (IsClosingContainer(character) && depth > 0)
                     --depth;
@@ -68,7 +71,7 @@ namespace Horo::Extensions::ManifestParsing {
         struct ParserFrame {
             ContainerKind kind{};
             std::string path;
-            std::unordered_set<std::string> keys;
+            std::set<std::string, std::less<>> keys;
             std::optional<std::string> pendingKey;
             std::size_t nextIndex = 0;
         };
@@ -82,7 +85,7 @@ namespace Horo::Extensions::ManifestParsing {
             explicit BoundedJsonParser(const ExtensionManifestLimits &limits) : limits_(limits) {}
 
             [[nodiscard]] Json Parse(const std::string_view content) {
-                const Json::parser_callback_t callback = [this](const int, const Json::parse_event_t event, Json &parsed) {
+                const Json::parser_callback_t callback = [this](const int, const Json::parse_event_t event, const Json &parsed) {
                     OnEvent(event, parsed);
                     return true;
                 };
@@ -152,21 +155,22 @@ namespace Horo::Extensions::ManifestParsing {
             }
 
             void OnEvent(const Json::parse_event_t event, const Json &parsed) {
+                using enum Json::parse_event_t;
                 switch (event) {
-                    case Json::parse_event_t::object_start:
+                    case object_start:
                         BeginContainer(ContainerKind::Object);
                         break;
-                    case Json::parse_event_t::array_start:
+                    case array_start:
                         BeginContainer(ContainerKind::Array);
                         break;
-                    case Json::parse_event_t::object_end:
-                    case Json::parse_event_t::array_end:
+                    case object_end:
+                    case array_end:
                         EndContainer();
                         break;
-                    case Json::parse_event_t::key:
+                    case key:
                         OnKey(parsed);
                         break;
-                    case Json::parse_event_t::value:
+                    case value:
                         OnValue(parsed);
                         break;
                 }

--- a/src/extensions/manifest/ExtensionManifestJson.cpp
+++ b/src/extensions/manifest/ExtensionManifestJson.cpp
@@ -1,0 +1,244 @@
+#include "ExtensionManifestParsing.h"
+#include "Horo/Extensions/ExtensionErrors.h"
+
+#include <algorithm>
+#include <format>
+#include <optional>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace Horo::Extensions::ManifestParsing {
+    namespace {
+        constexpr std::string_view ManifestSource = "extension.json";
+
+        [[nodiscard]] bool HasValidLimits(const ExtensionManifestLimits &limits) noexcept {
+            return limits.maximumDocumentBytes > 0 && limits.maximumNestingDepth > 0 && limits.maximumObjectMembers > 0 &&
+                   limits.maximumArrayElements > 0 && limits.maximumStringBytes > 0 && limits.maximumIdentifierBytes > 0 &&
+                   limits.maximumModules > 0 && limits.maximumContributions > 0 && limits.maximumPlatforms > 0;
+        }
+
+        [[nodiscard]] bool IsOpeningContainer(const char character) noexcept {
+            return character == '{' || character == '[';
+        }
+
+        [[nodiscard]] bool IsClosingContainer(const char character) noexcept {
+            return character == '}' || character == ']';
+        }
+
+        [[nodiscard]] bool ConsumeQuotedCharacter(const char character, bool &inString, bool &escaped) noexcept {
+            if (!inString) {
+                if (character == '"') {
+                    inString = true;
+                    return true;
+                }
+                return false;
+            }
+            if (escaped) {
+                escaped = false;
+            } else if (character == '\\') {
+                escaped = true;
+            } else if (character == '"') {
+                inString = false;
+            }
+            return true;
+        }
+
+        [[nodiscard]] std::optional<Error> CheckRawNesting(const std::string_view content, const ExtensionManifestLimits &limits) {
+            std::size_t depth = 0;
+            bool inString = false;
+            bool escaped = false;
+            for (const char character : content) {
+                if (ConsumeQuotedCharacter(character, inString, escaped))
+                    continue;
+                if (IsOpeningContainer(character) && ++depth > limits.maximumNestingDepth) {
+                    return ManifestError("$", "extension.manifest.nesting_limit", "JSON nesting exceeds the configured limit.");
+                }
+                if (IsClosingContainer(character) && depth > 0)
+                    --depth;
+            }
+            return std::nullopt;
+        }
+
+        enum class ContainerKind {
+            Object,
+            Array,
+        };
+
+        struct ParserFrame {
+            ContainerKind kind{};
+            std::string path;
+            std::unordered_set<std::string> keys;
+            std::optional<std::string> pendingKey;
+            std::size_t nextIndex = 0;
+        };
+
+        struct ParserFailure {
+            Error error;
+        };
+
+        class BoundedJsonParser final {
+        public:
+            explicit BoundedJsonParser(const ExtensionManifestLimits &limits) : limits_(limits) {}
+
+            [[nodiscard]] Json Parse(const std::string_view content) {
+                const Json::parser_callback_t callback = [this](const int, const Json::parse_event_t event, Json &parsed) {
+                    OnEvent(event, parsed);
+                    return true;
+                };
+                return Json::parse(content.begin(), content.end(), callback, true, false);
+            }
+
+        private:
+            [[nodiscard]] std::string NextPath() const {
+                if (frames_.empty())
+                    return "$";
+                const ParserFrame &parent = frames_.back();
+                if (parent.kind == ContainerKind::Array)
+                    return ElementPath(parent.path, parent.nextIndex);
+                return parent.pendingKey.has_value() ? ChildPath(parent.path, *parent.pendingKey) : parent.path;
+            }
+
+            void ConsumeParentValue() {
+                if (frames_.empty())
+                    return;
+                ParserFrame &parent = frames_.back();
+                if (parent.kind == ContainerKind::Object) {
+                    parent.pendingKey.reset();
+                    return;
+                }
+                if (++arrayElements_ > limits_.maximumArrayElements) {
+                    Fail(ElementPath(parent.path, parent.nextIndex), "extension.manifest.array_limit",
+                         "Total array elements exceed the configured limit.");
+                }
+                ++parent.nextIndex;
+            }
+
+            void BeginContainer(const ContainerKind kind) {
+                const std::string path = NextPath();
+                if (!frames_.empty() && frames_.back().kind == ContainerKind::Array)
+                    ConsumeParentValue();
+                frames_.push_back(ParserFrame{.kind = kind, .path = path});
+            }
+
+            void EndContainer() {
+                if (frames_.empty())
+                    return;
+                frames_.pop_back();
+                if (!frames_.empty() && frames_.back().kind == ContainerKind::Object)
+                    frames_.back().pendingKey.reset();
+            }
+
+            void OnKey(const Json &parsed) {
+                if (frames_.empty() || frames_.back().kind != ContainerKind::Object)
+                    return;
+                ParserFrame &object = frames_.back();
+                const std::string &key = parsed.get_ref<const std::string &>();
+                const std::string path = ChildPath(object.path, key);
+                if (key.size() > limits_.maximumIdentifierBytes)
+                    Fail(path, "extension.manifest.identifier_limit", "Field name exceeds the configured identifier limit.");
+                if (++objectMembers_ > limits_.maximumObjectMembers)
+                    Fail(path, "extension.manifest.object_limit", "Total object members exceed the configured limit.");
+                if (!object.keys.insert(key).second)
+                    Fail(path, "extension.manifest.duplicate_field", "Duplicate field is not allowed.");
+                object.pendingKey = key;
+            }
+
+            void OnValue(const Json &parsed) {
+                const std::string path = NextPath();
+                if (parsed.is_string() && parsed.get_ref<const std::string &>().size() > limits_.maximumStringBytes)
+                    Fail(path, "extension.manifest.string_limit", "String exceeds the configured limit.");
+                ConsumeParentValue();
+            }
+
+            void OnEvent(const Json::parse_event_t event, const Json &parsed) {
+                switch (event) {
+                    case Json::parse_event_t::object_start:
+                        BeginContainer(ContainerKind::Object);
+                        break;
+                    case Json::parse_event_t::array_start:
+                        BeginContainer(ContainerKind::Array);
+                        break;
+                    case Json::parse_event_t::object_end:
+                    case Json::parse_event_t::array_end:
+                        EndContainer();
+                        break;
+                    case Json::parse_event_t::key:
+                        OnKey(parsed);
+                        break;
+                    case Json::parse_event_t::value:
+                        OnValue(parsed);
+                        break;
+                }
+            }
+
+            [[noreturn]] static void Fail(const std::string_view path, const std::string_view code, const std::string_view reason) {
+                throw ParserFailure{ManifestError(path, code, reason)};
+            }
+
+            const ExtensionManifestLimits &limits_;
+            std::vector<ParserFrame> frames_;
+            std::size_t objectMembers_ = 0;
+            std::size_t arrayElements_ = 0;
+        };
+
+        [[nodiscard]] std::pair<std::uint32_t, std::uint32_t> LocationAt(const std::string_view content, const std::size_t byte) noexcept {
+            std::uint32_t line = 1;
+            std::uint32_t column = 1;
+            const std::size_t end = std::min(byte > 0 ? byte - 1 : 0, content.size());
+            for (std::size_t index = 0; index < end; ++index) {
+                if (content[index] == '\n') {
+                    ++line;
+                    column = 1;
+                } else {
+                    ++column;
+                }
+            }
+            return {line, column};
+        }
+
+        [[nodiscard]] Result<Json> ParseJson(const std::string_view content, const ExtensionManifestLimits &limits) {
+            try {
+                return Result<Json>::Success(BoundedJsonParser{limits}.Parse(content));
+            } catch (ParserFailure &failure) {
+                return Result<Json>::Failure(std::move(failure.error));
+            } catch (const Json::parse_error &exception) {
+                const auto [line, column] = LocationAt(content, exception.byte);
+                return Result<Json>::Failure(ManifestError("$", "extension.manifest.invalid_json", "Malformed JSON syntax.", line, column));
+            }
+        }
+    }  // namespace
+
+    std::string ChildPath(const std::string_view parent, const std::string_view key) {
+        return std::format("{}.{}", parent, key);
+    }
+
+    std::string ElementPath(const std::string_view parent, const std::size_t index) {
+        return std::format("{}[{}]", parent, index);
+    }
+
+    Error ManifestError(const std::string_view path, const std::string_view diagnosticCode, const std::string_view reason,
+                        const std::uint32_t line, const std::uint32_t column) {
+        const std::string message = std::format("{}: {}", path, reason);
+        Error error = MakeError(ExtensionErrors::InvalidManifest, message);
+        error.diagnostics.push_back(Diagnostic{
+            .code = DiagnosticCode{std::string{diagnosticCode}},
+            .severity = DiagnosticSeverity::Error,
+            .message = message,
+            .location = SourceLocation{.source = std::string{ManifestSource}, .line = line, .column = column},
+        });
+        return error;
+    }
+
+    Result<Json> ParseBoundedJson(const std::string_view content, const ExtensionManifestLimits &limits) {
+        if (!HasValidLimits(limits))
+            return Result<Json>::Failure(
+                ManifestError("$", "extension.manifest.invalid_limits", "Every parser limit must be greater than zero."));
+        if (content.size() > limits.maximumDocumentBytes)
+            return Result<Json>::Failure(
+                ManifestError("$", "extension.manifest.document_limit", "Document exceeds the configured byte limit."));
+        if (const std::optional<Error> nestingError = CheckRawNesting(content, limits); nestingError.has_value())
+            return Result<Json>::Failure(*nestingError);
+        return ParseJson(content, limits);
+    }
+}  // namespace Horo::Extensions::ManifestParsing

--- a/src/extensions/manifest/ExtensionManifestJson.cpp
+++ b/src/extensions/manifest/ExtensionManifestJson.cpp
@@ -2,6 +2,7 @@
 #include "Horo/Extensions/ExtensionErrors.h"
 
 #include <algorithm>
+#include <array>
 #include <format>
 #include <optional>
 #include <set>
@@ -13,9 +14,14 @@ namespace Horo::Extensions::ManifestParsing {
         constexpr std::string_view ManifestSource = "extension.json";
 
         [[nodiscard]] bool HasValidLimits(const ExtensionManifestLimits &limits) noexcept {
-            return limits.maximumDocumentBytes > 0 && limits.maximumNestingDepth > 0 && limits.maximumObjectMembers > 0 &&
-                   limits.maximumArrayElements > 0 && limits.maximumStringBytes > 0 && limits.maximumIdentifierBytes > 0 &&
-                   limits.maximumModules > 0 && limits.maximumContributions > 0 && limits.maximumPlatforms > 0;
+            const std::array values = {
+                limits.maximumDocumentBytes, limits.maximumNestingDepth,  limits.maximumObjectMembers,
+                limits.maximumArrayElements, limits.maximumStringBytes,   limits.maximumIdentifierBytes,
+                limits.maximumModules,       limits.maximumContributions, limits.maximumPlatforms,
+            };
+            return std::ranges::all_of(values, [](const std::size_t value) {
+                return value > 0;
+            });
         }
 
         [[nodiscard]] bool IsOpeningContainer(const char character) noexcept {

--- a/src/extensions/manifest/ExtensionManifestParser.cpp
+++ b/src/extensions/manifest/ExtensionManifestParser.cpp
@@ -167,8 +167,8 @@ namespace Horo::Extensions {
                 const Json *package = SelectPackage(document);
                 if (package == nullptr)
                     return CurrentFailure();
-                const std::string packagePath = document.contains("package") ? "$.package" : "$";
-                if (!ParseManifestSections(document, *package, packagePath, manifest))
+                if (const std::string packagePath = document.contains("package") ? "$.package" : "$";
+                    !ParseManifestSections(document, *package, packagePath, manifest))
                     return CurrentFailure();
                 return Result<ExtensionManifest>::Success(std::move(manifest));
             }

--- a/src/extensions/manifest/ExtensionManifestParser.cpp
+++ b/src/extensions/manifest/ExtensionManifestParser.cpp
@@ -1,11 +1,12 @@
 #include "ExtensionManifestParsing.h"
 #include "Horo/Extensions/ExtensionManifest.h"
 
+#include <array>
 #include <initializer_list>
 #include <optional>
 #include <ranges>
+#include <set>
 #include <string>
-#include <unordered_set>
 #include <utility>
 
 namespace Horo::Extensions {
@@ -45,11 +46,12 @@ namespace Horo::Extensions {
             std::size_t identifierStart = 0;
             while (identifierStart <= prerelease.size()) {
                 const std::size_t end = prerelease.find('.', identifierStart);
-                const std::string_view identifier =
-                    prerelease.substr(identifierStart,
-                                      end == std::string_view::npos ? prerelease.size() - identifierStart : end - identifierStart);
-                if (!IsValidPrereleaseIdentifier(identifier))
+                if (const std::string_view identifier =
+                        prerelease.substr(identifierStart,
+                                          end == std::string_view::npos ? prerelease.size() - identifierStart : end - identifierStart);
+                    !IsValidPrereleaseIdentifier(identifier)) {
                     return false;
+                }
                 if (end == std::string_view::npos)
                     return true;
                 identifierStart = end + 1;
@@ -63,9 +65,10 @@ namespace Horo::Extensions {
                 const std::size_t end = component == 2 ? core.size() : core.find('.', componentStart);
                 if (end == std::string_view::npos || end == componentStart)
                     return false;
-                const std::string_view digits = core.substr(componentStart, end - componentStart);
-                if (!IsCanonicalNumericComponent(digits))
+                if (const std::string_view digits = core.substr(componentStart, end - componentStart);
+                    !IsCanonicalNumericComponent(digits)) {
                     return false;
+                }
                 componentStart = end + 1;
             }
             return componentStart == core.size() + 1;
@@ -94,9 +97,11 @@ namespace Horo::Extensions {
             std::size_t start = 0;
             while (start <= value.size()) {
                 const std::size_t end = value.find('.', start);
-                const std::string_view segment = value.substr(start, end == std::string_view::npos ? value.size() - start : end - start);
-                if (!IsCanonicalIdSegment(segment))
+                if (const std::string_view segment =
+                        value.substr(start, end == std::string_view::npos ? value.size() - start : end - start);
+                    !IsCanonicalIdSegment(segment)) {
                     return false;
+                }
                 if (end == std::string_view::npos)
                     return true;
                 start = end + 1;
@@ -128,9 +133,11 @@ namespace Horo::Extensions {
             std::size_t start = 0;
             while (start <= value.size()) {
                 const std::size_t end = value.find('/', start);
-                const std::string_view component = value.substr(start, end == std::string_view::npos ? value.size() - start : end - start);
-                if (!IsSafeEntryComponent(component))
+                if (const std::string_view component =
+                        value.substr(start, end == std::string_view::npos ? value.size() - start : end - start);
+                    !IsSafeEntryComponent(component)) {
                     return false;
+                }
                 if (end == std::string_view::npos)
                     return true;
                 start = end + 1;
@@ -155,8 +162,8 @@ namespace Horo::Extensions {
                 const Json *package = SelectPackage(document);
                 if (package == nullptr)
                     return CurrentFailure();
-                const std::string packagePath = document.contains("package") ? "$.package" : "$";
-                if (!ParsePackage(*package, packagePath, manifest) || !ParseCompatibility(document, manifest) ||
+                if (const std::string packagePath = document.contains("package") ? "$.package" : "$";
+                    !ParsePackage(*package, packagePath, manifest) || !ParseCompatibility(document, manifest) ||
                     !ParseModules(document, manifest) || !ParseContributions(document, manifest)) {
                     return CurrentFailure();
                 }
@@ -234,7 +241,9 @@ namespace Horo::Extensions {
                     static_cast<void>(Reject("$.package", "extension.manifest.invalid_type", "Package field must be an object."));
                     return nullptr;
                 }
-                constexpr std::string_view packageFields[] = {"id", "version", "kind", "displayName", "description", "author"};
+                constexpr std::array packageFields = {std::string_view{"id"},          std::string_view{"version"},
+                                                      std::string_view{"kind"},        std::string_view{"displayName"},
+                                                      std::string_view{"description"}, std::string_view{"author"}};
                 for (const std::string_view field : packageFields) {
                     if (document.contains(field)) {
                         static_cast<void>(Reject(ChildPath("$", field), "extension.manifest.ambiguous_field",
@@ -287,8 +296,8 @@ namespace Horo::Extensions {
 
             [[nodiscard]] bool ValidateCompatibilityValues(const ExtensionManifest &manifest) {
                 const bool invalidMinimum = !manifest.engineMin.empty() && !IsCanonicalSemanticVersion(manifest.engineMin);
-                const bool invalidMaximum = !manifest.engineMax.empty() && !IsCanonicalSemanticVersion(manifest.engineMax);
-                if (invalidMinimum || invalidMaximum) {
+                if (const bool invalidMaximum = !manifest.engineMax.empty() && !IsCanonicalSemanticVersion(manifest.engineMax);
+                    invalidMinimum || invalidMaximum) {
                     return Reject("$.compatibility", "extension.manifest.invalid_version",
                                   "Engine compatibility values must be canonical semantic versions.");
                 }
@@ -306,7 +315,7 @@ namespace Horo::Extensions {
                 if (found->size() > limits_.maximumPlatforms)
                     return Reject("$.compatibility.platforms", "extension.manifest.collection_limit",
                                   "Platform count exceeds the configured limit.");
-                std::unordered_set<std::string> identities;
+                std::set<std::string, std::less<>> identities;
                 platforms.reserve(found->size());
                 for (std::size_t index = 0; index < found->size(); ++index) {
                     const Json &value = (*found)[index];
@@ -332,44 +341,44 @@ namespace Horo::Extensions {
                 if (found->empty() || found->size() > limits_.maximumModules)
                     return Reject("$.modules", "extension.manifest.collection_limit", "Module count must be within configured limits.");
 
-                std::unordered_set<std::string> identities;
+                std::set<std::string, std::less<>> identities;
                 manifest.modules.reserve(found->size());
                 for (std::size_t index = 0; index < found->size(); ++index) {
                     const Json &value = (*found)[index];
                     const std::string path = ElementPath("$.modules", index);
-                    ExtensionModuleManifest module;
-                    if (!ParseModule(value, path, module))
+                    ExtensionModuleManifest moduleManifest;
+                    if (!ParseModule(value, path, moduleManifest))
                         return false;
-                    if (!identities.insert(module.id).second)
+                    if (!identities.insert(moduleManifest.id).second)
                         return Reject(ChildPath(path, "id"), "extension.manifest.duplicate_identifier",
                                       "Module ID must be unique within the package.");
-                    manifest.modules.push_back(std::move(module));
+                    manifest.modules.push_back(std::move(moduleManifest));
                 }
                 return true;
             }
 
-            [[nodiscard]] bool ParseModule(const Json &value, const std::string_view path, ExtensionModuleManifest &module) {
+            [[nodiscard]] bool ParseModule(const Json &value, const std::string_view path, ExtensionModuleManifest &moduleManifest) {
                 if (!value.is_object())
                     return Reject(path, "extension.manifest.invalid_type", "Module must be an object.");
                 if (!AllowFields(value, path, {"id", "version", "kind", "entry"}))
                     return false;
-                return ReadModuleFields(value, path, module) && ValidateModuleValues(path, module);
+                return ReadModuleFields(value, path, moduleManifest) && ValidateModuleValues(path, moduleManifest);
             }
 
-            [[nodiscard]] bool ReadModuleFields(const Json &value, const std::string_view path, ExtensionModuleManifest &module) {
-                return ReadId(value, "id", path, module.id) &&
-                       ReadString(value, "version", path, module.version, MaximumSemanticVersionBytes, true) &&
-                       ReadString(value, "kind", path, module.kind, limits_.maximumIdentifierBytes, true) &&
-                       ReadString(value, "entry", path, module.entry, MaximumEntryBytes, false);
+            [[nodiscard]] bool ReadModuleFields(const Json &value, const std::string_view path, ExtensionModuleManifest &moduleManifest) {
+                return ReadId(value, "id", path, moduleManifest.id) &&
+                       ReadString(value, "version", path, moduleManifest.version, MaximumSemanticVersionBytes, true) &&
+                       ReadString(value, "kind", path, moduleManifest.kind, limits_.maximumIdentifierBytes, true) &&
+                       ReadString(value, "entry", path, moduleManifest.entry, MaximumEntryBytes, false);
             }
 
-            [[nodiscard]] bool ValidateModuleValues(const std::string_view path, const ExtensionModuleManifest &module) {
-                if (!IsCanonicalSemanticVersion(module.version))
+            [[nodiscard]] bool ValidateModuleValues(const std::string_view path, const ExtensionModuleManifest &moduleManifest) {
+                if (!IsCanonicalSemanticVersion(moduleManifest.version))
                     return Reject(ChildPath(path, "version"), "extension.manifest.invalid_version",
                                   "Module version must be canonical semantic version text.");
-                if (!IsCanonicalToken(module.kind, limits_.maximumIdentifierBytes))
+                if (!IsCanonicalToken(moduleManifest.kind, limits_.maximumIdentifierBytes))
                     return Reject(ChildPath(path, "kind"), "extension.manifest.invalid_value", "Module kind is not canonical.");
-                if (!module.entry.empty() && !IsSafeEntry(module.entry))
+                if (!moduleManifest.entry.empty() && !IsSafeEntry(moduleManifest.entry))
                     return Reject(ChildPath(path, "entry"), "extension.manifest.invalid_path",
                                   "Module entry must be a safe package-relative path.");
                 return true;
@@ -385,7 +394,7 @@ namespace Horo::Extensions {
                     return Reject("$.contributions", "extension.manifest.collection_limit",
                                   "Contribution count exceeds the configured limit.");
 
-                std::unordered_set<std::string> identities;
+                std::set<std::string, std::less<>> identities;
                 manifest.contributions.reserve(found->size());
                 for (std::size_t index = 0; index < found->size(); ++index) {
                     const Json &value = (*found)[index];
@@ -420,8 +429,8 @@ namespace Horo::Extensions {
 
             [[nodiscard]] static bool HasOwningModule(const std::vector<ExtensionModuleManifest> &modules,
                                                       const std::string_view moduleId) {
-                return std::ranges::any_of(modules, [moduleId](const ExtensionModuleManifest &module) {
-                    return module.id == moduleId;
+                return std::ranges::any_of(modules, [moduleId](const ExtensionModuleManifest &moduleManifest) {
+                    return moduleManifest.id == moduleId;
                 });
             }
 

--- a/src/extensions/manifest/ExtensionManifestParser.cpp
+++ b/src/extensions/manifest/ExtensionManifestParser.cpp
@@ -24,6 +24,10 @@ namespace Horo::Extensions {
             return character >= 'a' && character <= 'z';
         }
 
+        [[nodiscard]] bool IsCanonicalTokenCharacter(const unsigned char character) noexcept {
+            return IsAsciiLower(character) || IsAsciiDigit(character) || character == '_' || character == '-';
+        }
+
         [[nodiscard]] bool IsPrereleaseCharacter(const unsigned char character) noexcept {
             const bool upper = character >= 'A' && character <= 'Z';
             return IsAsciiLower(character) || upper || IsAsciiDigit(character) || character == '-';
@@ -84,7 +88,9 @@ namespace Horo::Extensions {
         }
 
         [[nodiscard]] bool IsCanonicalIdSegment(const std::string_view segment) {
-            if (segment.empty() || !IsAsciiLower(static_cast<unsigned char>(segment.front())) || segment.back() == '-')
+            if (segment.empty())
+                return false;
+            if (!IsAsciiLower(static_cast<unsigned char>(segment.front())) || segment.back() == '-')
                 return false;
             return std::ranges::all_of(segment, [](const unsigned char character) {
                 return IsAsciiLower(character) || IsAsciiDigit(character) || character == '-';
@@ -110,17 +116,19 @@ namespace Horo::Extensions {
         }
 
         [[nodiscard]] bool IsCanonicalToken(const std::string_view value, const std::size_t maximumBytes) {
-            if (value.empty() || value.size() > maximumBytes || value.front() == '_' || value.back() == '_')
+            if (value.empty() || value.size() > maximumBytes)
                 return false;
-            return std::ranges::all_of(value, [](const unsigned char character) {
-                return (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9') || character == '_' ||
-                       character == '-';
-            });
+            if (value.front() == '_' || value.back() == '_')
+                return false;
+            return std::ranges::all_of(value, IsCanonicalTokenCharacter);
         }
 
         [[nodiscard]] bool HasSafeEntryPrefix(const std::string_view value) {
-            return !value.empty() && value.size() <= MaximumEntryBytes && value.front() != '/' && value.front() != '\\' &&
-                   value.find('\\') == std::string_view::npos && value.find(':') == std::string_view::npos;
+            if (value.empty() || value.size() > MaximumEntryBytes)
+                return false;
+            if (value.front() == '/' || value.front() == '\\')
+                return false;
+            return value.find('\\') == std::string_view::npos && value.find(':') == std::string_view::npos;
         }
 
         [[nodiscard]] bool IsSafeEntryComponent(const std::string_view value) {
@@ -152,21 +160,16 @@ namespace Horo::Extensions {
             [[nodiscard]] Result<ExtensionManifest> Validate(const Json &document) {
                 if (!document.is_object())
                     return Failure("$", "extension.manifest.invalid_type", "Manifest root must be an object.");
-                if (!ValidateRootFields(document))
-                    return CurrentFailure();
-
                 ExtensionManifest manifest;
-                if (!ValidateSchemaVersion(document, manifest.schemaVersion))
+                if (!ValidateRootFields(document) || !ValidateSchemaVersion(document, manifest.schemaVersion))
                     return CurrentFailure();
 
                 const Json *package = SelectPackage(document);
                 if (package == nullptr)
                     return CurrentFailure();
-                if (const std::string packagePath = document.contains("package") ? "$.package" : "$";
-                    !ParsePackage(*package, packagePath, manifest) || !ParseCompatibility(document, manifest) ||
-                    !ParseModules(document, manifest) || !ParseContributions(document, manifest)) {
+                const std::string packagePath = document.contains("package") ? "$.package" : "$";
+                if (!ParseManifestSections(document, *package, packagePath, manifest))
                     return CurrentFailure();
-                }
                 return Result<ExtensionManifest>::Success(std::move(manifest));
             }
 
@@ -257,21 +260,38 @@ namespace Horo::Extensions {
             }
 
             [[nodiscard]] bool ParsePackage(const Json &package, const std::string_view path, ExtensionManifest &manifest) {
-                if (!ReadId(package, "id", path, manifest.id) ||
-                    !ReadString(package, "version", path, manifest.version, MaximumSemanticVersionBytes, true)) {
+                if (!ReadPackageIdentity(package, path, manifest))
                     return false;
-                }
                 if (!IsCanonicalSemanticVersion(manifest.version))
                     return Reject(ChildPath(path, "version"), "extension.manifest.invalid_version",
                                   "Version must be canonical semantic version text.");
-                if (!ReadString(package, "kind", path, manifest.kind, limits_.maximumIdentifierBytes, false) ||
-                    !ReadString(package, "displayName", path, manifest.displayName, limits_.maximumStringBytes, false) ||
-                    !ReadString(package, "description", path, manifest.description, limits_.maximumStringBytes, false) ||
-                    !ReadString(package, "author", path, manifest.author, limits_.maximumStringBytes, false)) {
+                if (!ReadPackageMetadata(package, path, manifest))
                     return false;
-                }
                 return manifest.kind.empty() || IsCanonicalToken(manifest.kind, limits_.maximumIdentifierBytes) ||
                        Reject(ChildPath(path, "kind"), "extension.manifest.invalid_value", "Package kind is not canonical.");
+            }
+
+            [[nodiscard]] bool ReadPackageIdentity(const Json &package, const std::string_view path, ExtensionManifest &manifest) {
+                return ReadId(package, "id", path, manifest.id) &&
+                       ReadString(package, "version", path, manifest.version, MaximumSemanticVersionBytes, true);
+            }
+
+            [[nodiscard]] bool ReadPackageMetadata(const Json &package, const std::string_view path, ExtensionManifest &manifest) {
+                return ReadString(package, "kind", path, manifest.kind, limits_.maximumIdentifierBytes, false) &&
+                       ReadString(package, "displayName", path, manifest.displayName, limits_.maximumStringBytes, false) &&
+                       ReadString(package, "description", path, manifest.description, limits_.maximumStringBytes, false) &&
+                       ReadString(package, "author", path, manifest.author, limits_.maximumStringBytes, false);
+            }
+
+            [[nodiscard]] bool ParseManifestSections(const Json &document, const Json &package, const std::string_view packagePath,
+                                                     ExtensionManifest &manifest) {
+                if (!ParsePackage(package, packagePath, manifest))
+                    return false;
+                if (!ParseCompatibility(document, manifest))
+                    return false;
+                if (!ParseModules(document, manifest))
+                    return false;
+                return ParseContributions(document, manifest);
             }
 
             [[nodiscard]] bool ParseCompatibility(const Json &document, ExtensionManifest &manifest) {
@@ -318,17 +338,23 @@ namespace Horo::Extensions {
                 std::set<std::string, std::less<>> identities;
                 platforms.reserve(found->size());
                 for (std::size_t index = 0; index < found->size(); ++index) {
-                    const Json &value = (*found)[index];
                     const std::string path = ElementPath("$.compatibility.platforms", index);
-                    if (!value.is_string())
-                        return Reject(path, "extension.manifest.invalid_type", "Platform ID must be a string.");
-                    std::string platform = value.get<std::string>();
-                    if (!IsCanonicalToken(platform, limits_.maximumIdentifierBytes))
-                        return Reject(path, "extension.manifest.invalid_identifier", "Platform ID is not canonical.");
-                    if (!identities.insert(platform).second)
-                        return Reject(path, "extension.manifest.duplicate_identifier", "Platform ID must be unique.");
-                    platforms.push_back(std::move(platform));
+                    if (!AppendPlatform((*found)[index], path, identities, platforms))
+                        return false;
                 }
+                return true;
+            }
+
+            [[nodiscard]] bool AppendPlatform(const Json &value, const std::string_view path,
+                                              std::set<std::string, std::less<>> &identities, std::vector<std::string> &platforms) {
+                if (!value.is_string())
+                    return Reject(path, "extension.manifest.invalid_type", "Platform ID must be a string.");
+                std::string platform = value.get<std::string>();
+                if (!IsCanonicalToken(platform, limits_.maximumIdentifierBytes))
+                    return Reject(path, "extension.manifest.invalid_identifier", "Platform ID is not canonical.");
+                if (!identities.insert(platform).second)
+                    return Reject(path, "extension.manifest.duplicate_identifier", "Platform ID must be unique.");
+                platforms.push_back(std::move(platform));
                 return true;
             }
 
@@ -344,16 +370,22 @@ namespace Horo::Extensions {
                 std::set<std::string, std::less<>> identities;
                 manifest.modules.reserve(found->size());
                 for (std::size_t index = 0; index < found->size(); ++index) {
-                    const Json &value = (*found)[index];
                     const std::string path = ElementPath("$.modules", index);
-                    ExtensionModuleManifest moduleManifest;
-                    if (!ParseModule(value, path, moduleManifest))
+                    if (!AppendModule((*found)[index], path, identities, manifest.modules))
                         return false;
-                    if (!identities.insert(moduleManifest.id).second)
-                        return Reject(ChildPath(path, "id"), "extension.manifest.duplicate_identifier",
-                                      "Module ID must be unique within the package.");
-                    manifest.modules.push_back(std::move(moduleManifest));
                 }
+                return true;
+            }
+
+            [[nodiscard]] bool AppendModule(const Json &value, const std::string_view path, std::set<std::string, std::less<>> &identities,
+                                            std::vector<ExtensionModuleManifest> &modules) {
+                ExtensionModuleManifest moduleManifest;
+                if (!ParseModule(value, path, moduleManifest))
+                    return false;
+                if (!identities.insert(moduleManifest.id).second)
+                    return Reject(ChildPath(path, "id"), "extension.manifest.duplicate_identifier",
+                                  "Module ID must be unique within the package.");
+                modules.push_back(std::move(moduleManifest));
                 return true;
             }
 
@@ -397,19 +429,27 @@ namespace Horo::Extensions {
                 std::set<std::string, std::less<>> identities;
                 manifest.contributions.reserve(found->size());
                 for (std::size_t index = 0; index < found->size(); ++index) {
-                    const Json &value = (*found)[index];
                     const std::string path = ElementPath("$.contributions", index);
-                    ExtensionContributionManifest contribution;
-                    if (!ParseContribution(value, path, contribution))
+                    if (!AppendContribution((*found)[index], path, identities, manifest.modules, manifest.contributions))
                         return false;
-                    if (!identities.insert(contribution.id).second)
-                        return Reject(ChildPath(path, "id"), "extension.manifest.duplicate_identifier",
-                                      "Contribution ID must be unique within the package.");
-                    if (!HasOwningModule(manifest.modules, contribution.owningModule))
-                        return Reject(ChildPath(path, "module"), "extension.manifest.unresolved_reference",
-                                      "Contribution references an undeclared module.");
-                    manifest.contributions.push_back(std::move(contribution));
                 }
+                return true;
+            }
+
+            [[nodiscard]] bool AppendContribution(const Json &value, const std::string_view path,
+                                                  std::set<std::string, std::less<>> &identities,
+                                                  const std::vector<ExtensionModuleManifest> &modules,
+                                                  std::vector<ExtensionContributionManifest> &contributions) {
+                ExtensionContributionManifest contribution;
+                if (!ParseContribution(value, path, contribution))
+                    return false;
+                if (!identities.insert(contribution.id).second)
+                    return Reject(ChildPath(path, "id"), "extension.manifest.duplicate_identifier",
+                                  "Contribution ID must be unique within the package.");
+                if (!HasOwningModule(modules, contribution.owningModule))
+                    return Reject(ChildPath(path, "module"), "extension.manifest.unresolved_reference",
+                                  "Contribution references an undeclared module.");
+                contributions.push_back(std::move(contribution));
                 return true;
             }
 

--- a/src/extensions/manifest/ExtensionManifestParser.cpp
+++ b/src/extensions/manifest/ExtensionManifestParser.cpp
@@ -1,15 +1,44 @@
-#include "Horo/Extensions/ExtensionErrors.h"
+#include "ExtensionManifestParsing.h"
 #include "Horo/Extensions/ExtensionManifest.h"
-#include "Horo/Foundation/Logging/Logger.h"
 
-#include <algorithm>
-#include <cctype>
-#include <nlohmann/json.hpp>
+#include <initializer_list>
+#include <optional>
+#include <ranges>
+#include <string>
+#include <unordered_set>
+#include <utility>
 
 namespace Horo::Extensions {
-    using Json = nlohmann::json;
-
     namespace {
+        using namespace ManifestParsing;
+
+        constexpr std::size_t MaximumSemanticVersionBytes = 64;
+        constexpr std::size_t MaximumEntryBytes = 512;
+
+        [[nodiscard]] bool IsAsciiDigit(const unsigned char character) noexcept {
+            return character >= '0' && character <= '9';
+        }
+
+        [[nodiscard]] bool IsAsciiLower(const unsigned char character) noexcept {
+            return character >= 'a' && character <= 'z';
+        }
+
+        [[nodiscard]] bool IsPrereleaseCharacter(const unsigned char character) noexcept {
+            const bool upper = character >= 'A' && character <= 'Z';
+            return IsAsciiLower(character) || upper || IsAsciiDigit(character) || character == '-';
+        }
+
+        [[nodiscard]] bool IsCanonicalNumericComponent(const std::string_view value) {
+            const bool leadingZero = value.size() > 1 && value.front() == '0';
+            return !value.empty() && !leadingZero && std::ranges::all_of(value, IsAsciiDigit);
+        }
+
+        [[nodiscard]] bool IsValidPrereleaseIdentifier(const std::string_view value) {
+            const bool numeric = std::ranges::all_of(value, IsAsciiDigit);
+            const bool leadingZero = numeric && value.size() > 1 && value.front() == '0';
+            return !value.empty() && !leadingZero && std::ranges::all_of(value, IsPrereleaseCharacter);
+        }
+
         [[nodiscard]] bool IsPrereleaseValid(const std::string_view prerelease) {
             if (prerelease.empty())
                 return false;
@@ -19,18 +48,8 @@ namespace Horo::Extensions {
                 const std::string_view identifier =
                     prerelease.substr(identifierStart,
                                       end == std::string_view::npos ? prerelease.size() - identifierStart : end - identifierStart);
-                if (identifier.empty() || !std::ranges::all_of(identifier, [](const unsigned char character) {
-                    return std::isalnum(character) != 0 || character == '-';
-                })) {
+                if (!IsValidPrereleaseIdentifier(identifier))
                     return false;
-                }
-                if (const bool numeric = std::ranges::all_of(identifier,
-                                                             [](const unsigned char character) {
-                    return std::isdigit(character) != 0;
-                });
-                    numeric && identifier.size() > 1 && identifier.front() == '0')
-                    return false;
-
                 if (end == std::string_view::npos)
                     return true;
                 identifierStart = end + 1;
@@ -38,194 +57,384 @@ namespace Horo::Extensions {
             return false;
         }
 
-        [[nodiscard]] bool IsCanonicalSemanticVersion(const std::string_view value) {
-            if (value.empty() || value.size() > 64 || value.find('+') != std::string_view::npos)
-                return false;
-            const std::size_t dash = value.find('-');
-            const std::string_view core = value.substr(0, dash);
+        [[nodiscard]] bool IsCanonicalCoreVersion(const std::string_view core) {
             std::size_t componentStart = 0;
             for (int component = 0; component < 3; ++component) {
                 const std::size_t end = component == 2 ? core.size() : core.find('.', componentStart);
                 if (end == std::string_view::npos || end == componentStart)
                     return false;
-                if (const std::string_view digits = core.substr(componentStart, end - componentStart);
-                    (digits.size() > 1 && digits.front() == '0') || !std::ranges::all_of(digits, [](const unsigned char character) {
-                    return std::isdigit(character) != 0;
-                })) {
+                const std::string_view digits = core.substr(componentStart, end - componentStart);
+                if (!IsCanonicalNumericComponent(digits))
                     return false;
-                }
                 componentStart = end + 1;
             }
-            if (componentStart != core.size() + 1)
+            return componentStart == core.size() + 1;
+        }
+
+        [[nodiscard]] bool IsCanonicalSemanticVersion(const std::string_view value) {
+            if (value.empty() || value.size() > MaximumSemanticVersionBytes || value.find('+') != std::string_view::npos)
                 return false;
-            if (dash == std::string_view::npos)
-                return true;
-            return IsPrereleaseValid(value.substr(dash + 1));
+            const std::size_t dash = value.find('-');
+            if (!IsCanonicalCoreVersion(value.substr(0, dash)))
+                return false;
+            return dash == std::string_view::npos || IsPrereleaseValid(value.substr(dash + 1));
         }
 
-        void AppendPlatforms(const Json &compatibility, std::vector<std::string> &platforms) {
-            if (!compatibility.contains("platforms") || !compatibility["platforms"].is_array())
-                return;
-            for (const auto &platform : compatibility["platforms"]) {
-                if (platform.is_string())
-                    platforms.push_back(platform.get<std::string>());
+        [[nodiscard]] bool IsCanonicalIdSegment(const std::string_view segment) {
+            if (segment.empty() || !IsAsciiLower(static_cast<unsigned char>(segment.front())) || segment.back() == '-')
+                return false;
+            return std::ranges::all_of(segment, [](const unsigned char character) {
+                return IsAsciiLower(character) || IsAsciiDigit(character) || character == '-';
+            });
+        }
+
+        [[nodiscard]] bool IsCanonicalId(const std::string_view value, const std::size_t maximumBytes) {
+            if (value.empty() || value.size() > maximumBytes)
+                return false;
+            std::size_t start = 0;
+            while (start <= value.size()) {
+                const std::size_t end = value.find('.', start);
+                const std::string_view segment = value.substr(start, end == std::string_view::npos ? value.size() - start : end - start);
+                if (!IsCanonicalIdSegment(segment))
+                    return false;
+                if (end == std::string_view::npos)
+                    return true;
+                start = end + 1;
             }
+            return false;
         }
 
-        Result<void> ParseCompatibility(const Json &json, ExtensionManifest &manifest) {
-            if (!json.contains("compatibility") || !json["compatibility"].is_object())
-                return Result<void>::Success();
-            const auto &compatibility = json["compatibility"];
-            if (compatibility.contains("engineMin") && compatibility["engineMin"].is_string())
-                manifest.engineMin = compatibility["engineMin"].get<std::string>();
-            if (compatibility.contains("engineMax") && compatibility["engineMax"].is_string())
-                manifest.engineMax = compatibility["engineMax"].get<std::string>();
-            if (compatibility.contains("sdkAbi") && compatibility["sdkAbi"].is_string())
-                manifest.sdkAbi = compatibility["sdkAbi"].get<std::string>();
-            AppendPlatforms(compatibility, manifest.platforms);
-            return Result<void>::Success();
+        [[nodiscard]] bool IsCanonicalToken(const std::string_view value, const std::size_t maximumBytes) {
+            if (value.empty() || value.size() > maximumBytes || value.front() == '_' || value.back() == '_')
+                return false;
+            return std::ranges::all_of(value, [](const unsigned char character) {
+                return (character >= 'a' && character <= 'z') || (character >= '0' && character <= '9') || character == '_' ||
+                       character == '-';
+            });
         }
 
-        [[nodiscard]] const Json *FindArrayProperty(const Json &json, const std::string_view key, Result<void> &error) {
-            if (const auto it = json.find(key); it != json.end()) {
-                if (!it->is_array()) {
-                    error = Result<void>::Failure(MakeError(ExtensionErrors::InvalidManifest, std::format("'{}' must be an array.", key)));
+        [[nodiscard]] bool HasSafeEntryPrefix(const std::string_view value) {
+            return !value.empty() && value.size() <= MaximumEntryBytes && value.front() != '/' && value.front() != '\\' &&
+                   value.find('\\') == std::string_view::npos && value.find(':') == std::string_view::npos;
+        }
+
+        [[nodiscard]] bool IsSafeEntryComponent(const std::string_view value) {
+            return !value.empty() && value != "." && value != "..";
+        }
+
+        [[nodiscard]] bool IsSafeEntry(const std::string_view value) {
+            if (!HasSafeEntryPrefix(value))
+                return false;
+            std::size_t start = 0;
+            while (start <= value.size()) {
+                const std::size_t end = value.find('/', start);
+                const std::string_view component = value.substr(start, end == std::string_view::npos ? value.size() - start : end - start);
+                if (!IsSafeEntryComponent(component))
+                    return false;
+                if (end == std::string_view::npos)
+                    return true;
+                start = end + 1;
+            }
+            return false;
+        }
+
+        class ManifestValidator final {
+        public:
+            explicit ManifestValidator(const ExtensionManifestLimits &limits) : limits_(limits) {}
+
+            [[nodiscard]] Result<ExtensionManifest> Validate(const Json &document) {
+                if (!document.is_object())
+                    return Failure("$", "extension.manifest.invalid_type", "Manifest root must be an object.");
+                if (!ValidateRootFields(document))
+                    return CurrentFailure();
+
+                ExtensionManifest manifest;
+                if (!ValidateSchemaVersion(document, manifest.schemaVersion))
+                    return CurrentFailure();
+
+                const Json *package = SelectPackage(document);
+                if (package == nullptr)
+                    return CurrentFailure();
+                const std::string packagePath = document.contains("package") ? "$.package" : "$";
+                if (!ParsePackage(*package, packagePath, manifest) || !ParseCompatibility(document, manifest) ||
+                    !ParseModules(document, manifest) || !ParseContributions(document, manifest)) {
+                    return CurrentFailure();
+                }
+                return Result<ExtensionManifest>::Success(std::move(manifest));
+            }
+
+        private:
+            [[nodiscard]] bool Reject(const std::string_view path, const std::string_view code, const std::string_view reason) {
+                failure_ = ManifestError(path, code, reason);
+                return false;
+            }
+
+            [[nodiscard]] Result<ExtensionManifest> Failure(const std::string_view path, const std::string_view code,
+                                                            const std::string_view reason) const {
+                return Result<ExtensionManifest>::Failure(ManifestError(path, code, reason));
+            }
+
+            [[nodiscard]] Result<ExtensionManifest> CurrentFailure() {
+                return Result<ExtensionManifest>::Failure(std::move(*failure_));
+            }
+
+            [[nodiscard]] bool AllowFields(const Json &object, const std::string_view path,
+                                           const std::initializer_list<std::string_view> allowed) {
+                for (const auto &[key, value] : object.items()) {
+                    static_cast<void>(value);
+                    if (std::ranges::find(allowed, std::string_view{key}) == allowed.end())
+                        return Reject(ChildPath(path, key), "extension.manifest.unknown_field", "Unknown field is not allowed.");
+                }
+                return true;
+            }
+
+            [[nodiscard]] bool ReadString(const Json &object, const std::string_view key, const std::string_view path, std::string &output,
+                                          const std::size_t maximumBytes, const bool required) {
+                const auto found = object.find(key);
+                if (found == object.end())
+                    return !required || Reject(ChildPath(path, key), "extension.manifest.missing_field", "Required field is missing.");
+                if (!found->is_string())
+                    return Reject(ChildPath(path, key), "extension.manifest.invalid_type", "Field must be a string.");
+                output = found->get<std::string>();
+                if ((required && output.empty()) || output.size() > maximumBytes)
+                    return Reject(ChildPath(path, key), "extension.manifest.invalid_value", "String value is empty or exceeds its limit.");
+                return true;
+            }
+
+            [[nodiscard]] bool ReadId(const Json &object, const std::string_view key, const std::string_view path, std::string &output) {
+                return ReadString(object, key, path, output, limits_.maximumIdentifierBytes, true) &&
+                       (IsCanonicalId(output, limits_.maximumIdentifierBytes) ||
+                        Reject(ChildPath(path, key), "extension.manifest.invalid_identifier",
+                               "Identity must use canonical lowercase dot-separated segments."));
+            }
+
+            [[nodiscard]] bool ValidateRootFields(const Json &document) {
+                return AllowFields(document, "$",
+                                   {"schemaVersion", "package", "id", "version", "kind", "displayName", "description", "author",
+                                    "compatibility", "modules", "contributions"});
+            }
+
+            [[nodiscard]] bool ValidateSchemaVersion(const Json &document, std::uint32_t &schemaVersion) {
+                const auto found = document.find("schemaVersion");
+                if (found == document.end()) {
+                    schemaVersion = 1;
+                    return true;
+                }
+                if (!found->is_number_unsigned() || found->get<std::uint64_t>() != 1)
+                    return Reject("$.schemaVersion", "extension.manifest.unsupported_schema", "Only integer schemaVersion 1 is supported.");
+                schemaVersion = 1;
+                return true;
+            }
+
+            [[nodiscard]] const Json *SelectPackage(const Json &document) {
+                const auto nested = document.find("package");
+                if (nested == document.end())
+                    return &document;
+                if (!nested->is_object()) {
+                    static_cast<void>(Reject("$.package", "extension.manifest.invalid_type", "Package field must be an object."));
                     return nullptr;
                 }
-                return std::to_address(it);
-            }
-            return nullptr;
-        }
-
-        Result<void> ParseModules(const Json &json, const std::string &defaultVersion, const std::string &defaultId,
-                                  const std::string &defaultKind, std::vector<ExtensionModuleManifest> &modules) {
-            Result<void> arrayError = Result<void>::Success();
-            if (const Json *modulesJson = FindArrayProperty(json, "modules", arrayError); modulesJson != nullptr) {
-                for (const auto &moduleJson : *modulesJson) {
-                    if (!moduleJson.is_object() || !moduleJson.contains("id") || !moduleJson["id"].is_string())
-                        return Result<void>::Failure(
-                            MakeError(ExtensionErrors::InvalidManifest, "Every extension module requires a stable 'id'."));
-                    ExtensionModuleManifest parsed{
-                        .id = moduleJson["id"].get<std::string>(),
-                        .version = moduleJson.value("version", defaultVersion),
-                        .kind = moduleJson.value("kind", std::string{}),
-                        .entry = moduleJson.value("entry", std::string{}),
-                    };
-                    if (parsed.id.empty() || !IsCanonicalSemanticVersion(parsed.version))
-                        return Result<void>::Failure(
-                            MakeError(ExtensionErrors::InvalidManifest, "Every extension module requires a canonical semantic version."));
-                    if (std::ranges::any_of(modules, [&parsed](const ExtensionModuleManifest &existing) {
-                        return existing.id == parsed.id;
-                    })) {
-                        return Result<void>::Failure(
-                            MakeError(ExtensionErrors::InvalidManifest, "Extension module identities must be unique within a package."));
+                constexpr std::string_view packageFields[] = {"id", "version", "kind", "displayName", "description", "author"};
+                for (const std::string_view field : packageFields) {
+                    if (document.contains(field)) {
+                        static_cast<void>(Reject(ChildPath("$", field), "extension.manifest.ambiguous_field",
+                                                 "Package fields cannot appear both at the root and in $.package."));
+                        return nullptr;
                     }
-                    modules.push_back(std::move(parsed));
                 }
-            } else if (arrayError.HasError()) {
-                return arrayError;
+                if (!AllowFields(*nested, "$.package", {"id", "version", "kind", "displayName", "description", "author"}))
+                    return nullptr;
+                return std::to_address(nested);
             }
-            if (modules.empty()) {
-                modules.push_back(ExtensionModuleManifest{
-                    .id = defaultId,
-                    .version = defaultVersion,
-                    .kind = defaultKind,
+
+            [[nodiscard]] bool ParsePackage(const Json &package, const std::string_view path, ExtensionManifest &manifest) {
+                if (!ReadId(package, "id", path, manifest.id) ||
+                    !ReadString(package, "version", path, manifest.version, MaximumSemanticVersionBytes, true)) {
+                    return false;
+                }
+                if (!IsCanonicalSemanticVersion(manifest.version))
+                    return Reject(ChildPath(path, "version"), "extension.manifest.invalid_version",
+                                  "Version must be canonical semantic version text.");
+                if (!ReadString(package, "kind", path, manifest.kind, limits_.maximumIdentifierBytes, false) ||
+                    !ReadString(package, "displayName", path, manifest.displayName, limits_.maximumStringBytes, false) ||
+                    !ReadString(package, "description", path, manifest.description, limits_.maximumStringBytes, false) ||
+                    !ReadString(package, "author", path, manifest.author, limits_.maximumStringBytes, false)) {
+                    return false;
+                }
+                return manifest.kind.empty() || IsCanonicalToken(manifest.kind, limits_.maximumIdentifierBytes) ||
+                       Reject(ChildPath(path, "kind"), "extension.manifest.invalid_value", "Package kind is not canonical.");
+            }
+
+            [[nodiscard]] bool ParseCompatibility(const Json &document, ExtensionManifest &manifest) {
+                const auto found = document.find("compatibility");
+                if (found == document.end())
+                    return true;
+                if (!found->is_object())
+                    return Reject("$.compatibility", "extension.manifest.invalid_type", "Compatibility field must be an object.");
+                if (!ReadCompatibilityFields(*found, manifest))
+                    return false;
+                if (!ValidateCompatibilityValues(manifest))
+                    return false;
+                return ParsePlatforms(*found, manifest.platforms);
+            }
+
+            [[nodiscard]] bool ReadCompatibilityFields(const Json &compatibility, ExtensionManifest &manifest) {
+                return AllowFields(compatibility, "$.compatibility", {"engineMin", "engineMax", "sdkAbi", "platforms"}) &&
+                       ReadString(compatibility, "engineMin", "$.compatibility", manifest.engineMin, MaximumSemanticVersionBytes, false) &&
+                       ReadString(compatibility, "engineMax", "$.compatibility", manifest.engineMax, MaximumSemanticVersionBytes, false) &&
+                       ReadString(compatibility, "sdkAbi", "$.compatibility", manifest.sdkAbi, limits_.maximumIdentifierBytes, false);
+            }
+
+            [[nodiscard]] bool ValidateCompatibilityValues(const ExtensionManifest &manifest) {
+                const bool invalidMinimum = !manifest.engineMin.empty() && !IsCanonicalSemanticVersion(manifest.engineMin);
+                const bool invalidMaximum = !manifest.engineMax.empty() && !IsCanonicalSemanticVersion(manifest.engineMax);
+                if (invalidMinimum || invalidMaximum) {
+                    return Reject("$.compatibility", "extension.manifest.invalid_version",
+                                  "Engine compatibility values must be canonical semantic versions.");
+                }
+                if (!manifest.sdkAbi.empty() && !IsCanonicalId(manifest.sdkAbi, limits_.maximumIdentifierBytes))
+                    return Reject("$.compatibility.sdkAbi", "extension.manifest.invalid_identifier", "SDK ABI ID is not canonical.");
+                return true;
+            }
+
+            [[nodiscard]] bool ParsePlatforms(const Json &compatibility, std::vector<std::string> &platforms) {
+                const auto found = compatibility.find("platforms");
+                if (found == compatibility.end())
+                    return true;
+                if (!found->is_array())
+                    return Reject("$.compatibility.platforms", "extension.manifest.invalid_type", "Platforms must be an array.");
+                if (found->size() > limits_.maximumPlatforms)
+                    return Reject("$.compatibility.platforms", "extension.manifest.collection_limit",
+                                  "Platform count exceeds the configured limit.");
+                std::unordered_set<std::string> identities;
+                platforms.reserve(found->size());
+                for (std::size_t index = 0; index < found->size(); ++index) {
+                    const Json &value = (*found)[index];
+                    const std::string path = ElementPath("$.compatibility.platforms", index);
+                    if (!value.is_string())
+                        return Reject(path, "extension.manifest.invalid_type", "Platform ID must be a string.");
+                    std::string platform = value.get<std::string>();
+                    if (!IsCanonicalToken(platform, limits_.maximumIdentifierBytes))
+                        return Reject(path, "extension.manifest.invalid_identifier", "Platform ID is not canonical.");
+                    if (!identities.insert(platform).second)
+                        return Reject(path, "extension.manifest.duplicate_identifier", "Platform ID must be unique.");
+                    platforms.push_back(std::move(platform));
+                }
+                return true;
+            }
+
+            [[nodiscard]] bool ParseModules(const Json &document, ExtensionManifest &manifest) {
+                const auto found = document.find("modules");
+                if (found == document.end())
+                    return Reject("$.modules", "extension.manifest.missing_field", "At least one explicit module is required.");
+                if (!found->is_array())
+                    return Reject("$.modules", "extension.manifest.invalid_type", "Modules must be an array.");
+                if (found->empty() || found->size() > limits_.maximumModules)
+                    return Reject("$.modules", "extension.manifest.collection_limit", "Module count must be within configured limits.");
+
+                std::unordered_set<std::string> identities;
+                manifest.modules.reserve(found->size());
+                for (std::size_t index = 0; index < found->size(); ++index) {
+                    const Json &value = (*found)[index];
+                    const std::string path = ElementPath("$.modules", index);
+                    ExtensionModuleManifest module;
+                    if (!ParseModule(value, path, module))
+                        return false;
+                    if (!identities.insert(module.id).second)
+                        return Reject(ChildPath(path, "id"), "extension.manifest.duplicate_identifier",
+                                      "Module ID must be unique within the package.");
+                    manifest.modules.push_back(std::move(module));
+                }
+                return true;
+            }
+
+            [[nodiscard]] bool ParseModule(const Json &value, const std::string_view path, ExtensionModuleManifest &module) {
+                if (!value.is_object())
+                    return Reject(path, "extension.manifest.invalid_type", "Module must be an object.");
+                if (!AllowFields(value, path, {"id", "version", "kind", "entry"}))
+                    return false;
+                return ReadModuleFields(value, path, module) && ValidateModuleValues(path, module);
+            }
+
+            [[nodiscard]] bool ReadModuleFields(const Json &value, const std::string_view path, ExtensionModuleManifest &module) {
+                return ReadId(value, "id", path, module.id) &&
+                       ReadString(value, "version", path, module.version, MaximumSemanticVersionBytes, true) &&
+                       ReadString(value, "kind", path, module.kind, limits_.maximumIdentifierBytes, true) &&
+                       ReadString(value, "entry", path, module.entry, MaximumEntryBytes, false);
+            }
+
+            [[nodiscard]] bool ValidateModuleValues(const std::string_view path, const ExtensionModuleManifest &module) {
+                if (!IsCanonicalSemanticVersion(module.version))
+                    return Reject(ChildPath(path, "version"), "extension.manifest.invalid_version",
+                                  "Module version must be canonical semantic version text.");
+                if (!IsCanonicalToken(module.kind, limits_.maximumIdentifierBytes))
+                    return Reject(ChildPath(path, "kind"), "extension.manifest.invalid_value", "Module kind is not canonical.");
+                if (!module.entry.empty() && !IsSafeEntry(module.entry))
+                    return Reject(ChildPath(path, "entry"), "extension.manifest.invalid_path",
+                                  "Module entry must be a safe package-relative path.");
+                return true;
+            }
+
+            [[nodiscard]] bool ParseContributions(const Json &document, ExtensionManifest &manifest) {
+                const auto found = document.find("contributions");
+                if (found == document.end())
+                    return true;
+                if (!found->is_array())
+                    return Reject("$.contributions", "extension.manifest.invalid_type", "Contributions must be an array.");
+                if (found->size() > limits_.maximumContributions)
+                    return Reject("$.contributions", "extension.manifest.collection_limit",
+                                  "Contribution count exceeds the configured limit.");
+
+                std::unordered_set<std::string> identities;
+                manifest.contributions.reserve(found->size());
+                for (std::size_t index = 0; index < found->size(); ++index) {
+                    const Json &value = (*found)[index];
+                    const std::string path = ElementPath("$.contributions", index);
+                    ExtensionContributionManifest contribution;
+                    if (!ParseContribution(value, path, contribution))
+                        return false;
+                    if (!identities.insert(contribution.id).second)
+                        return Reject(ChildPath(path, "id"), "extension.manifest.duplicate_identifier",
+                                      "Contribution ID must be unique within the package.");
+                    if (!HasOwningModule(manifest.modules, contribution.owningModule))
+                        return Reject(ChildPath(path, "module"), "extension.manifest.unresolved_reference",
+                                      "Contribution references an undeclared module.");
+                    manifest.contributions.push_back(std::move(contribution));
+                }
+                return true;
+            }
+
+            [[nodiscard]] bool ParseContribution(const Json &value, const std::string_view path,
+                                                 ExtensionContributionManifest &contribution) {
+                if (!value.is_object())
+                    return Reject(path, "extension.manifest.invalid_type", "Contribution must be an object.");
+                if (!AllowFields(value, path, {"type", "id", "module"}))
+                    return false;
+                if (!ReadString(value, "type", path, contribution.type, limits_.maximumIdentifierBytes, true) ||
+                    !ReadId(value, "id", path, contribution.id) || !ReadId(value, "module", path, contribution.owningModule)) {
+                    return false;
+                }
+                return IsCanonicalId(contribution.type, limits_.maximumIdentifierBytes) ||
+                       Reject(ChildPath(path, "type"), "extension.manifest.invalid_identifier", "Contribution type is not canonical.");
+            }
+
+            [[nodiscard]] static bool HasOwningModule(const std::vector<ExtensionModuleManifest> &modules,
+                                                      const std::string_view moduleId) {
+                return std::ranges::any_of(modules, [moduleId](const ExtensionModuleManifest &module) {
+                    return module.id == moduleId;
                 });
             }
-            return Result<void>::Success();
-        }
 
-        Result<void> ParseContributions(const Json &json, const std::vector<ExtensionModuleManifest> &modules,
-                                        std::vector<ExtensionContributionManifest> &contributions) {
-            Result<void> arrayError = Result<void>::Success();
-            if (const Json *contributionsJson = FindArrayProperty(json, "contributions", arrayError); contributionsJson != nullptr) {
-                for (const auto &contribution : *contributionsJson) {
-                    if (!contribution.is_object() || !contribution.contains("type") || !contribution["type"].is_string() ||
-                        !contribution.contains("id") || !contribution["id"].is_string() || !contribution.contains("module") ||
-                        !contribution["module"].is_string()) {
-                        return Result<void>::Failure(
-                            MakeError(ExtensionErrors::InvalidManifest, "Every contribution requires string type, id, and module fields."));
-                    }
-                    ExtensionContributionManifest parsed{
-                        .type = contribution["type"].get<std::string>(),
-                        .id = contribution["id"].get<std::string>(),
-                        .owningModule = contribution["module"].get<std::string>(),
-                    };
-                    if (parsed.type.empty() || parsed.id.empty() ||
-                        !std::ranges::any_of(modules,
-                                             [&parsed](const ExtensionModuleManifest &manifestModule) {
-                        return manifestModule.id == parsed.owningModule;
-                    }) ||
-                        std::ranges::any_of(contributions, [&parsed](const ExtensionContributionManifest &existing) {
-                        return existing.id == parsed.id;
-                    })) {
-                        return Result<void>::Failure(MakeError(ExtensionErrors::InvalidManifest,
-                                                               "Contributions must declare non-empty types, unique identities, "
-                                                               "and target valid declared package modules."));
-                    }
-                    contributions.push_back(std::move(parsed));
-                }
-            } else if (arrayError.HasError()) {
-                return arrayError;
-            }
-            return Result<void>::Success();
-        }
-
+            const ExtensionManifestLimits &limits_;
+            std::optional<Error> failure_;
+        };
     }  // namespace
 
-    Result<ExtensionManifest> ParseExtensionManifest(const std::string &jsonContent) {
-        try {
-            Json json = Json::parse(jsonContent);
-
-            ExtensionManifest manifest;
-
-            if (!json.is_object())
-                return Result<ExtensionManifest>::Failure(
-                    MakeError(ExtensionErrors::InvalidManifest, "Extension manifest must be an object."));
-            // Top-level package fields are canonical. The nested package object
-            // remains accepted while existing development extensions migrate.
-            const Json &package = json.contains("package") && json["package"].is_object() ? json["package"] : json;
-
-            if (package.contains("id") && package["id"].is_string())
-                manifest.id = package["id"].get<std::string>();
-            else
-                return Result<ExtensionManifest>::Failure(MakeError(ExtensionErrors::InvalidManifest, "Missing extension package 'id'."));
-
-            if (package.contains("version") && package["version"].is_string())
-                manifest.version = package["version"].get<std::string>();
-            if (!IsCanonicalSemanticVersion(manifest.version))
-                return Result<ExtensionManifest>::Failure(
-                    MakeError(ExtensionErrors::InvalidManifest, "Package 'version' must be canonical semantic version text."));
-
-            if (package.contains("kind") && package["kind"].is_string())
-                manifest.kind = package["kind"].get<std::string>();
-
-            if (package.contains("displayName") && package["displayName"].is_string())
-                manifest.displayName = package["displayName"].get<std::string>();
-
-            if (package.contains("description") && package["description"].is_string())
-                manifest.description = package["description"].get<std::string>();
-
-            if (package.contains("author") && package["author"].is_string())
-                manifest.author = package["author"].get<std::string>();
-
-            if (auto compatRes = ParseCompatibility(json, manifest); compatRes.HasError())
-                return Result<ExtensionManifest>::Failure(compatRes.ErrorValue());
-
-            if (auto modRes = ParseModules(json, manifest.version, manifest.id, manifest.kind, manifest.modules); modRes.HasError())
-                return Result<ExtensionManifest>::Failure(modRes.ErrorValue());
-
-            if (auto contribRes = ParseContributions(json, manifest.modules, manifest.contributions); contribRes.HasError())
-                return Result<ExtensionManifest>::Failure(contribRes.ErrorValue());
-
-            return Result<ExtensionManifest>::Success(std::move(manifest));
-        } catch (const Json::parse_error &e) {
-            LOG_ERROR("ExtensionManifestParser", "JSON parse error: %s", e.what());
-            return Result<ExtensionManifest>::Failure(MakeError(ExtensionErrors::InvalidManifest, "Malformed JSON syntax"));
-        } catch (const std::exception &e) {  // NOSONAR(cpp:S1181) JSON value access and schema error boundary.
-            LOG_ERROR("ExtensionManifestParser", "Failed to parse manifest: %s", e.what());
-
-            return Result<ExtensionManifest>::Failure(MakeError(ExtensionErrors::InvalidManifest, e.what()));
-        }
+    /** @copydoc ParseExtensionManifest */
+    Result<ExtensionManifest> ParseExtensionManifest(const std::string_view jsonContent, const ExtensionManifestLimits &limits) {
+        auto parsed = ManifestParsing::ParseBoundedJson(jsonContent, limits);
+        if (parsed.HasError())
+            return Result<ExtensionManifest>::Failure(parsed.ErrorValue());
+        return ManifestValidator{limits}.Validate(parsed.Value());
     }
 }  // namespace Horo::Extensions

--- a/src/extensions/manifest/ExtensionManifestParsing.h
+++ b/src/extensions/manifest/ExtensionManifestParsing.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Horo/Extensions/ExtensionManifest.h"
+
+#include <nlohmann/json.hpp>
+#include <string>
+#include <string_view>
+
+namespace Horo::Extensions::ManifestParsing {
+    using Json = nlohmann::json;
+
+    [[nodiscard]] std::string ChildPath(std::string_view parent, std::string_view key);
+    [[nodiscard]] std::string ElementPath(std::string_view parent, std::size_t index);
+    [[nodiscard]] Error ManifestError(std::string_view path, std::string_view diagnosticCode, std::string_view reason,
+                                      std::uint32_t line = 0, std::uint32_t column = 0);
+    [[nodiscard]] Result<Json> ParseBoundedJson(std::string_view content, const ExtensionManifestLimits &limits);
+}  // namespace Horo::Extensions::ManifestParsing

--- a/src/extensions/registry/ExtensionInventory.cpp
+++ b/src/extensions/registry/ExtensionInventory.cpp
@@ -79,6 +79,14 @@ namespace Horo::Extensions {
             return true;
         }
 
+        [[nodiscard]] bool IsSafeRelativePath(const fs::path &relative) {
+            if (relative.empty() || relative.is_absolute())
+                return false;
+            return std::ranges::none_of(relative, [](const fs::path &component) {
+                return component == "..";
+            });
+        }
+
         [[nodiscard]] std::string BuildCompositionVersion(const std::string_view packageVersion,
                                                           const std::vector<ExtensionModuleManifest> &modules) {
             std::string fingerprint{packageVersion};
@@ -127,11 +135,7 @@ namespace Horo::Extensions {
                     MakeError(ExtensionErrors::LoadFailed, "Extension packages may not contain symlinks."));
             }
             const fs::path relative = fs::relative(entry.path(), source, error);
-            if (const bool escapesRoot = std::ranges::any_of(relative,
-                                                             [](const fs::path &component) {
-                return component == "..";
-            });
-                error || relative.empty() || relative.is_absolute() || escapesRoot) {
+            if (error || !IsSafeRelativePath(relative)) {
                 return Result<ValidatedPackageEntry>::Failure(
                     MakeError(ExtensionErrors::LoadFailed, "Extension package path escaped its source root."));
             }
@@ -309,6 +313,38 @@ namespace Horo::Extensions {
             }
             return Result<void>::Success();
         }
+
+        /** @brief Reads and validates the identity needed to install a package. */
+        [[nodiscard]] Result<ExtensionManifest> ReadInstallManifest(const fs::path &source) {
+            auto parsed = ReadManifest(source / "extension.json");
+            if (parsed.HasError())
+                return Result<ExtensionManifest>::Failure(parsed.ErrorValue());
+            if (!IsSafePackageId(parsed.Value().id))
+                return Result<ExtensionManifest>::Failure(
+                    MakeError(ExtensionErrors::InvalidManifest, "Extension package ID is unsafe for installation."));
+            return parsed;
+        }
+
+        /** @brief Creates the managed root and resolves an unused package destination. */
+        [[nodiscard]] Result<fs::path> PrepareInstallDestination(const fs::path &installRoot, const std::string_view packageId) {
+            std::error_code error;
+            fs::create_directories(installRoot, error);
+            if (error)
+                return Result<fs::path>::Failure(MakeError(ExtensionErrors::LoadFailed, "Unable to create the user extension directory."));
+            const fs::path destination = installRoot / packageId;
+            if (fs::exists(destination, error) || error)
+                return Result<fs::path>::Failure(
+                    MakeError(ExtensionErrors::LoadFailed, "An extension with this package ID is already installed."));
+            return Result<fs::path>::Success(destination);
+        }
+
+        /** @brief Inserts string values from one persisted JSON array into a state set. */
+        void LoadStringSet(const Json &state, const std::string_view field, TransparentStringSet &values) {
+            for (const auto &id : state.value(field, Json::array())) {
+                if (id.is_string())
+                    values.insert(id.get<std::string>());
+            }
+        }
     }  // namespace
 
     /** @copydoc ExtensionInventory::ExtensionInventory */
@@ -366,20 +402,14 @@ namespace Horo::Extensions {
         if (validatedSource.HasError())
             return Result<std::string>::Failure(validatedSource.ErrorValue());
         const fs::path source = std::move(validatedSource).Value();
-        auto parsed = ReadManifest(source / "extension.json");
+        auto parsed = ReadInstallManifest(source);
         if (parsed.HasError())
             return Result<std::string>::Failure(parsed.ErrorValue());
         const ExtensionManifest &manifest = parsed.Value();
-        if (!IsSafePackageId(manifest.id))
-            return Result<std::string>::Failure(
-                MakeError(ExtensionErrors::InvalidManifest, "Extension package ID is unsafe for installation."));
-
-        std::error_code error;
-        fs::create_directories(installRoot_, error);
-        const fs::path destination = installRoot_ / manifest.id;
-        if (error || fs::exists(destination, error))
-            return Result<std::string>::Failure(
-                MakeError(ExtensionErrors::LoadFailed, "An extension with this package ID is already installed."));
+        auto preparedDestination = PrepareInstallDestination(installRoot_, manifest.id);
+        if (preparedDestination.HasError())
+            return Result<std::string>::Failure(preparedDestination.ErrorValue());
+        const fs::path destination = std::move(preparedDestination).Value();
         const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
         const fs::path staging = installRoot_ / std::format(".install-{}-{}", manifest.id, nonce);
         if (auto published = PublishPackage(source, staging, destination); published.HasError())
@@ -469,12 +499,8 @@ namespace Horo::Extensions {
         std::ifstream input(statePath_, std::ios::binary);
         try {
             const Json state = Json::parse(input);
-            for (const auto &id : state.value("enabled", Json::array()))
-                if (id.is_string())
-                    enabled_.insert(id.get<std::string>());
-            for (const auto &id : state.value("trusted", Json::array()))
-                if (id.is_string())
-                    trusted_.insert(id.get<std::string>());
+            LoadStringSet(state, "enabled", enabled_);
+            LoadStringSet(state, "trusted", trusted_);
         } catch (const Json::exception &) {
             return Result<void>::Failure(MakeError(ExtensionErrors::InvalidManifest, "Extension activation state is malformed."));
         }

--- a/src/extensions/registry/ExtensionInventory.cpp
+++ b/src/extensions/registry/ExtensionInventory.cpp
@@ -21,7 +21,7 @@ namespace Horo::Extensions {
         namespace fs = std::filesystem;
         using Json = nlohmann::json;
 
-        constexpr std::uintmax_t kMaximumManifestBytes = 1024U * 1024U;
+        constexpr ExtensionManifestLimits kManifestLimits{};
         constexpr std::size_t kMaximumPackageEntries = 4096;
         constexpr std::uintmax_t kMaximumPackageBytes = 1024ULL * 1024ULL * 1024ULL;
 
@@ -81,13 +81,14 @@ namespace Horo::Extensions {
                 return Result<ExtensionManifest>::Failure(
                     MakeError(ExtensionErrors::InvalidManifest, "Extension manifest must be a regular non-symlink file."));
             }
-            if (const std::uintmax_t size = fs::file_size(absoluteManifestPath, error); error || size > kMaximumManifestBytes)
+            if (const std::uintmax_t size = fs::file_size(absoluteManifestPath, error);
+                error || size > kManifestLimits.maximumDocumentBytes)
                 return Result<ExtensionManifest>::Failure(
                     MakeError(ExtensionErrors::InvalidManifest, "Extension manifest exceeds the bounded size."));
             std::ifstream input(absoluteManifestPath, std::ios::binary);
             std::ostringstream contents;
             contents << input.rdbuf();
-            return ParseExtensionManifest(contents.str());
+            return ParseExtensionManifest(contents.str(), kManifestLimits);
         }
 
         [[nodiscard]] Result<void> CopyPackageTree(const fs::path &source, const fs::path &destination) {

--- a/src/extensions/registry/ExtensionInventory.cpp
+++ b/src/extensions/registry/ExtensionInventory.cpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <ranges>
 #include <span>
 #include <sstream>
@@ -24,6 +25,27 @@ namespace Horo::Extensions {
         constexpr ExtensionManifestLimits kManifestLimits{};
         constexpr std::size_t kMaximumPackageEntries = 4096;
         constexpr std::uintmax_t kMaximumPackageBytes = 1024ULL * 1024ULL * 1024ULL;
+
+        /** @brief Tracks bounded resource consumption while staging a package tree. */
+        struct PackageCopyBudget {
+            std::size_t entryCount{};
+            std::uintmax_t totalBytes{};
+        };
+
+        /** @brief Carries the validated relative path and filesystem type of one package entry. */
+        struct ValidatedPackageEntry {
+            fs::path relativePath;
+            fs::file_status status;
+        };
+
+        /** @brief Preserves process-local activation state across inventory refreshes. */
+        struct RuntimeState {
+            bool active{};
+            std::string loadError;
+            std::string compositionVersion;
+        };
+
+        using RuntimeStateMap = TransparentStringMap<RuntimeState>;
 
         [[nodiscard]] std::string EnvironmentValue(const char *name) {
 #if defined(_WIN32)
@@ -91,6 +113,56 @@ namespace Horo::Extensions {
             return ParseExtensionManifest(contents.str(), kManifestLimits);
         }
 
+        /** @brief Validates one source entry and accounts for the package entry limit. */
+        [[nodiscard]] Result<ValidatedPackageEntry> ValidatePackageEntry(const fs::directory_entry &entry, const fs::path &source,
+                                                                         PackageCopyBudget &budget) {
+            if (++budget.entryCount > kMaximumPackageEntries) {
+                return Result<ValidatedPackageEntry>::Failure(
+                    MakeError(ExtensionErrors::LoadFailed, "Extension package traversal failed or exceeded entry limits."));
+            }
+            std::error_code error;
+            const fs::file_status status = entry.symlink_status(error);
+            if (error || fs::is_symlink(status)) {
+                return Result<ValidatedPackageEntry>::Failure(
+                    MakeError(ExtensionErrors::LoadFailed, "Extension packages may not contain symlinks."));
+            }
+            const fs::path relative = fs::relative(entry.path(), source, error);
+            const bool escapesRoot = std::ranges::any_of(relative, [](const fs::path &component) {
+                return component == "..";
+            });
+            if (error || relative.empty() || relative.is_absolute() || escapesRoot) {
+                return Result<ValidatedPackageEntry>::Failure(
+                    MakeError(ExtensionErrors::LoadFailed, "Extension package path escaped its source root."));
+            }
+            return Result<ValidatedPackageEntry>::Success({.relativePath = relative, .status = status});
+        }
+
+        /** @brief Copies one validated package entry while enforcing the aggregate byte limit. */
+        [[nodiscard]] Result<void> CopyPackageEntry(const fs::directory_entry &entry, const fs::path &target, const fs::file_status &status,
+                                                    PackageCopyBudget &budget) {
+            std::error_code error;
+            if (fs::is_directory(status)) {
+                fs::create_directories(target, error);
+            } else if (fs::is_regular_file(status)) {
+                const std::uintmax_t size = fs::file_size(entry.path(), error);
+                if (error || size > kMaximumPackageBytes - budget.totalBytes) {
+                    return Result<void>::Failure(
+                        MakeError(ExtensionErrors::LoadFailed, "Extension package exceeds the bounded byte size."));
+                }
+                budget.totalBytes += size;
+                fs::create_directories(target.parent_path(), error);
+                if (!error)
+                    fs::copy_file(entry.path(), target, fs::copy_options::none, error);
+            } else {
+                return Result<void>::Failure(
+                    MakeError(ExtensionErrors::LoadFailed, "Extension packages may contain only regular files and directories."));
+            }
+            if (error)
+                return Result<void>::Failure(MakeError(ExtensionErrors::LoadFailed, "Unable to stage extension package contents."));
+            return Result<void>::Success();
+        }
+
+        /** @brief Copies a bounded, symlink-free package tree into a staging directory. */
         [[nodiscard]] Result<void> CopyPackageTree(const fs::path &source, const fs::path &destination) {
             std::error_code error;
             fs::create_directories(destination, error);
@@ -98,44 +170,141 @@ namespace Horo::Extensions {
                 return Result<void>::Failure(
                     MakeError(ExtensionErrors::LoadFailed, "Unable to create extension installation staging directory."));
 
-            std::size_t entryCount = 0;
-            std::uintmax_t totalBytes = 0;
+            PackageCopyBudget budget;
             fs::recursive_directory_iterator it{source, fs::directory_options::skip_permission_denied, error};
             const fs::recursive_directory_iterator end;
             while (!error && it != end) {
-                ++entryCount;
-                if (entryCount > kMaximumPackageEntries)
-                    return Result<void>::Failure(
-                        MakeError(ExtensionErrors::LoadFailed, "Extension package traversal failed or exceeded entry limits."));
-                const fs::file_status status = it->symlink_status(error);
-                if (error || fs::is_symlink(status))
-                    return Result<void>::Failure(MakeError(ExtensionErrors::LoadFailed, "Extension packages may not contain symlinks."));
-                const fs::path relative = fs::relative(it->path(), source, error);
-                if (error || relative.empty() || relative.is_absolute() || std::ranges::any_of(relative, [](const fs::path &component) {
-                    return component == "..";
-                })) {
-                    return Result<void>::Failure(MakeError(ExtensionErrors::LoadFailed, "Extension package path escaped its source root."));
-                }
-                const fs::path target = destination / relative;
-                if (fs::is_directory(status)) {
-                    fs::create_directories(target, error);
-                } else if (fs::is_regular_file(status)) {
-                    const std::uintmax_t size = fs::file_size(it->path(), error);
-                    if (error || size > kMaximumPackageBytes - totalBytes)
-                        return Result<void>::Failure(
-                            MakeError(ExtensionErrors::LoadFailed, "Extension package exceeds the bounded byte size."));
-                    totalBytes += size;
-                    fs::create_directories(target.parent_path(), error);
-                    if (!error)
-                        fs::copy_file(it->path(), target, fs::copy_options::none, error);
-                } else {
-                    return Result<void>::Failure(
-                        MakeError(ExtensionErrors::LoadFailed, "Extension packages may contain only regular files and directories."));
-                }
+                auto validated = ValidatePackageEntry(*it, source, budget);
+                if (validated.HasError())
+                    return Result<void>::Failure(validated.ErrorValue());
+                const ValidatedPackageEntry &packageEntry = validated.Value();
+                if (auto copied = CopyPackageEntry(*it, destination / packageEntry.relativePath, packageEntry.status, budget);
+                    copied.HasError())
+                    return copied;
                 it.increment(error);
             }
             if (error)
                 return Result<void>::Failure(MakeError(ExtensionErrors::LoadFailed, "Unable to stage extension package contents."));
+            return Result<void>::Success();
+        }
+
+        /** @brief Moves current runtime-only state out of inventory entries before rediscovery. */
+        [[nodiscard]] RuntimeStateMap CaptureRuntimeStates(std::vector<ExtensionInventoryEntry> &entries) {
+            RuntimeStateMap runtimeStates;
+            runtimeStates.reserve(entries.size());
+            for (auto &entry : entries) {
+                runtimeStates.try_emplace(entry.packageId, RuntimeState{.active = entry.runtimeActive,
+                                                                        .loadError = std::move(entry.loadError),
+                                                                        .compositionVersion = std::move(entry.runtimeCompositionVersion)});
+            }
+            return runtimeStates;
+        }
+
+        /** @brief Restores runtime-only state onto newly discovered entries with matching identities. */
+        void RestoreRuntimeStates(std::vector<ExtensionInventoryEntry> &entries, RuntimeStateMap &runtimeStates) {
+            for (auto &entry : entries) {
+                if (auto runtime = runtimeStates.find(entry.packageId); runtime != runtimeStates.end()) {
+                    entry.runtimeActive = runtime->second.active;
+                    entry.loadError = std::move(runtime->second.loadError);
+                    entry.runtimeCompositionVersion = std::move(runtime->second.compositionVersion);
+                }
+            }
+        }
+
+        /** @brief Reports whether a directory entry is eligible for manifest discovery. */
+        [[nodiscard]] bool IsDiscoverableDirectory(const fs::directory_entry &directory, std::error_code &error) {
+            const fs::file_status status = directory.symlink_status(error);
+            return !error && !fs::is_symlink(status) && fs::is_directory(status) &&
+                   !directory.path().filename().string().starts_with(".install-");
+        }
+
+        /** @brief Builds one installed-package projection, or skips an invalid or duplicate package. */
+        [[nodiscard]] std::optional<ExtensionInventoryEntry> ReadInstalledEntry(const fs::directory_entry &directory,
+                                                                                const std::vector<ExtensionInventoryEntry> &existing,
+                                                                                const TransparentStringSet &enabled,
+                                                                                const TransparentStringSet &trusted) {
+            auto parsed = ReadManifest(fs::absolute(directory.path() / "extension.json"));
+            if (parsed.HasError())
+                return std::nullopt;
+            ExtensionManifest manifest = std::move(parsed).Value();
+            const bool duplicate = std::ranges::any_of(existing, [&manifest](const ExtensionInventoryEntry &entry) {
+                return entry.packageId == manifest.id;
+            });
+            if (!IsSafePackageId(manifest.id) || directory.path().filename() != fs::path{manifest.id} || duplicate)
+                return std::nullopt;
+            const std::string compositionVersion = BuildCompositionVersion(manifest.version, manifest.modules);
+            return ExtensionInventoryEntry{
+                .packageId = manifest.id,
+                .displayName = manifest.displayName.empty() ? manifest.id : manifest.displayName,
+                .description = manifest.description,
+                .version = manifest.version,
+                .author = manifest.author,
+                .origin = ExtensionOrigin::UserInstalled,
+                .absoluteRootPath = fs::absolute(directory.path()).lexically_normal(),
+                .absoluteManifestPath = fs::absolute(directory.path() / "extension.json").lexically_normal(),
+                .modules = std::move(manifest.modules),
+                .contributions = std::move(manifest.contributions),
+                .enabled = enabled.contains(manifest.id),
+                .locallyTrusted = trusted.contains(manifest.id),
+                .compositionVersion = compositionVersion,
+            };
+        }
+
+        /** @brief Adds valid installed packages from the managed root to the inventory projection. */
+        [[nodiscard]] Result<void> DiscoverInstalledEntries(const fs::path &installRoot, std::vector<ExtensionInventoryEntry> &entries,
+                                                            const TransparentStringSet &enabled, const TransparentStringSet &trusted) {
+            std::error_code error;
+            fs::create_directories(installRoot, error);
+            if (error)
+                return Result<void>::Failure(MakeError(ExtensionErrors::LoadFailed, "Unable to create the user extension directory."));
+            for (const auto &directory : fs::directory_iterator(installRoot, error)) {
+                if (error)
+                    return Result<void>::Failure(MakeError(ExtensionErrors::LoadFailed, "Unable to enumerate installed extensions."));
+                if (!IsDiscoverableDirectory(directory, error))
+                    continue;
+                if (auto entry = ReadInstalledEntry(directory, entries, enabled, trusted); entry.has_value())
+                    entries.push_back(std::move(*entry));
+            }
+            return Result<void>::Success();
+        }
+
+        /** @brief Resolves and validates an installation source outside the managed root. */
+        [[nodiscard]] Result<fs::path> ValidateInstallSource(const fs::path &absoluteSourceDirectory, const fs::path &installRoot) {
+            if (!absoluteSourceDirectory.is_absolute())
+                return Result<fs::path>::Failure(
+                    MakeError(ExtensionErrors::InvalidManifest, "Extension source directory must be absolute."));
+            std::error_code error;
+            const fs::path source = fs::weakly_canonical(absoluteSourceDirectory, error);
+            if (error || !fs::is_directory(source, error) || fs::is_symlink(fs::symlink_status(source, error))) {
+                return Result<fs::path>::Failure(
+                    MakeError(ExtensionErrors::InvalidManifest, "Extension source must be a regular non-symlink directory."));
+            }
+            if (const fs::path canonicalInstallRoot = fs::weakly_canonical(installRoot, error);
+                !error && IsPathContainedBy(canonicalInstallRoot, source)) {
+                return Result<fs::path>::Failure(
+                    MakeError(ExtensionErrors::InvalidManifest, "Extension source must be outside the managed installation directory."));
+            }
+            return Result<fs::path>::Success(source);
+        }
+
+        /** @brief Removes an unpublished staging tree without masking the primary operation result. */
+        void RemoveStagingTree(const fs::path &staging) noexcept {
+            std::error_code ignored;
+            fs::remove_all(staging, ignored);
+        }
+
+        /** @brief Copies and atomically publishes a validated package directory. */
+        [[nodiscard]] Result<void> PublishPackage(const fs::path &source, const fs::path &staging, const fs::path &destination) {
+            if (auto copied = CopyPackageTree(source, staging); copied.HasError()) {
+                RemoveStagingTree(staging);
+                return copied;
+            }
+            std::error_code error;
+            fs::rename(staging, destination, error);
+            if (error) {
+                RemoveStagingTree(staging);
+                return Result<void>::Failure(MakeError(ExtensionErrors::LoadFailed, "Unable to publish the staged extension package."));
+            }
             return Result<void>::Success();
         }
     }  // namespace
@@ -163,69 +332,14 @@ namespace Horo::Extensions {
 
     /** @copydoc ExtensionInventory::Refresh */
     Result<void> ExtensionInventory::Refresh() {
-        struct RuntimeState {
-            bool active{};
-            std::string loadError;
-            std::string compositionVersion;
-        };
-
-        TransparentStringMap<RuntimeState> runtimeStates;
-        runtimeStates.reserve(entries_.size());
-        for (auto &entry : entries_) {
-            runtimeStates.try_emplace(entry.packageId, RuntimeState{.active = entry.runtimeActive,
-                                                                    .loadError = std::move(entry.loadError),
-                                                                    .compositionVersion = std::move(entry.runtimeCompositionVersion)});
-        }
-
+        RuntimeStateMap runtimeStates = CaptureRuntimeStates(entries_);
         entries_.clear();
         if (auto loaded = LoadState(); loaded.HasError())
             return loaded;
         AddBuiltInPackages();
-
-        std::error_code error;
-        fs::create_directories(installRoot_, error);
-        if (error)
-            return Result<void>::Failure(MakeError(ExtensionErrors::LoadFailed, "Unable to create the user extension directory."));
-        for (const auto &directory : fs::directory_iterator(installRoot_, error)) {
-            if (error)
-                return Result<void>::Failure(MakeError(ExtensionErrors::LoadFailed, "Unable to enumerate installed extensions."));
-            if (const fs::file_status status = directory.symlink_status(error);
-                error || fs::is_symlink(status) || !fs::is_directory(status) ||
-                directory.path().filename().string().starts_with(".install-"))
-                continue;
-            auto parsed = ReadManifest(fs::absolute(directory.path() / "extension.json"));
-            if (parsed.HasError())
-                continue;
-            ExtensionManifest manifest = std::move(parsed).Value();
-            if (!IsSafePackageId(manifest.id) || directory.path().filename() != fs::path{manifest.id} ||
-                std::ranges::any_of(entries_, [&manifest](const ExtensionInventoryEntry &entry) {
-                return entry.packageId == manifest.id;
-            }))
-                continue;
-            const std::string compositionVersion = BuildCompositionVersion(manifest.version, manifest.modules);
-            entries_.push_back(ExtensionInventoryEntry{
-                .packageId = manifest.id,
-                .displayName = manifest.displayName.empty() ? manifest.id : manifest.displayName,
-                .description = manifest.description,
-                .version = manifest.version,
-                .author = manifest.author,
-                .origin = ExtensionOrigin::UserInstalled,
-                .absoluteRootPath = fs::absolute(directory.path()).lexically_normal(),
-                .absoluteManifestPath = fs::absolute(directory.path() / "extension.json").lexically_normal(),
-                .modules = std::move(manifest.modules),
-                .contributions = std::move(manifest.contributions),
-                .enabled = enabled_.contains(manifest.id),
-                .locallyTrusted = trusted_.contains(manifest.id),
-                .compositionVersion = compositionVersion,
-            });
-        }
-        for (auto &entry : entries_) {
-            if (auto runtime = runtimeStates.find(entry.packageId); runtime != runtimeStates.end()) {
-                entry.runtimeActive = runtime->second.active;
-                entry.loadError = std::move(runtime->second.loadError);
-                entry.runtimeCompositionVersion = std::move(runtime->second.compositionVersion);
-            }
-        }
+        if (auto discovered = DiscoverInstalledEntries(installRoot_, entries_, enabled_, trusted_); discovered.HasError())
+            return discovered;
+        RestoreRuntimeStates(entries_, runtimeStates);
         std::ranges::sort(entries_, [](const ExtensionInventoryEntry &left, const ExtensionInventoryEntry &right) {
             if (left.origin != right.origin)
                 return left.origin == ExtensionOrigin::BuiltIn;
@@ -246,21 +360,10 @@ namespace Horo::Extensions {
 
     /** @copydoc ExtensionInventory::InstallFromDirectory */
     Result<std::string> ExtensionInventory::InstallFromDirectory(const fs::path &absoluteSourceDirectory) {
-        if (!absoluteSourceDirectory.is_absolute())
-            return Result<std::string>::Failure(
-                MakeError(ExtensionErrors::InvalidManifest, "Extension source directory must be absolute."));
-        std::error_code error;
-        const fs::path source = fs::weakly_canonical(absoluteSourceDirectory, error);
-        if (error || !fs::is_directory(source, error) || fs::is_symlink(fs::symlink_status(source, error))) {
-            return Result<std::string>::Failure(
-                MakeError(ExtensionErrors::InvalidManifest, "Extension source must be a regular non-symlink directory."));
-        }
-        if (const fs::path canonicalInstallRoot = fs::weakly_canonical(installRoot_, error);
-            !error && IsPathContainedBy(canonicalInstallRoot, source)) {
-            return Result<std::string>::Failure(
-                MakeError(ExtensionErrors::InvalidManifest, "Extension source must be outside the managed installation directory."));
-        }
-        error.clear();
+        auto validatedSource = ValidateInstallSource(absoluteSourceDirectory, installRoot_);
+        if (validatedSource.HasError())
+            return Result<std::string>::Failure(validatedSource.ErrorValue());
+        const fs::path source = std::move(validatedSource).Value();
         auto parsed = ReadManifest(source / "extension.json");
         if (parsed.HasError())
             return Result<std::string>::Failure(parsed.ErrorValue());
@@ -269,6 +372,7 @@ namespace Horo::Extensions {
             return Result<std::string>::Failure(
                 MakeError(ExtensionErrors::InvalidManifest, "Extension package ID is unsafe for installation."));
 
+        std::error_code error;
         fs::create_directories(installRoot_, error);
         const fs::path destination = installRoot_ / manifest.id;
         if (error || fs::exists(destination, error))
@@ -276,19 +380,8 @@ namespace Horo::Extensions {
                 MakeError(ExtensionErrors::LoadFailed, "An extension with this package ID is already installed."));
         const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
         const fs::path staging = installRoot_ / std::format(".install-{}-{}", manifest.id, nonce);
-        const auto cleanup = [&staging]() {
-            std::error_code ignored;
-            fs::remove_all(staging, ignored);
-        };
-        if (auto copied = CopyPackageTree(source, staging); copied.HasError()) {
-            cleanup();
-            return Result<std::string>::Failure(copied.ErrorValue());
-        }
-        fs::rename(staging, destination, error);
-        if (error) {
-            cleanup();
-            return Result<std::string>::Failure(MakeError(ExtensionErrors::LoadFailed, "Unable to publish the staged extension package."));
-        }
+        if (auto published = PublishPackage(source, staging, destination); published.HasError())
+            return Result<std::string>::Failure(published.ErrorValue());
         enabled_.erase(manifest.id);
         trusted_.erase(manifest.id);
         if (auto saved = SaveState(); saved.HasError()) {

--- a/src/extensions/registry/ExtensionInventory.cpp
+++ b/src/extensions/registry/ExtensionInventory.cpp
@@ -127,10 +127,11 @@ namespace Horo::Extensions {
                     MakeError(ExtensionErrors::LoadFailed, "Extension packages may not contain symlinks."));
             }
             const fs::path relative = fs::relative(entry.path(), source, error);
-            const bool escapesRoot = std::ranges::any_of(relative, [](const fs::path &component) {
+            if (const bool escapesRoot = std::ranges::any_of(relative,
+                                                             [](const fs::path &component) {
                 return component == "..";
             });
-            if (error || relative.empty() || relative.is_absolute() || escapesRoot) {
+                error || relative.empty() || relative.is_absolute() || escapesRoot) {
                 return Result<ValidatedPackageEntry>::Failure(
                     MakeError(ExtensionErrors::LoadFailed, "Extension package path escaped its source root."));
             }
@@ -227,10 +228,11 @@ namespace Horo::Extensions {
             if (parsed.HasError())
                 return std::nullopt;
             ExtensionManifest manifest = std::move(parsed).Value();
-            const bool duplicate = std::ranges::any_of(existing, [&manifest](const ExtensionInventoryEntry &entry) {
+            if (const bool duplicate = std::ranges::any_of(existing,
+                                                           [&manifest](const ExtensionInventoryEntry &entry) {
                 return entry.packageId == manifest.id;
             });
-            if (!IsSafePackageId(manifest.id) || directory.path().filename() != fs::path{manifest.id} || duplicate)
+                !IsSafePackageId(manifest.id) || directory.path().filename() != fs::path{manifest.id} || duplicate)
                 return std::nullopt;
             const std::string compositionVersion = BuildCompositionVersion(manifest.version, manifest.modules);
             return ExtensionInventoryEntry{

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -844,6 +844,7 @@ target_include_directories(HoroModularAssetImportIntegrationTests PRIVATE
 )
 add_executable(HoroExtensionManagerTests
         unit/extensions/ExtensionManagerTests.cpp
+        unit/extensions/ExtensionManifestParserTests.cpp
 )
 target_compile_features(HoroExtensionManagerTests PRIVATE cxx_std_20)
 target_link_libraries(HoroExtensionManagerTests PRIVATE HoroEngine::Extensions Catch2::Catch2WithMain)

--- a/tests/unit/extensions/ExtensionManagerTests.cpp
+++ b/tests/unit/extensions/ExtensionManagerTests.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <iterator>
 #include <ranges>
+#include <string>
 
 namespace Horo::Extensions::Tests {
     namespace fs = std::filesystem;
@@ -149,13 +150,13 @@ namespace Horo::Extensions::Tests {
             REQUIRE(manifest.modules[0].version == "2.0.0");
         }
 
-        SECTION("Module version defaults to package version") {
+        SECTION("Module version is explicit") {
             auto result = ParseExtensionManifest(R"({
                 "package": {"id": "com.example.defaulted", "version": "3.2.1"},
                 "modules": [{"id": "com.example.defaulted.importer", "kind": "asset_importer"}]
             })");
-            REQUIRE(result.HasValue());
-            REQUIRE(result.Value().modules[0].version == "3.2.1");
+            REQUIRE(result.HasError());
+            REQUIRE_THAT(result.ErrorValue().message, Catch::Matchers::ContainsSubstring("$.modules[0].version"));
         }
 
         SECTION("Canonical top-level package manifest is accepted") {
@@ -179,6 +180,7 @@ namespace Horo::Extensions::Tests {
                 "version": "1.0.0",
                 "modules": [{
                     "id": "com.example.contributions.native",
+                    "version": "1.0.0",
                     "kind": "asset_importer"
                 }],
                 "contributions": [{
@@ -230,6 +232,21 @@ namespace Horo::Extensions::Tests {
         REQUIRE(reloaded.Refresh().HasValue());
         REQUIRE_FALSE(reloaded.IsEnabled(builtIn.packageId));
         REQUIRE(reloaded.InstallRoot() == installRoot.lexically_normal());
+    }
+
+    TEST_CASE_METHOD(ExtensionManagerTestFixture, "Extension manifest files are bounded before decoding", "[Extensions][Inventory]") {
+        const fs::path source = fs::absolute(tempDir / "oversized");
+        fs::create_directories(source);
+        {
+            std::ofstream manifest{source / "extension.json", std::ios::binary};
+            manifest << std::string(ExtensionManifestLimits{}.maximumDocumentBytes + 1U, 'x');
+        }
+
+        ExtensionManager manager;
+        REQUIRE(manager.LoadExtension(source.string()).HasError());
+
+        ExtensionInventory inventory{fs::absolute(tempDir / "managed")};
+        REQUIRE(inventory.InstallFromDirectory(source).HasError());
     }
 
 #ifdef HORO_BASIC_EXTENSION_DIR

--- a/tests/unit/extensions/ExtensionManifestParserTests.cpp
+++ b/tests/unit/extensions/ExtensionManifestParserTests.cpp
@@ -1,0 +1,339 @@
+#include "Horo/Extensions/ExtensionManifest.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <string>
+#include <string_view>
+
+namespace Horo::Extensions::Tests {
+    namespace {
+        constexpr std::string_view MinimalManifest = R"json({
+            "schemaVersion": 1,
+            "id": "com.example.minimum",
+            "version": "1.0.0",
+            "modules": [{
+                "id": "com.example.minimum.native",
+                "version": "1.0.0",
+                "kind": "native"
+            }]
+        })json";
+
+        void RequireError(const Result<ExtensionManifest> &result, const std::string_view path, const std::string_view diagnosticCode) {
+            REQUIRE(result.HasError());
+            const Error &error = result.ErrorValue();
+            REQUIRE_THAT(error.message, Catch::Matchers::StartsWith(std::string{path} + ':'));
+            REQUIRE(error.diagnostics.size() == 1);
+            CHECK(error.diagnostics.front().code.Value() == diagnosticCode);
+            CHECK(error.diagnostics.front().message == error.message);
+            CHECK(error.diagnostics.front().location.source == "extension.json");
+        }
+    }  // namespace
+
+    TEST_CASE("Extension manifest accepts bounded canonical and transitional package documents", "[Extensions][Manifest]") {
+        SECTION("canonical document owns validated values") {
+            auto result = ParseExtensionManifest(R"json({
+                "schemaVersion": 1,
+                "id": "com.example.importer",
+                "version": "1.2.3-beta.1",
+                "kind": "asset_importer",
+                "displayName": "Example Importer",
+                "description": "Imports example assets.",
+                "author": "Example",
+                "compatibility": {
+                    "engineMin": "0.1.0",
+                    "engineMax": "0.9.0",
+                    "sdkAbi": "horo.extension-1",
+                    "platforms": ["linux", "macos"]
+                },
+                "modules": [{
+                    "id": "com.example.importer.native",
+                    "version": "2.0.0",
+                    "kind": "asset_importer",
+                    "entry": "bin/importer"
+                }],
+                "contributions": [{
+                    "type": "asset.importer",
+                    "id": "com.example.importer.raw",
+                    "module": "com.example.importer.native"
+                }]
+            })json");
+
+            REQUIRE(result.HasValue());
+            const ExtensionManifest &manifest = result.Value();
+            CHECK(manifest.schemaVersion == 1);
+            CHECK(manifest.id == "com.example.importer");
+            CHECK(manifest.version == "1.2.3-beta.1");
+            CHECK(manifest.engineMin == "0.1.0");
+            CHECK(manifest.platforms.size() == 2);
+            REQUIRE(manifest.modules.size() == 1);
+            CHECK(manifest.modules.front().entry == "bin/importer");
+            REQUIRE(manifest.contributions.size() == 1);
+            CHECK(manifest.contributions.front().owningModule == manifest.modules.front().id);
+        }
+
+        SECTION("transitional package envelope remains explicit") {
+            auto result = ParseExtensionManifest(R"json({
+                "package": {"id": "com.example.legacy", "version": "1.0.0"},
+                "modules": [{"id": "com.example.legacy.native", "version": "1.0.0", "kind": "native"}]
+            })json");
+            REQUIRE(result.HasValue());
+            CHECK(result.Value().schemaVersion == 1);
+            CHECK(result.Value().id == "com.example.legacy");
+        }
+    }
+
+    TEST_CASE("Extension manifest rejects unsupported and ambiguous schemas", "[Extensions][Manifest]") {
+        SECTION("unsupported version") {
+            auto result = ParseExtensionManifest(R"json({"schemaVersion":2})json");
+            RequireError(result, "$.schemaVersion", "extension.manifest.unsupported_schema");
+        }
+
+        SECTION("schema version has an exact integer type") {
+            auto result = ParseExtensionManifest(R"json({"schemaVersion":"1"})json");
+            RequireError(result, "$.schemaVersion", "extension.manifest.unsupported_schema");
+        }
+
+        SECTION("unknown root field") {
+            auto result = ParseExtensionManifest(R"json({"futureAuthority":true})json");
+            RequireError(result, "$.futureAuthority", "extension.manifest.unknown_field");
+        }
+
+        SECTION("unknown nested field") {
+            auto result = ParseExtensionManifest(R"json({
+                "id":"com.example.test","version":"1.0.0",
+                "modules":[{"id":"com.example.test.native","version":"1.0.0","kind":"native","autorun":true}]
+            })json");
+            RequireError(result, "$.modules[0].autorun", "extension.manifest.unknown_field");
+        }
+
+        SECTION("nested and root package fields cannot compete") {
+            auto result = ParseExtensionManifest(R"json({
+                "id":"com.example.root",
+                "package":{"id":"com.example.nested","version":"1.0.0"}
+            })json");
+            RequireError(result, "$.id", "extension.manifest.ambiguous_field");
+        }
+
+        SECTION("root type is exact") {
+            auto result = ParseExtensionManifest("[]");
+            RequireError(result, "$", "extension.manifest.invalid_type");
+        }
+    }
+
+    TEST_CASE("Extension manifest enforces syntax resource limits before validation", "[Extensions][Manifest]") {
+        SECTION("document bytes include an accepted boundary") {
+            ExtensionManifestLimits limits;
+            limits.maximumDocumentBytes = MinimalManifest.size();
+            REQUIRE(ParseExtensionManifest(MinimalManifest, limits).HasValue());
+
+            --limits.maximumDocumentBytes;
+            RequireError(ParseExtensionManifest(MinimalManifest, limits), "$", "extension.manifest.document_limit");
+        }
+
+        SECTION("nesting includes an accepted boundary") {
+            ExtensionManifestLimits limits;
+            limits.maximumNestingDepth = 3;
+            REQUIRE(ParseExtensionManifest(MinimalManifest, limits).HasValue());
+
+            limits.maximumNestingDepth = 2;
+            RequireError(ParseExtensionManifest(MinimalManifest, limits), "$", "extension.manifest.nesting_limit");
+        }
+
+        SECTION("object member budget") {
+            ExtensionManifestLimits limits;
+            limits.maximumObjectMembers = 7;
+            REQUIRE(ParseExtensionManifest(MinimalManifest, limits).HasValue());
+
+            limits.maximumObjectMembers = 6;
+            RequireError(ParseExtensionManifest(MinimalManifest, limits), "$.modules[0].kind", "extension.manifest.object_limit");
+        }
+    }
+
+    TEST_CASE("Extension manifest enforces collection and text parse budgets", "[Extensions][Manifest]") {
+        SECTION("array element budget") {
+            ExtensionManifestLimits limits;
+            limits.maximumArrayElements = 1;
+            REQUIRE(ParseExtensionManifest(MinimalManifest, limits).HasValue());
+
+            limits.maximumArrayElements = 1;
+            auto result = ParseExtensionManifest(R"json({
+                "id":"com.example.test","version":"1.0.0",
+                "modules":[
+                    {"id":"com.example.test.one","version":"1.0.0","kind":"native"},
+                    {"id":"com.example.test.two","version":"1.0.0","kind":"native"}
+                ]
+            })json",
+                                                 limits);
+            RequireError(result, "$.modules[1]", "extension.manifest.array_limit");
+        }
+
+        SECTION("decoded string budget") {
+            ExtensionManifestLimits limits;
+            limits.maximumStringBytes = 5;
+            auto result = ParseExtensionManifest(R"json({"description":"123456"})json", limits);
+            RequireError(result, "$.description", "extension.manifest.string_limit");
+        }
+
+        SECTION("field-name budget") {
+            ExtensionManifestLimits limits;
+            limits.maximumIdentifierBytes = 4;
+            auto result = ParseExtensionManifest(R"json({"longName":true})json", limits);
+            RequireError(result, "$.longName", "extension.manifest.identifier_limit");
+        }
+
+        SECTION("zero parser limits are invalid configuration") {
+            ExtensionManifestLimits limits;
+            limits.maximumModules = 0;
+            RequireError(ParseExtensionManifest(MinimalManifest, limits), "$", "extension.manifest.invalid_limits");
+        }
+    }
+
+    TEST_CASE("Extension manifest reports duplicate fields and malformed JSON", "[Extensions][Manifest]") {
+        SECTION("duplicate field includes its nested path") {
+            auto result = ParseExtensionManifest(R"json({
+                "id":"com.example.test","version":"1.0.0",
+                "modules":[{"id":"com.example.first","id":"com.example.second","version":"1.0.0","kind":"native"}]
+            })json");
+            RequireError(result, "$.modules[0].id", "extension.manifest.duplicate_field");
+        }
+
+        SECTION("malformed JSON includes source coordinates") {
+            auto result = ParseExtensionManifest("{\n  \"id\": }");
+            RequireError(result, "$", "extension.manifest.invalid_json");
+            CHECK(result.ErrorValue().diagnostics.front().location.line == 2);
+            CHECK(result.ErrorValue().diagnostics.front().location.column > 1);
+        }
+    }
+
+    TEST_CASE("Extension manifest validates package, compatibility and entry values", "[Extensions][Manifest]") {
+        SECTION("package identity") {
+            auto result = ParseExtensionManifest(R"json({"id":"Com.Example","version":"1.0.0","modules":[]})json");
+            RequireError(result, "$.id", "extension.manifest.invalid_identifier");
+        }
+
+        SECTION("package version") {
+            auto result = ParseExtensionManifest(R"json({"id":"com.example.test","version":"01.0.0","modules":[]})json");
+            RequireError(result, "$.version", "extension.manifest.invalid_version");
+        }
+
+        SECTION("compatibility field type") {
+            auto result = ParseExtensionManifest(R"json({
+                "id":"com.example.test","version":"1.0.0","compatibility":[],"modules":[]
+            })json");
+            RequireError(result, "$.compatibility", "extension.manifest.invalid_type");
+        }
+
+        SECTION("compatibility version") {
+            auto result = ParseExtensionManifest(R"json({
+                "id":"com.example.test","version":"1.0.0","compatibility":{"engineMin":"next"},"modules":[]
+            })json");
+            RequireError(result, "$.compatibility", "extension.manifest.invalid_version");
+        }
+
+        SECTION("module entry containment") {
+            auto result = ParseExtensionManifest(R"json({
+                "id":"com.example.test","version":"1.0.0",
+                "modules":[{"id":"com.example.test.native","version":"1.0.0","kind":"native","entry":"../escape"}]
+            })json");
+            RequireError(result, "$.modules[0].entry", "extension.manifest.invalid_path");
+        }
+    }
+
+    TEST_CASE("Extension manifest validates collection bounds and identities", "[Extensions][Manifest]") {
+        SECTION("module collection limit") {
+            ExtensionManifestLimits limits;
+            limits.maximumModules = 1;
+            REQUIRE(ParseExtensionManifest(MinimalManifest, limits).HasValue());
+
+            auto result = ParseExtensionManifest(R"json({
+                "id":"com.example.test","version":"1.0.0",
+                "modules":[
+                    {"id":"com.example.test.one","version":"1.0.0","kind":"native"},
+                    {"id":"com.example.test.two","version":"1.0.0","kind":"native"}
+                ]
+            })json",
+                                                 limits);
+            RequireError(result, "$.modules", "extension.manifest.collection_limit");
+        }
+
+        SECTION("duplicate module identity") {
+            auto result = ParseExtensionManifest(R"json({
+                "id":"com.example.test","version":"1.0.0",
+                "modules":[
+                    {"id":"com.example.test.native","version":"1.0.0","kind":"native"},
+                    {"id":"com.example.test.native","version":"2.0.0","kind":"native"}
+                ]
+            })json");
+            RequireError(result, "$.modules[1].id", "extension.manifest.duplicate_identifier");
+        }
+
+        SECTION("duplicate platform identity") {
+            auto result = ParseExtensionManifest(R"json({
+                "id":"com.example.test","version":"1.0.0","compatibility":{"platforms":["linux","linux"]},
+                "modules":[{"id":"com.example.test.native","version":"1.0.0","kind":"native"}]
+            })json");
+            RequireError(result, "$.compatibility.platforms[1]", "extension.manifest.duplicate_identifier");
+        }
+
+        SECTION("platform collection limit") {
+            ExtensionManifestLimits limits;
+            constexpr std::string_view manifest = R"json({
+                "id":"com.example.test","version":"1.0.0","compatibility":{"platforms":["linux","macos"]},
+                "modules":[{"id":"com.example.test.native","version":"1.0.0","kind":"native"}]
+            })json";
+            limits.maximumPlatforms = 2;
+            REQUIRE(ParseExtensionManifest(manifest, limits).HasValue());
+
+            limits.maximumPlatforms = 1;
+            auto result = ParseExtensionManifest(manifest, limits);
+            RequireError(result, "$.compatibility.platforms", "extension.manifest.collection_limit");
+        }
+    }
+
+    TEST_CASE("Extension manifest validates contribution references before resolution", "[Extensions][Manifest]") {
+        SECTION("unresolved module") {
+            auto result = ParseExtensionManifest(R"json({
+                "id":"com.example.test","version":"1.0.0",
+                "modules":[{"id":"com.example.test.native","version":"1.0.0","kind":"native"}],
+                "contributions":[{"type":"asset.importer","id":"com.example.test.raw","module":"com.example.missing"}]
+            })json");
+            RequireError(result, "$.contributions[0].module", "extension.manifest.unresolved_reference");
+        }
+
+        SECTION("duplicate contribution identity") {
+            auto result = ParseExtensionManifest(R"json({
+                "id":"com.example.test","version":"1.0.0",
+                "modules":[{"id":"com.example.test.native","version":"1.0.0","kind":"native"}],
+                "contributions":[
+                    {"type":"asset.importer","id":"com.example.test.raw","module":"com.example.test.native"},
+                    {"type":"asset.importer","id":"com.example.test.raw","module":"com.example.test.native"}
+                ]
+            })json");
+            RequireError(result, "$.contributions[1].id", "extension.manifest.duplicate_identifier");
+        }
+
+        SECTION("contribution collection limit") {
+            ExtensionManifestLimits limits;
+            constexpr std::string_view oneContribution = R"json({
+                "id":"com.example.test","version":"1.0.0",
+                "modules":[{"id":"com.example.test.native","version":"1.0.0","kind":"native"}],
+                "contributions":[
+                    {"type":"asset.importer","id":"com.example.test.one","module":"com.example.test.native"}
+                ]
+            })json";
+            limits.maximumContributions = 1;
+            REQUIRE(ParseExtensionManifest(oneContribution, limits).HasValue());
+
+            auto result = ParseExtensionManifest(R"json({
+                "id":"com.example.test","version":"1.0.0",
+                "modules":[{"id":"com.example.test.native","version":"1.0.0","kind":"native"}],
+                "contributions":[
+                    {"type":"asset.importer","id":"com.example.test.one","module":"com.example.test.native"},
+                    {"type":"asset.importer","id":"com.example.test.two","module":"com.example.test.native"}
+                ]
+            })json",
+                                                 limits);
+            RequireError(result, "$.contributions", "extension.manifest.collection_limit");
+        }
+    }
+}  // namespace Horo::Extensions::Tests


### PR DESCRIPTION
## Summary

- Bounds untrusted `extension.json` decoding before extension resolution or native loading.
- Enforces strict schema, identity, semantic-version, collection, path-containment, duplicate, and cross-reference validation with exact JSON-path diagnostics.
- Adds focused hostile-input and accepted-boundary regressions; updates the example manifest and both direct loader paths to use the same limits.

## Motivation

The transitional extension loader previously materialized an unrestricted JSON DOM, accepted unknown or weakly typed fields, defaulted module versions, and could read an oversized manifest before rejecting it. This allowed malformed metadata to survive too far into resolution and made failures hard to act on.

## Implementation Notes

- Performs an encoded-size and raw nesting pass before JSON DOM construction, then applies total member, element, string, and identifier budgets while decoding.
- Separates bounded JSON mechanics from schema validation to keep complexity localized and testable.
- Rejects unknown fields, unsupported schema versions, duplicate fields/IDs, unsafe package-relative entry paths, and unresolved contribution-to-module references.
- Keeps missing `schemaVersion` as the existing transitional v1 adapter path, while new/canonical emitters write integer `schemaVersion: 1`.
- Requires module identity, version, and kind explicitly; package-version inheritance is removed.
- This change hardens the current direct-directory inventory/manager. ADR-054 verified package authority and the complete ADR-055 typed activation model remain outside this ticket's parser boundary.

## Validation

- [x] Build passed
- [x] Relevant tests passed
- [x] Manual smoke tested if applicable (not applicable: no UI behavior)

Commands run:
```bash
cmake -S . -B build/horo71 -DBUILD_TESTING=ON
cmake --build build/horo71 --parallel
ctest --test-dir build/horo71 --output-on-failure
ctest --test-dir build/horo71 -R '^HoroExtensionManagerTests$' --output-on-failure

cmake -S . -B build/horo71-coverage -G Ninja -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug \
  '-DCMAKE_CXX_FLAGS=-fprofile-instr-generate -fcoverage-mapping' \
  '-DCMAKE_EXE_LINKER_FLAGS=-fprofile-instr-generate'
cmake --build build/horo71-coverage --target HoroExtensionManagerTests --parallel
LLVM_PROFILE_FILE=/tmp/horo71-final-%p.profraw build/horo71-coverage/tests/HoroExtensionManagerTests
xcrun llvm-profdata merge -sparse /tmp/horo71-final-*.profraw -o /tmp/horo71-final.profdata
xcrun llvm-cov report build/horo71-coverage/tests/HoroExtensionManagerTests \
  -instr-profile=/tmp/horo71-final.profdata \
  src/extensions/manifest/ExtensionManifestParser.cpp \
  src/extensions/manifest/ExtensionManifestJson.cpp \
  src/extensions/host/ExtensionManager.cpp \
  src/extensions/registry/ExtensionInventory.cpp

codacy-cli analyze --tool lizard --format sarif --output /tmp/horo71-codacy-final.sarif
sonar list issues -p abdullahbodur_horo-engine --branch main --statuses OPEN --page-size 500
sonar analyze --base origin/main --project abdullahbodur_horo-engine --force --format json
```

Results:

- 662/662 CTest tests passed.
- `HoroExtensionManagerTests`: 17 cases, 284 assertions passed.
- Changed production line coverage: 485/521 = **93.09%** (required minimum: 80%).
- Parser line coverage: 90.61%; bounded JSON line coverage: 97.24%.
- Codacy/Lizard: no findings in the new parser and parser-test files. Reported findings in `ExtensionManager.cpp` and `ExtensionInventory.cpp` are pre-existing functions outside the changed hunks.
- SonarCloud open issues: no matching existing issue for the touched extension files; secret analysis returned zero issues. Local C++ Vortex analysis was unavailable for the organization (`403 Forbidden`) and skipped the 11 changed files.
- `pytest` was unavailable during CMake configure, so repository Python tests were not registered; the C++ suite and architecture configure gate ran successfully.

## Risks

- Existing legacy manifests that relied on implicit module versions, unknown fields, invalid IDs, or unsafe entry syntax now fail closed with a field-path diagnostic.
- The default document limit is 64 KiB; both inventory and runtime loader reject larger files before buffering.
- PR #2513 touches the same two CMake list files, but at different hunks (`src/CMakeLists.txt` around 644 here versus 250/304/505 there; `tests/CMakeLists.txt` around 835 here versus 849 there).

## Issue Links

- Jira: [HORO-71](https://horo-engine.atlassian.net/browse/HORO-71)
- GitHub: Closes #71

## Reviewer Notes

- Review `ExtensionManifestJson.cpp` first for allocation bounds and diagnostic paths.
- Then review `ExtensionManifestParser.cpp` for fail-closed schema rules and `ExtensionManifestParserTests.cpp` for hostile/boundary coverage.
- The parser has no code-loading or registry side effects; activation remains in the existing host boundary.


[HORO-71]: https://horo-engine.atlassian.net/browse/HORO-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ