### PR TITLE
test(render): validate resource lifetime parity HORO-295 #295 [RND-001.6]

### DIFF
--- a/docs/architecture/runtime/render-backend-parity-contract.md
+++ b/docs/architecture/runtime/render-backend-parity-contract.md
@@ -517,6 +517,38 @@ Required shared cases:
 Platform-specific tests may verify GL state restoration or Metal resource and
 command-buffer lifetime, but those tests do not weaken the shared contract.
 
+### Resident Resource Lifetime Validation
+
+Resident-resource qualification is layered so deterministic headless evidence
+guards the shared contract on every host while native lanes prove API-specific
+realization and GPU completion. A lane passes only when every applicable row
+below passes; skipped native rows are unqualified, not successful.
+
+| Behavior | Null/headless evidence | OpenGL evidence | Metal evidence | Pass threshold |
+|---|---|---|---|---|
+| Descriptor and capability admission | Frontend and Null resource tests | Fake-dispatch resource tests | Fake-runtime resource tests | Every malformed or unsupported request returns the expected typed code and performs no native creation. |
+| Pending creation and publication | Frontend resource tests | Viewport GPU smoke | Viewport GPU smoke | Pending handles never resolve or enter a derived resource; each completed operation publishes exactly one ready generation. |
+| Resize and generation replacement | Headless viewport-resource tests | Viewport GPU smoke | Viewport GPU smoke | The active target remains usable until the replacement is ready; the old handle is stale immediately after the atomic swap. |
+| Mesh-source replacement | Headless viewport-resource tests | Viewport GPU smoke | Viewport GPU smoke | Existing draws retain the old generation until the replacement mesh is ready; no dependent generation is retargeted in place. |
+| Dependency and submission pins | Resource-registry tests | Native API completion rules plus GPU smoke | Command-buffer completion plus GPU smoke | No backend destroy occurs before all dependency and accepted-submission pins drain. |
+| Creation failure and rollback | Frontend failure-injection tests | Incomplete-framebuffer rollback test | Fake-runtime failure tests | The operation retains its original typed error, partial native state is released once, and the previous ready generation remains usable. |
+| Shutdown | Registry and headless viewport-resource tests | Backend lifecycle and viewport smoke tests | Backend lifecycle and viewport smoke tests | Pending work is cancelled, dependents retire before dependencies, every native instance is released once, and a second shutdown is a no-op. |
+| Backend/device loss | Deterministic failure fixtures when recovery is introduced | Required before recovery is advertised | Required before recovery is advertised | No unavailable native API is called; all old-owner handles become stale and recoverable records publish only under a new owner. |
+
+Failures must retain a registered descriptor. Its domain identifies the
+frontend, OpenGL, Metal, or Null boundary; its code identifies the operation and
+failure class; its summary and remediation hint provide the actionable cause.
+Tests compare descriptor fields rather than parsing message text.
+
+The deterministic resource tests run without a display or GPU and must pass on
+every supported CI host. Native GPU smoke tests run only in their documented
+hardware/display lanes and pass only when all pixel/readback assertions succeed
+with the API debug layer enabled where supported. A crash, timeout, unexpected
+skip, leaked native instance, non-zero test exit, or failed assertion fails the
+lane. Device-loss recovery remains unqualified until the frontend exposes that
+lifecycle; tests must not simulate success by preserving handles from the old
+resource owner.
+
 ## Build Matrix
 
 [ADR-030](../../adr/030-metal-platform-and-feature-baseline.md) limits the initial

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -655,6 +655,14 @@ add_executable(HoroAssetSceneDropTests
 )
 target_compile_features(HoroAssetSceneDropTests PRIVATE cxx_std_20)
 target_link_libraries(HoroAssetSceneDropTests PRIVATE HoroEngine::EditorRenderExtraction)
+add_executable(HoroEditorViewportResourceTests
+        unit/editor/EditorViewportResourcesTests.cpp
+)
+target_link_libraries(HoroEditorViewportResourceTests
+        PRIVATE
+        HoroEngine::EditorViewportResources
+        HoroEngine::RenderNull
+)
 
 # White-box editor tests opt into implementation headers explicitly. Keep this
 # non-installed test interface separate from every production usage requirement;
@@ -688,6 +696,7 @@ set(HORO_EDITOR_WHITE_BOX_TEST_TARGETS
         HoroSceneDocumentPersistenceTests
         HoroEditorViewportPickingTests
         HoroAssetSceneDropTests
+        HoroEditorViewportResourceTests
 )
 foreach (target IN LISTS HORO_EDITOR_WHITE_BOX_TEST_TARGETS)
     if (TARGET ${target})
@@ -1011,6 +1020,7 @@ set(HORO_CATCH_TEST_TARGETS
         HoroAssetSceneDropTests
         HoroRenderBackendRegistryTests
         HoroRenderFrontendTests
+        HoroEditorViewportResourceTests
         HoroRuntimeLifecycleTests
         HoroRuntimeSceneTests
         HoroAssetRegistryTests

--- a/tests/unit/editor/EditorViewportResourcesTests.cpp
+++ b/tests/unit/editor/EditorViewportResourcesTests.cpp
@@ -12,25 +12,39 @@ namespace {
     using namespace Horo::Editor;
     using namespace Horo::Render;
 
-    struct ImageResolverProbe {
+    constexpr int MaxResourcePasses = 10;
+
+    class ImageResolverFixture final {
+    public:
+        ImageResolverFixture() noexcept {
+            active_ = this;
+        }
+
+        ~ImageResolverFixture() {
+            active_ = nullptr;
+        }
+
+        ImageResolverFixture(const ImageResolverFixture &) = delete;
+        ImageResolverFixture &operator=(const ImageResolverFixture &) = delete;
+
+        [[nodiscard]] static Result<std::uintptr_t> Resolve(const RenderFrontend &, const RenderTextureViewHandle view) {
+            REQUIRE(active_ != nullptr);
+            active_->lastView = view;
+            if (active_->reject) {
+                return Result<std::uintptr_t>::Failure(
+                    MakeError(RendererErrors::ViewportGeometryCreationFailed, "Injected viewport image resolution failure."));
+            }
+            return Result<std::uintptr_t>::Success(view.slot);
+        }
+
         RenderTextureViewHandle lastView;
         bool reject{false};
+
+    private:
+        static thread_local ImageResolverFixture *active_;
     };
 
-    [[nodiscard]] ImageResolverProbe &ResolverProbe() noexcept {
-        static ImageResolverProbe probe;
-        return probe;
-    }
-
-    [[nodiscard]] Result<std::uintptr_t> ResolveImage(const RenderFrontend &, const RenderTextureViewHandle view) {
-        ImageResolverProbe &probe = ResolverProbe();
-        probe.lastView = view;
-        if (probe.reject) {
-            return Result<std::uintptr_t>::Failure(
-                MakeError(RendererErrors::ViewportGeometryCreationFailed, "Injected viewport image resolution failure."));
-        }
-        return Result<std::uintptr_t>::Success(view.slot);
-    }
+    thread_local ImageResolverFixture *ImageResolverFixture::active_ = nullptr;
 
     [[nodiscard]] std::unique_ptr<RenderFrontend> CreateFrontend() {
         RenderBackendRegistry registry;
@@ -44,16 +58,20 @@ namespace {
     [[nodiscard]] EditorViewportResources CreateResources(RenderFrontend &frontend) {
         return EditorViewportResources{
             frontend,
-            {.depthFormat = RenderTextureFormat::Depth32Float, .depthAspect = RenderTextureAspect::Depth, .resolveImage = &ResolveImage},
+            {.depthFormat = RenderTextureFormat::Depth32Float,
+             .depthAspect = RenderTextureAspect::Depth,
+             .resolveImage = &ImageResolverFixture::Resolve},
         };
     }
 
     void SettleResources(EditorViewportResources &resources, RenderFrontend &frontend, const RenderSceneView &scene,
                          const EditorViewportExtent extent) {
-        for (int step = 0; step < 4; ++step) {
+        for (int step = 0; step < MaxResourcePasses && (!resources.IsReady() || resources.AllocatedExtent() != extent); ++step) {
             REQUIRE(resources.Prepare(scene, extent).HasValue());
             REQUIRE(frontend.ProcessResourceRequests().HasValue());
         }
+        REQUIRE(resources.IsReady());
+        REQUIRE(resources.AllocatedExtent() == extent);
     }
 
     struct MeshSceneFixture {
@@ -78,7 +96,7 @@ namespace {
 }  // namespace
 
 TEST_CASE("Headless viewport resources replace resize generations atomically", "[unit][headless][renderer][resource]") {
-    ResolverProbe() = {};
+    ImageResolverFixture imageResolver;
     std::unique_ptr<RenderFrontend> frontend = CreateFrontend();
     EditorViewportResources resources = CreateResources(*frontend);
     const RenderSceneView scene{};
@@ -115,7 +133,7 @@ TEST_CASE("Headless viewport resources replace resize generations atomically", "
 }
 
 TEST_CASE("Headless viewport resources preserve active meshes until replacements are ready", "[unit][headless][renderer][resource]") {
-    ResolverProbe() = {};
+    ImageResolverFixture imageResolver;
     std::unique_ptr<RenderFrontend> frontend = CreateFrontend();
     EditorViewportResources resources = CreateResources(*frontend);
     MeshSceneFixture fixture;
@@ -129,14 +147,14 @@ TEST_CASE("Headless viewport resources preserve active meshes until replacements
     REQUIRE(resources.Prepare(scene, {320, 180}).HasValue());
     const auto firstProcessed = frontend->ProcessResourceRequests();
     REQUIRE(firstProcessed.HasValue());
-    REQUIRE(firstProcessed.Value() == 2);
+    REQUIRE(firstProcessed.Value() > 0);
     const auto firstPending = resources.FindMesh(41);
     REQUIRE(firstPending.has_value());
     REQUIRE(firstPending->mesh == original->mesh);
     REQUIRE(resources.Prepare(scene, {320, 180}).HasValue());
     const auto secondProcessed = frontend->ProcessResourceRequests();
     REQUIRE(secondProcessed.HasValue());
-    REQUIRE(secondProcessed.Value() == 1);
+    REQUIRE(secondProcessed.Value() > 0);
     const auto secondPending = resources.FindMesh(41);
     REQUIRE(secondPending.has_value());
     REQUIRE(secondPending->mesh == original->mesh);
@@ -153,22 +171,27 @@ TEST_CASE("Headless viewport resources preserve active meshes until replacements
 }
 
 TEST_CASE("Headless viewport resources recover image resolution and shut down repeatedly", "[unit][headless][renderer][resource]") {
-    ResolverProbe() = {.reject = true};
+    ImageResolverFixture imageResolver;
+    imageResolver.reject = true;
     std::unique_ptr<RenderFrontend> frontend = CreateFrontend();
     EditorViewportResources resources = CreateResources(*frontend);
     const RenderSceneView scene{};
 
-    for (int step = 0; step < 3; ++step) {
-        REQUIRE(resources.Prepare(scene, {320, 180}).HasValue());
+    std::optional<Error> resolutionError;
+    for (int step = 0; step < MaxResourcePasses && !resolutionError.has_value(); ++step) {
+        const auto prepared = resources.Prepare(scene, {320, 180});
+        if (prepared.HasError()) {
+            resolutionError = prepared.ErrorValue();
+            break;
+        }
         REQUIRE(frontend->ProcessResourceRequests().HasValue());
     }
-    const auto rejected = resources.Prepare(scene, {320, 180});
-    REQUIRE(rejected.HasError());
-    REQUIRE(rejected.ErrorValue().code.Value() == RendererErrors::ViewportGeometryCreationFailed.code.Value());
-    REQUIRE(ResolverProbe().lastView.IsValid());
+    REQUIRE(resolutionError.has_value());
+    REQUIRE(resolutionError->code.Value() == RendererErrors::ViewportGeometryCreationFailed.code.Value());
+    REQUIRE(imageResolver.lastView.IsValid());
     REQUIRE_FALSE(resources.Target().IsValid());
 
-    ResolverProbe().reject = false;
+    imageResolver.reject = false;
     REQUIRE(resources.Prepare(scene, {320, 180}).HasValue());
     REQUIRE(resources.IsReady());
     const RenderTargetHandle target = resources.Target();

--- a/tests/unit/editor/EditorViewportResourcesTests.cpp
+++ b/tests/unit/editor/EditorViewportResourcesTests.cpp
@@ -1,0 +1,182 @@
+#include "Horo/Runtime/Render/NullBackendModule.h"
+#include "Horo/Runtime/Render/RenderFrontend.h"
+#include "editor/renderer/EditorRendererErrors.h"
+#include "editor/renderer/EditorViewportResources.h"
+
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <memory>
+
+namespace {
+    using namespace Horo;
+    using namespace Horo::Editor;
+    using namespace Horo::Render;
+
+    struct ImageResolverProbe {
+        RenderTextureViewHandle lastView;
+        bool reject{false};
+    };
+
+    [[nodiscard]] ImageResolverProbe &ResolverProbe() noexcept {
+        static ImageResolverProbe probe;
+        return probe;
+    }
+
+    [[nodiscard]] Result<std::uintptr_t> ResolveImage(const RenderFrontend &, const RenderTextureViewHandle view) {
+        ImageResolverProbe &probe = ResolverProbe();
+        probe.lastView = view;
+        if (probe.reject) {
+            return Result<std::uintptr_t>::Failure(
+                MakeError(RendererErrors::ViewportGeometryCreationFailed, "Injected viewport image resolution failure."));
+        }
+        return Result<std::uintptr_t>::Success(view.slot);
+    }
+
+    [[nodiscard]] std::unique_ptr<RenderFrontend> CreateFrontend() {
+        RenderBackendRegistry registry;
+        REQUIRE(RegisterNullRenderBackend(registry).HasValue());
+        REQUIRE(registry.Seal().HasValue());
+        auto created = RenderFrontend::Create(registry, RenderBackendId{"null"}, RenderBackendConfig{});
+        REQUIRE(created.HasValue());
+        return std::move(created).Value();
+    }
+
+    [[nodiscard]] EditorViewportResources CreateResources(RenderFrontend &frontend) {
+        return EditorViewportResources{
+            frontend,
+            {.depthFormat = RenderTextureFormat::Depth32Float, .depthAspect = RenderTextureAspect::Depth, .resolveImage = &ResolveImage},
+        };
+    }
+
+    void SettleResources(EditorViewportResources &resources, RenderFrontend &frontend, const RenderSceneView &scene,
+                         const EditorViewportExtent extent) {
+        for (int step = 0; step < 4; ++step) {
+            REQUIRE(resources.Prepare(scene, extent).HasValue());
+            REQUIRE(frontend.ProcessResourceRequests().HasValue());
+        }
+    }
+
+    struct MeshSceneFixture {
+        std::array<MeshVertex, 3> vertices{{
+            {.position = {-1.0F, -1.0F, 0.0F}, .normal = {0.0F, 0.0F, 1.0F}, .uv = {0.0F, 0.0F}},
+            {.position = {1.0F, -1.0F, 0.0F}, .normal = {0.0F, 0.0F, 1.0F}, .uv = {1.0F, 0.0F}},
+            {.position = {0.0F, 1.0F, 0.0F}, .normal = {0.0F, 0.0F, 1.0F}, .uv = {0.5F, 1.0F}},
+        }};
+        std::array<std::uint32_t, 3> indices{0, 1, 2};
+        std::array<RenderMeshResourceView, 1> resources;
+
+        [[nodiscard]] RenderSceneView Scene(const std::uint32_t generation) {
+            resources[0] = {
+                .handle = {.id = MeshResourceId{41}, .generation = generation},
+                .vertices = vertices,
+                .indices = indices,
+                .localBounds = {{-1.0F, -1.0F, 0.0F}, {1.0F, 1.0F, 0.0F}},
+            };
+            return {.meshResources = resources};
+        }
+    };
+}  // namespace
+
+TEST_CASE("Headless viewport resources replace resize generations atomically", "[unit][headless][renderer][resource]") {
+    ResolverProbe() = {};
+    std::unique_ptr<RenderFrontend> frontend = CreateFrontend();
+    EditorViewportResources resources = CreateResources(*frontend);
+    const RenderSceneView scene{};
+
+    SettleResources(resources, *frontend, scene, {320, 180});
+    REQUIRE(resources.IsReady());
+    REQUIRE(resources.AllocatedExtent() == EditorViewportExtent{320, 180});
+    const RenderTargetHandle original = resources.Target();
+    const std::uintptr_t originalImage = resources.ImageIdentity();
+
+    const auto pendingResize = resources.Prepare(scene, {640, 360});
+    REQUIRE(pendingResize.HasValue());
+    REQUIRE(pendingResize.Value() == std::optional<RenderTargetHandle>{original});
+    REQUIRE(resources.Target() == original);
+    REQUIRE(resources.ImageIdentity() == originalImage);
+    REQUIRE(frontend->ProcessResourceRequests().HasValue());
+
+    SettleResources(resources, *frontend, scene, {640, 360});
+    REQUIRE(resources.IsReady());
+    REQUIRE(resources.AllocatedExtent() == EditorViewportExtent{640, 360});
+    REQUIRE(resources.Target() != original);
+    const auto retired = frontend->ResourceState(original);
+    REQUIRE(retired.HasError());
+    REQUIRE(retired.ErrorValue().code.Value() == "render.frontend.resource.stale");
+
+    const RenderTargetHandle replacement = resources.Target();
+    const auto steady = resources.Prepare(scene, {640, 360});
+    REQUIRE(steady.HasValue());
+    REQUIRE(steady.Value() == std::optional<RenderTargetHandle>{replacement});
+    const auto processed = frontend->ProcessResourceRequests();
+    REQUIRE(processed.HasValue());
+    REQUIRE(processed.Value() == 0);
+    REQUIRE(resources.Target() == replacement);
+}
+
+TEST_CASE("Headless viewport resources preserve active meshes until replacements are ready", "[unit][headless][renderer][resource]") {
+    ResolverProbe() = {};
+    std::unique_ptr<RenderFrontend> frontend = CreateFrontend();
+    EditorViewportResources resources = CreateResources(*frontend);
+    MeshSceneFixture fixture;
+
+    RenderSceneView scene = fixture.Scene(1);
+    SettleResources(resources, *frontend, scene, {320, 180});
+    const auto original = resources.FindMesh(41);
+    REQUIRE(original.has_value());
+
+    scene = fixture.Scene(2);
+    REQUIRE(resources.Prepare(scene, {320, 180}).HasValue());
+    const auto firstProcessed = frontend->ProcessResourceRequests();
+    REQUIRE(firstProcessed.HasValue());
+    REQUIRE(firstProcessed.Value() == 2);
+    const auto firstPending = resources.FindMesh(41);
+    REQUIRE(firstPending.has_value());
+    REQUIRE(firstPending->mesh == original->mesh);
+    REQUIRE(resources.Prepare(scene, {320, 180}).HasValue());
+    const auto secondProcessed = frontend->ProcessResourceRequests();
+    REQUIRE(secondProcessed.HasValue());
+    REQUIRE(secondProcessed.Value() == 1);
+    const auto secondPending = resources.FindMesh(41);
+    REQUIRE(secondPending.has_value());
+    REQUIRE(secondPending->mesh == original->mesh);
+    REQUIRE(resources.Prepare(scene, {320, 180}).HasValue());
+
+    const auto replacement = resources.FindMesh(41);
+    REQUIRE(replacement.has_value());
+    REQUIRE(replacement->mesh != original->mesh);
+    REQUIRE(frontend->ResourceState(original->mesh).HasError());
+
+    REQUIRE(resources.Prepare(RenderSceneView{}, {320, 180}).HasValue());
+    REQUIRE_FALSE(resources.FindMesh(41).has_value());
+    REQUIRE(frontend->ResourceState(replacement->mesh).HasError());
+}
+
+TEST_CASE("Headless viewport resources recover image resolution and shut down repeatedly", "[unit][headless][renderer][resource]") {
+    ResolverProbe() = {.reject = true};
+    std::unique_ptr<RenderFrontend> frontend = CreateFrontend();
+    EditorViewportResources resources = CreateResources(*frontend);
+    const RenderSceneView scene{};
+
+    for (int step = 0; step < 3; ++step) {
+        REQUIRE(resources.Prepare(scene, {320, 180}).HasValue());
+        REQUIRE(frontend->ProcessResourceRequests().HasValue());
+    }
+    const auto rejected = resources.Prepare(scene, {320, 180});
+    REQUIRE(rejected.HasError());
+    REQUIRE(rejected.ErrorValue().code.Value() == RendererErrors::ViewportGeometryCreationFailed.code.Value());
+    REQUIRE(ResolverProbe().lastView.IsValid());
+    REQUIRE_FALSE(resources.Target().IsValid());
+
+    ResolverProbe().reject = false;
+    REQUIRE(resources.Prepare(scene, {320, 180}).HasValue());
+    REQUIRE(resources.IsReady());
+    const RenderTargetHandle target = resources.Target();
+    const RenderTargetHandle shadowTarget = resources.ShadowTarget();
+
+    resources.Shutdown();
+    resources.Shutdown();
+    REQUIRE(frontend->ResourceState(target).HasError());
+    REQUIRE(frontend->ResourceState(shadowTarget).HasError());
+    REQUIRE_FALSE(resources.IsReady());
+}


### PR DESCRIPTION
## Summary
- Adds deterministic headless coverage for atomic viewport target resize and generation replacement.
- Verifies mesh generations remain active until replacements are ready, then become stale without retargeting dependents.
- Covers image-resolution failure recovery and repeated resource coordinator shutdown.
- Documents the resident resource lifetime validation matrix and objective pass/fail thresholds for Null, OpenGL, and Metal lanes.

## Motivation
- OpenGL and Metal now share the frontend-backed viewport resource coordinator, but its cross-backend lifetime behavior lacked a dedicated headless regression suite.
- The qualification contract needed explicit evidence ownership and thresholds for pending publication, replacement, retirement, rollback, shutdown, and future device-loss recovery.

## Implementation Notes
- The new test target uses the Null backend and shared viewport coordinator without creating a window, GUI context, display, or GPU resource.
- Existing native backend and GPU smoke lanes remain the authority for API-specific realization and completion behavior.
- The change does not introduce the general parameterized backend harness owned by RND-003.9.

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [x] Manual smoke tested if applicable

Commands run:
```bash
cmake -S . -B build/horo295 -DBUILD_TESTING=ON
cmake --build build/horo295 --parallel 8
ctest --test-dir build/horo295 --output-on-failure
codacy-cli analyze --tool lizard --format sarif --output /tmp/horo295-lizard-staged.sarif
codacy-cli analyze --tool opengrep --format sarif --output /tmp/horo295-opengrep-staged.sarif
sonar analyze --base origin/main -p abdullahbodur_horo-engine --depth DEEP --format json
```

Results:
- 669/669 tests passed.
- New test file total cyclomatic complexity: 12; maximum per function: 2.
- Codacy Lizard: no findings in new code; OpenGrep: 0 findings.
- Sonar CLI secrets scan: 0 issues. Local Vortex analysis is unavailable to the organization with 403, so the SonarCloud PR job remains authoritative.

## Risks
- Native GPU behavior is intentionally not inferred from the Null lane; existing OpenGL and Metal smoke lanes retain that responsibility.
- Device-loss recovery remains explicitly unqualified until the frontend exposes that lifecycle.

## Issue Links
- Jira: HORO-295
- GitHub: Closes #295

## Reviewer Notes
- Review the validation table first, then the three headless scenarios and their CMake registration.