### PR TITLE
feat(render): migrate Metal viewport resources HORO-294 #294 [RND-001.5]

### DIFF
--- a/apps/HoroEditor/app/HoroEditorApp.cpp
+++ b/apps/HoroEditor/app/HoroEditorApp.cpp
@@ -648,7 +648,7 @@ namespace Horo::Editor {
                 if (const Result<void> initialized = guiRenderer->Initialize(); initialized.HasError()) {
                     return Result<EditorRenderComposition>::Failure(initialized.ErrorValue());
                 }
-                auto viewportRenderer = std::make_unique<EditorViewportRendererMetal>(graphicsBridge);
+                auto viewportRenderer = std::make_unique<EditorViewportRendererMetal>(*composition.frontend, graphicsBridge);
                 if (const Result<void> initialized = viewportRenderer->Initialize(); initialized.HasError()) {
                     return Result<EditorRenderComposition>::Failure(initialized.ErrorValue());
                 }
@@ -661,14 +661,6 @@ namespace Horo::Editor {
                 attached.HasError()) {
                 return Result<EditorRenderComposition>::Failure(attached.ErrorValue());
             }
-            if (options.rendererBackend != "opengl") {
-                auto viewportTarget = composition.frontend->CreateOffscreenTarget({1, 1});
-                if (viewportTarget.HasError()) {
-                    return Result<EditorRenderComposition>::Failure(viewportTarget.ErrorValue());
-                }
-                composition.viewportTarget = viewportTarget.Value();
-            }
-
             return Result<EditorRenderComposition>::Success(std::move(composition));
         }
 
@@ -1269,7 +1261,8 @@ namespace Horo::Editor {
 
         DestroyEditorTextures(textures, *composition.guiRenderer);
         composition.frontend->DetachStaticMeshPassExecutor(*composition.viewportRenderer);
-        (void)composition.frontend->ReleaseOffscreenTarget(composition.viewportTarget);
+        if (!composition.frontend->Capabilities().supportsRenderTargetResources)
+            (void)composition.frontend->ReleaseOffscreenTarget(composition.viewportTarget);
         composition.viewportRenderer.reset();
         composition.guiRenderer.reset();
         ImGui::DestroyContext();

--- a/cmake/HoroDependencyPolicy.cmake
+++ b/cmake/HoroDependencyPolicy.cmake
@@ -35,6 +35,8 @@ horo_allow_target_dependencies(TARGET HoroRenderMetal)
 horo_allow_target_dependencies(TARGET HoroEditorModel
     DEPENDENCIES HoroFoundation HoroSceneModel HoroRuntimeScene)
 horo_allow_target_dependencies(TARGET HoroEditorViewportScene DEPENDENCIES HoroEditorModel)
+horo_allow_target_dependencies(TARGET HoroEditorViewportResources
+    DEPENDENCIES HoroEditorViewportScene HoroRenderFrontend)
 horo_allow_target_dependencies(TARGET HoroEditorRenderExtraction
     DEPENDENCIES HoroEditorModel HoroEditorViewportScene)
 horo_allow_target_dependencies(TARGET HoroEditorServices
@@ -49,9 +51,9 @@ horo_allow_target_dependencies(TARGET HoroEditorServices
         HoroProjectMigrations
         HoroAssets)
 horo_allow_target_dependencies(TARGET HoroEditorViewportOpenGL
-    DEPENDENCIES HoroEditorViewportScene HoroRenderOpenGL HoroRenderFrontend)
+    DEPENDENCIES HoroEditorViewportScene HoroEditorViewportResources HoroRenderOpenGL HoroRenderFrontend)
 horo_allow_target_dependencies(TARGET HoroEditorViewportMetal
-    DEPENDENCIES HoroEditorViewportScene HoroRenderMetal)
+    DEPENDENCIES HoroEditorViewportScene HoroEditorViewportResources HoroRenderMetal HoroRenderFrontend)
 horo_allow_target_dependencies(TARGET HoroGui
     DEPENDENCIES HoroEditorServices HoroFoundation HoroEditorRenderExtraction HoroExtensions)
 horo_allow_target_dependencies(TARGET HoroExtensions

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -331,6 +331,7 @@ if (HORO_BUILD_RENDER_METAL)
     add_library(HoroRenderMetal STATIC
             runtime/renderer/modules/metal/MetalRenderBackend.cpp
             runtime/renderer/modules/metal/MetalRenderBackendErrors.cpp
+            runtime/renderer/modules/metal/MetalResourceRuntime.mm
             runtime/renderer/modules/metal/MetalRuntime.mm
     )
     add_library(HoroEngine::RenderMetal ALIAS HoroRenderMetal)
@@ -390,6 +391,22 @@ target_include_directories(HoroEditorViewportScene
 )
 target_link_libraries(HoroEditorViewportScene PUBLIC HoroEngine::EditorModel)
 
+add_library(HoroEditorViewportResources STATIC
+        editor/renderer/EditorViewportResources.cpp
+)
+add_library(HoroEngine::EditorViewportResources ALIAS HoroEditorViewportResources)
+
+target_compile_features(HoroEditorViewportResources PUBLIC cxx_std_20)
+target_include_directories(HoroEditorViewportResources
+        PRIVATE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+)
+target_link_libraries(HoroEditorViewportResources
+        PUBLIC
+        HoroEngine::EditorViewportScene
+        HoroEngine::RenderFrontend
+)
+
 add_library(HoroEditorRenderExtraction STATIC
         editor/document/EditorAssetMeshCache.cpp
         editor/document/EditorRenderExtractionErrors.cpp
@@ -415,6 +432,8 @@ if (HORO_BUILD_EDITOR_GUI AND HORO_BUILD_RENDER_METAL)
     add_library(HoroEditorViewportMetal STATIC
             editor/renderer/metal/EditorGuiRendererMetal.mm
             editor/renderer/metal/EditorViewportRendererMetal.mm
+            editor/renderer/metal/MetalViewportResourceBridge.mm
+            editor/renderer/metal/MetalViewportShaders.cpp
             editor/renderer/metal/SdlMetalPresentationPort.mm
     )
     add_library(HoroEngine::EditorViewportMetal ALIAS HoroEditorViewportMetal)
@@ -429,7 +448,9 @@ if (HORO_BUILD_EDITOR_GUI AND HORO_BUILD_RENDER_METAL)
     target_link_libraries(HoroEditorViewportMetal
             PUBLIC
             HoroEngine::EditorViewportScene
+            HoroEngine::EditorViewportResources
             HoroEngine::RenderMetal
+            HoroEngine::RenderFrontend
             ${HORO_SDL3_TARGET}
             PRIVATE
             HoroThirdParty::ImGuiMetal
@@ -512,7 +533,6 @@ if (HORO_BUILD_EDITOR_GUI AND HORO_BUILD_RENDER_OPENGL)
             editor/renderer/opengl/OpenGLViewportResourceBridge.cpp
             editor/renderer/opengl/OpenGLStateSnapshot.cpp
             editor/renderer/opengl/EditorViewportRendererOpenGL.cpp
-            editor/renderer/opengl/OpenGLViewportResources.cpp
             editor/renderer/opengl/SdlOpenGLPresentationPort.cpp
     )
     add_library(HoroEngine::EditorViewportOpenGL ALIAS HoroEditorViewportOpenGL)
@@ -528,6 +548,7 @@ if (HORO_BUILD_EDITOR_GUI AND HORO_BUILD_RENDER_OPENGL)
     target_link_libraries(HoroEditorViewportOpenGL
             PUBLIC
             HoroEngine::EditorViewportScene
+            HoroEngine::EditorViewportResources
             HoroEngine::RenderOpenGL
             HoroEngine::RenderFrontend
             ${HORO_SDL3_TARGET}

--- a/src/editor/renderer/EditorRendererErrors.h
+++ b/src/editor/renderer/EditorRendererErrors.h
@@ -5,6 +5,7 @@
 namespace Horo::Editor::RendererErrors {
     inline const ErrorDomainId GuiOpenGLDomain{"horo.editor.gui.opengl"};
     inline const ErrorDomainId ViewportOpenGLDomain{"horo.editor.viewport.opengl"};
+    inline const ErrorDomainId ViewportMetalDomain{"horo.editor.viewport.metal"};
     inline const ErrorDomainId SdlOpenGLDomain{"horo.editor.sdl.opengl"};
     inline const ErrorDomainId ViewportDomain{"horo.editor.viewport"};
 
@@ -44,14 +45,14 @@ namespace Horo::Editor::RendererErrors {
                                                               true,
                                                               false};
 
-    inline const ErrorCodeDescriptor ViewportShaderCompileFailed{ViewportOpenGLDomain,
+    inline const ErrorCodeDescriptor ViewportShaderCompileFailed{ViewportDomain,
                                                                  ErrorCode{"editor.viewport.shader_compile_failed"},
                                                                  ErrorSeverity::Error,
                                                                  "Viewport shader compilation failed.",
                                                                  {},
                                                                  false,
                                                                  false};
-    inline const ErrorCodeDescriptor ViewportAlreadyInitialized{ViewportOpenGLDomain,
+    inline const ErrorCodeDescriptor ViewportAlreadyInitialized{ViewportDomain,
                                                                 ErrorCode{"editor.viewport.already_initialized"},
                                                                 ErrorSeverity::Error,
                                                                 "Viewport renderer is already initialized.",
@@ -65,49 +66,49 @@ namespace Horo::Editor::RendererErrors {
                                                                   {},
                                                                   false,
                                                                   false};
-    inline const ErrorCodeDescriptor ViewportNotInitialized{ViewportOpenGLDomain,
+    inline const ErrorCodeDescriptor ViewportNotInitialized{ViewportDomain,
                                                             ErrorCode{"editor.viewport.not_initialized"},
                                                             ErrorSeverity::Error,
                                                             "Viewport renderer is not initialized.",
                                                             {},
                                                             false,
                                                             false};
-    inline const ErrorCodeDescriptor ViewportInvalidScene{ViewportOpenGLDomain,
+    inline const ErrorCodeDescriptor ViewportInvalidScene{ViewportDomain,
                                                           ErrorCode{"editor.viewport.invalid_scene"},
                                                           ErrorSeverity::Error,
                                                           "Viewport scene data is invalid.",
                                                           {},
                                                           false,
                                                           false};
-    inline const ErrorCodeDescriptor ViewportStaleTarget{ViewportOpenGLDomain,
+    inline const ErrorCodeDescriptor ViewportStaleTarget{ViewportDomain,
                                                          ErrorCode{"editor.viewport.stale_target"},
                                                          ErrorSeverity::Error,
                                                          "Viewport pass references a stale target.",
                                                          {},
                                                          false,
                                                          false};
-    inline const ErrorCodeDescriptor ViewportStaleMeshResource{ViewportOpenGLDomain,
+    inline const ErrorCodeDescriptor ViewportStaleMeshResource{ViewportDomain,
                                                                ErrorCode{"editor.viewport.stale_mesh_resource"},
                                                                ErrorSeverity::Error,
                                                                "Viewport instance references a stale mesh resource.",
                                                                {},
                                                                false,
                                                                false};
-    inline const ErrorCodeDescriptor ViewportShaderLinkFailed{ViewportOpenGLDomain,
+    inline const ErrorCodeDescriptor ViewportShaderLinkFailed{ViewportDomain,
                                                               ErrorCode{"editor.viewport.shader_link_failed"},
                                                               ErrorSeverity::Error,
                                                               "Viewport shader linking failed.",
                                                               {},
                                                               false,
                                                               false};
-    inline const ErrorCodeDescriptor ViewportShaderContractInvalid{ViewportOpenGLDomain,
+    inline const ErrorCodeDescriptor ViewportShaderContractInvalid{ViewportDomain,
                                                                    ErrorCode{"editor.viewport.shader_contract_invalid"},
                                                                    ErrorSeverity::Error,
                                                                    "Viewport shader contract is invalid.",
                                                                    {},
                                                                    false,
                                                                    false};
-    inline const ErrorCodeDescriptor ViewportGeometryCreationFailed{ViewportOpenGLDomain,
+    inline const ErrorCodeDescriptor ViewportGeometryCreationFailed{ViewportDomain,
                                                                     ErrorCode{"editor.viewport.geometry_creation_failed"},
                                                                     ErrorSeverity::Error,
                                                                     "Viewport geometry creation failed.",
@@ -121,6 +122,52 @@ namespace Horo::Editor::RendererErrors {
                                                                    {},
                                                                    true,
                                                                    false};
+
+    inline const ErrorCodeDescriptor ViewportMetalDeviceUnavailable{
+        .domain = ViewportMetalDomain,
+        .code = ErrorCode{"editor.viewport.metal_device_unavailable"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "Metal presentation device is unavailable.",
+        .remediationHint = {},
+        .retryable = false,
+        .userActionable = false,
+    };
+    inline const ErrorCodeDescriptor ViewportMetalPipelineCreationFailed{
+        .domain = ViewportMetalDomain,
+        .code = ErrorCode{"editor.viewport.pipeline_creation_failed"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "Metal viewport pipeline creation failed.",
+        .remediationHint = {},
+        .retryable = true,
+        .userActionable = false,
+    };
+    inline const ErrorCodeDescriptor ViewportMetalResourceCreationFailed{
+        .domain = ViewportMetalDomain,
+        .code = ErrorCode{"editor.viewport.resource_creation_failed"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "Metal viewport helper resource creation failed.",
+        .remediationHint = {},
+        .retryable = true,
+        .userActionable = false,
+    };
+    inline const ErrorCodeDescriptor ViewportMetalNoActiveFrame{
+        .domain = ViewportMetalDomain,
+        .code = ErrorCode{"editor.viewport.no_active_frame"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "Metal viewport rendering requires an active frame.",
+        .remediationHint = {},
+        .retryable = false,
+        .userActionable = false,
+    };
+    inline const ErrorCodeDescriptor ViewportMetalEncoderCreationFailed{
+        .domain = ViewportMetalDomain,
+        .code = ErrorCode{"editor.viewport.encoder_creation_failed"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "Metal viewport encoder creation failed.",
+        .remediationHint = {},
+        .retryable = true,
+        .userActionable = false,
+    };
 
     inline const ErrorCodeDescriptor SdlContextExists{SdlOpenGLDomain,
                                                       ErrorCode{"render.sdl.context_exists"},

--- a/src/editor/renderer/EditorViewportResources.cpp
+++ b/src/editor/renderer/EditorViewportResources.cpp
@@ -1,6 +1,6 @@
-#include "OpenGLViewportResources.h"
+#include "EditorViewportResources.h"
 
-#include "OpenGLViewportResourceBridge.h"
+#include "Horo/Runtime/Render/RenderFrontend.h"
 #include "editor/renderer/EditorRendererErrors.h"
 #include "runtime/renderer/frontend/RenderFrontendErrors.h"
 
@@ -70,9 +70,10 @@ namespace Horo::Editor {
         }
     }  // namespace
 
-    OpenGLViewportResources::OpenGLViewportResources(Render::RenderFrontend &frontend) noexcept : frontend_(&frontend) {}
+    EditorViewportResources::EditorViewportResources(Render::RenderFrontend &frontend, const EditorViewportResourceConfig config) noexcept
+        : frontend_(&frontend), config_(config) {}
 
-    Result<std::optional<Render::RenderTargetHandle>> OpenGLViewportResources::Prepare(const Render::RenderSceneView &scene,
+    Result<std::optional<Render::RenderTargetHandle>> EditorViewportResources::Prepare(const Render::RenderSceneView &scene,
                                                                                        const EditorViewportExtent requestedExtent) {
         if (const Result<void> meshes = SynchronizeMeshes(scene.meshResources); meshes.HasError())
             return Result<std::optional<Render::RenderTargetHandle>>::Failure(meshes.ErrorValue());
@@ -89,7 +90,7 @@ namespace Horo::Editor {
         return Result<std::optional<Render::RenderTargetHandle>>::Success(std::nullopt);
     }
 
-    void OpenGLViewportResources::Shutdown() noexcept {
+    void EditorViewportResources::Shutdown() noexcept {
         ReleaseShadowResources();
         ReleaseViewportTarget(pendingViewportTarget_);
         ReleaseViewportTarget(viewportTarget_);
@@ -103,37 +104,37 @@ namespace Horo::Editor {
         meshesReady_ = false;
     }
 
-    std::optional<OpenGLViewportResources::MeshBinding> OpenGLViewportResources::FindMesh(const std::uint64_t sourceId) const noexcept {
+    std::optional<EditorViewportResources::MeshBinding> EditorViewportResources::FindMesh(const std::uint64_t sourceId) const noexcept {
         if (const auto mesh = meshes_.find(sourceId); mesh != meshes_.end())
             return MeshBinding{mesh->second.mesh, mesh->second.indexCount};
         return std::nullopt;
     }
 
-    Render::RenderTargetHandle OpenGLViewportResources::Target() const noexcept {
+    Render::RenderTargetHandle EditorViewportResources::Target() const noexcept {
         return viewportTarget_.target;
     }
 
-    Render::RenderTargetHandle OpenGLViewportResources::ShadowTarget() const noexcept {
+    Render::RenderTargetHandle EditorViewportResources::ShadowTarget() const noexcept {
         return shadowTarget_;
     }
 
-    Render::RenderTextureViewHandle OpenGLViewportResources::ShadowTextureView() const noexcept {
+    Render::RenderTextureViewHandle EditorViewportResources::ShadowTextureView() const noexcept {
         return shadowDepthTextureView_;
     }
 
-    EditorViewportExtent OpenGLViewportResources::AllocatedExtent() const noexcept {
+    EditorViewportExtent EditorViewportResources::AllocatedExtent() const noexcept {
         return allocatedExtent_;
     }
 
-    std::uintptr_t OpenGLViewportResources::ImageIdentity() const noexcept {
+    std::uintptr_t EditorViewportResources::ImageIdentity() const noexcept {
         return viewportTarget_.imageIdentity;
     }
 
-    bool OpenGLViewportResources::IsReady() const noexcept {
+    bool EditorViewportResources::IsReady() const noexcept {
         return meshesReady_ && viewportTarget_.imageIdentity != 0 && viewportTarget_.target.IsValid() && allocatedExtent_.IsValid();
     }
 
-    Result<void> OpenGLViewportResources::SynchronizeMeshes(const std::span<const EditorViewportMeshResourceView> resources) {
+    Result<void> EditorViewportResources::SynchronizeMeshes(const std::span<const EditorViewportMeshResourceView> resources) {
         meshesReady_ = true;
         for (const EditorViewportMeshResourceView &resource : resources) {
             const auto ready = SynchronizeMesh(resource);
@@ -145,7 +146,7 @@ namespace Horo::Editor {
         return Result<void>::Success();
     }
 
-    Result<bool> OpenGLViewportResources::SynchronizeMesh(const EditorViewportMeshResourceView &resource) {
+    Result<bool> EditorViewportResources::SynchronizeMesh(const EditorViewportMeshResourceView &resource) {
         const std::uint64_t id = resource.handle.id.value;
         auto [activePosition, inserted] = meshes_.try_emplace(id);
         ResidentMesh &active = activePosition->second;
@@ -176,7 +177,7 @@ namespace Horo::Editor {
         return Result<bool>::Success(true);
     }
 
-    Result<bool> OpenGLViewportResources::AdvanceResidentMesh(const EditorViewportMeshResourceView &resource, ResidentMesh &resident) {
+    Result<bool> EditorViewportResources::AdvanceResidentMesh(const EditorViewportMeshResourceView &resource, ResidentMesh &resident) {
         if (resident.sourceGeneration == 0) {
             if (const Result<void> created = CreateResidentMeshBuffers(resource, resident); created.HasError())
                 return Result<bool>::Failure(created.ErrorValue());
@@ -204,7 +205,7 @@ namespace Horo::Editor {
         return ResourceReady(*frontend_, resident.mesh, resident.meshOperation);
     }
 
-    Result<void> OpenGLViewportResources::CreateResidentMeshBuffers(const EditorViewportMeshResourceView &resource,
+    Result<void> EditorViewportResources::CreateResidentMeshBuffers(const EditorViewportMeshResourceView &resource,
                                                                     ResidentMesh &resident) {
         if (resource.vertices.size() > std::numeric_limits<std::uint32_t>::max() ||
             resource.indices.size() > std::numeric_limits<std::uint32_t>::max()) {
@@ -234,7 +235,7 @@ namespace Horo::Editor {
         return Result<void>::Success();
     }
 
-    bool OpenGLViewportResources::IsResidentMeshReady(const ResidentMesh &resident) const {
+    bool EditorViewportResources::IsResidentMeshReady(const ResidentMesh &resident) const {
         if (!resident.mesh.IsValid())
             return false;
         if (const auto state = frontend_->ResourceState(resident.mesh); state.HasValue())
@@ -242,7 +243,7 @@ namespace Horo::Editor {
         return false;
     }
 
-    void OpenGLViewportResources::RetireMissingMeshes(const std::span<const EditorViewportMeshResourceView> resources) noexcept {
+    void EditorViewportResources::RetireMissingMeshes(const std::span<const EditorViewportMeshResourceView> resources) noexcept {
         for (auto mesh = meshes_.begin(); mesh != meshes_.end();) {
             const bool present = std::ranges::any_of(resources, [&](const EditorViewportMeshResourceView &resource) {
                 return resource.handle.id.value == mesh->first;
@@ -260,7 +261,7 @@ namespace Horo::Editor {
         }
     }
 
-    Result<void> OpenGLViewportResources::SynchronizeTarget(const EditorViewportExtent extent) {
+    Result<void> EditorViewportResources::SynchronizeTarget(const EditorViewportExtent extent) {
         if (allocatedExtent_ == extent) {
             if (pendingViewportTarget_.extent.IsValid())
                 ReleaseViewportTarget(pendingViewportTarget_);
@@ -274,7 +275,11 @@ namespace Horo::Editor {
             return Result<void>::Failure(targetReady.ErrorValue());
         if (!targetReady.Value())
             return Result<void>::Success();
-        auto image = OpenGLViewportResourceBridge::EditorImageIdentity(*frontend_, pendingViewportTarget_.colorView);
+        if (config_.resolveImage == nullptr) {
+            return Result<void>::Failure(
+                MakeViewportError(RendererErrors::ViewportGeometryCreationFailed, "Viewport image resolver is unavailable."));
+        }
+        auto image = config_.resolveImage(*frontend_, pendingViewportTarget_.colorView);
         if (image.HasError())
             return Result<void>::Failure(image.ErrorValue());
         pendingViewportTarget_.imageIdentity = image.Value();
@@ -284,7 +289,7 @@ namespace Horo::Editor {
         return Result<void>::Success();
     }
 
-    Result<bool> OpenGLViewportResources::AdvanceViewportTarget(ViewportTargetResources &resources) {
+    Result<bool> EditorViewportResources::AdvanceViewportTarget(ViewportTargetResources &resources) {
         if (const auto texturesReady = AdvanceViewportTextures(resources); texturesReady.HasError() || !texturesReady.Value())
             return texturesReady;
         if (const auto viewsReady = AdvanceViewportViews(resources); viewsReady.HasError() || !viewsReady.Value())
@@ -295,7 +300,7 @@ namespace Horo::Editor {
                                    resources.target, resources.targetOperation);
     }
 
-    Result<bool> OpenGLViewportResources::AdvanceViewportTextures(ViewportTargetResources &resources) {
+    Result<bool> EditorViewportResources::AdvanceViewportTextures(ViewportTargetResources &resources) {
         using enum Render::RenderTextureUsage;
         const Render::FramebufferExtent extent{resources.extent.width, resources.extent.height};
         const auto color =
@@ -304,16 +309,14 @@ namespace Horo::Editor {
                            resources.colorTexture, resources.colorTextureOperation);
         if (color.HasError())
             return Result<bool>::Failure(color.ErrorValue());
-        const auto depth =
-            AdvanceTexture(*frontend_,
-                           {.extent = extent, .format = Render::RenderTextureFormat::Depth24Stencil8, .usage = RenderAttachment},
-                           resources.depthTexture, resources.depthTextureOperation);
+        const auto depth = AdvanceTexture(*frontend_, {.extent = extent, .format = config_.depthFormat, .usage = RenderAttachment},
+                                          resources.depthTexture, resources.depthTextureOperation);
         if (depth.HasError())
             return Result<bool>::Failure(depth.ErrorValue());
         return Result<bool>::Success(color.Value() && depth.Value());
     }
 
-    Result<bool> OpenGLViewportResources::AdvanceViewportViews(ViewportTargetResources &resources) {
+    Result<bool> EditorViewportResources::AdvanceViewportViews(ViewportTargetResources &resources) {
         const auto color = AdvanceTextureView(*frontend_,
                                               {.texture = resources.colorTexture,
                                                .format = Render::RenderTextureFormat::Rgba8Unorm,
@@ -321,17 +324,16 @@ namespace Horo::Editor {
                                               resources.colorView, resources.colorViewOperation);
         if (color.HasError())
             return Result<bool>::Failure(color.ErrorValue());
-        const auto depth = AdvanceTextureView(*frontend_,
-                                              {.texture = resources.depthTexture,
-                                               .format = Render::RenderTextureFormat::Depth24Stencil8,
-                                               .aspect = Render::RenderTextureAspect::DepthStencil},
-                                              resources.depthView, resources.depthViewOperation);
+        const auto depth =
+            AdvanceTextureView(*frontend_,
+                               {.texture = resources.depthTexture, .format = config_.depthFormat, .aspect = config_.depthAspect},
+                               resources.depthView, resources.depthViewOperation);
         if (depth.HasError())
             return Result<bool>::Failure(depth.ErrorValue());
         return Result<bool>::Success(color.Value() && depth.Value());
     }
 
-    Result<void> OpenGLViewportResources::SynchronizeShadowResources() {
+    Result<void> EditorViewportResources::SynchronizeShadowResources() {
         const auto targetReady = AdvanceShadowTarget();
         if (targetReady.HasError())
             return Result<void>::Failure(targetReady.ErrorValue());
@@ -339,7 +341,7 @@ namespace Horo::Editor {
         return Result<void>::Success();
     }
 
-    Result<bool> OpenGLViewportResources::AdvanceShadowTarget() {
+    Result<bool> EditorViewportResources::AdvanceShadowTarget() {
         using enum Render::RenderTextureUsage;
         constexpr Render::FramebufferExtent shadowExtent{EditorViewportDirectionalShadowMapResolution,
                                                          EditorViewportDirectionalShadowMapResolution};
@@ -361,7 +363,7 @@ namespace Horo::Editor {
                                    shadowTargetOperation_);
     }
 
-    void OpenGLViewportResources::ReleaseMesh(ResidentMesh &mesh) noexcept {
+    void EditorViewportResources::ReleaseMesh(ResidentMesh &mesh) noexcept {
         if (mesh.mesh.IsValid())
             static_cast<void>(frontend_->ReleaseMesh(mesh.mesh));
         if (mesh.indexBuffer.IsValid())
@@ -371,7 +373,7 @@ namespace Horo::Editor {
         mesh = {};
     }
 
-    void OpenGLViewportResources::ReleaseShadowResources() noexcept {
+    void EditorViewportResources::ReleaseShadowResources() noexcept {
         if (shadowTarget_.IsValid())
             static_cast<void>(frontend_->ReleaseRenderTarget(shadowTarget_));
         if (shadowDepthTextureView_.IsValid())
@@ -386,7 +388,7 @@ namespace Horo::Editor {
         shadowTargetOperation_ = {};
     }
 
-    void OpenGLViewportResources::ReleaseViewportTarget(ViewportTargetResources &resources) noexcept {
+    void EditorViewportResources::ReleaseViewportTarget(ViewportTargetResources &resources) noexcept {
         if (resources.target.IsValid())
             static_cast<void>(frontend_->ReleaseRenderTarget(resources.target));
         if (resources.depthView.IsValid())

--- a/src/editor/renderer/EditorViewportResources.h
+++ b/src/editor/renderer/EditorViewportResources.h
@@ -6,15 +6,25 @@
 #include <unordered_map>
 
 namespace Horo::Editor {
-    /** @brief Owns frontend-backed OpenGL viewport resources and atomic replacement state. */
-    class OpenGLViewportResources final {
+    /** @brief Resolves a ready typed texture view into the selected GUI backend's image identity. */
+    using EditorViewportImageResolver = Result<std::uintptr_t> (*)(const Render::RenderFrontend &, Render::RenderTextureViewHandle);
+
+    /** @brief Backend-specific attachment policy used by the shared viewport resource coordinator. */
+    struct EditorViewportResourceConfig {
+        Render::RenderTextureFormat depthFormat{Render::RenderTextureFormat::Depth32Float};
+        Render::RenderTextureAspect depthAspect{Render::RenderTextureAspect::Depth};
+        EditorViewportImageResolver resolveImage{nullptr};
+    };
+
+    /** @brief Owns frontend-backed viewport resources and atomic replacement state. */
+    class EditorViewportResources final {
     public:
         struct MeshBinding {
             Render::RenderMeshHandle mesh;
             std::uint32_t indexCount{0};
         };
 
-        explicit OpenGLViewportResources(Render::RenderFrontend &frontend) noexcept;
+        EditorViewportResources(Render::RenderFrontend &frontend, EditorViewportResourceConfig config) noexcept;
 
         [[nodiscard]] Result<std::optional<Render::RenderTargetHandle>> Prepare(const Render::RenderSceneView &scene,
                                                                                 EditorViewportExtent requestedExtent);
@@ -72,6 +82,7 @@ namespace Horo::Editor {
         void ReleaseViewportTarget(ViewportTargetResources &resources) noexcept;
 
         Render::RenderFrontend *frontend_{nullptr};
+        EditorViewportResourceConfig config_;
         std::unordered_map<std::uint64_t, ResidentMesh> meshes_;
         std::unordered_map<std::uint64_t, ResidentMesh> pendingMeshes_;
         ViewportTargetResources viewportTarget_;

--- a/src/editor/renderer/metal/EditorViewportRendererMetal.h
+++ b/src/editor/renderer/metal/EditorViewportRendererMetal.h
@@ -9,8 +9,8 @@ namespace Horo::Editor {
     /** @brief Metal editor adapter that renders backend-neutral editor scene instances into an offscreen target. */
     class EditorViewportRendererMetal final : public IEditorViewportRenderer {
     public:
-        /** @brief Borrows the initialized runtime Metal bridge used by the editor composition. */
-        explicit EditorViewportRendererMetal(Render::MetalEditorGraphicsBridge &graphicsBridge) noexcept;
+        /** @brief Borrows the frontend resource owner and initialized runtime Metal bridge used by editor composition. */
+        EditorViewportRendererMetal(Render::RenderFrontend &frontend, Render::MetalEditorGraphicsBridge &graphicsBridge) noexcept;
         ~EditorViewportRendererMetal() override;
 
         EditorViewportRendererMetal(const EditorViewportRendererMetal &) = delete;
@@ -28,6 +28,8 @@ namespace Horo::Editor {
         [[nodiscard]] EditorViewportExtent RequestedExtent() const noexcept override;
         [[nodiscard]] Math::ClipDepthRange ClipDepthRange() const noexcept override;
         [[nodiscard]] Result<void> ExecuteStaticMeshPass(const Render::StaticMeshPassDescriptor &descriptor) override;
+        [[nodiscard]] Result<std::optional<Render::RenderTargetHandle>> PrepareResources(Render::RenderFrontend &frontend,
+                                                                                         const Render::RenderSceneView &scene) override;
         [[nodiscard]] EditorViewportTextureView TextureView() const noexcept override;
         [[nodiscard]] bool IsReady() const noexcept override;
 

--- a/src/editor/renderer/metal/EditorViewportRendererMetal.mm
+++ b/src/editor/renderer/metal/EditorViewportRendererMetal.mm
@@ -1,67 +1,33 @@
 #include "EditorViewportRendererMetal.h"
 
+#include "MetalViewportResourceBridge.h"
+#include "MetalViewportShaderTypes.h"
+#include "MetalViewportShaders.h"
+#include "editor/renderer/EditorRendererErrors.h"
+#include "editor/renderer/EditorViewportResources.h"
 #include "editor/renderer/grid/EditorViewportGridGeometry.h"
 #include "editor/screens/workspace/panels/viewport/visualizers/light/LightVisualizerGeometry.h"
 
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <cstring>
 #include <string>
-#include <unordered_map>
 #include <utility>
 
 namespace Horo::Editor {
     namespace {
         constexpr std::uint32_t maxViewportDimension = 8192;
 
-        struct MetalSelectionStyle {
-            Math::Vec3 color;
-            float strength;
+        struct MetalViewportFrameResources {
+            __strong id<MTLTexture> colorTexture{nil};
+            __strong id<MTLTexture> depthTexture{nil};
+            __strong id<MTLTexture> shadowTexture{nil};
         };
 
-        static_assert(sizeof(MetalSelectionStyle) == sizeof(float) * 4);
-
-        struct MetalLight {
-            Math::Vec4 positionKind;
-            Math::Vec4 directionRange;
-            Math::Vec4 colorIntensity;
-            Math::Vec4 cone;
-        };
-
-        static_assert(sizeof(MetalLight) == sizeof(float) * 16);
-
-        struct MetalSceneLighting {
-            std::array<MetalLight, Render::MaximumForwardLights> lights{};
-            Math::Vec3 cameraPosition{};
-            std::uint32_t lightCount{0};
-            std::uint32_t shadowEnabled{0};
-            std::uint32_t shadowLightIndex{0};
-            Math::Vec2 padding{};
-        };
-
-        static_assert(sizeof(MetalSceneLighting) == sizeof(MetalLight) * Render::MaximumForwardLights + sizeof(float) * 8);
-
-        struct MetalObjectTransforms {
-            Math::Mat4 mvp;
-            Math::Mat4 model;
-            Math::Mat4 shadowMvp;
-        };
-
-        struct MetalGridStyle {
-            Math::Vec3 color;
-            float padding{0.0F};
-        };
-
-        static_assert(sizeof(MetalGridStyle) == sizeof(float) * 4);
-
-        [[nodiscard]] Error MakeViewportError(const char *code, std::string message) {
-            return Error{.code = ErrorCode{code},
-                         .domain = ErrorDomainId{"horo.editor.viewport.metal"},
-                         .severity = ErrorSeverity::Error,
-                         .message = std::move(message)};
+        [[nodiscard]] Error MakeViewportError(const ErrorCodeDescriptor &descriptor, std::string message) {
+            return MakeError(descriptor, std::move(message));
         }
 
         [[nodiscard]] std::string ErrorMessage(NSString *prefix, NSError *error) {
@@ -76,16 +42,15 @@ namespace Horo::Editor {
     }  // namespace
 
     struct EditorViewportRendererMetal::Impl {
-        struct GpuMesh {
-            __strong id<MTLBuffer> vertexBuffer{nil};
-            __strong id<MTLBuffer> indexBuffer{nil};
-            NSUInteger indexCount{0};
-            std::uint32_t generation{0};
-        };
+        Impl(Render::RenderFrontend &resourceFrontend, Render::MetalEditorGraphicsBridge &borrowedGraphicsBridge) noexcept
+            : frontend(&resourceFrontend), graphicsBridge(&borrowedGraphicsBridge),
+              resources(resourceFrontend, {.depthFormat = Render::RenderTextureFormat::Depth32Float,
+                                           .depthAspect = Render::RenderTextureAspect::Depth,
+                                           .resolveImage = &MetalViewportResourceBridge::EditorImageIdentity}) {}
 
-        explicit Impl(Render::MetalEditorGraphicsBridge &borrowedGraphicsBridge) noexcept : graphicsBridge(&borrowedGraphicsBridge) {}
-
+        Render::RenderFrontend *frontend{nullptr};
         Render::MetalEditorGraphicsBridge *graphicsBridge{nullptr};
+        EditorViewportResources resources;
         __strong id<MTLDevice> device{nil};
         __strong id<MTLLibrary> library{nil};
         __strong id<MTLRenderPipelineState> pipeline{nil};
@@ -95,23 +60,342 @@ namespace Horo::Editor {
         __strong id<MTLDepthStencilState> gridDepthState{nil};
         __strong id<MTLSamplerState> shadowSampler{nil};
         __strong id<MTLBuffer> gridVertexBuffer{nil};
-        std::unordered_map<std::uint64_t, GpuMesh> meshes;
-        __strong id<MTLTexture> colorTexture{nil};
-        __strong id<MTLTexture> depthTexture{nil};
-        __strong id<MTLTexture> shadowDepthTexture{nil};
-        std::array<__strong id<MTLTexture>, 3> retiredColorTextures{};
-        std::size_t nextRetiredTexture{0};
         EditorViewportExtent requestedExtent{};
-        EditorViewportExtent allocatedExtent{};
         EditorViewportGridOptions gridOptions{};
         EditorViewportLightVisualizerOptions lightVisualizerOptions{};
-        Render::RenderTargetHandle targetHandle{};
         bool initialized{false};
+
+        [[nodiscard]] Result<void> CreateMainPipelines();
+        [[nodiscard]] Result<void> CreateShadowPipeline();
+        [[nodiscard]] Result<void> CreateSupportResources();
+        [[nodiscard]] Result<void> ValidatePassRequest(const Render::StaticMeshPassDescriptor &descriptor,
+                                                       EditorViewportExtent renderExtent) const;
+        [[nodiscard]] Result<MetalViewportFrameResources> ResolveFrameResources() const;
+        [[nodiscard]] Result<void> EncodeShadowPass(id<MTLCommandBuffer> commandBuffer, const Render::RenderSceneView &scene,
+                                                    const EditorViewportDirectionalShadowView &shadow, id<MTLTexture> shadowTexture) const;
+        [[nodiscard]] Result<void> EncodeViewportPass(id<MTLCommandBuffer> commandBuffer,
+                                                      const Render::StaticMeshPassDescriptor &descriptor,
+                                                      const std::optional<EditorViewportDirectionalShadowView> &shadow,
+                                                      const MetalViewportFrameResources &frameResources, float aspect);
+        [[nodiscard]] Result<void> DrawGrid(id<MTLRenderCommandEncoder> encoder, const Render::RenderCameraView &camera, float aspect,
+                                            float viewportHeightPixels) const;
+        [[nodiscard]] Result<void> DrawMeshes(id<MTLRenderCommandEncoder> encoder, const Render::RenderSceneView &scene,
+                                              const std::optional<EditorViewportDirectionalShadowView> &shadow, float aspect) const;
+        [[nodiscard]] Result<void> DrawLightVisualizer(id<MTLRenderCommandEncoder> encoder, const Render::RenderCameraView &camera,
+                                                       float aspect);
+        void UploadLighting(id<MTLRenderCommandEncoder> encoder, const Render::RenderSceneView &scene,
+                            const std::optional<EditorViewportDirectionalShadowView> &shadow) const;
     };
 
+    Result<void> EditorViewportRendererMetal::Impl::CreateMainPipelines() {
+        NSError *error = nil;
+        MTLRenderPipelineDescriptor *pipelineDescriptor = [MTLRenderPipelineDescriptor new];
+        pipelineDescriptor.label = @"Horo Editor Viewport";
+        pipelineDescriptor.vertexFunction = [library newFunctionWithName:@"viewport_vertex"];
+        pipelineDescriptor.fragmentFunction = [library newFunctionWithName:@"viewport_fragment"];
+        pipelineDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatRGBA8Unorm;
+        pipelineDescriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
+        pipeline = [device newRenderPipelineStateWithDescriptor:pipelineDescriptor error:&error];
+        if (pipeline == nil) {
+            return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportMetalPipelineCreationFailed,
+                                                           ErrorMessage(@"Metal viewport pipeline creation failed", error)));
+        }
+
+        MTLRenderPipelineDescriptor *gridDescriptor = [MTLRenderPipelineDescriptor new];
+        gridDescriptor.label = @"Horo Editor Viewport Grid";
+        gridDescriptor.vertexFunction = [library newFunctionWithName:@"viewport_grid_vertex"];
+        gridDescriptor.fragmentFunction = [library newFunctionWithName:@"viewport_grid_fragment"];
+        gridDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatRGBA8Unorm;
+        gridDescriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
+        gridPipeline = [device newRenderPipelineStateWithDescriptor:gridDescriptor error:&error];
+        if (gridPipeline == nil) {
+            return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportMetalPipelineCreationFailed,
+                                                           ErrorMessage(@"Metal viewport grid pipeline creation failed", error)));
+        }
+        return Result<void>::Success();
+    }
+
+    Result<void> EditorViewportRendererMetal::Impl::CreateShadowPipeline() {
+        NSError *error = nil;
+        MTLRenderPipelineDescriptor *descriptor = [MTLRenderPipelineDescriptor new];
+        descriptor.label = @"Horo Editor Directional Shadow";
+        descriptor.vertexFunction = [library newFunctionWithName:@"viewport_shadow_vertex"];
+        descriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
+        shadowPipeline = [device newRenderPipelineStateWithDescriptor:descriptor error:&error];
+        if (shadowPipeline == nil) {
+            return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportMetalPipelineCreationFailed,
+                                                           ErrorMessage(@"Metal viewport shadow pipeline creation failed", error)));
+        }
+        return Result<void>::Success();
+    }
+
+    Result<void> EditorViewportRendererMetal::Impl::CreateSupportResources() {
+        MTLDepthStencilDescriptor *depthDescriptor = [MTLDepthStencilDescriptor new];
+        depthDescriptor.depthCompareFunction = MTLCompareFunctionLess;
+        depthDescriptor.depthWriteEnabled = YES;
+        depthState = [device newDepthStencilStateWithDescriptor:depthDescriptor];
+
+        MTLDepthStencilDescriptor *gridDepthDescriptor = [MTLDepthStencilDescriptor new];
+        gridDepthDescriptor.depthCompareFunction = MTLCompareFunctionLess;
+        gridDepthDescriptor.depthWriteEnabled = NO;
+        gridDepthState = [device newDepthStencilStateWithDescriptor:gridDepthDescriptor];
+        constexpr NSUInteger gridBufferSize = sizeof(Math::Vec3) * (ViewportGridGeometry::MaxRegularVertices + 4);
+        gridVertexBuffer = [device newBufferWithLength:gridBufferSize options:MTLResourceStorageModeShared];
+
+        MTLSamplerDescriptor *samplerDescriptor = [MTLSamplerDescriptor new];
+        samplerDescriptor.minFilter = MTLSamplerMinMagFilterLinear;
+        samplerDescriptor.magFilter = MTLSamplerMinMagFilterLinear;
+        samplerDescriptor.sAddressMode = MTLSamplerAddressModeClampToBorderColor;
+        samplerDescriptor.tAddressMode = MTLSamplerAddressModeClampToBorderColor;
+        samplerDescriptor.borderColor = MTLSamplerBorderColorOpaqueWhite;
+        shadowSampler = [device newSamplerStateWithDescriptor:samplerDescriptor];
+        if (depthState == nil || gridDepthState == nil || gridVertexBuffer == nil || shadowSampler == nil) {
+            return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportMetalResourceCreationFailed,
+                                                           "Failed to create Metal viewport geometry or depth state."));
+        }
+        return Result<void>::Success();
+    }
+
+    Result<void> EditorViewportRendererMetal::Impl::ValidatePassRequest(const Render::StaticMeshPassDescriptor &descriptor,
+                                                                        const EditorViewportExtent renderExtent) const {
+        if (!descriptor.IsValid() || descriptor.extent.width != renderExtent.width || descriptor.extent.height != renderExtent.height) {
+            return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportInvalidScene, "Editor viewport scene data is invalid."));
+        }
+        if (resources.Target().IsValid() && resources.Target() != descriptor.target) {
+            return Result<void>::Failure(
+                MakeViewportError(RendererErrors::ViewportStaleTarget, "Viewport pass references a stale render target."));
+        }
+        const EditorViewportExtent allocatedExtent = resources.AllocatedExtent();
+        if (renderExtent.width != allocatedExtent.width || renderExtent.height != allocatedExtent.height) {
+            return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportStaleTarget, "Viewport target extent is not ready."));
+        }
+        return Result<void>::Success();
+    }
+
+    Result<MetalViewportFrameResources> EditorViewportRendererMetal::Impl::ResolveFrameResources() const {
+        const auto viewportTarget = MetalViewportResourceBridge::ResolveRenderTarget(*frontend, resources.Target());
+        if (viewportTarget.HasError())
+            return Result<MetalViewportFrameResources>::Failure(viewportTarget.ErrorValue());
+        const auto shadowTexture = MetalViewportResourceBridge::ResolveTexture(*frontend, resources.ShadowTextureView());
+        if (shadowTexture.HasError())
+            return Result<MetalViewportFrameResources>::Failure(shadowTexture.ErrorValue());
+        return Result<MetalViewportFrameResources>::Success({
+            .colorTexture = (__bridge id<MTLTexture>)viewportTarget.Value().colorTexture,
+            .depthTexture = (__bridge id<MTLTexture>)viewportTarget.Value().depthTexture,
+            .shadowTexture = (__bridge id<MTLTexture>)shadowTexture.Value(),
+        });
+    }
+
+    Result<void> EditorViewportRendererMetal::Impl::EncodeShadowPass(id<MTLCommandBuffer> commandBuffer,
+                                                                     const Render::RenderSceneView &scene,
+                                                                     const EditorViewportDirectionalShadowView &shadow,
+                                                                     id<MTLTexture> shadowTexture) const {
+        MTLRenderPassDescriptor *pass = [MTLRenderPassDescriptor renderPassDescriptor];
+        pass.depthAttachment.texture = shadowTexture;
+        pass.depthAttachment.loadAction = MTLLoadActionClear;
+        pass.depthAttachment.storeAction = MTLStoreActionStore;
+        pass.depthAttachment.clearDepth = 1.0;
+        id<MTLRenderCommandEncoder> encoder = [commandBuffer renderCommandEncoderWithDescriptor:pass];
+        if (encoder == nil) {
+            return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportMetalEncoderCreationFailed,
+                                                           "Failed to create the Metal directional shadow render encoder."));
+        }
+        [encoder pushDebugGroup:@"Horo Editor Directional Shadow"];
+        [encoder setRenderPipelineState:shadowPipeline];
+        [encoder setDepthStencilState:depthState];
+        [encoder setCullMode:MTLCullModeFront];
+        [encoder setDepthBias:0.00045F slopeScale:2.5F clamp:0.01F];
+        for (const Render::RenderStaticMeshInstance &instance : scene.instances) {
+            const auto mesh = resources.FindMesh(instance.mesh.id.value);
+            if (!mesh.has_value()) {
+                [encoder endEncoding];
+                return Result<void>::Failure(
+                    MakeViewportError(RendererErrors::ViewportStaleMeshResource, "Shadow pass instance references a stale mesh resource."));
+            }
+            const auto binding = MetalViewportResourceBridge::ResolveMesh(*frontend, mesh->mesh);
+            if (binding.HasError()) {
+                [encoder endEncoding];
+                return Result<void>::Failure(binding.ErrorValue());
+            }
+            const Math::Mat4 shadowMvp = Math::Multiply(shadow.viewProjection, instance.localToWorld);
+            [encoder setVertexBuffer:(__bridge id<MTLBuffer>)binding.Value().vertexBuffer offset:0 atIndex:0];
+            [encoder setVertexBytes:&shadowMvp length:sizeof(shadowMvp) atIndex:1];
+            [encoder drawIndexedPrimitives:MTLPrimitiveTypeTriangle
+                                indexCount:mesh->indexCount
+                                 indexType:MTLIndexTypeUInt32
+                               indexBuffer:(__bridge id<MTLBuffer>)binding.Value().indexBuffer
+                         indexBufferOffset:0];
+        }
+        [encoder popDebugGroup];
+        [encoder endEncoding];
+        return Result<void>::Success();
+    }
+
+    Result<void> EditorViewportRendererMetal::Impl::EncodeViewportPass(id<MTLCommandBuffer> commandBuffer,
+                                                                       const Render::StaticMeshPassDescriptor &descriptor,
+                                                                       const std::optional<EditorViewportDirectionalShadowView> &shadow,
+                                                                       const MetalViewportFrameResources &frameResources,
+                                                                       const float aspect) {
+        MTLRenderPassDescriptor *pass = [MTLRenderPassDescriptor renderPassDescriptor];
+        pass.colorAttachments[0].texture = frameResources.colorTexture;
+        pass.colorAttachments[0].loadAction = MTLLoadActionClear;
+        pass.colorAttachments[0].storeAction = MTLStoreActionStore;
+        pass.colorAttachments[0].clearColor = MTLClearColorMake(descriptor.clearColor.red, descriptor.clearColor.green,
+                                                                descriptor.clearColor.blue, descriptor.clearColor.alpha);
+        pass.depthAttachment.texture = frameResources.depthTexture;
+        pass.depthAttachment.loadAction = MTLLoadActionClear;
+        pass.depthAttachment.storeAction = MTLStoreActionDontCare;
+        pass.depthAttachment.clearDepth = 1.0;
+        id<MTLRenderCommandEncoder> encoder = [commandBuffer renderCommandEncoderWithDescriptor:pass];
+        if (encoder == nil) {
+            return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportMetalEncoderCreationFailed,
+                                                           "Failed to create the Metal viewport render encoder."));
+        }
+        [encoder pushDebugGroup:@"Horo Editor Viewport"];
+        [encoder setCullMode:MTLCullModeNone];
+        const EditorViewportExtent extent = resources.AllocatedExtent();
+        if (const Result<void> grid = DrawGrid(encoder, descriptor.scene.camera, aspect, static_cast<float>(extent.height));
+            grid.HasError()) {
+            [encoder endEncoding];
+            return grid;
+        }
+        [encoder setRenderPipelineState:pipeline];
+        [encoder setDepthStencilState:depthState];
+        UploadLighting(encoder, descriptor.scene, shadow);
+        [encoder setFragmentTexture:frameResources.shadowTexture atIndex:0];
+        [encoder setFragmentSamplerState:shadowSampler atIndex:0];
+        if (const Result<void> meshes = DrawMeshes(encoder, descriptor.scene, shadow, aspect); meshes.HasError()) {
+            [encoder endEncoding];
+            return meshes;
+        }
+        if (const Result<void> visualizer = DrawLightVisualizer(encoder, descriptor.scene.camera, aspect); visualizer.HasError()) {
+            [encoder endEncoding];
+            return visualizer;
+        }
+        [encoder popDebugGroup];
+        [encoder endEncoding];
+        return Result<void>::Success();
+    }
+
+    Result<void> EditorViewportRendererMetal::Impl::DrawGrid(id<MTLRenderCommandEncoder> encoder, const Render::RenderCameraView &camera,
+                                                             const float aspect, const float viewportHeightPixels) const {
+        if (!gridOptions.visible)
+            return Result<void>::Success();
+        ViewportGridGeometry grid;
+        if (!BuildViewportGridGeometry({.camera = camera,
+                                        .aspect = aspect,
+                                        .viewportHeightPixels = viewportHeightPixels,
+                                        .targetMinorSpacingPixels = gridOptions.targetMinorSpacingPixels,
+                                        .targetLineWidthPixels = gridOptions.targetLineWidthPixels},
+                                       grid)) {
+            return Result<void>::Failure(
+                MakeViewportError(RendererErrors::ViewportInvalidScene, "Failed to build finite viewport grid geometry."));
+        }
+        const Result<Math::Mat4> viewProjection = BuildRenderMvp(camera, Math::Mat4::Identity(), aspect, Math::ClipDepthRange::ZeroToOne);
+        if (viewProjection.HasError())
+            return Result<void>::Failure(viewProjection.ErrorValue());
+        std::byte *gridBytes = static_cast<std::byte *>(gridVertexBuffer.contents);
+        NSUInteger gridOffset = 0;
+        const auto encodeBatch = [&](const ViewportGridLineBatch batch) {
+            if (batch.positions.empty())
+                return;
+            const NSUInteger byteCount = static_cast<NSUInteger>(batch.positions.size_bytes());
+            std::memcpy(gridBytes + gridOffset, batch.positions.data(), byteCount);
+            [encoder setVertexBuffer:gridVertexBuffer offset:gridOffset atIndex:0];
+            [encoder setVertexBytes:viewProjection.Value().values.data() length:sizeof(viewProjection.Value().values) atIndex:1];
+            const MetalGridStyle style{.color = batch.color};
+            [encoder setFragmentBytes:&style length:sizeof(style) atIndex:0];
+            const MTLPrimitiveType primitive =
+                batch.topology == ViewportGridPrimitiveTopology::Triangles ? MTLPrimitiveTypeTriangle : MTLPrimitiveTypeLine;
+            [encoder drawPrimitives:primitive vertexStart:0 vertexCount:static_cast<NSUInteger>(batch.positions.size())];
+            gridOffset += byteCount;
+        };
+        [encoder setRenderPipelineState:gridPipeline];
+        [encoder setDepthStencilState:gridDepthState];
+        encodeBatch(grid.RegularLines());
+        encodeBatch(grid.Axes());
+        return Result<void>::Success();
+    }
+
+    Result<void> EditorViewportRendererMetal::Impl::DrawMeshes(id<MTLRenderCommandEncoder> encoder, const Render::RenderSceneView &scene,
+                                                               const std::optional<EditorViewportDirectionalShadowView> &shadow,
+                                                               const float aspect) const {
+        for (const Render::RenderStaticMeshInstance &instance : scene.instances) {
+            const auto mesh = resources.FindMesh(instance.mesh.id.value);
+            if (!mesh.has_value()) {
+                return Result<void>::Failure(
+                    MakeViewportError(RendererErrors::ViewportStaleMeshResource, "Viewport instance references a stale mesh resource."));
+            }
+            const auto binding = MetalViewportResourceBridge::ResolveMesh(*frontend, mesh->mesh);
+            if (binding.HasError())
+                return Result<void>::Failure(binding.ErrorValue());
+            const Result<Math::Mat4> mvp = BuildRenderMvp(scene.camera, instance.localToWorld, aspect, Math::ClipDepthRange::ZeroToOne);
+            if (mvp.HasError())
+                return Result<void>::Failure(mvp.ErrorValue());
+            const MetalObjectTransforms transforms{
+                .mvp = mvp.Value(),
+                .model = instance.localToWorld,
+                .shadowMvp = shadow.has_value() ? Math::Multiply(shadow->viewProjection, instance.localToWorld) : Math::Mat4::Identity(),
+            };
+            const MetalSelectionStyle selectionStyle{instance.presentation.tint, instance.presentation.tintStrength};
+            [encoder setVertexBuffer:(__bridge id<MTLBuffer>)binding.Value().vertexBuffer offset:0 atIndex:0];
+            [encoder setVertexBytes:&transforms length:sizeof(transforms) atIndex:1];
+            [encoder setFragmentBytes:&selectionStyle length:sizeof(selectionStyle) atIndex:0];
+            [encoder drawIndexedPrimitives:MTLPrimitiveTypeTriangle
+                                indexCount:mesh->indexCount
+                                 indexType:MTLIndexTypeUInt32
+                               indexBuffer:(__bridge id<MTLBuffer>)binding.Value().indexBuffer
+                         indexBufferOffset:0];
+        }
+        return Result<void>::Success();
+    }
+
+    Result<void> EditorViewportRendererMetal::Impl::DrawLightVisualizer(id<MTLRenderCommandEncoder> encoder,
+                                                                        const Render::RenderCameraView &camera, const float aspect) {
+        if (!lightVisualizerOptions.selectedLight.has_value())
+            return Result<void>::Success();
+        LightVisualizerGeometry geometry;
+        if (!BuildLightVisualizerGeometry({.camera = camera, .light = *lightVisualizerOptions.selectedLight}, geometry)) {
+            return Result<void>::Failure(
+                MakeViewportError(RendererErrors::ViewportInvalidScene, "Failed to build selected Light visualizer geometry."));
+        }
+        const Result<Math::Mat4> viewProjection = BuildRenderMvp(camera, Math::Mat4::Identity(), aspect, Math::ClipDepthRange::ZeroToOne);
+        if (viewProjection.HasError())
+            return Result<void>::Failure(viewProjection.ErrorValue());
+        std::memcpy(gridVertexBuffer.contents, geometry.Lines().data(), geometry.Lines().size_bytes());
+        [encoder setRenderPipelineState:gridPipeline];
+        [encoder setDepthStencilState:gridDepthState];
+        [encoder setVertexBuffer:gridVertexBuffer offset:0 atIndex:0];
+        [encoder setVertexBytes:viewProjection.Value().values.data() length:sizeof(viewProjection.Value().values) atIndex:1];
+        const MetalGridStyle style{.color = geometry.color};
+        [encoder setFragmentBytes:&style length:sizeof(style) atIndex:0];
+        [encoder drawPrimitives:MTLPrimitiveTypeLine vertexStart:0 vertexCount:static_cast<NSUInteger>(geometry.vertexCount)];
+        return Result<void>::Success();
+    }
+
+    void EditorViewportRendererMetal::Impl::UploadLighting(id<MTLRenderCommandEncoder> encoder, const Render::RenderSceneView &scene,
+                                                           const std::optional<EditorViewportDirectionalShadowView> &shadow) const {
+        MetalSceneLighting sceneLighting;
+        sceneLighting.cameraPosition = scene.camera.position;
+        sceneLighting.lightCount = static_cast<std::uint32_t>(scene.lights.size());
+        sceneLighting.shadowEnabled = shadow.has_value() ? 1U : 0U;
+        sceneLighting.shadowLightIndex = shadow.has_value() ? static_cast<std::uint32_t>(shadow->lightIndex) : 0U;
+        for (std::size_t index = 0; index < scene.lights.size(); ++index) {
+            const Render::RenderLight &light = scene.lights[index];
+            sceneLighting.lights[index] = {
+                .positionKind = {light.position.x, light.position.y, light.position.z, static_cast<float>(light.kind)},
+                .directionRange = {light.direction.x, light.direction.y, light.direction.z, light.range},
+                .colorIntensity = {light.color.x, light.color.y, light.color.z, light.intensity},
+                .cone = {light.innerConeCosine, light.outerConeCosine, 0.0F, 0.0F},
+            };
+        }
+        [encoder setFragmentBytes:&sceneLighting length:sizeof(sceneLighting) atIndex:1];
+    }
+
     /** @copydoc EditorViewportRendererMetal::EditorViewportRendererMetal */
-    EditorViewportRendererMetal::EditorViewportRendererMetal(Render::MetalEditorGraphicsBridge &graphicsBridge) noexcept
-        : impl_(std::make_unique<Impl>(graphicsBridge)) {}
+    EditorViewportRendererMetal::EditorViewportRendererMetal(Render::RenderFrontend &frontend,
+                                                             Render::MetalEditorGraphicsBridge &graphicsBridge) noexcept
+        : impl_(std::make_unique<Impl>(frontend, graphicsBridge)) {}
 
     /** @copydoc EditorViewportRendererMetal::~EditorViewportRendererMetal */
     EditorViewportRendererMetal::~EditorViewportRendererMetal() {
@@ -122,231 +406,34 @@ namespace Horo::Editor {
     Result<void> EditorViewportRendererMetal::Initialize() {
         if (impl_->initialized) {
             return Result<void>::Failure(
-                MakeViewportError("editor.viewport.already_initialized", "Editor viewport renderer is already initialized."));
+                MakeViewportError(RendererErrors::ViewportAlreadyInitialized, "Editor viewport renderer is already initialized."));
         }
         impl_->device = (__bridge id<MTLDevice>)impl_->graphicsBridge->Device();
         if (impl_->device == nil) {
             return Result<void>::Failure(
-                MakeViewportError("editor.viewport.metal_device_unavailable", "Metal presentation device is unavailable."));
+                MakeViewportError(RendererErrors::ViewportMetalDeviceUnavailable, "Metal presentation device is unavailable."));
         }
-
-        static NSString *shaderSource = @R"metal(
-#include <metal_stdlib>
-using namespace metal;
-struct Vertex { packed_float3 position; packed_float3 normal; packed_float2 uv; };
-struct SelectionStyle { packed_float3 color; float strength; };
-struct Light { float4 positionKind; float4 directionRange; float4 colorIntensity; float4 cone; };
-struct SceneLighting {
-    Light lights[16];
-    packed_float3 cameraPosition;
-    uint lightCount;
-    uint shadowEnabled;
-    uint shadowLightIndex;
-    float2 padding;
-};
-struct ObjectTransforms { float4x4 mvp; float4x4 model; float4x4 shadowMvp; };
-struct VertexOut {
-    float4 position [[position]];
-    float3 worldPosition;
-    float3 worldNormal;
-    float4 shadowPosition;
-};
-struct GridVertexOut { float4 position [[position]]; };
-vertex VertexOut viewport_vertex(uint vertexId [[vertex_id]],
-                                 const device Vertex* vertices [[buffer(0)]],
-                                 constant ObjectTransforms& transforms [[buffer(1)]])
-{
-    VertexOut output;
-    float4 worldPosition = transforms.model * float4(vertices[vertexId].position, 1.0);
-    float3x3 model3x3 = float3x3(transforms.model[0].xyz, transforms.model[1].xyz,
-                                transforms.model[2].xyz);
-    float3 inverseRow0 = cross(model3x3[1], model3x3[2]);
-    float3 inverseRow1 = cross(model3x3[2], model3x3[0]);
-    float3 inverseRow2 = cross(model3x3[0], model3x3[1]);
-    float determinant = dot(model3x3[0], inverseRow0);
-    float inverseDeterminant = abs(determinant) > 0.0000001 ? 1.0 / determinant : 1.0;
-    float3x3 normalMatrix = float3x3(inverseRow0 * inverseDeterminant,
-                                     inverseRow1 * inverseDeterminant,
-                                     inverseRow2 * inverseDeterminant);
-    output.position = transforms.mvp * float4(vertices[vertexId].position, 1.0);
-    output.worldPosition = worldPosition.xyz;
-    output.worldNormal = normalize(normalMatrix * float3(vertices[vertexId].normal));
-    output.shadowPosition = transforms.shadowMvp * float4(vertices[vertexId].position, 1.0);
-    return output;
-}
-vertex float4 viewport_shadow_vertex(uint vertexId [[vertex_id]],
-                                     const device Vertex* vertices [[buffer(0)]],
-                                     constant float4x4& shadowMvp [[buffer(1)]])
-{
-    return shadowMvp * float4(vertices[vertexId].position, 1.0);
-}
-vertex GridVertexOut viewport_grid_vertex(uint vertexId [[vertex_id]],
-                                          const device packed_float3* vertices [[buffer(0)]],
-                                          constant float4x4& viewProjection [[buffer(1)]])
-{
-    GridVertexOut output;
-    output.position = viewProjection * float4(float3(vertices[vertexId]), 1.0);
-    return output;
-}
-fragment float4 viewport_fragment(VertexOut input [[stage_in]],
-                                  constant SelectionStyle& selection [[buffer(0)]],
-                                  constant SceneLighting& scene [[buffer(1)]],
-                                  depth2d<float> shadowMap [[texture(0)]],
-                                  sampler shadowSampler [[sampler(0)]])
-{
-    float3 normal = normalize(input.worldNormal);
-    float3 viewDirection = normalize(float3(scene.cameraPosition) - input.worldPosition);
-    float3 baseColor = float3(0.68, 0.70, 0.74);
-    float3 lighting = baseColor * 0.08;
-    for (uint index = 0; index < scene.lightCount; ++index)
-    {
-        constant Light& light = scene.lights[index];
-        uint kind = uint(light.positionKind.w + 0.5);
-        float3 lightDirection;
-        float attenuation = 1.0;
-        if (kind == 0)
-        {
-            lightDirection = normalize(-light.directionRange.xyz);
-        }
-        else
-        {
-            float3 toLight = light.positionKind.xyz - input.worldPosition;
-            float distanceToLight = length(toLight);
-            lightDirection = distanceToLight > 0.0001 ? toLight / distanceToLight : normal;
-            float range = max(light.directionRange.w, 0.0001);
-            float normalizedDistance = distanceToLight / range;
-            float rangeFade = max(1.0 - normalizedDistance * normalizedDistance, 0.0);
-            attenuation = rangeFade * rangeFade;
-            if (kind == 2)
-            {
-                float coneCosine = dot(normalize(light.directionRange.xyz), -lightDirection);
-                attenuation *= smoothstep(light.cone.y, light.cone.x, coneCosine);
-            }
-        }
-        float diffuse = max(dot(normal, lightDirection), 0.0);
-        float3 halfDirection = normalize(lightDirection + viewDirection);
-        float specular = pow(max(dot(normal, halfDirection), 0.0), 48.0) * 0.18;
-        float3 radiance = light.colorIntensity.rgb * light.colorIntensity.a * attenuation;
-        float visibility = 1.0;
-        if (scene.shadowEnabled != 0 && index == scene.shadowLightIndex)
-        {
-            float3 projected = input.shadowPosition.xyz / input.shadowPosition.w;
-            float3 shadowCoordinate = float3(projected.x * 0.5 + 0.5, 0.5 - projected.y * 0.5, projected.z);
-            if (shadowCoordinate.x > 0.0 && shadowCoordinate.x < 1.0 &&
-                shadowCoordinate.y > 0.0 && shadowCoordinate.y < 1.0 &&
-                shadowCoordinate.z > 0.0 && shadowCoordinate.z < 1.0)
-            {
-                float2 texel = 1.0 / float2(shadowMap.get_width(), shadowMap.get_height());
-                float bias = max(0.0025 * (1.0 - dot(normal, lightDirection)), 0.00045);
-                visibility = 0.0;
-                for (int y = -1; y <= 1; ++y)
-                    for (int x = -1; x <= 1; ++x)
-                    {
-                        float closestDepth = shadowMap.sample(shadowSampler,
-                            shadowCoordinate.xy + float2(x, y) * texel);
-                        visibility += shadowCoordinate.z - bias <= closestDepth ? 1.0 : 0.0;
-                    }
-                visibility /= 9.0;
-            }
-        }
-        lighting += radiance * (baseColor * diffuse + specular) * visibility;
-    }
-    float3 mapped = lighting / (lighting + 1.0);
-    float3 displayColor = pow(max(mapped, 0.0), float3(1.0 / 2.2));
-    return float4(mix(displayColor, float3(selection.color), selection.strength), 1.0);
-}
-fragment float4 viewport_grid_fragment(GridVertexOut input [[stage_in]],
-                                       constant SelectionStyle& style [[buffer(0)]])
-{
-    (void)input;
-    return float4(style.color, 1.0);
-}
-)metal";
 
         NSError *error = nil;
+        NSString *shaderSource = [NSString stringWithUTF8String:MetalViewportShaderSource()];
         impl_->library = [impl_->device newLibraryWithSource:shaderSource options:nil error:&error];
         if (impl_->library == nil) {
             Shutdown();
-            return Result<void>::Failure(MakeViewportError("editor.viewport.shader_compile_failed",
+            return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportShaderCompileFailed,
                                                            ErrorMessage(@"Metal viewport shader compilation failed", error)));
         }
 
-        id<MTLFunction> vertexFunction = [impl_->library newFunctionWithName:@"viewport_vertex"];
-        id<MTLFunction> fragmentFunction = [impl_->library newFunctionWithName:@"viewport_fragment"];
-        id<MTLFunction> gridVertexFunction = [impl_->library newFunctionWithName:@"viewport_grid_vertex"];
-        id<MTLFunction> gridFragmentFunction = [impl_->library newFunctionWithName:@"viewport_grid_fragment"];
-        id<MTLFunction> shadowVertexFunction = [impl_->library newFunctionWithName:@"viewport_shadow_vertex"];
-        MTLRenderPipelineDescriptor *pipelineDescriptor = [MTLRenderPipelineDescriptor new];
-        pipelineDescriptor.label = @"Horo Editor Viewport";
-        pipelineDescriptor.vertexFunction = vertexFunction;
-        pipelineDescriptor.fragmentFunction = fragmentFunction;
-        pipelineDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
-        pipelineDescriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
-        impl_->pipeline = [impl_->device newRenderPipelineStateWithDescriptor:pipelineDescriptor error:&error];
-        if (impl_->pipeline == nil) {
+        if (const Result<void> pipelines = impl_->CreateMainPipelines(); pipelines.HasError()) {
             Shutdown();
-            return Result<void>::Failure(MakeViewportError("editor.viewport.pipeline_creation_failed",
-                                                           ErrorMessage(@"Metal viewport pipeline creation failed", error)));
+            return pipelines;
         }
-
-        MTLRenderPipelineDescriptor *gridPipelineDescriptor = [MTLRenderPipelineDescriptor new];
-        gridPipelineDescriptor.label = @"Horo Editor Viewport Grid";
-        gridPipelineDescriptor.vertexFunction = gridVertexFunction;
-        gridPipelineDescriptor.fragmentFunction = gridFragmentFunction;
-        gridPipelineDescriptor.colorAttachments[0].pixelFormat = MTLPixelFormatBGRA8Unorm;
-        gridPipelineDescriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
-        impl_->gridPipeline = [impl_->device newRenderPipelineStateWithDescriptor:gridPipelineDescriptor error:&error];
-        if (impl_->gridPipeline == nil) {
+        if (const Result<void> shadowPipeline = impl_->CreateShadowPipeline(); shadowPipeline.HasError()) {
             Shutdown();
-            return Result<void>::Failure(MakeViewportError("editor.viewport.grid_pipeline_creation_failed",
-                                                           ErrorMessage(@"Metal viewport grid pipeline creation failed", error)));
+            return shadowPipeline;
         }
-
-        MTLRenderPipelineDescriptor *shadowPipelineDescriptor = [MTLRenderPipelineDescriptor new];
-        shadowPipelineDescriptor.label = @"Horo Editor Directional Shadow";
-        shadowPipelineDescriptor.vertexFunction = shadowVertexFunction;
-        shadowPipelineDescriptor.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float;
-        impl_->shadowPipeline = [impl_->device newRenderPipelineStateWithDescriptor:shadowPipelineDescriptor error:&error];
-        if (impl_->shadowPipeline == nil) {
+        if (const Result<void> resources = impl_->CreateSupportResources(); resources.HasError()) {
             Shutdown();
-            return Result<void>::Failure(MakeViewportError("editor.viewport.shadow_pipeline_creation_failed",
-                                                           ErrorMessage(@"Metal viewport shadow pipeline creation failed", error)));
-        }
-
-        MTLDepthStencilDescriptor *depthDescriptor = [MTLDepthStencilDescriptor new];
-        depthDescriptor.depthCompareFunction = MTLCompareFunctionLess;
-        depthDescriptor.depthWriteEnabled = YES;
-        impl_->depthState = [impl_->device newDepthStencilStateWithDescriptor:depthDescriptor];
-
-        MTLDepthStencilDescriptor *gridDepthDescriptor = [MTLDepthStencilDescriptor new];
-        gridDepthDescriptor.depthCompareFunction = MTLCompareFunctionLess;
-        gridDepthDescriptor.depthWriteEnabled = NO;
-        impl_->gridDepthState = [impl_->device newDepthStencilStateWithDescriptor:gridDepthDescriptor];
-        constexpr NSUInteger gridBufferSize = sizeof(Math::Vec3) * (ViewportGridGeometry::MaxRegularVertices + 4);
-        impl_->gridVertexBuffer = [impl_->device newBufferWithLength:gridBufferSize options:MTLResourceStorageModeShared];
-
-        MTLSamplerDescriptor *shadowSamplerDescriptor = [MTLSamplerDescriptor new];
-        shadowSamplerDescriptor.minFilter = MTLSamplerMinMagFilterLinear;
-        shadowSamplerDescriptor.magFilter = MTLSamplerMinMagFilterLinear;
-        shadowSamplerDescriptor.sAddressMode = MTLSamplerAddressModeClampToBorderColor;
-        shadowSamplerDescriptor.tAddressMode = MTLSamplerAddressModeClampToBorderColor;
-        shadowSamplerDescriptor.borderColor = MTLSamplerBorderColorOpaqueWhite;
-        impl_->shadowSampler = [impl_->device newSamplerStateWithDescriptor:shadowSamplerDescriptor];
-
-        constexpr NSUInteger shadowMapResolution = EditorViewportDirectionalShadowMapResolution;
-        MTLTextureDescriptor *shadowTextureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatDepth32Float
-                                                                                                           width:shadowMapResolution
-                                                                                                          height:shadowMapResolution
-                                                                                                       mipmapped:NO];
-        shadowTextureDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
-        shadowTextureDescriptor.storageMode = MTLStorageModePrivate;
-        impl_->shadowDepthTexture = [impl_->device newTextureWithDescriptor:shadowTextureDescriptor];
-
-        if (impl_->depthState == nil || impl_->gridDepthState == nil || impl_->gridVertexBuffer == nil || impl_->shadowSampler == nil ||
-            impl_->shadowDepthTexture == nil) {
-            Shutdown();
-            return Result<void>::Failure(
-                MakeViewportError("editor.viewport.resource_creation_failed", "Failed to create Metal viewport geometry or depth state."));
+            return resources;
         }
 
         impl_->initialized = true;
@@ -356,12 +443,7 @@ fragment float4 viewport_grid_fragment(GridVertexOut input [[stage_in]],
     /** @copydoc EditorViewportRendererMetal::Shutdown */
     void EditorViewportRendererMetal::Shutdown() noexcept {
         impl_->graphicsBridge->WaitUntilIdle();
-        impl_->depthTexture = nil;
-        impl_->shadowDepthTexture = nil;
-        impl_->colorTexture = nil;
-        impl_->retiredColorTextures = {};
-        impl_->nextRetiredTexture = 0;
-        impl_->meshes.clear();
+        impl_->resources.Shutdown();
         impl_->gridVertexBuffer = nil;
         impl_->gridDepthState = nil;
         impl_->depthState = nil;
@@ -372,10 +454,8 @@ fragment float4 viewport_grid_fragment(GridVertexOut input [[stage_in]],
         impl_->library = nil;
         impl_->device = nil;
         impl_->requestedExtent = {};
-        impl_->allocatedExtent = {};
         impl_->gridOptions = {};
         impl_->lightVisualizerOptions = {};
-        impl_->targetHandle = {};
         impl_->initialized = false;
     }
 
@@ -394,12 +474,13 @@ fragment float4 viewport_grid_fragment(GridVertexOut input [[stage_in]],
 
     /** @copydoc EditorViewportRendererMetal::RequestLightVisualizer */
     void EditorViewportRendererMetal::RequestLightVisualizer(const EditorViewportLightVisualizerOptions &options) noexcept {
-        impl_->lightVisualizerOptions = std::move(options);
+        impl_->lightVisualizerOptions = options;
     }
 
     /** @copydoc EditorViewportRendererMetal::RequestedExtent */
     EditorViewportExtent EditorViewportRendererMetal::RequestedExtent() const noexcept {
-        return impl_->requestedExtent;
+        const EditorViewportExtent allocatedExtent = impl_->resources.AllocatedExtent();
+        return impl_->requestedExtent.IsValid() && allocatedExtent.IsValid() ? allocatedExtent : impl_->requestedExtent;
     }
 
     /** @copydoc EditorViewportRendererMetal::ClipDepthRange */
@@ -407,288 +488,58 @@ fragment float4 viewport_grid_fragment(GridVertexOut input [[stage_in]],
         return Math::ClipDepthRange::ZeroToOne;
     }
 
+    /** @copydoc EditorViewportRendererMetal::PrepareResources */
+    Result<std::optional<Render::RenderTargetHandle>> EditorViewportRendererMetal::PrepareResources(Render::RenderFrontend &frontend,
+                                                                                                    const Render::RenderSceneView &scene) {
+        if (!impl_->initialized || impl_->frontend != &frontend) {
+            return Result<std::optional<Render::RenderTargetHandle>>::Failure(
+                MakeViewportError(RendererErrors::ViewportNotInitialized, "Viewport resource owner is not initialized."));
+        }
+        return impl_->resources.Prepare(scene, impl_->requestedExtent);
+    }
+
     /** @copydoc EditorViewportRendererMetal::ExecuteStaticMeshPass */
     Result<void> EditorViewportRendererMetal::ExecuteStaticMeshPass(const Render::StaticMeshPassDescriptor &descriptor) {
         if (!impl_->initialized) {
-            return Result<void>::Failure(MakeViewportError("editor.viewport.not_initialized", "Viewport renderer is not initialized."));
-        }
-        const EditorViewportExtent requestedExtent = std::exchange(impl_->requestedExtent, {});
-        if (!requestedExtent.IsValid()) {
-            return Result<void>::Success();
-        }
-        if (!descriptor.IsValid() || descriptor.extent.width != requestedExtent.width ||
-            descriptor.extent.height != requestedExtent.height) {
-            return Result<void>::Failure(MakeViewportError("editor.viewport.invalid_scene", "Editor viewport scene data is invalid."));
-        }
-        if (impl_->targetHandle.IsValid() && impl_->targetHandle != descriptor.target) {
             return Result<void>::Failure(
-                MakeViewportError("editor.viewport.stale_target", "Viewport pass references a stale render target."));
+                MakeViewportError(RendererErrors::ViewportNotInitialized, "Viewport renderer is not initialized."));
         }
-        impl_->targetHandle = descriptor.target;
-
-        if (requestedExtent.width != impl_->allocatedExtent.width || requestedExtent.height != impl_->allocatedExtent.height) {
-            MTLTextureDescriptor *colorDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
-                                                                                                       width:requestedExtent.width
-                                                                                                      height:requestedExtent.height
-                                                                                                   mipmapped:NO];
-            colorDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
-            colorDescriptor.storageMode = MTLStorageModePrivate;
-            id<MTLTexture> colorTexture = [impl_->device newTextureWithDescriptor:colorDescriptor];
-
-            MTLTextureDescriptor *depthDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatDepth32Float
-                                                                                                       width:requestedExtent.width
-                                                                                                      height:requestedExtent.height
-                                                                                                   mipmapped:NO];
-            depthDescriptor.usage = MTLTextureUsageRenderTarget;
-            depthDescriptor.storageMode = MTLStorageModePrivate;
-            id<MTLTexture> depthTexture = [impl_->device newTextureWithDescriptor:depthDescriptor];
-            if (colorTexture == nil || depthTexture == nil) {
-                return Result<void>::Failure(
-                    MakeViewportError("editor.viewport.target_creation_failed", "Failed to create Metal viewport render targets."));
-            }
-            impl_->retiredColorTextures[impl_->nextRetiredTexture] = impl_->colorTexture;
-            impl_->nextRetiredTexture = (impl_->nextRetiredTexture + 1U) % impl_->retiredColorTextures.size();
-            impl_->colorTexture = colorTexture;
-            impl_->depthTexture = depthTexture;
-            impl_->allocatedExtent = requestedExtent;
-        }
+        // A panel must request an extent every UI frame. Consuming the request keeps
+        // hidden/inactive viewport tabs from spending GPU time in the background.
+        const EditorViewportExtent requestedExtent = std::exchange(impl_->requestedExtent, {});
+        if (!requestedExtent.IsValid())
+            return Result<void>::Success();
+        const EditorViewportExtent allocatedExtent = impl_->resources.AllocatedExtent();
+        const EditorViewportExtent renderExtent = allocatedExtent.IsValid() ? allocatedExtent : requestedExtent;
+        if (const Result<void> valid = impl_->ValidatePassRequest(descriptor, renderExtent); valid.HasError())
+            return valid;
 
         id<MTLCommandBuffer> commandBuffer = (__bridge id<MTLCommandBuffer>)impl_->graphicsBridge->CurrentCommandBuffer();
         if (commandBuffer == nil) {
-            return Result<void>::Failure(
-                MakeViewportError("editor.viewport.no_active_frame", "Metal viewport rendering requires an active renderer frame."));
+            return Result<void>::Failure(MakeViewportError(RendererErrors::ViewportMetalNoActiveFrame,
+                                                           "Metal viewport rendering requires an active renderer frame."));
         }
-
-        for (const Render::RenderMeshResourceView &resource : descriptor.scene.meshResources) {
-            if (auto existing = impl_->meshes.find(resource.handle.id.value); existing != impl_->meshes.end()) {
-                if (existing->second.generation == resource.handle.generation)
-                    continue;
-                id<MTLBuffer> retiredVertex = existing->second.vertexBuffer;
-                id<MTLBuffer> retiredIndex = existing->second.indexBuffer;
-                [commandBuffer addCompletedHandler:^(__unused id<MTLCommandBuffer> completed) {
-                  (void)retiredVertex;
-                  (void)retiredIndex;
-                }];
-                impl_->meshes.erase(existing);
-            }
-            Impl::GpuMesh mesh;
-            mesh.generation = resource.handle.generation;
-            mesh.vertexBuffer = [impl_->device newBufferWithBytes:resource.vertices.data()
-                                                           length:resource.vertices.size_bytes()
-                                                          options:MTLResourceStorageModeShared];
-            mesh.indexBuffer = [impl_->device newBufferWithBytes:resource.indices.data()
-                                                          length:resource.indices.size_bytes()
-                                                         options:MTLResourceStorageModeShared];
-            mesh.indexCount = resource.indices.size();
-            if (mesh.vertexBuffer == nil || mesh.indexBuffer == nil)
-                return Result<void>::Failure(
-                    MakeViewportError("editor.viewport.resource_creation_failed", "Failed to upload a Metal viewport mesh resource."));
-            impl_->meshes.emplace(resource.handle.id.value, std::move(mesh));
-        }
-        for (auto mesh = impl_->meshes.begin(); mesh != impl_->meshes.end();) {
-            const bool present = std::ranges::any_of(descriptor.scene.meshResources, [&](const Render::RenderMeshResourceView &resource) {
-                return resource.handle.id.value == mesh->first && resource.handle.generation == mesh->second.generation;
-            });
-            if (!present) {
-                id<MTLBuffer> retiredVertex = mesh->second.vertexBuffer;
-                id<MTLBuffer> retiredIndex = mesh->second.indexBuffer;
-                [commandBuffer addCompletedHandler:^(__unused id<MTLCommandBuffer> completed) {
-                  (void)retiredVertex;
-                  (void)retiredIndex;
-                }];
-                mesh = impl_->meshes.erase(mesh);
-            } else
-                ++mesh;
-        }
-
-        const float aspect = static_cast<float>(impl_->allocatedExtent.width) / static_cast<float>(impl_->allocatedExtent.height);
         const Result<std::optional<EditorViewportDirectionalShadowView>> shadow =
             BuildEditorViewportDirectionalShadowView(descriptor.scene, Math::ClipDepthRange::ZeroToOne);
-        if (shadow.HasError()) {
+        if (shadow.HasError())
             return Result<void>::Failure(shadow.ErrorValue());
-        }
-
+        const auto frameResources = impl_->ResolveFrameResources();
+        if (frameResources.HasError())
+            return Result<void>::Failure(frameResources.ErrorValue());
+        const float aspect = static_cast<float>(allocatedExtent.width) / static_cast<float>(allocatedExtent.height);
         if (shadow.Value().has_value()) {
-            MTLRenderPassDescriptor *shadowPass = [MTLRenderPassDescriptor renderPassDescriptor];
-            shadowPass.depthAttachment.texture = impl_->shadowDepthTexture;
-            shadowPass.depthAttachment.loadAction = MTLLoadActionClear;
-            shadowPass.depthAttachment.storeAction = MTLStoreActionStore;
-            shadowPass.depthAttachment.clearDepth = 1.0;
-            id<MTLRenderCommandEncoder> shadowEncoder = [commandBuffer renderCommandEncoderWithDescriptor:shadowPass];
-            if (shadowEncoder == nil) {
-                return Result<void>::Failure(MakeViewportError("editor.viewport.shadow_encoder_creation_failed",
-                                                               "Failed to create the Metal directional shadow render encoder."));
-            }
-            [shadowEncoder pushDebugGroup:@"Horo Editor Directional Shadow"];
-            [shadowEncoder setRenderPipelineState:impl_->shadowPipeline];
-            [shadowEncoder setDepthStencilState:impl_->depthState];
-            [shadowEncoder setCullMode:MTLCullModeFront];
-            [shadowEncoder setDepthBias:0.00045F slopeScale:2.5F clamp:0.01F];
-            for (const Render::RenderStaticMeshInstance &instance : descriptor.scene.instances) {
-                const auto mesh = impl_->meshes.find(instance.mesh.id.value);
-                if (mesh == impl_->meshes.end()) {
-                    [shadowEncoder endEncoding];
-                    return Result<void>::Failure(
-                        MakeViewportError("editor.viewport.stale_mesh_resource", "Shadow pass instance references a stale mesh resource."));
-                }
-                const Math::Mat4 shadowMvp = Math::Multiply(shadow.Value()->viewProjection, instance.localToWorld);
-                [shadowEncoder setVertexBuffer:mesh->second.vertexBuffer offset:0 atIndex:0];
-                [shadowEncoder setVertexBytes:&shadowMvp length:sizeof(shadowMvp) atIndex:1];
-                [shadowEncoder drawIndexedPrimitives:MTLPrimitiveTypeTriangle
-                                          indexCount:mesh->second.indexCount
-                                           indexType:MTLIndexTypeUInt32
-                                         indexBuffer:mesh->second.indexBuffer
-                                   indexBufferOffset:0];
-            }
-            [shadowEncoder popDebugGroup];
-            [shadowEncoder endEncoding];
+            const Result<void> encoded =
+                impl_->EncodeShadowPass(commandBuffer, descriptor.scene, *shadow.Value(), frameResources.Value().shadowTexture);
+            if (encoded.HasError())
+                return encoded;
         }
-
-        MTLRenderPassDescriptor *pass = [MTLRenderPassDescriptor renderPassDescriptor];
-        pass.colorAttachments[0].texture = impl_->colorTexture;
-        pass.colorAttachments[0].loadAction = MTLLoadActionClear;
-        pass.colorAttachments[0].storeAction = MTLStoreActionStore;
-        pass.colorAttachments[0].clearColor = MTLClearColorMake(descriptor.clearColor.red, descriptor.clearColor.green,
-                                                                descriptor.clearColor.blue, descriptor.clearColor.alpha);
-        pass.depthAttachment.texture = impl_->depthTexture;
-        pass.depthAttachment.loadAction = MTLLoadActionClear;
-        pass.depthAttachment.storeAction = MTLStoreActionDontCare;
-        pass.depthAttachment.clearDepth = 1.0;
-
-        id<MTLRenderCommandEncoder> encoder = [commandBuffer renderCommandEncoderWithDescriptor:pass];
-        if (encoder == nil) {
-            return Result<void>::Failure(
-                MakeViewportError("editor.viewport.encoder_creation_failed", "Failed to create the Metal viewport render encoder."));
-        }
-        [encoder pushDebugGroup:@"Horo Editor Viewport"];
-        [encoder setCullMode:MTLCullModeNone];
-        if (impl_->gridOptions.visible) {
-            ViewportGridGeometry grid;
-            if (!BuildViewportGridGeometry(
-                    ViewportGridGeometryRequest{
-                        .camera = descriptor.scene.camera,
-                        .aspect = aspect,
-                        .viewportHeightPixels = static_cast<float>(impl_->allocatedExtent.height),
-                        .targetMinorSpacingPixels = impl_->gridOptions.targetMinorSpacingPixels,
-                        .targetLineWidthPixels = impl_->gridOptions.targetLineWidthPixels,
-                    },
-                    grid)) {
-                [encoder endEncoding];
-                return Result<void>::Failure(
-                    MakeViewportError("editor.viewport.invalid_grid", "Failed to build finite viewport grid geometry."));
-            }
-            const Result<Math::Mat4> viewProjection =
-                BuildRenderMvp(descriptor.scene.camera, Math::Mat4::Identity(), aspect, Math::ClipDepthRange::ZeroToOne);
-            if (viewProjection.HasError()) {
-                [encoder endEncoding];
-                return Result<void>::Failure(viewProjection.ErrorValue());
-            }
-
-            std::byte *gridBytes = static_cast<std::byte *>(impl_->gridVertexBuffer.contents);
-            NSUInteger gridOffset = 0;
-            const auto encodeBatch = [&](const ViewportGridLineBatch batch) {
-                if (batch.positions.empty())
-                    return;
-                const NSUInteger byteCount = static_cast<NSUInteger>(batch.positions.size_bytes());
-                std::memcpy(gridBytes + gridOffset, batch.positions.data(), byteCount);
-                [encoder setVertexBuffer:impl_->gridVertexBuffer offset:gridOffset atIndex:0];
-                [encoder setVertexBytes:viewProjection.Value().values.data() length:sizeof(viewProjection.Value().values) atIndex:1];
-                const MetalGridStyle style{.color = batch.color};
-                [encoder setFragmentBytes:&style length:sizeof(style) atIndex:0];
-                const MTLPrimitiveType primitive =
-                    batch.topology == ViewportGridPrimitiveTopology::Triangles ? MTLPrimitiveTypeTriangle : MTLPrimitiveTypeLine;
-                [encoder drawPrimitives:primitive vertexStart:0 vertexCount:static_cast<NSUInteger>(batch.positions.size())];
-                gridOffset += byteCount;
-            };
-            [encoder setRenderPipelineState:impl_->gridPipeline];
-            [encoder setDepthStencilState:impl_->gridDepthState];
-            encodeBatch(grid.RegularLines());
-            encodeBatch(grid.Axes());
-        }
-        [encoder setRenderPipelineState:impl_->pipeline];
-        [encoder setDepthStencilState:impl_->depthState];
-        MetalSceneLighting sceneLighting;
-        sceneLighting.cameraPosition = descriptor.scene.camera.position;
-        sceneLighting.lightCount = static_cast<std::uint32_t>(descriptor.scene.lights.size());
-        sceneLighting.shadowEnabled = shadow.Value().has_value() ? 1U : 0U;
-        sceneLighting.shadowLightIndex = shadow.Value().has_value() ? static_cast<std::uint32_t>(shadow.Value()->lightIndex) : 0U;
-        for (std::size_t index = 0; index < descriptor.scene.lights.size(); ++index) {
-            const Render::RenderLight &light = descriptor.scene.lights[index];
-            sceneLighting.lights[index] = {
-                .positionKind = {light.position.x, light.position.y, light.position.z, static_cast<float>(light.kind)},
-                .directionRange = {light.direction.x, light.direction.y, light.direction.z, light.range},
-                .colorIntensity = {light.color.x, light.color.y, light.color.z, light.intensity},
-                .cone = {light.innerConeCosine, light.outerConeCosine, 0.0F, 0.0F},
-            };
-        }
-        [encoder setFragmentBytes:&sceneLighting length:sizeof(sceneLighting) atIndex:1];
-        [encoder setFragmentTexture:impl_->shadowDepthTexture atIndex:0];
-        [encoder setFragmentSamplerState:impl_->shadowSampler atIndex:0];
-        for (const Render::RenderStaticMeshInstance &instance : descriptor.scene.instances) {
-            const auto mesh = impl_->meshes.find(instance.mesh.id.value);
-            if (mesh == impl_->meshes.end()) {
-                [encoder endEncoding];
-                return Result<void>::Failure(
-                    MakeViewportError("editor.viewport.stale_mesh_resource", "Viewport instance references a stale mesh resource."));
-            }
-            [encoder setVertexBuffer:mesh->second.vertexBuffer offset:0 atIndex:0];
-            const Result<Math::Mat4> mvp =
-                BuildRenderMvp(descriptor.scene.camera, instance.localToWorld, aspect, Math::ClipDepthRange::ZeroToOne);
-            if (mvp.HasError()) {
-                [encoder endEncoding];
-                return Result<void>::Failure(mvp.ErrorValue());
-            }
-            const MetalObjectTransforms transforms{
-                .mvp = mvp.Value(),
-                .model = instance.localToWorld,
-                .shadowMvp = shadow.Value().has_value() ? Math::Multiply(shadow.Value()->viewProjection, instance.localToWorld)
-                                                        : Math::Mat4::Identity(),
-            };
-            const MetalSelectionStyle selectionStyle{instance.presentation.tint, instance.presentation.tintStrength};
-            [encoder setVertexBytes:&transforms length:sizeof(transforms) atIndex:1];
-            [encoder setFragmentBytes:&selectionStyle length:sizeof(selectionStyle) atIndex:0];
-            [encoder drawIndexedPrimitives:MTLPrimitiveTypeTriangle
-                                indexCount:mesh->second.indexCount
-                                 indexType:MTLIndexTypeUInt32
-                               indexBuffer:mesh->second.indexBuffer
-                         indexBufferOffset:0];
-        }
-        if (impl_->lightVisualizerOptions.selectedLight.has_value()) {
-            LightVisualizerGeometry geometry;
-            if (!BuildLightVisualizerGeometry(
-                    LightVisualizerGeometryRequest{
-                        .camera = descriptor.scene.camera,
-                        .light = *impl_->lightVisualizerOptions.selectedLight,
-                    },
-                    geometry)) {
-                [encoder endEncoding];
-                return Result<void>::Failure(
-                    MakeViewportError("editor.viewport.invalid_light_visualizer", "Failed to build selected Light visualizer geometry."));
-            }
-            const Result<Math::Mat4> viewProjection =
-                BuildRenderMvp(descriptor.scene.camera, Math::Mat4::Identity(), aspect, Math::ClipDepthRange::ZeroToOne);
-            if (viewProjection.HasError()) {
-                [encoder endEncoding];
-                return Result<void>::Failure(viewProjection.ErrorValue());
-            }
-            std::memcpy(impl_->gridVertexBuffer.contents, geometry.Lines().data(), geometry.Lines().size_bytes());
-            [encoder setRenderPipelineState:impl_->gridPipeline];
-            [encoder setDepthStencilState:impl_->gridDepthState];
-            [encoder setVertexBuffer:impl_->gridVertexBuffer offset:0 atIndex:0];
-            [encoder setVertexBytes:viewProjection.Value().values.data() length:sizeof(viewProjection.Value().values) atIndex:1];
-            const MetalGridStyle style{.color = geometry.color};
-            [encoder setFragmentBytes:&style length:sizeof(style) atIndex:0];
-            [encoder drawPrimitives:MTLPrimitiveTypeLine vertexStart:0 vertexCount:static_cast<NSUInteger>(geometry.vertexCount)];
-        }
-        [encoder popDebugGroup];
-        [encoder endEncoding];
-        return Result<void>::Success();
+        return impl_->EncodeViewportPass(commandBuffer, descriptor, shadow.Value(), frameResources.Value(), aspect);
     }
 
     /** @copydoc EditorViewportRendererMetal::TextureView */
     EditorViewportTextureView EditorViewportRendererMetal::TextureView() const noexcept {
         return EditorViewportTextureView{
-            .textureId = reinterpret_cast<std::uintptr_t>((__bridge void *)impl_->colorTexture),
+            .textureId = impl_->resources.ImageIdentity(),
             .u0 = 0.0F,
             .v0 = 0.0F,
             .u1 = 1.0F,
@@ -698,6 +549,6 @@ fragment float4 viewport_grid_fragment(GridVertexOut input [[stage_in]],
 
     /** @copydoc EditorViewportRendererMetal::IsReady */
     bool EditorViewportRendererMetal::IsReady() const noexcept {
-        return impl_->initialized && impl_->colorTexture != nil && impl_->allocatedExtent.IsValid();
+        return impl_->initialized && impl_->resources.IsReady();
     }
 }  // namespace Horo::Editor

--- a/src/editor/renderer/metal/MetalViewportResourceBridge.h
+++ b/src/editor/renderer/metal/MetalViewportResourceBridge.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Horo/Runtime/Render/RenderFrontend.h"
+
+namespace Horo::Editor {
+    struct MetalViewportMeshBinding {
+        void *vertexBuffer{nullptr};
+        void *indexBuffer{nullptr};
+    };
+
+    struct MetalViewportTargetBinding {
+        void *colorTexture{nullptr};
+        void *depthTexture{nullptr};
+    };
+
+    /** @brief Resolves typed frontend resources into Metal objects at the private editor/backend boundary. */
+    class MetalViewportResourceBridge final {
+    public:
+        [[nodiscard]] static Result<MetalViewportMeshBinding> ResolveMesh(const Render::RenderFrontend &frontend,
+                                                                          Render::RenderMeshHandle mesh);
+        [[nodiscard]] static Result<MetalViewportTargetBinding> ResolveRenderTarget(const Render::RenderFrontend &frontend,
+                                                                                    Render::RenderTargetHandle target);
+        [[nodiscard]] static Result<void *> ResolveTexture(const Render::RenderFrontend &frontend, Render::RenderTextureViewHandle view);
+        [[nodiscard]] static Result<std::uintptr_t> EditorImageIdentity(const Render::RenderFrontend &frontend,
+                                                                        Render::RenderTextureViewHandle view);
+    };
+}  // namespace Horo::Editor

--- a/src/editor/renderer/metal/MetalViewportResourceBridge.mm
+++ b/src/editor/renderer/metal/MetalViewportResourceBridge.mm
@@ -1,0 +1,72 @@
+#include "MetalViewportResourceBridge.h"
+
+#include "runtime/renderer/frontend/RenderFrontendResourceAccess.h"
+#include "runtime/renderer/modules/metal/MetalRenderBackendErrors.h"
+#include "runtime/renderer/modules/metal/MetalResourceInstances.h"
+
+#include <limits>
+
+namespace Horo::Editor {
+    namespace {
+        template <typename Instance>
+        [[nodiscard]] Result<Instance *> ResolveMetalInstance(const Render::RenderFrontend &frontend,
+                                                              const Result<std::uint64_t> &resolved) {
+            if (frontend.Capabilities().backend != Render::RenderBackendId{"metal"}) {
+                return Result<Instance *>::Failure(MakeError(Render::MetalBackendErrors::UnsupportedResourceOperation,
+                                                             "Metal editor bridge received a non-Metal frontend."));
+            }
+            if (resolved.HasError())
+                return Result<Instance *>::Failure(resolved.ErrorValue());
+            if (resolved.Value() == 0 || resolved.Value() > std::numeric_limits<std::uintptr_t>::max()) {
+                return Result<Instance *>::Failure(MakeError(Render::MetalBackendErrors::ResourceIdentityInvalid,
+                                                             "Metal resource identity is outside the native pointer range."));
+            }
+            return Result<Instance *>::Success(reinterpret_cast<Instance *>(static_cast<std::uintptr_t>(resolved.Value())));
+        }
+    }  // namespace
+
+    Result<MetalViewportMeshBinding> MetalViewportResourceBridge::ResolveMesh(const Render::RenderFrontend &frontend,
+                                                                              const Render::RenderMeshHandle mesh) {
+        const auto instance =
+            ResolveMetalInstance<Render::Detail::MetalMeshInstance>(frontend,
+                                                                    Render::Detail::RenderFrontendResourceAccess::BackendInstance(frontend,
+                                                                                                                                  mesh));
+        if (instance.HasError())
+            return Result<MetalViewportMeshBinding>::Failure(instance.ErrorValue());
+        return Result<MetalViewportMeshBinding>::Success({
+            .vertexBuffer = (__bridge void *)instance.Value()->vertexBuffer,
+            .indexBuffer = (__bridge void *)instance.Value()->indexBuffer,
+        });
+    }
+
+    Result<MetalViewportTargetBinding> MetalViewportResourceBridge::ResolveRenderTarget(const Render::RenderFrontend &frontend,
+                                                                                        const Render::RenderTargetHandle target) {
+        const auto instance = ResolveMetalInstance<
+            Render::Detail::MetalRenderTargetInstance>(frontend,
+                                                       Render::Detail::RenderFrontendResourceAccess::BackendInstance(frontend, target));
+        if (instance.HasError())
+            return Result<MetalViewportTargetBinding>::Failure(instance.ErrorValue());
+        return Result<MetalViewportTargetBinding>::Success({
+            .colorTexture = (__bridge void *)instance.Value()->colorTexture,
+            .depthTexture = (__bridge void *)instance.Value()->depthTexture,
+        });
+    }
+
+    Result<void *> MetalViewportResourceBridge::ResolveTexture(const Render::RenderFrontend &frontend,
+                                                               const Render::RenderTextureViewHandle view) {
+        const auto instance = ResolveMetalInstance<
+            Render::Detail::MetalTextureViewInstance>(frontend,
+                                                      Render::Detail::RenderFrontendResourceAccess::BackendInstance(frontend, view));
+        if (instance.HasError())
+            return Result<void *>::Failure(instance.ErrorValue());
+        return Result<void *>::Success((__bridge void *)instance.Value()->texture);
+    }
+
+    Result<std::uintptr_t> MetalViewportResourceBridge::EditorImageIdentity(const Render::RenderFrontend &frontend,
+                                                                            const Render::RenderTextureViewHandle view) {
+        const auto texture = ResolveTexture(frontend, view);
+        if (texture.HasError())
+            return Result<std::uintptr_t>::Failure(texture.ErrorValue());
+        return Result<std::uintptr_t>::Success(reinterpret_cast<std::uintptr_t>(texture.Value()));
+    }
+}  // namespace Horo::Editor

--- a/src/editor/renderer/metal/MetalViewportShaderTypes.h
+++ b/src/editor/renderer/metal/MetalViewportShaderTypes.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "Horo/Math/SceneMath.h"
+#include "Horo/Runtime/Render/RenderScene.h"
+
+#include <array>
+#include <cstdint>
+
+namespace Horo::Editor {
+    struct MetalSelectionStyle {
+        Math::Vec3 color;
+        float strength;
+    };
+
+    static_assert(sizeof(MetalSelectionStyle) == sizeof(float) * 4);
+
+    struct MetalLight {
+        Math::Vec4 positionKind;
+        Math::Vec4 directionRange;
+        Math::Vec4 colorIntensity;
+        Math::Vec4 cone;
+    };
+
+    static_assert(sizeof(MetalLight) == sizeof(float) * 16);
+
+    struct MetalSceneLighting {
+        std::array<MetalLight, Render::MaximumForwardLights> lights{};
+        Math::Vec3 cameraPosition{};
+        std::uint32_t lightCount{0};
+        std::uint32_t shadowEnabled{0};
+        std::uint32_t shadowLightIndex{0};
+        Math::Vec2 padding{};
+    };
+
+    static_assert(sizeof(MetalSceneLighting) == sizeof(MetalLight) * Render::MaximumForwardLights + sizeof(float) * 8);
+
+    struct MetalObjectTransforms {
+        Math::Mat4 mvp;
+        Math::Mat4 model;
+        Math::Mat4 shadowMvp;
+    };
+
+    struct MetalGridStyle {
+        Math::Vec3 color;
+        float padding{0.0F};
+    };
+
+    static_assert(sizeof(MetalGridStyle) == sizeof(float) * 4);
+}  // namespace Horo::Editor

--- a/src/editor/renderer/metal/MetalViewportShaders.cpp
+++ b/src/editor/renderer/metal/MetalViewportShaders.cpp
@@ -1,0 +1,142 @@
+#include "MetalViewportShaders.h"
+
+namespace Horo::Editor {
+    namespace {
+        constexpr char viewportShaderSource[] = R"metal(
+#include <metal_stdlib>
+using namespace metal;
+struct Vertex { packed_float3 position; packed_float3 normal; packed_float2 uv; };
+struct SelectionStyle { packed_float3 color; float strength; };
+struct Light { float4 positionKind; float4 directionRange; float4 colorIntensity; float4 cone; };
+struct SceneLighting {
+    Light lights[16];
+    packed_float3 cameraPosition;
+    uint lightCount;
+    uint shadowEnabled;
+    uint shadowLightIndex;
+    float2 padding;
+};
+struct ObjectTransforms { float4x4 mvp; float4x4 model; float4x4 shadowMvp; };
+struct VertexOut {
+    float4 position [[position]];
+    float3 worldPosition;
+    float3 worldNormal;
+    float4 shadowPosition;
+};
+struct GridVertexOut { float4 position [[position]]; };
+vertex VertexOut viewport_vertex(uint vertexId [[vertex_id]],
+                                 const device Vertex* vertices [[buffer(0)]],
+                                 constant ObjectTransforms& transforms [[buffer(1)]])
+{
+    VertexOut output;
+    float4 worldPosition = transforms.model * float4(vertices[vertexId].position, 1.0);
+    float3x3 model3x3 = float3x3(transforms.model[0].xyz, transforms.model[1].xyz,
+                                transforms.model[2].xyz);
+    float3 inverseRow0 = cross(model3x3[1], model3x3[2]);
+    float3 inverseRow1 = cross(model3x3[2], model3x3[0]);
+    float3 inverseRow2 = cross(model3x3[0], model3x3[1]);
+    float determinant = dot(model3x3[0], inverseRow0);
+    float inverseDeterminant = abs(determinant) > 0.0000001 ? 1.0 / determinant : 1.0;
+    float3x3 normalMatrix = float3x3(inverseRow0 * inverseDeterminant,
+                                     inverseRow1 * inverseDeterminant,
+                                     inverseRow2 * inverseDeterminant);
+    output.position = transforms.mvp * float4(vertices[vertexId].position, 1.0);
+    output.worldPosition = worldPosition.xyz;
+    output.worldNormal = normalize(normalMatrix * float3(vertices[vertexId].normal));
+    output.shadowPosition = transforms.shadowMvp * float4(vertices[vertexId].position, 1.0);
+    return output;
+}
+vertex float4 viewport_shadow_vertex(uint vertexId [[vertex_id]],
+                                     const device Vertex* vertices [[buffer(0)]],
+                                     constant float4x4& shadowMvp [[buffer(1)]])
+{
+    return shadowMvp * float4(vertices[vertexId].position, 1.0);
+}
+vertex GridVertexOut viewport_grid_vertex(uint vertexId [[vertex_id]],
+                                          const device packed_float3* vertices [[buffer(0)]],
+                                          constant float4x4& viewProjection [[buffer(1)]])
+{
+    GridVertexOut output;
+    output.position = viewProjection * float4(float3(vertices[vertexId]), 1.0);
+    return output;
+}
+fragment float4 viewport_fragment(VertexOut input [[stage_in]],
+                                  constant SelectionStyle& selection [[buffer(0)]],
+                                  constant SceneLighting& scene [[buffer(1)]],
+                                  depth2d<float> shadowMap [[texture(0)]],
+                                  sampler shadowSampler [[sampler(0)]])
+{
+    float3 normal = normalize(input.worldNormal);
+    float3 viewDirection = normalize(float3(scene.cameraPosition) - input.worldPosition);
+    float3 baseColor = float3(0.68, 0.70, 0.74);
+    float3 lighting = baseColor * 0.08;
+    for (uint index = 0; index < scene.lightCount; ++index)
+    {
+        constant Light& light = scene.lights[index];
+        uint kind = uint(light.positionKind.w + 0.5);
+        float3 lightDirection;
+        float attenuation = 1.0;
+        if (kind == 0)
+        {
+            lightDirection = normalize(-light.directionRange.xyz);
+        }
+        else
+        {
+            float3 toLight = light.positionKind.xyz - input.worldPosition;
+            float distanceToLight = length(toLight);
+            lightDirection = distanceToLight > 0.0001 ? toLight / distanceToLight : normal;
+            float range = max(light.directionRange.w, 0.0001);
+            float normalizedDistance = distanceToLight / range;
+            float rangeFade = max(1.0 - normalizedDistance * normalizedDistance, 0.0);
+            attenuation = rangeFade * rangeFade;
+            if (kind == 2)
+            {
+                float coneCosine = dot(normalize(light.directionRange.xyz), -lightDirection);
+                attenuation *= smoothstep(light.cone.y, light.cone.x, coneCosine);
+            }
+        }
+        float diffuse = max(dot(normal, lightDirection), 0.0);
+        float3 halfDirection = normalize(lightDirection + viewDirection);
+        float specular = pow(max(dot(normal, halfDirection), 0.0), 48.0) * 0.18;
+        float3 radiance = light.colorIntensity.rgb * light.colorIntensity.a * attenuation;
+        float visibility = 1.0;
+        if (scene.shadowEnabled != 0 && index == scene.shadowLightIndex)
+        {
+            float3 projected = input.shadowPosition.xyz / input.shadowPosition.w;
+            float3 shadowCoordinate = float3(projected.x * 0.5 + 0.5, 0.5 - projected.y * 0.5, projected.z);
+            if (shadowCoordinate.x > 0.0 && shadowCoordinate.x < 1.0 &&
+                shadowCoordinate.y > 0.0 && shadowCoordinate.y < 1.0 &&
+                shadowCoordinate.z > 0.0 && shadowCoordinate.z < 1.0)
+            {
+                float2 texel = 1.0 / float2(shadowMap.get_width(), shadowMap.get_height());
+                float bias = max(0.0025 * (1.0 - dot(normal, lightDirection)), 0.00045);
+                visibility = 0.0;
+                for (int y = -1; y <= 1; ++y)
+                    for (int x = -1; x <= 1; ++x)
+                    {
+                        float closestDepth = shadowMap.sample(shadowSampler,
+                            shadowCoordinate.xy + float2(x, y) * texel);
+                        visibility += shadowCoordinate.z - bias <= closestDepth ? 1.0 : 0.0;
+                    }
+                visibility /= 9.0;
+            }
+        }
+        lighting += radiance * (baseColor * diffuse + specular) * visibility;
+    }
+    float3 mapped = lighting / (lighting + 1.0);
+    float3 displayColor = pow(max(mapped, 0.0), float3(1.0 / 2.2));
+    return float4(mix(displayColor, float3(selection.color), selection.strength), 1.0);
+}
+fragment float4 viewport_grid_fragment(GridVertexOut input [[stage_in]],
+                                       constant SelectionStyle& style [[buffer(0)]])
+{
+    (void)input;
+    return float4(style.color, 1.0);
+}
+)metal";
+    }
+
+    const char *MetalViewportShaderSource() noexcept {
+        return viewportShaderSource;
+    }
+}  // namespace Horo::Editor

--- a/src/editor/renderer/metal/MetalViewportShaders.h
+++ b/src/editor/renderer/metal/MetalViewportShaders.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace Horo::Editor {
+    /** @brief Returns the immutable Metal shader source used by the editor viewport pipelines. */
+    [[nodiscard]] const char *MetalViewportShaderSource() noexcept;
+}  // namespace Horo::Editor

--- a/src/editor/renderer/opengl/EditorViewportRendererOpenGL.cpp
+++ b/src/editor/renderer/opengl/EditorViewportRendererOpenGL.cpp
@@ -1,6 +1,7 @@
 #include "EditorViewportRendererOpenGL.h"
 
 #include "OpenGLStateSnapshot.h"
+#include "OpenGLViewportResourceBridge.h"
 #include "OpenGLViewportShaders.h"
 #include "editor/renderer/EditorRendererErrors.h"
 #include "editor/renderer/grid/EditorViewportGridGeometry.h"
@@ -46,7 +47,9 @@ namespace Horo::Editor {
 
     /** @copydoc EditorViewportRendererOpenGL::EditorViewportRendererOpenGL */
     EditorViewportRendererOpenGL::EditorViewportRendererOpenGL(Render::RenderFrontend &frontend) noexcept
-        : frontend_(&frontend), resources_(frontend) {}
+        : frontend_(&frontend), resources_(frontend, {.depthFormat = Render::RenderTextureFormat::Depth24Stencil8,
+                                                      .depthAspect = Render::RenderTextureAspect::DepthStencil,
+                                                      .resolveImage = &OpenGLViewportResourceBridge::EditorImageIdentity}) {}
 
     /** @copydoc EditorViewportRendererOpenGL::~EditorViewportRendererOpenGL */
     EditorViewportRendererOpenGL::~EditorViewportRendererOpenGL() {

--- a/src/editor/renderer/opengl/EditorViewportRendererOpenGL.h
+++ b/src/editor/renderer/opengl/EditorViewportRendererOpenGL.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "editor/renderer/EditorViewportRenderer.h"
+#include "editor/renderer/EditorViewportResources.h"
 #include "editor/renderer/opengl/OpenGLViewportResourceBridge.h"
-#include "editor/renderer/opengl/OpenGLViewportResources.h"
 
 #include <optional>
 
@@ -73,7 +73,7 @@ namespace Horo::Editor {
         std::uint32_t gridVertexArray_{0};
         std::uint32_t gridVertexBuffer_{0};
         Render::RenderFrontend *frontend_{nullptr};
-        OpenGLViewportResources resources_;
+        EditorViewportResources resources_;
         UniformLocations uniforms_{};
         EditorViewportExtent requestedExtent_{};
         EditorViewportGridOptions gridOptions_{};

--- a/src/runtime/renderer/modules/metal/MetalBackendInternal.h
+++ b/src/runtime/renderer/modules/metal/MetalBackendInternal.h
@@ -11,6 +11,20 @@ namespace Horo::Render::Detail {
         virtual ~IMetalRuntime() = default;
 
         [[nodiscard]] virtual Result<void> Initialize(const MetalPresentationDescriptor &descriptor) = 0;
+        [[nodiscard]] virtual Result<std::uint64_t> CreateBuffer(const RenderBufferDescriptor &descriptor,
+                                                                 std::span<const std::byte> initialData) = 0;
+        [[nodiscard]] virtual Result<std::uint64_t> CreateMesh(const RenderMeshDescriptor &descriptor, std::uint64_t vertexBuffer,
+                                                               std::uint64_t indexBuffer) = 0;
+        [[nodiscard]] virtual Result<std::uint64_t> CreateTexture(const RenderTextureDescriptor &descriptor) = 0;
+        [[nodiscard]] virtual Result<std::uint64_t> CreateTextureView(const RenderTextureViewDescriptor &descriptor,
+                                                                      std::uint64_t texture) = 0;
+        [[nodiscard]] virtual Result<std::uint64_t> CreateRenderTarget(const RenderTargetDescriptor &descriptor,
+                                                                       std::uint64_t colorAttachment, std::uint64_t depthAttachment) = 0;
+        virtual void DestroyBuffer(std::uint64_t backendInstance) noexcept = 0;
+        virtual void DestroyMesh(std::uint64_t backendInstance) noexcept = 0;
+        virtual void DestroyTexture(std::uint64_t backendInstance) noexcept = 0;
+        virtual void DestroyTextureView(std::uint64_t backendInstance) noexcept = 0;
+        virtual void DestroyRenderTarget(std::uint64_t backendInstance) noexcept = 0;
         [[nodiscard]] virtual Result<void> BeginFrame(FramebufferExtent extent) = 0;
         [[nodiscard]] virtual Result<void> ExecutePrimaryOutput(const PrimaryOutputAttachment &attachment) = 0;
         [[nodiscard]] virtual Result<void> Present() = 0;

--- a/src/runtime/renderer/modules/metal/MetalRenderBackend.cpp
+++ b/src/runtime/renderer/modules/metal/MetalRenderBackend.cpp
@@ -72,47 +72,66 @@ namespace Horo::Render {
             }
 
             /** @copydoc IRenderBackend::CreateBuffer */
-            Result<std::uint64_t> CreateBuffer(const RenderBufferDescriptor &, std::span<const std::byte>) override {
-                return Result<std::uint64_t>::Failure(MakeMetalError(MetalBackendErrors::UnsupportedResourceOperation,
-                                                                     "Metal generic buffer migration is owned by RND-001.5."));
+            Result<std::uint64_t> CreateBuffer(const RenderBufferDescriptor &descriptor,
+                                               const std::span<const std::byte> initialData) override {
+                if (!initialized_)
+                    return ResourceNotInitialized("Metal buffer creation requires an initialized backend.");
+                return runtime_->CreateBuffer(descriptor, initialData);
             }
 
             /** @copydoc IRenderBackend::CreateMesh */
-            Result<std::uint64_t> CreateMesh(const RenderMeshDescriptor &, std::uint64_t, std::uint64_t) override {
-                return Result<std::uint64_t>::Failure(MakeMetalError(MetalBackendErrors::UnsupportedResourceOperation,
-                                                                     "Metal generic mesh migration is owned by RND-001.5."));
+            Result<std::uint64_t> CreateMesh(const RenderMeshDescriptor &descriptor, const std::uint64_t vertexBuffer,
+                                             const std::uint64_t indexBuffer) override {
+                if (!initialized_)
+                    return ResourceNotInitialized("Metal mesh creation requires an initialized backend.");
+                return runtime_->CreateMesh(descriptor, vertexBuffer, indexBuffer);
             }
 
-            Result<std::uint64_t> CreateTexture(const RenderTextureDescriptor &) override {
-                return Result<std::uint64_t>::Failure(MakeMetalError(MetalBackendErrors::UnsupportedResourceOperation,
-                                                                     "Metal generic texture migration is owned by RND-001.5."));
+            Result<std::uint64_t> CreateTexture(const RenderTextureDescriptor &descriptor) override {
+                if (!initialized_)
+                    return ResourceNotInitialized("Metal texture creation requires an initialized backend.");
+                return runtime_->CreateTexture(descriptor);
             }
 
-            Result<std::uint64_t> CreateTextureView(const RenderTextureViewDescriptor &, std::uint64_t) override {
-                return Result<std::uint64_t>::Failure(MakeMetalError(MetalBackendErrors::UnsupportedResourceOperation,
-                                                                     "Metal generic texture-view migration is owned by RND-001.5."));
+            Result<std::uint64_t> CreateTextureView(const RenderTextureViewDescriptor &descriptor, const std::uint64_t texture) override {
+                if (!initialized_)
+                    return ResourceNotInitialized("Metal texture-view creation requires an initialized backend.");
+                return runtime_->CreateTextureView(descriptor, texture);
             }
 
-            Result<std::uint64_t> CreateRenderTarget(const RenderTargetDescriptor &, std::uint64_t, std::uint64_t) override {
-                return Result<std::uint64_t>::Failure(MakeMetalError(MetalBackendErrors::UnsupportedResourceOperation,
-                                                                     "Metal generic render-target migration is owned by RND-001.5."));
+            Result<std::uint64_t> CreateRenderTarget(const RenderTargetDescriptor &descriptor, const std::uint64_t colorAttachment,
+                                                     const std::uint64_t depthAttachment) override {
+                if (!initialized_)
+                    return ResourceNotInitialized("Metal render-target creation requires an initialized backend.");
+                return runtime_->CreateRenderTarget(descriptor, colorAttachment, depthAttachment);
             }
 
             /** @copydoc IRenderBackend::DestroyBuffer */
-            void DestroyBuffer(std::uint64_t) noexcept override {
-                // Generic Metal buffers cannot exist until the focused RND-001.5 migration.
+            void DestroyBuffer(const std::uint64_t backendInstance) noexcept override {
+                if (runtimeInitialized_)
+                    runtime_->DestroyBuffer(backendInstance);
             }
 
             /** @copydoc IRenderBackend::DestroyMesh */
-            void DestroyMesh(std::uint64_t) noexcept override {
-                // Generic Metal meshes cannot exist until the focused RND-001.5 migration.
+            void DestroyMesh(const std::uint64_t backendInstance) noexcept override {
+                if (runtimeInitialized_)
+                    runtime_->DestroyMesh(backendInstance);
             }
 
-            void DestroyTexture(std::uint64_t) noexcept override {}
+            void DestroyTexture(const std::uint64_t backendInstance) noexcept override {
+                if (runtimeInitialized_)
+                    runtime_->DestroyTexture(backendInstance);
+            }
 
-            void DestroyTextureView(std::uint64_t) noexcept override {}
+            void DestroyTextureView(const std::uint64_t backendInstance) noexcept override {
+                if (runtimeInitialized_)
+                    runtime_->DestroyTextureView(backendInstance);
+            }
 
-            void DestroyRenderTarget(std::uint64_t) noexcept override {}
+            void DestroyRenderTarget(const std::uint64_t backendInstance) noexcept override {
+                if (runtimeInitialized_)
+                    runtime_->DestroyRenderTarget(backendInstance);
+            }
 
             /** @copydoc IRenderBackend::BeginFrame */
             Result<FrameToken> BeginFrame(const FrameDescriptor &descriptor) override {
@@ -220,6 +239,10 @@ namespace Horo::Render {
             }
 
         private:
+            [[nodiscard]] static Result<std::uint64_t> ResourceNotInitialized(std::string message) {
+                return Result<std::uint64_t>::Failure(MakeMetalError(MetalBackendErrors::NotInitialized, std::move(message)));
+            }
+
             [[nodiscard]] Result<void> ValidateActiveFrame(const FrameToken frame) const {
                 if (!initialized_) {
                     return Result<void>::Failure(
@@ -285,11 +308,15 @@ namespace Horo::Render {
             RenderBackendCapabilities capabilities_{
                 .backend = RenderBackendId{"metal"},
                 .presentsToWindow = true,
-                .supportsOffscreenTargets = false,
+                .supportsOffscreenTargets = true,
                 .supportsTimestampQueries = false,
                 .supportsCompute = false,
                 .supportsBindlessResources = false,
                 .supportsRayTracing = false,
+                .supportsBufferResources = true,
+                .supportsMeshResources = true,
+                .supportsTextureResources = true,
+                .supportsRenderTargetResources = true,
             };
             FrameToken activeFrame_{};
             std::uint64_t nextFrameToken_{1};

--- a/src/runtime/renderer/modules/metal/MetalRenderBackendErrors.cpp
+++ b/src/runtime/renderer/modules/metal/MetalRenderBackendErrors.cpp
@@ -101,6 +101,23 @@ namespace Horo::Render::MetalBackendErrors {
                                                 .retryable = true,
                                                 .userActionable = false};
 
+    const ErrorCodeDescriptor ResourceCreationFailed{.domain = Domain,
+                                                     .code = ErrorCode{"render.metal.resource_creation_failed"},
+                                                     .defaultSeverity = ErrorSeverity::Error,
+                                                     .summary = "Metal resource creation failed.",
+                                                     .remediationHint = "Reduce resource demand or inspect the Metal device diagnostics.",
+                                                     .retryable = true,
+                                                     .userActionable = false};
+
+    const ErrorCodeDescriptor ResourceIdentityInvalid{.domain = Domain,
+                                                      .code = ErrorCode{"render.metal.resource_identity_invalid"},
+                                                      .defaultSeverity = ErrorSeverity::Error,
+                                                      .summary = "Metal backend resource identity is invalid.",
+                                                      .remediationHint =
+                                                          "Use the exact ready resource generations supplied by the frontend.",
+                                                      .retryable = false,
+                                                      .userActionable = false};
+
     const ErrorCodeDescriptor UnsupportedFramesInFlight{.domain = Domain,
                                                         .code = ErrorCode{"render.metal.unsupported_frames_in_flight"},
                                                         .defaultSeverity = ErrorSeverity::Error,

--- a/src/runtime/renderer/modules/metal/MetalRenderBackendErrors.h
+++ b/src/runtime/renderer/modules/metal/MetalRenderBackendErrors.h
@@ -15,6 +15,8 @@ namespace Horo::Render::MetalBackendErrors {
     extern const ErrorCodeDescriptor NoActiveFrame;
     extern const ErrorCodeDescriptor NotInitialized;
     extern const ErrorCodeDescriptor PresentationInUse;
+    extern const ErrorCodeDescriptor ResourceCreationFailed;
+    extern const ErrorCodeDescriptor ResourceIdentityInvalid;
     extern const ErrorCodeDescriptor UnsupportedFramesInFlight;
     extern const ErrorCodeDescriptor UnsupportedPassKind;
     extern const ErrorCodeDescriptor UnsupportedResourceOperation;

--- a/src/runtime/renderer/modules/metal/MetalResourceInstances.h
+++ b/src/runtime/renderer/modules/metal/MetalResourceInstances.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Horo/Runtime/Render/RenderBackend.h"
+
+#ifdef __OBJC__
+#import <Metal/Metal.h>
+
+namespace Horo::Render::Detail {
+    struct MetalBufferInstance {
+        __strong id<MTLBuffer> buffer{nil};
+    };
+
+    struct MetalMeshInstance {
+        __strong id<MTLBuffer> vertexBuffer{nil};
+        __strong id<MTLBuffer> indexBuffer{nil};
+    };
+
+    struct MetalTextureInstance {
+        __strong id<MTLTexture> texture{nil};
+        RenderTextureFormat format{RenderTextureFormat::Rgba8Unorm};
+    };
+
+    struct MetalTextureViewInstance {
+        __strong id<MTLTexture> texture{nil};
+        RenderTextureFormat format{RenderTextureFormat::Rgba8Unorm};
+        RenderTextureAspect aspect{RenderTextureAspect::Color};
+    };
+
+    struct MetalRenderTargetInstance {
+        __strong id<MTLTexture> colorTexture{nil};
+        __strong id<MTLTexture> depthTexture{nil};
+    };
+}  // namespace Horo::Render::Detail
+#endif

--- a/src/runtime/renderer/modules/metal/MetalResourceRuntime.h
+++ b/src/runtime/renderer/modules/metal/MetalResourceRuntime.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Horo/Runtime/Render/RenderBackend.h"
+
+#include <memory>
+
+namespace Horo::Render::Detail {
+    /** @brief Owns Metal realizations for backend-neutral resident resources. */
+    class MetalResourceRuntime final {
+    public:
+        MetalResourceRuntime();
+        ~MetalResourceRuntime();
+
+        MetalResourceRuntime(const MetalResourceRuntime &) = delete;
+        MetalResourceRuntime &operator=(const MetalResourceRuntime &) = delete;
+
+        void Initialize(void *device) noexcept;
+        [[nodiscard]] Result<std::uint64_t> CreateBuffer(const RenderBufferDescriptor &descriptor, std::span<const std::byte> initialData);
+        [[nodiscard]] Result<std::uint64_t> CreateMesh(const RenderMeshDescriptor &descriptor, std::uint64_t vertexBuffer,
+                                                       std::uint64_t indexBuffer);
+        [[nodiscard]] Result<std::uint64_t> CreateTexture(const RenderTextureDescriptor &descriptor);
+        [[nodiscard]] Result<std::uint64_t> CreateTextureView(const RenderTextureViewDescriptor &descriptor, std::uint64_t texture);
+        [[nodiscard]] Result<std::uint64_t> CreateRenderTarget(const RenderTargetDescriptor &descriptor, std::uint64_t colorAttachment,
+                                                               std::uint64_t depthAttachment);
+        void DestroyBuffer(std::uint64_t backendInstance) noexcept;
+        void DestroyMesh(std::uint64_t backendInstance) noexcept;
+        void DestroyTexture(std::uint64_t backendInstance) noexcept;
+        void DestroyTextureView(std::uint64_t backendInstance) noexcept;
+        void DestroyRenderTarget(std::uint64_t backendInstance) noexcept;
+        void Shutdown() noexcept;
+
+    private:
+        struct Impl;
+        std::unique_ptr<Impl> impl_;
+    };
+}  // namespace Horo::Render::Detail

--- a/src/runtime/renderer/modules/metal/MetalResourceRuntime.mm
+++ b/src/runtime/renderer/modules/metal/MetalResourceRuntime.mm
@@ -1,0 +1,248 @@
+#include "MetalResourceRuntime.h"
+
+#include "MetalRenderBackendErrors.h"
+#include "MetalResourceInstances.h"
+
+#import <Metal/Metal.h>
+#include <limits>
+#include <new>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+namespace Horo::Render::Detail {
+    namespace {
+        [[nodiscard]] Error ResourceError(const ErrorCodeDescriptor &descriptor, std::string message) {
+            return MakeError(descriptor, std::move(message));
+        }
+
+        [[nodiscard]] MTLPixelFormat PixelFormat(const RenderTextureFormat format) noexcept {
+            using enum RenderTextureFormat;
+            switch (format) {
+                case Rgba8Unorm:
+                    return MTLPixelFormatRGBA8Unorm;
+                case Depth24Stencil8:
+                    return MTLPixelFormatDepth24Unorm_Stencil8;
+                case Depth32Float:
+                    return MTLPixelFormatDepth32Float;
+            }
+            return MTLPixelFormatInvalid;
+        }
+
+        [[nodiscard]] MTLTextureUsage TextureUsage(const RenderTextureUsage usage) noexcept {
+            MTLTextureUsage nativeUsage = MTLTextureUsageUnknown;
+            if (HasTextureUsage(usage, RenderTextureUsage::Sampled))
+                nativeUsage |= MTLTextureUsageShaderRead;
+            if (HasTextureUsage(usage, RenderTextureUsage::RenderAttachment))
+                nativeUsage |= MTLTextureUsageRenderTarget;
+            return nativeUsage;
+        }
+
+        template <typename Instance> [[nodiscard]] Instance *Decode(const std::uint64_t identity) noexcept {
+            if (identity == 0 || identity > std::numeric_limits<std::uintptr_t>::max())
+                return nullptr;
+            return reinterpret_cast<Instance *>(static_cast<std::uintptr_t>(identity));
+        }
+
+        template <typename Instance> [[nodiscard]] std::uint64_t Identity(Instance *instance) noexcept {
+            return static_cast<std::uint64_t>(reinterpret_cast<std::uintptr_t>(instance));
+        }
+
+        template <typename Instance> void DestroyTracked(std::unordered_set<Instance *> &instances, const std::uint64_t identity) noexcept {
+            Instance *instance = Decode<Instance>(identity);
+            if (instance != nullptr && instances.erase(instance) > 0)
+                delete instance;
+        }
+
+        template <typename Instance> void DestroyAll(std::unordered_set<Instance *> &instances) noexcept {
+            for (Instance *instance : instances)
+                delete instance;
+            instances.clear();
+        }
+
+        [[nodiscard]] bool AspectMatches(const RenderTextureFormat format, const RenderTextureAspect aspect) noexcept {
+            if (format == RenderTextureFormat::Rgba8Unorm)
+                return aspect == RenderTextureAspect::Color;
+            if (format == RenderTextureFormat::Depth24Stencil8)
+                return aspect == RenderTextureAspect::Depth || aspect == RenderTextureAspect::DepthStencil;
+            return format == RenderTextureFormat::Depth32Float && aspect == RenderTextureAspect::Depth;
+        }
+
+        enum class AttachmentKind : std::uint8_t {
+            Color,
+            Depth,
+        };
+
+        [[nodiscard]] Result<MetalTextureViewInstance *> ResolveAttachment(const std::unordered_set<MetalTextureViewInstance *> &instances,
+                                                                           const std::uint64_t identity, const AttachmentKind kind) {
+            if (identity == 0)
+                return Result<MetalTextureViewInstance *>::Success(nullptr);
+            MetalTextureViewInstance *instance = Decode<MetalTextureViewInstance>(identity);
+            const bool aspectMatches =
+                instance != nullptr && (kind == AttachmentKind::Color ? instance->aspect == RenderTextureAspect::Color
+                                                                      : instance->aspect != RenderTextureAspect::Color);
+            if (!aspectMatches || !instances.contains(instance)) {
+                return Result<MetalTextureViewInstance *>::Failure(
+                    ResourceError(MetalBackendErrors::ResourceIdentityInvalid, "Metal render target attachment is invalid."));
+            }
+            return Result<MetalTextureViewInstance *>::Success(instance);
+        }
+
+        [[nodiscard]] bool ExtentMatches(const MetalTextureViewInstance *attachment, const FramebufferExtent extent) noexcept {
+            return attachment == nullptr || (attachment->texture.width == extent.width && attachment->texture.height == extent.height);
+        }
+    }  // namespace
+
+    struct MetalResourceRuntime::Impl {
+        __strong id<MTLDevice> device{nil};
+        std::unordered_set<MetalBufferInstance *> buffers;
+        std::unordered_set<MetalMeshInstance *> meshes;
+        std::unordered_set<MetalTextureInstance *> textures;
+        std::unordered_set<MetalTextureViewInstance *> textureViews;
+        std::unordered_set<MetalRenderTargetInstance *> renderTargets;
+    };
+
+    MetalResourceRuntime::MetalResourceRuntime() : impl_(std::make_unique<Impl>()) {}
+
+    MetalResourceRuntime::~MetalResourceRuntime() {
+        Shutdown();
+    }
+
+    void MetalResourceRuntime::Initialize(void *device) noexcept {
+        impl_->device = (__bridge id<MTLDevice>)device;
+    }
+
+    Result<std::uint64_t> MetalResourceRuntime::CreateBuffer(const RenderBufferDescriptor &descriptor,
+                                                             const std::span<const std::byte> initialData) {
+        if (impl_->device == nil || !descriptor.IsValid() || initialData.size() != descriptor.byteSize)
+            return Result<std::uint64_t>::Failure(
+                ResourceError(MetalBackendErrors::InvalidConfig, "Metal buffer creation request is invalid."));
+        id<MTLBuffer> buffer = [impl_->device newBufferWithBytes:initialData.data()
+                                                          length:initialData.size()
+                                                         options:MTLResourceStorageModeShared];
+        if (buffer == nil)
+            return Result<std::uint64_t>::Failure(
+                ResourceError(MetalBackendErrors::ResourceCreationFailed, "Metal failed to allocate a resident buffer."));
+        auto *instance = new (std::nothrow) MetalBufferInstance{.buffer = buffer};
+        if (instance == nullptr)
+            return Result<std::uint64_t>::Failure(
+                ResourceError(MetalBackendErrors::ResourceCreationFailed, "Metal buffer identity allocation failed."));
+        impl_->buffers.insert(instance);
+        return Result<std::uint64_t>::Success(Identity(instance));
+    }
+
+    Result<std::uint64_t> MetalResourceRuntime::CreateMesh(const RenderMeshDescriptor &descriptor, const std::uint64_t vertexBuffer,
+                                                           const std::uint64_t indexBuffer) {
+        MetalBufferInstance *vertex = Decode<MetalBufferInstance>(vertexBuffer);
+        MetalBufferInstance *index = Decode<MetalBufferInstance>(indexBuffer);
+        if (!descriptor.IsValid() || vertex == nullptr || index == nullptr || !impl_->buffers.contains(vertex) ||
+            !impl_->buffers.contains(index)) {
+            return Result<std::uint64_t>::Failure(
+                ResourceError(MetalBackendErrors::ResourceIdentityInvalid, "Metal mesh references unknown buffer instances."));
+        }
+        auto *instance = new (std::nothrow) MetalMeshInstance{.vertexBuffer = vertex->buffer, .indexBuffer = index->buffer};
+        if (instance == nullptr)
+            return Result<std::uint64_t>::Failure(
+                ResourceError(MetalBackendErrors::ResourceCreationFailed, "Metal mesh identity allocation failed."));
+        impl_->meshes.insert(instance);
+        return Result<std::uint64_t>::Success(Identity(instance));
+    }
+
+    Result<std::uint64_t> MetalResourceRuntime::CreateTexture(const RenderTextureDescriptor &descriptor) {
+        if (impl_->device == nil || !descriptor.IsValid())
+            return Result<std::uint64_t>::Failure(
+                ResourceError(MetalBackendErrors::InvalidConfig, "Metal texture creation request is invalid."));
+        MTLTextureDescriptor *native = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:PixelFormat(descriptor.format)
+                                                                                          width:descriptor.extent.width
+                                                                                         height:descriptor.extent.height
+                                                                                      mipmapped:NO];
+        native.usage = TextureUsage(descriptor.usage);
+        native.storageMode = MTLStorageModePrivate;
+        id<MTLTexture> texture = [impl_->device newTextureWithDescriptor:native];
+        if (texture == nil)
+            return Result<std::uint64_t>::Failure(
+                ResourceError(MetalBackendErrors::ResourceCreationFailed, "Metal failed to allocate a resident texture."));
+        auto *instance = new (std::nothrow) MetalTextureInstance{.texture = texture, .format = descriptor.format};
+        if (instance == nullptr)
+            return Result<std::uint64_t>::Failure(
+                ResourceError(MetalBackendErrors::ResourceCreationFailed, "Metal texture identity allocation failed."));
+        impl_->textures.insert(instance);
+        return Result<std::uint64_t>::Success(Identity(instance));
+    }
+
+    Result<std::uint64_t> MetalResourceRuntime::CreateTextureView(const RenderTextureViewDescriptor &descriptor,
+                                                                  const std::uint64_t texture) {
+        MetalTextureInstance *source = Decode<MetalTextureInstance>(texture);
+        if (!descriptor.IsValid() || source == nullptr || !impl_->textures.contains(source) || source->format != descriptor.format ||
+            !AspectMatches(descriptor.format, descriptor.aspect)) {
+            return Result<std::uint64_t>::Failure(
+                ResourceError(MetalBackendErrors::ResourceIdentityInvalid, "Metal texture view source or aspect is invalid."));
+        }
+        id<MTLTexture> view = [source->texture newTextureViewWithPixelFormat:PixelFormat(descriptor.format)];
+        if (view == nil)
+            return Result<std::uint64_t>::Failure(
+                ResourceError(MetalBackendErrors::ResourceCreationFailed, "Metal failed to create a resident texture view."));
+        auto *instance =
+            new (std::nothrow) MetalTextureViewInstance{.texture = view, .format = descriptor.format, .aspect = descriptor.aspect};
+        if (instance == nullptr)
+            return Result<std::uint64_t>::Failure(
+                ResourceError(MetalBackendErrors::ResourceCreationFailed, "Metal texture-view identity allocation failed."));
+        impl_->textureViews.insert(instance);
+        return Result<std::uint64_t>::Success(Identity(instance));
+    }
+
+    Result<std::uint64_t> MetalResourceRuntime::CreateRenderTarget(const RenderTargetDescriptor &descriptor,
+                                                                   const std::uint64_t colorAttachment,
+                                                                   const std::uint64_t depthAttachment) {
+        if (!descriptor.IsValid())
+            return Result<std::uint64_t>::Failure(
+                ResourceError(MetalBackendErrors::InvalidConfig, "Metal render target descriptor is invalid."));
+        const auto color = ResolveAttachment(impl_->textureViews, colorAttachment, AttachmentKind::Color);
+        if (color.HasError())
+            return Result<std::uint64_t>::Failure(color.ErrorValue());
+        const auto depth = ResolveAttachment(impl_->textureViews, depthAttachment, AttachmentKind::Depth);
+        if (depth.HasError())
+            return Result<std::uint64_t>::Failure(depth.ErrorValue());
+        if (!ExtentMatches(color.Value(), descriptor.extent) || !ExtentMatches(depth.Value(), descriptor.extent))
+            return Result<std::uint64_t>::Failure(
+                ResourceError(MetalBackendErrors::InvalidExtent, "Metal render target attachment extent does not match its descriptor."));
+        auto *instance = new (std::nothrow) MetalRenderTargetInstance{
+            .colorTexture = color.Value() == nullptr ? nil : color.Value()->texture,
+            .depthTexture = depth.Value() == nullptr ? nil : depth.Value()->texture,
+        };
+        if (instance == nullptr)
+            return Result<std::uint64_t>::Failure(
+                ResourceError(MetalBackendErrors::ResourceCreationFailed, "Metal render-target identity allocation failed."));
+        impl_->renderTargets.insert(instance);
+        return Result<std::uint64_t>::Success(Identity(instance));
+    }
+
+    void MetalResourceRuntime::DestroyBuffer(const std::uint64_t backendInstance) noexcept {
+        DestroyTracked(impl_->buffers, backendInstance);
+    }
+
+    void MetalResourceRuntime::DestroyMesh(const std::uint64_t backendInstance) noexcept {
+        DestroyTracked(impl_->meshes, backendInstance);
+    }
+
+    void MetalResourceRuntime::DestroyTexture(const std::uint64_t backendInstance) noexcept {
+        DestroyTracked(impl_->textures, backendInstance);
+    }
+
+    void MetalResourceRuntime::DestroyTextureView(const std::uint64_t backendInstance) noexcept {
+        DestroyTracked(impl_->textureViews, backendInstance);
+    }
+
+    void MetalResourceRuntime::DestroyRenderTarget(const std::uint64_t backendInstance) noexcept {
+        DestroyTracked(impl_->renderTargets, backendInstance);
+    }
+
+    void MetalResourceRuntime::Shutdown() noexcept {
+        DestroyAll(impl_->renderTargets);
+        DestroyAll(impl_->textureViews);
+        DestroyAll(impl_->meshes);
+        DestroyAll(impl_->textures);
+        DestroyAll(impl_->buffers);
+        impl_->device = nil;
+    }
+}  // namespace Horo::Render::Detail

--- a/src/runtime/renderer/modules/metal/MetalRuntime.mm
+++ b/src/runtime/renderer/modules/metal/MetalRuntime.mm
@@ -1,4 +1,5 @@
 #include "MetalBackendInternal.h"
+#include "MetalResourceRuntime.h"
 
 #import <Metal/Metal.h>
 #import <QuartzCore/CAMetalLayer.h>
@@ -95,7 +96,51 @@ namespace Horo::Render::Detail {
                 layer_.displaySyncEnabled = descriptor.presentMode == PresentMode::Fifo;
                 MetalEditorGraphicsAccess::PublishPersistent(*editorGraphicsBridge_, (__bridge void *)device_,
                                                              (__bridge void *)commandQueue_, this, &WaitUntilIdleThunk);
+                resources_.Initialize((__bridge void *)device_);
                 return Result<void>::Success();
+            }
+
+            Result<std::uint64_t> CreateBuffer(const RenderBufferDescriptor &descriptor,
+                                               const std::span<const std::byte> initialData) override {
+                return resources_.CreateBuffer(descriptor, initialData);
+            }
+
+            Result<std::uint64_t> CreateMesh(const RenderMeshDescriptor &descriptor, const std::uint64_t vertexBuffer,
+                                             const std::uint64_t indexBuffer) override {
+                return resources_.CreateMesh(descriptor, vertexBuffer, indexBuffer);
+            }
+
+            Result<std::uint64_t> CreateTexture(const RenderTextureDescriptor &descriptor) override {
+                return resources_.CreateTexture(descriptor);
+            }
+
+            Result<std::uint64_t> CreateTextureView(const RenderTextureViewDescriptor &descriptor, const std::uint64_t texture) override {
+                return resources_.CreateTextureView(descriptor, texture);
+            }
+
+            Result<std::uint64_t> CreateRenderTarget(const RenderTargetDescriptor &descriptor, const std::uint64_t colorAttachment,
+                                                     const std::uint64_t depthAttachment) override {
+                return resources_.CreateRenderTarget(descriptor, colorAttachment, depthAttachment);
+            }
+
+            void DestroyBuffer(const std::uint64_t backendInstance) noexcept override {
+                resources_.DestroyBuffer(backendInstance);
+            }
+
+            void DestroyMesh(const std::uint64_t backendInstance) noexcept override {
+                resources_.DestroyMesh(backendInstance);
+            }
+
+            void DestroyTexture(const std::uint64_t backendInstance) noexcept override {
+                resources_.DestroyTexture(backendInstance);
+            }
+
+            void DestroyTextureView(const std::uint64_t backendInstance) noexcept override {
+                resources_.DestroyTextureView(backendInstance);
+            }
+
+            void DestroyRenderTarget(const std::uint64_t backendInstance) noexcept override {
+                resources_.DestroyRenderTarget(backendInstance);
             }
 
             Result<void> BeginFrame(const FramebufferExtent extent) override {
@@ -185,6 +230,7 @@ namespace Horo::Render::Detail {
             void Shutdown() noexcept override {
                 AbortFrame();
                 WaitUntilIdle();
+                resources_.Shutdown();
                 MetalEditorGraphicsAccess::Clear(*editorGraphicsBridge_);
                 if (layer_ != nil) {
                     layer_.device = nil;
@@ -241,6 +287,7 @@ namespace Horo::Render::Detail {
             __strong id<MTLRenderCommandEncoder> renderEncoder_{nil};
             __strong MTLRenderPassDescriptor *renderPassDescriptor_{nil};
             __strong id<MTLCommandBuffer> lastSubmittedCommandBuffer_{nil};
+            MetalResourceRuntime resources_;
             bool surfaceCreated_{false};
         };
     }  // namespace

--- a/tests/helpers/editor_ui/InteractiveMetalEditorUiTestSurface.mm
+++ b/tests/helpers/editor_ui/InteractiveMetalEditorUiTestSurface.mm
@@ -60,7 +60,7 @@ namespace Horo::Tests {
                 if (frontend.HasError())
                     ThrowRendererError(frontend.ErrorValue());
 
-                auto viewportRenderer = std::make_unique<Editor::EditorViewportRendererMetal>(*graphicsBridge_);
+                auto viewportRenderer = std::make_unique<Editor::EditorViewportRendererMetal>(*frontend.Value(), *graphicsBridge_);
                 const Result<void> viewportInitialized = viewportRenderer->Initialize();
                 if (viewportInitialized.HasError())
                     ThrowRendererError(viewportInitialized.ErrorValue());

--- a/tests/integration/renderer/EditorViewportMetalSmoke.mm
+++ b/tests/integration/renderer/EditorViewportMetalSmoke.mm
@@ -23,6 +23,64 @@ namespace {
     void Check(const bool condition) {
         REQUIRE((condition));
     }
+
+    RenderTargetHandle PrepareViewportTarget(EditorViewportRendererMetal &viewport, RenderFrontend &frontend,
+                                             const EditorViewportSceneView &scene) {
+        const RenderSceneView renderScene{ToRenderCamera(scene.camera), scene.meshResources, scene.instances, scene.lights};
+        for (std::size_t attempt = 0; attempt < 4; ++attempt) {
+            auto prepared = viewport.PrepareResources(frontend, renderScene);
+            Check(prepared.HasValue());
+            Check(frontend.ProcessResourceRequests().HasValue());
+            if (prepared.Value().has_value())
+                return *prepared.Value();
+        }
+        Check(false);
+        return {};
+    }
+
+    void CheckSeamlessResourceTransition(EditorViewportRendererMetal &viewport, RenderFrontend &frontend,
+                                         const EditorViewportSceneView &scene, const RenderTargetHandle activeTarget,
+                                         const EditorViewportTextureView activeTexture) {
+        constexpr EditorViewportExtent activeExtent{128, 128};
+        constexpr EditorViewportExtent resizedExtent{96, 64};
+        std::vector<EditorViewportMeshResourceView> replacementMeshes{scene.meshResources.begin(), scene.meshResources.end()};
+        replacementMeshes.front().handle.generation = 2;
+        std::vector<EditorViewportInstance> replacementInstances{scene.instances.begin(), scene.instances.end()};
+        replacementInstances.front().mesh.generation = 2;
+        const EditorViewportSceneView replacementScene{scene.camera, replacementMeshes, replacementInstances, scene.lights};
+        const RenderSceneView renderScene{ToRenderCamera(replacementScene.camera), replacementScene.meshResources,
+                                          replacementScene.instances, replacementScene.lights};
+
+        viewport.RequestExtent(resizedExtent);
+        auto pending = viewport.PrepareResources(frontend, renderScene);
+        Check(pending.HasValue() && pending.Value() == activeTarget);
+        Check(viewport.IsReady() && viewport.TextureView().textureId == activeTexture.textureId);
+        Check(viewport.RequestedExtent() == activeExtent);
+
+        auto begun = frontend.BeginFrame(FrameDescriptor{.frameNumber = 2, .outputExtent = {256, 256}});
+        Check(begun.HasValue());
+        RenderFrameScope frame = std::move(begun).Value();
+        const std::array passes{RenderPassDescriptor{
+            .id = RenderPassId{1},
+            .kind = RenderPassKind::Graphics,
+            .staticMesh = StaticMeshPassDescriptor{.target = activeTarget, .extent = {128, 128}, .scene = renderScene},
+        }};
+        Check(frame.Execute(passes).HasValue());
+        Check(frame.Present().HasValue());
+
+        RenderTargetHandle resizedTarget;
+        for (std::size_t attempt = 0; attempt < 4 && !resizedTarget.IsValid(); ++attempt) {
+            viewport.RequestExtent(resizedExtent);
+            auto prepared = viewport.PrepareResources(frontend, renderScene);
+            Check(prepared.HasValue());
+            Check(frontend.ProcessResourceRequests().HasValue());
+            if (prepared.Value().has_value() && *prepared.Value() != activeTarget)
+                resizedTarget = *prepared.Value();
+        }
+        Check(resizedTarget.IsValid());
+        Check(viewport.RequestedExtent() == resizedExtent);
+        Check(viewport.TextureView().textureId != activeTexture.textureId);
+    }
 }  // namespace
 
 TEST_CASE("Editor Viewport Metal Smoke", "[integration][renderer][gpu]") {
@@ -46,7 +104,7 @@ TEST_CASE("Editor Viewport Metal Smoke", "[integration][renderer][gpu]") {
     Check(frontendResult.HasValue());
     std::unique_ptr<RenderFrontend> frontend = std::move(frontendResult).Value();
 
-    EditorViewportRendererMetal viewport{graphicsBridge};
+    EditorViewportRendererMetal viewport{*frontend, graphicsBridge};
     Check(viewport.Initialize().HasValue());
     Runtime::PrimitiveMeshCache meshCache;
     constexpr std::array primitiveTypes{Runtime::PrimitiveMeshType::Box,     Runtime::PrimitiveMeshType::Sphere,
@@ -87,9 +145,8 @@ TEST_CASE("Editor Viewport Metal Smoke", "[integration][renderer][gpu]") {
                                                 .instances = viewportInstances,
                                                 .lights = lights};
     Check(frontend->AttachStaticMeshPassExecutor(viewport).HasValue());
-    auto viewportTargetResult = frontend->CreateOffscreenTarget({128, 128});
-    Check(viewportTargetResult.HasValue());
-    const RenderTargetHandle viewportTarget = viewportTargetResult.Value();
+    viewport.RequestExtent(EditorViewportExtent{128, 128});
+    const RenderTargetHandle viewportTarget = PrepareViewportTarget(viewport, *frontend, viewportScene);
     Check(frontend->Resize(FramebufferExtent{256, 256}).HasValue());
     auto begun = frontend->BeginFrame(FrameDescriptor{.frameNumber = 1, .outputExtent = {256, 256}});
     Check(begun.HasValue());
@@ -127,8 +184,6 @@ TEST_CASE("Editor Viewport Metal Smoke", "[integration][renderer][gpu]") {
     Check(textureView.u0 == 0.0F && textureView.v0 == 0.0F);
     Check(textureView.u1 == 1.0F && textureView.v1 == 1.0F);
     Check(frame.Present().HasValue());
-    frontend->DetachStaticMeshPassExecutor(viewport);
-    Check(frontend->ReleaseOffscreenTarget(viewportTarget).HasValue());
     graphicsBridge.WaitUntilIdle();
 
     id<MTLTexture> texture = (__bridge id<MTLTexture>)(reinterpret_cast<void *>(textureView.textureId));
@@ -164,8 +219,10 @@ TEST_CASE("Editor Viewport Metal Smoke", "[integration][renderer][gpu]") {
     }
     Check(maximum > minimum + 32);
     const std::size_t center = (static_cast<std::size_t>(texture.height / 2) * texture.width + texture.width / 2) * 4;
-    Check(rgba[center] > 150 && rgba[center + 1] > 130 && rgba[center + 2] < 150);
+    Check(rgba[center] < 150 && rgba[center + 1] > 130 && rgba[center + 2] > 150);
 
+    CheckSeamlessResourceTransition(viewport, *frontend, viewportScene, viewportTarget, textureView);
+    frontend->DetachStaticMeshPassExecutor(viewport);
     viewport.Shutdown();
     frontend.reset();
     SDL_DestroyWindow(window);

--- a/tests/unit/runtime/renderer/MetalRenderBackendTests.cpp
+++ b/tests/unit/runtime/renderer/MetalRenderBackendTests.cpp
@@ -34,6 +34,8 @@ namespace {
         int abortCount{0};
         int resizeCount{0};
         int destroyCount{0};
+        int resourceCreateCount{0};
+        int resourceDestroyCount{0};
         MetalPresentationDescriptor descriptor{};
         FramebufferExtent frameExtent{};
         FramebufferExtent resizedExtent{};
@@ -93,6 +95,51 @@ namespace {
             return Result<void>::Success();
         }
 
+        Result<std::uint64_t> CreateBuffer(const RenderBufferDescriptor &, std::span<const std::byte>) override {
+            ++state_->resourceCreateCount;
+            return Result<std::uint64_t>::Success(nextResourceIdentity_++);
+        }
+
+        Result<std::uint64_t> CreateMesh(const RenderMeshDescriptor &, std::uint64_t, std::uint64_t) override {
+            ++state_->resourceCreateCount;
+            return Result<std::uint64_t>::Success(nextResourceIdentity_++);
+        }
+
+        Result<std::uint64_t> CreateTexture(const RenderTextureDescriptor &) override {
+            ++state_->resourceCreateCount;
+            return Result<std::uint64_t>::Success(nextResourceIdentity_++);
+        }
+
+        Result<std::uint64_t> CreateTextureView(const RenderTextureViewDescriptor &, std::uint64_t) override {
+            ++state_->resourceCreateCount;
+            return Result<std::uint64_t>::Success(nextResourceIdentity_++);
+        }
+
+        Result<std::uint64_t> CreateRenderTarget(const RenderTargetDescriptor &, std::uint64_t, std::uint64_t) override {
+            ++state_->resourceCreateCount;
+            return Result<std::uint64_t>::Success(nextResourceIdentity_++);
+        }
+
+        void DestroyBuffer(std::uint64_t) noexcept override {
+            ++state_->resourceDestroyCount;
+        }
+
+        void DestroyMesh(std::uint64_t) noexcept override {
+            ++state_->resourceDestroyCount;
+        }
+
+        void DestroyTexture(std::uint64_t) noexcept override {
+            ++state_->resourceDestroyCount;
+        }
+
+        void DestroyTextureView(std::uint64_t) noexcept override {
+            ++state_->resourceDestroyCount;
+        }
+
+        void DestroyRenderTarget(std::uint64_t) noexcept override {
+            ++state_->resourceDestroyCount;
+        }
+
         Result<void> ExecutePrimaryOutput(const PrimaryOutputAttachment &attachment) override {
             ++state_->executeCount;
             state_->attachment = attachment;
@@ -135,6 +182,7 @@ namespace {
     private:
         IMetalPresentationPort *presentationPort_{nullptr};
         PortState *state_{nullptr};
+        std::uint64_t nextResourceIdentity_{1};
         bool initialized_{false};
     };
 
@@ -160,6 +208,75 @@ namespace {
         auto created = registry.Create(RenderBackendId{"metal"});
         Check(created.HasValue());
         return std::move(created).Value();
+    }
+
+    struct GenericResourceIdentities {
+        std::uint64_t vertex{0};
+        std::uint64_t index{0};
+        std::uint64_t mesh{0};
+        std::uint64_t color{0};
+        std::uint64_t depth{0};
+        std::uint64_t colorView{0};
+        std::uint64_t depthView{0};
+        std::uint64_t target{0};
+    };
+
+    [[nodiscard]] GenericResourceIdentities CreateGenericResources(IRenderBackend &backend) {
+        GenericResourceIdentities identities;
+        constexpr std::array<std::byte, 12> bytes{};
+        const auto vertex =
+            backend.CreateBuffer({.byteSize = bytes.size(), .usage = RenderBufferUsage::Vertex, .access = RenderBufferAccess::DeviceLocal},
+                                 bytes);
+        const auto index =
+            backend.CreateBuffer({.byteSize = bytes.size(), .usage = RenderBufferUsage::Index, .access = RenderBufferAccess::DeviceLocal},
+                                 bytes);
+        Check(vertex.HasValue() && index.HasValue());
+        identities.vertex = vertex.Value();
+        identities.index = index.Value();
+        const auto mesh = backend.CreateMesh({.vertexBuffer = {{1}, 1, 1},
+                                              .indexBuffer = {{1}, 2, 1},
+                                              .vertexStride = sizeof(float) * 3,
+                                              .vertexCount = 1,
+                                              .indexCount = 3,
+                                              .localBounds = {{-1.0F, -1.0F, -1.0F}, {1.0F, 1.0F, 1.0F}}},
+                                             identities.vertex, identities.index);
+        Check(mesh.HasValue());
+        identities.mesh = mesh.Value();
+        const auto color = backend.CreateTexture({.extent = {64, 64},
+                                                  .format = RenderTextureFormat::Rgba8Unorm,
+                                                  .usage = RenderTextureUsage::Sampled | RenderTextureUsage::RenderAttachment});
+        const auto depth = backend.CreateTexture(
+            {.extent = {64, 64}, .format = RenderTextureFormat::Depth32Float, .usage = RenderTextureUsage::RenderAttachment});
+        Check(color.HasValue() && depth.HasValue());
+        identities.color = color.Value();
+        identities.depth = depth.Value();
+        const auto colorView = backend.CreateTextureView({.texture = {{1}, 1, 1},
+                                                          .format = RenderTextureFormat::Rgba8Unorm,
+                                                          .aspect = RenderTextureAspect::Color},
+                                                         identities.color);
+        const auto depthView = backend.CreateTextureView({.texture = {{1}, 2, 1},
+                                                          .format = RenderTextureFormat::Depth32Float,
+                                                          .aspect = RenderTextureAspect::Depth},
+                                                         identities.depth);
+        Check(colorView.HasValue() && depthView.HasValue());
+        identities.colorView = colorView.Value();
+        identities.depthView = depthView.Value();
+        const auto target = backend.CreateRenderTarget({.colorAttachment = {{1}, 1, 1}, .depthAttachment = {{1}, 2, 1}, .extent = {64, 64}},
+                                                       identities.colorView, identities.depthView);
+        Check(target.HasValue());
+        identities.target = target.Value();
+        return identities;
+    }
+
+    void DestroyGenericResources(IRenderBackend &backend, const GenericResourceIdentities &resources) {
+        backend.DestroyRenderTarget(resources.target);
+        backend.DestroyTextureView(resources.depthView);
+        backend.DestroyTextureView(resources.colorView);
+        backend.DestroyTexture(resources.depth);
+        backend.DestroyTexture(resources.color);
+        backend.DestroyMesh(resources.mesh);
+        backend.DestroyBuffer(resources.index);
+        backend.DestroyBuffer(resources.vertex);
     }
 
     TEST_CASE("Provider Is Inert And Backend Owns Presentation Lifecycle", "[unit][runtime][renderer]") {
@@ -308,6 +425,24 @@ namespace {
         Check(invalid.ErrorValue().code.Value() == "render.metal.unsupported_pass_kind");
         Check(state.executeCount == 0);
         backend->AbortActiveFrame();
+        backend->Shutdown();
+    }
+
+    TEST_CASE("Generic Resources Delegate To Metal Runtime", "[unit][runtime][renderer]") {
+        PortState state;
+        FakePresentationPort port{state};
+        MetalEditorGraphicsBridge bridge;
+        std::unique_ptr<IRenderBackend> backend = CreateBackend(port, state, bridge);
+        Check(backend->Initialize(RenderBackendConfig{}).HasValue());
+        Check(backend->Capabilities().supportsBufferResources);
+        Check(backend->Capabilities().supportsMeshResources);
+        Check(backend->Capabilities().supportsTextureResources);
+        Check(backend->Capabilities().supportsRenderTargetResources);
+
+        const GenericResourceIdentities resources = CreateGenericResources(*backend);
+        Check(state.resourceCreateCount == 8);
+        DestroyGenericResources(*backend, resources);
+        Check(state.resourceDestroyCount == 8);
         backend->Shutdown();
     }
 


### PR DESCRIPTION
## Summary
- Migrates Metal viewport color, depth, shadow, mesh buffer, mesh, texture-view, and render-target ownership to typed `RenderFrontend` resources.
- Generalizes the existing OpenGL viewport resource coordinator so both interactive backends share bounded asynchronous creation and seamless replacement behavior.
- Adds private Metal realization and editor bridge layers while preserving backend-neutral public contracts.

## Motivation
- The Metal viewport directly owned native textures and buffers, bypassing the generic resource lifecycle established by RND-001.
- Resize, mesh-generation replacement, retirement, and shutdown now follow the same explicit frontend-owned contract as OpenGL.

## Implementation Notes
- `EditorViewportResources` owns active and pending typed resource generations; backend-specific image identity resolution is injected through a narrow configuration.
- Metal native objects remain private to `HoroRenderMetal`; the editor resolves only ready backend instances through `MetalViewportResourceBridge`.
- Error paths use predefined descriptors with designated fields. Rendering and resource creation are split into focused helpers to stay below configured Lizard complexity thresholds.
- Metal shaders and shader buffer layouts are separated from the renderer implementation.

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [x] Manual smoke tested if applicable

Commands run:
```bash
cmake -S . -B build/horo294 -DBUILD_TESTING=ON
cmake --build build/horo294 --parallel 8
ctest --test-dir build/horo294 --output-on-failure
./build/horo294/tests/HoroEditorViewportOpenGLSmoke
MTL_DEBUG_LAYER=1 ./build/horo294/tests/HoroEditorViewportMetalSmoke
codacy-cli analyze --tool lizard --format sarif --output /tmp/horo294-lizard-staged.sarif
codacy-cli analyze --tool opengrep --format sarif --output /tmp/horo294-opengrep-staged.sarif
sonar analyze --base origin/main -p abdullahbodur_horo-engine --depth DEEP --format json
```

## Risks
- Metal resource realization is platform-specific; the Metal validation smoke covers actual native allocation, rendering, readback, resize, mesh-generation replacement, and shutdown on macOS.
- Sonar CLI secret analysis returned zero findings. Local deep Vortex analysis was unavailable for the organization with HTTP 403, so the authoritative SonarCloud PR job remains the quality gate.

## Issue Links

- Jira: HORO-294
- GitHub: Closes #294

## Reviewer Notes
- Review `EditorViewportResources` first for shared lifecycle semantics, then `MetalResourceRuntime` and `MetalViewportResourceBridge` for the native boundary, and finally the renderer and smoke tests.