### PR TITLE
feat(gameplay): complete generated descriptor bundle HORO-144 #144 [GAM-001.2]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,8 @@ jobs:
               libxext-dev libxss-dev libxtst-dev libxxf86vm-dev \
               libgl1-mesa-dev libglu1-mesa-dev
             python3 -m venv /tmp/horo-gcovr
-            /tmp/horo-gcovr/bin/pip install --disable-pip-version-check --no-cache-dir gcovr==8.6
+            /tmp/horo-gcovr/bin/pip install --disable-pip-version-check --no-cache-dir \
+              coverage==7.6.10 gcovr==8.6 pytest==8.3.4
       - run:
           name: Configure and build
           command: |
@@ -63,6 +64,8 @@ jobs:
               -DHORO_ENABLE_OPENTELEMETRY=ON
             cmake --build build/sonar --parallel
             xvfb-run -a ctest --test-dir build/sonar --output-on-failure -LE 'gui|editor'
+            /tmp/horo-gcovr/bin/coverage run --source=scripts -m pytest tests/python --quiet
+            /tmp/horo-gcovr/bin/coverage xml -o build/sonar/python-coverage.xml
             /tmp/horo-gcovr/bin/gcovr --sonarqube build/sonar/coverage.xml \
               --sonarqube-metric line \
               --root "$CIRCLE_WORKING_DIRECTORY" \
@@ -95,6 +98,7 @@ jobs:
               -Dsonar.sourceEncoding=UTF-8 \
               -Dsonar.cfamily.compile-commands=build/sonar/compile_commands.json \
               -Dsonar.coverageReportPaths=build/sonar/coverage.xml \
+              -Dsonar.python.coverage.reportPaths=build/sonar/python-coverage.xml \
               -Dsonar.cfamily.analysisCache.mode=fs \
               -Dsonar.cfamily.analysisCache.path="$CIRCLE_WORKING_DIRECTORY/.sonar/cfamily-cache" \
               -Dsonar.qualitygate.wait=true \

--- a/cmake/HoroGameplayModule.cmake
+++ b/cmake/HoroGameplayModule.cmake
@@ -60,6 +60,7 @@ function(horo_add_gameplay_module target)
         COMMAND "${gameplay_python_executable}" "${gameplay_codegen_script}"
                 --output "${generated}"
                 --revision-output "${generated_revision}"
+                --output-root "${CMAKE_CURRENT_BINARY_DIR}"
                 --module-id "${ARG_MODULE_ID}"
                 --fingerprint "${ARG_BUILD_FINGERPRINT}"
                 ${gameplay_sources}

--- a/cmake/HoroGameplayModule.cmake
+++ b/cmake/HoroGameplayModule.cmake
@@ -54,10 +54,12 @@ function(horo_add_gameplay_module target)
     endforeach()
 
     set(generated "${CMAKE_CURRENT_BINARY_DIR}/${target}_generated_behavior_bundle.cpp")
+    set(generated_revision "${CMAKE_CURRENT_BINARY_DIR}/${target}_generated_behavior_bundle.revision")
     add_custom_command(
-        OUTPUT "${generated}"
+        OUTPUT "${generated}" "${generated_revision}"
         COMMAND "${gameplay_python_executable}" "${gameplay_codegen_script}"
                 --output "${generated}"
+                --revision-output "${generated_revision}"
                 --module-id "${ARG_MODULE_ID}"
                 --fingerprint "${ARG_BUILD_FINGERPRINT}"
                 ${gameplay_sources}
@@ -99,10 +101,11 @@ function(horo_add_gameplay_module target)
                     "-DMODULE_ID=${ARG_MODULE_ID}"
                     "-DBUILD_FINGERPRINT=${ARG_BUILD_FINGERPRINT}"
                     "-DMODULE_PATH=$<TARGET_FILE:${target}>"
-                    -DDESCRIPTOR_REVISION=1
+                    "-DDESCRIPTOR_REVISION_FILE=${generated_revision}"
                     -P "${gameplay_module_cmake_dir}/WriteGameplayModuleManifest.cmake"
             VERBATIM
             COMMENT "Publishing gameplay module artifact manifest for ${target}"
         )
     endif()
+    set_property(TARGET ${target} PROPERTY HORO_GAMEPLAY_DESCRIPTOR_REVISION_FILE "${generated_revision}")
 endfunction()

--- a/cmake/WriteGameplayModuleManifest.cmake
+++ b/cmake/WriteGameplayModuleManifest.cmake
@@ -1,7 +1,19 @@
 if(NOT DEFINED MANIFEST_OUTPUT OR NOT DEFINED MODULE_ID OR
    NOT DEFINED BUILD_FINGERPRINT OR NOT DEFINED MODULE_PATH OR
-   NOT DEFINED DESCRIPTOR_REVISION)
+   NOT DEFINED DESCRIPTOR_REVISION_FILE)
     message(FATAL_ERROR "Gameplay module manifest inputs are incomplete")
+endif()
+
+if(NOT EXISTS "${DESCRIPTOR_REVISION_FILE}")
+    message(FATAL_ERROR "Gameplay module descriptor revision is missing")
+endif()
+file(READ "${DESCRIPTOR_REVISION_FILE}" DESCRIPTOR_REVISION LIMIT 32)
+string(STRIP "${DESCRIPTOR_REVISION}" DESCRIPTOR_REVISION)
+string(LENGTH "${DESCRIPTOR_REVISION}" _descriptor_revision_length)
+if(NOT DESCRIPTOR_REVISION MATCHES "^[0-9]+$" OR DESCRIPTOR_REVISION STREQUAL "0" OR
+   _descriptor_revision_length GREATER 20 OR
+   (_descriptor_revision_length EQUAL 20 AND DESCRIPTOR_REVISION STRGREATER "18446744073709551615"))
+    message(FATAL_ERROR "Gameplay module descriptor revision is invalid")
 endif()
 
 get_filename_component(_manifest_directory "${MANIFEST_OUTPUT}" DIRECTORY)

--- a/docs/architecture/extensions/gameplay-module-boundary.md
+++ b/docs/architecture/extensions/gameplay-module-boundary.md
@@ -94,8 +94,9 @@ Lifecycle order is:
 ```text
 LoadLibrary
   -> GetGameModuleDescriptor
+  -> GetGameplayDescriptorBundle
+  -> validate manifest identity, complete registrations, diagnostics, and lifecycle callbacks
   -> CreateGameModule
-  -> Register
   -> Start
   -> Stop
   -> DestroyGameModule
@@ -177,6 +178,8 @@ not through project-authored registration code:
 
 ```cpp
 struct GeneratedGameplayDescriptorBundle {
+    uint32_t schemaVersion;
+    uint32_t sdkBoundaryVersion;
     GameModuleId moduleId;
     BuildFingerprint buildFingerprint;
     DescriptorSetRevision descriptorRevision;
@@ -184,11 +187,15 @@ struct GeneratedGameplayDescriptorBundle {
     std::span<const BehaviorFactoryBinding> nativeFactoryBindings;
     std::span<const BehaviorFieldMigrationDescriptor> behaviorMigrations;
     std::span<const GeneratedDescriptorDiagnostic> diagnostics;
+    GameModuleLifecycleCallbacks lifecycle;
 };
 ```
 
-The host accepts the bundle only when it matches the loaded module fingerprint
-and SDK boundary. The bundle is a complete descriptor snapshot for that
+The host accepts the bundle only when its module ID, fingerprint, descriptor
+revision, schema, and SDK boundary match the validated artifact manifest and
+module descriptor. It validates those fields, bounded counts, factory/type-ID
+pairings, diagnostics, and lifecycle callbacks before invoking project code.
+The bundle is a complete descriptor snapshot for that
 fingerprint and descriptor revision; partial behavior bundles are not accepted.
 Incremental builds may regenerate only changed files internally, but the
 artifact handed to the host represents the full current generated behavior set.

--- a/docs/architecture/extensions/gameplay-module-boundary.md
+++ b/docs/architecture/extensions/gameplay-module-boundary.md
@@ -204,6 +204,13 @@ descriptors. Duplicate IDs, schema conflicts, invalid schedule dependencies,
 stale generated output, or descriptor diagnostics reject the bundle before
 runtime scene activation.
 
+The built-in annotation scanner treats malformed, duplicate, oversized, and
+otherwise invalid annotations as build failures, so it never publishes a bundle
+containing diagnostics. The diagnostics span remains part of the boundary for
+other generators that can produce an inspectable complete snapshot alongside
+non-fatal diagnostics; the host validates and rejects any populated span before
+activation.
+
 Generated behavior bundles are metadata snapshots plus module-owned factory
 bindings. Metadata such as type IDs, fields, dependencies, phase access,
 schedule nodes, and migrations is copied into host registries during validation.

--- a/docs/architecture/extensions/gameplay-module-contract-audit.md
+++ b/docs/architecture/extensions/gameplay-module-contract-audit.md
@@ -39,7 +39,7 @@ architecture. Those gaps remain owned by focused follow-up tickets listed below.
 ```text
 project CMake + source inputs
   -> horo_add_gameplay_module(HoroGameGameplay)
-  -> regex annotation scanner
+  -> bounded token-aware annotation scanner
   -> generated behavior bundle translation unit
   -> exact-SDK shared library
   -> candidate_gameplay_module.json
@@ -74,7 +74,7 @@ Status terms mean:
 | Exported gameplay SDK package | Implemented | `HoroEngineGameplay` exports `HoroEngine::GameplayApi`, CMake helpers, the generator, and exact compiler/platform fingerprint checks. |
 | Primary native gameplay library | Implemented | `horo_add_gameplay_module` builds one conventional `HoroGameGameplay` target; build input and published manifest paths are project-global, so multiple primary modules are not composed. |
 | C-linkage entry-point names | Implemented | Descriptor, generated bundle, create, and destroy symbols are mandatory. Their signatures cross C++ types and virtual interfaces. |
-| Generated native behavior bundle | Partial | A complete array is emitted for scanner matches, but scanning is regex-based, descriptor revision is fixed at `1`, and migrations or generated diagnostics are absent. |
+| Generated native behavior bundle | Partial | A deterministic complete snapshot carries schema/SDK identity, separate metadata and native factory bindings, a content-derived non-zero revision, bounded diagnostics, and lifecycle callbacks. Behavior field migrations remain absent. |
 | Module artifact manifest | Partial | Schema `1` records module ID, fingerprint, descriptor revision, and absolute artifact path. It has no artifact digest, size, architecture, configuration, or toolchain identity. |
 | Asynchronous project build | Implemented | Requests are coalesced; input hashing, project lock, cancellation, timeouts, configure/build, candidate load validation, and last-success preservation exist. |
 | Build publication integrity | Partial | State records artifact hash and toolchain evidence, but the published manifest does not bind the artifact digest and discovery does not compare it with build state. `IsUpToDate` checks inputs and manifest existence, not artifact identity. |
@@ -97,7 +97,7 @@ Status terms mean:
 
 ## Exact ABI Assumptions
 
-`GameModule.h` defines boundary version `1` and requires these symbols:
+`GameModule.h` defines boundary version `2` and requires these symbols:
 
 ```text
 GetGameModuleDescriptor
@@ -120,7 +120,7 @@ The boundary relies on all of the following assumptions:
 2. C linkage stabilizes only the four exported names. Struct layout, virtual
    dispatch, `Result<void>`, and factory signatures remain C++ ABI.
 3. Exact `sizeof` equality is required for descriptor and bundle structures.
-   Structure growth is not append-compatible within boundary version `1`.
+   Structure growth is not append-compatible within boundary version `2`.
 4. Descriptor strings, registration arrays, descriptors, and factory function
    pointers are borrowed from the loaded library. They are valid only while the
    library remains loaded.
@@ -137,28 +137,28 @@ The boundary relies on all of the following assumptions:
 8. The module ID and fingerprint are non-empty, at most 256 bytes, and exactly
    equal between descriptor, generated bundle, expected host fingerprint, and
    manifest validation.
-9. The generated bundle revision is non-zero, but the current generator always
-   emits revision `1`; no revision migration or compatibility range exists.
+9. The generated bundle revision is a deterministic, non-zero SHA-256-derived
+   identity over the module ID, sorted annotations, and declared source content.
+   No revision migration or compatibility range exists.
 10. `GameRuntimeContext` is currently empty. Module `Start` therefore receives no
     scene, assets, jobs, diagnostics, configuration, or mediated platform
     capabilities.
 
 ## Generated Descriptor And Build Contract
 
-The annotation scanner reads the declared source files and recognizes
-`HORO_BEHAVIOR(SimpleIdentifier, "game.*")`. It rejects duplicate generated
-symbols and type IDs, then emits descriptor and factory records into one static
-array. This creates a complete snapshot only for matches the regex can see.
+The annotation scanner reads a bounded set of declared source files and recognizes
+`HORO_BEHAVIOR(SimpleIdentifier, "game.*")` from significant C++ tokens. It
+ignores comments and string contents, rejects duplicate generated symbols and
+type IDs, sorts inputs and registrations, and atomically emits separate descriptor
+and factory arrays plus a deterministic revision sidecar.
 
 Current scanner limitations are contract-relevant:
 
-- It is not compiler- or AST-aware and may observe text in comments or strings;
+- It is token-aware but not compiler- or AST-aware;
 - The annotated C++ type must be a simple identifier, not a qualified name;
 - Preprocessor expansion and semantic C++ validity are left to compilation;
-- Input size and file count are not explicitly bounded by the generator;
-- Output replacement is not an explicit durable temp-file transaction;
-- Only behavior registrations exist; field migrations and bundle diagnostics do
-  not.
+- Preprocessor conditionals are not evaluated by the scanner;
+- Only behavior registrations exist; field migrations do not.
 
 The helper and build service exchange these machine-local artifacts:
 
@@ -178,12 +178,11 @@ and state and restores the previous manifest if state publication fails. A faile
 build leaves the previous successful pair available.
 
 Candidate parsing does not apply a file-size bound before JSON decoding. The build
-service validates manifest schema, fingerprint, and artifact-path type, then relies
-on the module host for the artifact's ABI; it does not compare manifest module ID
-or descriptor revision with the loaded module. The generated absolute artifact
-path is not required to remain within the project or build root. Editor discovery
-later applies a 64 KiB manifest bound and compares the manifest module ID and
-descriptor revision with the loaded module.
+service validates manifest schema, module ID, fingerprint, non-zero descriptor
+revision, and artifact-path type, then passes the complete identity to the module
+host for pre-activation validation. The generated absolute artifact path is not
+required to remain within the project or build root. Editor discovery later
+applies a 64 KiB manifest bound and repeats the same identity validation.
 
 The remaining integrity gap is between publication and later activation. Build
 state contains the artifact SHA-256, size, and modification time, but the manifest

--- a/include/Horo/Gameplay/GameModule.h
+++ b/include/Horo/Gameplay/GameModule.h
@@ -7,6 +7,7 @@
 
 #include "Horo/Gameplay/Behavior.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <span>
 #include <string_view>
@@ -18,7 +19,12 @@
 #endif
 
 namespace Horo::Gameplay {
-    inline constexpr std::uint32_t GameplaySdkBoundaryVersion = 1;
+    inline constexpr std::uint32_t GameplaySdkBoundaryVersion = 2;
+    inline constexpr std::uint32_t GameplayDescriptorBundleSchemaVersion = 1;
+    inline constexpr std::size_t MaximumGeneratedBehaviorDescriptors = 4096;
+    inline constexpr std::size_t MaximumGeneratedDescriptorDiagnostics = 256;
+    inline constexpr std::size_t MaximumGeneratedDiagnosticCodeBytes = 160;
+    inline constexpr std::size_t MaximumGeneratedDiagnosticMessageBytes = 1024;
     inline constexpr std::string_view GetGameModuleDescriptorSymbol = "GetGameModuleDescriptor";
     inline constexpr std::string_view GetGameplayDescriptorBundleSymbol = "GetGameplayDescriptorBundle";
     inline constexpr std::string_view CreateGameModuleSymbol = "CreateGameModule";
@@ -35,16 +41,6 @@ namespace Horo::Gameplay {
         const char *buildFingerprint{};
     };
 
-    /** @brief Complete generated behavior snapshot tied to one module build fingerprint. */
-    struct GeneratedGameplayDescriptorBundle {
-        std::uint32_t structSize{sizeof(GeneratedGameplayDescriptorBundle)};
-        const char *moduleId{};
-        const char *buildFingerprint{};
-        std::uint64_t descriptorRevision{};
-        const BehaviorRegistration *behaviors{};
-        std::size_t behaviorCount{};
-    };
-
     /** @brief Narrow startup context for project module-owned services. */
     struct GameRuntimeContext {};
 
@@ -57,7 +53,68 @@ namespace Horo::Gameplay {
     };
 
     using GetGameModuleDescriptorFunction = const GameModuleDescriptor *(*)() noexcept;
-    using GetGameplayDescriptorBundleFunction = const GeneratedGameplayDescriptorBundle *(*)() noexcept;
     using CreateGameModuleFunction = IGameModule *(*)() noexcept;
     using DestroyGameModuleFunction = void (*)(IGameModule *) noexcept;
+
+    /** @brief Module-owned implementation binding paired with one generated behavior identity. */
+    struct GeneratedBehaviorFactoryBinding {
+        BehaviorTypeId typeId;
+        BehaviorFactoryBinding factory;
+    };
+
+    /** @brief Bounded code and context emitted when descriptor generation cannot produce an activatable snapshot. */
+    struct GeneratedDescriptorDiagnostic {
+        const char *code{};
+        const char *message{};
+    };
+
+    /** @brief Module-owned lifecycle callbacks validated before project code activation. */
+    struct GameModuleLifecycleCallbacks {
+        CreateGameModuleFunction create{};
+        DestroyGameModuleFunction destroy{};
+    };
+
+    /** @brief Complete generated behavior snapshot tied to one module build fingerprint. */
+    struct GeneratedGameplayDescriptorBundle {
+        std::uint32_t structSize{sizeof(GeneratedGameplayDescriptorBundle)};
+        std::uint32_t schemaVersion{GameplayDescriptorBundleSchemaVersion};
+        std::uint32_t sdkBoundaryVersion{GameplaySdkBoundaryVersion};
+        const char *moduleId{};
+        const char *buildFingerprint{};
+        std::uint64_t descriptorRevision{};
+        const BehaviorDescriptor *behaviors{};
+        std::size_t behaviorCount{};
+        const GeneratedBehaviorFactoryBinding *nativeFactoryBindings{};
+        std::size_t nativeFactoryBindingCount{};
+        const GeneratedDescriptorDiagnostic *diagnostics{};
+        std::size_t diagnosticCount{};
+        GameModuleLifecycleCallbacks lifecycle;
+    };
+
+    using GetGameplayDescriptorBundleFunction = const GeneratedGameplayDescriptorBundle *(*)() noexcept;
+
+    /** @brief Exact manifest identity that a candidate must satisfy before its lifecycle starts. */
+    struct GameModuleLoadExpectation {
+        std::string_view moduleId;
+        std::string_view buildFingerprint;
+        std::uint64_t descriptorRevision{};
+    };
+
+    /**
+     * @brief Validates static module compatibility metadata before generated records are read.
+     * @param descriptor Candidate module descriptor.
+     * @param expectation Identity selected by the validated artifact manifest.
+     * @return Success or a stable module-descriptor compatibility error.
+     */
+    [[nodiscard]] Result<void> ValidateGameModuleDescriptor(const GameModuleDescriptor &descriptor,
+                                                            const GameModuleLoadExpectation &expectation);
+
+    /**
+     * @brief Validates a complete generated snapshot and all module-owned bindings before activation.
+     * @param bundle Candidate generated descriptor bundle.
+     * @param expectation Identity selected by the validated artifact manifest.
+     * @return Success or a stable bundle validation error.
+     */
+    [[nodiscard]] Result<void> ValidateGeneratedGameplayDescriptorBundle(const GeneratedGameplayDescriptorBundle &bundle,
+                                                                         const GameModuleLoadExpectation &expectation);
 }  // namespace Horo::Gameplay

--- a/include/Horo/Gameplay/GameModuleHost.h
+++ b/include/Horo/Gameplay/GameModuleHost.h
@@ -44,16 +44,16 @@ namespace Horo::Gameplay {
         /**
          * @brief Loads and starts one gameplay candidate after complete compatibility validation.
          * @param libraryPath Absolute dynamic-library artifact path.
-         * @param expectedBuildFingerprint Fingerprint selected by the active engine/toolchain build.
+         * @param expectation Manifest identity selected by the active engine/toolchain build.
          * @return Owned active module or a typed failure with no remaining project callable.
          */
         [[nodiscard]] Result<std::unique_ptr<LoadedGameModule>> Load(const std::filesystem::path &libraryPath,
-                                                                     std::string_view expectedBuildFingerprint) const;
+                                                                     const GameModuleLoadExpectation &expectation) const;
         /**
          * @brief Copies a candidate to a unique artifact before validating and loading it.
          * @param libraryPath Absolute source artifact produced by the project build.
          * @param shadowRoot Absolute editor-owned directory for reload candidates.
-         * @param expectedBuildFingerprint Fingerprint selected by the active engine/toolchain build.
+         * @param expectation Manifest identity selected by the active engine/toolchain build.
          * @return Independently loaded candidate; its shadow artifact is removed after unload.
          *
          * The currently active module can remain loaded while this candidate is validated. The
@@ -62,6 +62,6 @@ namespace Horo::Gameplay {
          */
         [[nodiscard]] Result<std::unique_ptr<LoadedGameModule>> LoadShadowCopy(const std::filesystem::path &libraryPath,
                                                                                const std::filesystem::path &shadowRoot,
-                                                                               std::string_view expectedBuildFingerprint) const;
+                                                                               const GameModuleLoadExpectation &expectation) const;
     };
 }  // namespace Horo::Gameplay

--- a/include/Horo/Gameplay/GameplayErrors.h
+++ b/include/Horo/Gameplay/GameplayErrors.h
@@ -18,4 +18,8 @@ namespace Horo::Gameplay::GameplayErrors {
     extern const ErrorCodeDescriptor BehaviorMultiplicityViolation;
     extern const ErrorCodeDescriptor EventQueueFull;
     extern const ErrorCodeDescriptor InvalidEvent;
+    extern const ErrorCodeDescriptor InvalidGameModuleDescriptor;
+    extern const ErrorCodeDescriptor IncompatibleGameModule;
+    extern const ErrorCodeDescriptor InvalidGeneratedDescriptorBundle;
+    extern const ErrorCodeDescriptor GeneratedDescriptorDiagnosticsPresent;
 }  // namespace Horo::Gameplay::GameplayErrors

--- a/include/Horo/Gameplay/NativeBehavior.h
+++ b/include/Horo/Gameplay/NativeBehavior.h
@@ -11,24 +11,37 @@
 #include <type_traits>
 
 namespace Horo::Gameplay {
-    /** @brief Builds one module-owned factory registration for an annotated native behavior type. */
-    template <typename Behavior> [[nodiscard]] BehaviorRegistration MakeNativeBehaviorRegistration(const char *stableTypeId) {
+    namespace Detail {
+        template <typename Behavior> [[nodiscard]] IBehaviorInstance *CreateNativeBehavior(void *) {
+            return std::make_unique<Behavior>().release();
+        }
+
+        template <typename Behavior> void DestroyNativeBehavior(void *, IBehaviorInstance *instance) noexcept {
+            const std::unique_ptr<Behavior> owned{static_cast<Behavior *>(instance)};
+        }
+    }  // namespace Detail
+
+    /** @brief Builds host-copyable descriptor metadata for an annotated native behavior type. */
+    template <typename Behavior> [[nodiscard]] BehaviorDescriptor MakeNativeBehaviorDescriptor(const char *stableTypeId) {
         static_assert(std::is_base_of_v<IBehaviorInstance, Behavior>);
         BehaviorDescriptor descriptor = Behavior::DescribeBehavior();
         descriptor.typeId = BehaviorTypeId::Parse(stableTypeId).Value();
-        return BehaviorRegistration{
-            std::move(descriptor),
-            BehaviorFactoryBinding{
-                nullptr,
-                [](void *) -> IBehaviorInstance * {
-            // The exporting gameplay module must allocate and destroy its own instances.
-            return std::make_unique<Behavior>().release();
-        },
-                [](void *, IBehaviorInstance *instance) noexcept {
-            const std::unique_ptr<Behavior> owned{static_cast<Behavior *>(instance)};
-        },
-            },
+        return descriptor;
+    }
+
+    /** @brief Builds the module-owned factory callbacks paired with generated descriptor metadata. */
+    template <typename Behavior> [[nodiscard]] BehaviorFactoryBinding MakeNativeBehaviorFactoryBinding() {
+        static_assert(std::is_base_of_v<IBehaviorInstance, Behavior>);
+        return {
+            .userData = nullptr,
+            .create = &Detail::CreateNativeBehavior<Behavior>,
+            .destroy = &Detail::DestroyNativeBehavior<Behavior>,
         };
+    }
+
+    /** @brief Builds one module-owned factory registration for an annotated native behavior type. */
+    template <typename Behavior> [[nodiscard]] BehaviorRegistration MakeNativeBehaviorRegistration(const char *stableTypeId) {
+        return {MakeNativeBehaviorDescriptor<Behavior>(stableTypeId), MakeNativeBehaviorFactoryBinding<Behavior>()};
     }
 }  // namespace Horo::Gameplay
 
@@ -40,6 +53,9 @@ namespace Horo::Gameplay {
  * separate from its C++ class name.
  */
 #define HORO_BEHAVIOR(Type, StableTypeId)                                                                                                  \
-    Horo::Gameplay::BehaviorRegistration HoroGeneratedBehaviorRegistration_##Type() {                                                      \
-        return Horo::Gameplay::MakeNativeBehaviorRegistration<Type>(StableTypeId);                                                         \
+    Horo::Gameplay::BehaviorDescriptor HoroGeneratedBehaviorDescriptor_##Type() {                                                          \
+        return Horo::Gameplay::MakeNativeBehaviorDescriptor<Type>(StableTypeId);                                                           \
+    }                                                                                                                                      \
+    Horo::Gameplay::BehaviorFactoryBinding HoroGeneratedBehaviorFactory_##Type() {                                                         \
+        return Horo::Gameplay::MakeNativeBehaviorFactoryBinding<Type>();                                                                   \
     }

--- a/scripts/generate_gameplay_behavior_bundle.py
+++ b/scripts/generate_gameplay_behavior_bundle.py
@@ -12,9 +12,12 @@ import sys
 
 
 MAXIMUM_SOURCE_FILES = 4096
+MAXIMUM_BEHAVIORS = 4096
 MAXIMUM_SOURCE_BYTES = 4 * 1024 * 1024
 MAXIMUM_TOTAL_SOURCE_BYTES = 32 * 1024 * 1024
+MAXIMUM_IDENTITY_BYTES = 256
 MODULE_ID = re.compile(r"[a-z][a-z0-9_]*(?:\.[a-z0-9_]+)+\Z")
+FINGERPRINT = re.compile(r"[A-Za-z0-9_.-]+\Z")
 TYPE_ID = re.compile(r"game\.[a-z0-9_]+(?:\.[a-z0-9_]+)+\Z")
 TOKEN = re.compile(
     r"(?P<space>\s+)|(?P<line_comment>//[^\n]*)|(?P<block_comment>/\*.*?\*/)|"
@@ -28,6 +31,7 @@ def parse() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--output", required=True, type=pathlib.Path)
     parser.add_argument("--revision-output", required=True, type=pathlib.Path)
+    parser.add_argument("--output-root", required=True, type=pathlib.Path)
     parser.add_argument("--module-id", required=True)
     parser.add_argument("--fingerprint", required=True)
     parser.add_argument("sources", nargs="+", type=pathlib.Path)
@@ -77,6 +81,8 @@ def read_sources(sources: list[pathlib.Path]) -> list[tuple[pathlib.Path, str, s
 
 
 def validate_annotations(annotations: list[tuple[str, str, pathlib.Path]]) -> None:
+    if len(annotations) > MAXIMUM_BEHAVIORS:
+        raise ValueError("native behavior annotation count exceeds the supported limit")
     seen_symbols: set[str] = set()
     seen_ids: set[str] = set()
     for symbol, type_id, source in annotations:
@@ -96,6 +102,14 @@ def descriptor_revision(module_id: str, annotations: list[tuple[str, str, pathli
     identity.extend(sorted(source_hashes))
     revision = int.from_bytes(hashlib.sha256("\n".join(identity).encode("utf-8")).digest()[:8], "big")
     return revision or 1
+
+
+def confined_output(root: pathlib.Path, path: pathlib.Path) -> pathlib.Path:
+    canonical_root = root.resolve(strict=True)
+    canonical_path = path.resolve(strict=False)
+    if not canonical_path.is_relative_to(canonical_root):
+        raise ValueError(f"generated output must remain inside {canonical_root}")
+    return canonical_path
 
 
 def write_atomic(path: pathlib.Path, content: str) -> None:
@@ -172,6 +186,7 @@ extern "C" HORO_GAME_EXPORT const Horo::Gameplay::GeneratedGameplayDescriptorBun
         .behaviorCount = {count},
         .nativeFactoryBindings = {factory_pointer},
         .nativeFactoryBindingCount = {count},
+        // Blocking scanner diagnostics abort generation before a bundle is published.
         .diagnostics = nullptr,
         .diagnosticCount = 0,
         .lifecycle = {{.create = &CreateGameModule, .destroy = &DestroyGameModule}},
@@ -190,11 +205,30 @@ def generated_source(
     return generated_storage(annotations) + generated_exports(module_id, fingerprint, revision, len(annotations))
 
 
-def main() -> int:
-    args = parse()
-    if not MODULE_ID.fullmatch(args.module_id) or not args.fingerprint or len(args.fingerprint.encode("utf-8")) > 256:
+def validate_identity(module_id: str, fingerprint: str) -> None:
+    if (
+        not MODULE_ID.fullmatch(module_id)
+        or len(module_id.encode("utf-8")) > MAXIMUM_IDENTITY_BYTES
+        or not FINGERPRINT.fullmatch(fingerprint)
+        or len(fingerprint.encode("utf-8")) > MAXIMUM_IDENTITY_BYTES
+    ):
         raise ValueError("module identity or build fingerprint is invalid")
-    sources = read_sources(args.sources)
+
+
+def generate_bundle(
+    output: pathlib.Path,
+    revision_output: pathlib.Path,
+    output_root: pathlib.Path,
+    module_id: str,
+    fingerprint: str,
+    source_paths: list[pathlib.Path],
+) -> None:
+    validate_identity(module_id, fingerprint)
+    generated_output = confined_output(output_root, output)
+    generated_revision = confined_output(output_root, revision_output)
+    if generated_output == generated_revision:
+        raise ValueError("generated source and revision outputs must be distinct")
+    sources = read_sources(source_paths)
     annotations = [
         (symbol, type_id, source)
         for source, text, _ in sources
@@ -202,15 +236,27 @@ def main() -> int:
     ]
     annotations.sort(key=lambda annotation: (annotation[1], annotation[0]))
     validate_annotations(annotations)
-    revision = descriptor_revision(args.module_id, annotations, [record[2] for record in sources])
-    write_atomic(args.output, generated_source(args.module_id, args.fingerprint, revision, annotations))
-    write_atomic(args.revision_output, f"{revision}\n")
+    revision = descriptor_revision(module_id, annotations, [record[2] for record in sources])
+    write_atomic(generated_output, generated_source(module_id, fingerprint, revision, annotations))
+    write_atomic(generated_revision, f"{revision}\n")
+
+
+def main() -> int:
+    args = parse()
+    generate_bundle(
+        args.output,
+        args.revision_output,
+        args.output_root,
+        args.module_id,
+        args.fingerprint,
+        args.sources,
+    )
     return 0
 
 
 if __name__ == "__main__":
     try:
         raise SystemExit(main())
-    except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as error:
+    except (OSError, ValueError) as error:
         print(f"gameplay descriptor generation failed: {error}", file=sys.stderr)
         raise SystemExit(1)

--- a/scripts/generate_gameplay_behavior_bundle.py
+++ b/scripts/generate_gameplay_behavior_bundle.py
@@ -1,40 +1,82 @@
 #!/usr/bin/env python3
-"""Generate one complete native gameplay descriptor bundle from HORO_BEHAVIOR annotations."""
+"""Generate one deterministic native gameplay descriptor bundle."""
 
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import pathlib
 import re
 import sys
 
 
-ANNOTATION = re.compile(
-    r"\bHORO_BEHAVIOR\s*\(\s*([A-Za-z_]\w*)\s*,\s*\"([^\"]+)\"\s*\)"
-)
+MAXIMUM_SOURCE_FILES = 4096
+MAXIMUM_SOURCE_BYTES = 4 * 1024 * 1024
+MAXIMUM_TOTAL_SOURCE_BYTES = 32 * 1024 * 1024
+MODULE_ID = re.compile(r"[a-z][a-z0-9_]*(?:\.[a-z0-9_]+)+\Z")
 TYPE_ID = re.compile(r"game\.[a-z0-9_]+(?:\.[a-z0-9_]+)+\Z")
+TOKEN = re.compile(
+    r"(?P<space>\s+)|(?P<line_comment>//[^\n]*)|(?P<block_comment>/\*.*?\*/)|"
+    r"(?P<string>\"(?:\\.|[^\"\\])*\")|(?P<identifier>[A-Za-z_]\w*)|"
+    r"(?P<punctuation>[(),])|(?P<other>.)",
+    re.DOTALL,
+)
 
 
 def parse() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--output", required=True, type=pathlib.Path)
+    parser.add_argument("--revision-output", required=True, type=pathlib.Path)
     parser.add_argument("--module-id", required=True)
     parser.add_argument("--fingerprint", required=True)
     parser.add_argument("sources", nargs="+", type=pathlib.Path)
     return parser.parse_args()
 
 
-def main() -> int:
-    args = parse()
-    annotations: list[tuple[str, str, pathlib.Path]] = []
-    for source in args.sources:
-        resolved_source = source.resolve()
-        if not resolved_source.is_file():
-            raise ValueError(f"source path does not exist or is not a regular file: {resolved_source}")
-        text = resolved_source.read_text(encoding="utf-8")
-        annotations.extend((symbol, type_id, resolved_source) for symbol, type_id in ANNOTATION.findall(text))
+def significant_tokens(text: str) -> list[tuple[str, str]]:
+    ignored = {"space", "line_comment", "block_comment"}
+    return [(match.lastgroup or "other", match.group()) for match in TOKEN.finditer(text) if match.lastgroup not in ignored]
 
 
+def annotations_in(text: str, source: pathlib.Path) -> list[tuple[str, str]]:
+    tokens = significant_tokens(text)
+    annotations: list[tuple[str, str]] = []
+    expected = ("identifier", "punctuation", "identifier", "punctuation", "string", "punctuation")
+    for index, token in enumerate(tokens):
+        if token != ("identifier", "HORO_BEHAVIOR"):
+            continue
+        candidate = tokens[index : index + len(expected)]
+        if len(candidate) != len(expected) or tuple(kind for kind, _ in candidate) != expected:
+            raise ValueError(f"malformed HORO_BEHAVIOR annotation in {source}")
+        _, opening, symbol, comma, encoded_type_id, closing = candidate
+        if opening[1] != "(" or comma[1] != "," or closing[1] != ")":
+            raise ValueError(f"malformed HORO_BEHAVIOR annotation in {source}")
+        type_id = json.loads(encoded_type_id[1])
+        annotations.append((symbol[1], type_id))
+    return annotations
+
+
+def read_sources(sources: list[pathlib.Path]) -> list[tuple[pathlib.Path, str, str]]:
+    if len(sources) > MAXIMUM_SOURCE_FILES:
+        raise ValueError("gameplay descriptor source count exceeds the supported limit")
+    resolved = sorted(source.resolve() for source in sources)
+    if len(set(resolved)) != len(resolved):
+        raise ValueError("gameplay descriptor sources contain duplicate paths")
+    records: list[tuple[pathlib.Path, str, str]] = []
+    total_bytes = 0
+    for source in resolved:
+        if not source.is_file():
+            raise ValueError(f"source path does not exist or is not a regular file: {source}")
+        encoded = source.read_bytes()
+        total_bytes += len(encoded)
+        if len(encoded) > MAXIMUM_SOURCE_BYTES or total_bytes > MAXIMUM_TOTAL_SOURCE_BYTES:
+            raise ValueError("gameplay descriptor source bytes exceed the supported limit")
+        records.append((source, encoded.decode("utf-8"), hashlib.sha256(encoded).hexdigest()))
+    return records
+
+
+def validate_annotations(annotations: list[tuple[str, str, pathlib.Path]]) -> None:
     seen_symbols: set[str] = set()
     seen_ids: set[str] = set()
     for symbol, type_id, source in annotations:
@@ -47,51 +89,128 @@ def main() -> int:
         seen_symbols.add(symbol)
         seen_ids.add(type_id)
 
+
+def descriptor_revision(module_id: str, annotations: list[tuple[str, str, pathlib.Path]], source_hashes: list[str]) -> int:
+    identity = ["horo.generated-gameplay-descriptor.v1", module_id]
+    identity.extend(f"{type_id}\0{symbol}" for symbol, type_id, _ in annotations)
+    identity.extend(sorted(source_hashes))
+    revision = int.from_bytes(hashlib.sha256("\n".join(identity).encode("utf-8")).digest()[:8], "big")
+    return revision or 1
+
+
+def write_atomic(path: pathlib.Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(path.name + ".tmp")
+    temporary.write_text(content, encoding="utf-8")
+    temporary.replace(path)
+
+
+def generated_storage(annotations: list[tuple[str, str, pathlib.Path]]) -> str:
     declarations = "\n".join(
-        f"Horo::Gameplay::BehaviorRegistration HoroGeneratedBehaviorRegistration_{symbol}();"
+        f"Horo::Gameplay::BehaviorDescriptor HoroGeneratedBehaviorDescriptor_{symbol}();\n"
+        f"Horo::Gameplay::BehaviorFactoryBinding HoroGeneratedBehaviorFactory_{symbol}();"
         for symbol, _, _ in annotations
     )
-    initializers = ",\n        ".join(
-        f"HoroGeneratedBehaviorRegistration_{symbol}()" for symbol, _, _ in annotations
+    descriptors = ",\n        ".join(f"HoroGeneratedBehaviorDescriptor_{symbol}()" for symbol, _, _ in annotations)
+    factories = ",\n        ".join(
+        "{.typeId = Horo::Gameplay::BehaviorTypeId::Parse(" + json.dumps(type_id) + ").Value(), "
+        f".factory = HoroGeneratedBehaviorFactory_{symbol}()}}"
+        for symbol, type_id, _ in annotations
     )
     count = len(annotations)
-    output = f'''// Generated by generate_gameplay_behavior_bundle.py. Do not edit.
+    return f'''// Generated by generate_gameplay_behavior_bundle.py. Do not edit.
 #include "Horo/Gameplay/GameModule.h"
 #include <array>
 
 {declarations}
 
+extern "C" HORO_GAME_EXPORT Horo::Gameplay::IGameModule *CreateGameModule() noexcept;
+extern "C" HORO_GAME_EXPORT void DestroyGameModule(Horo::Gameplay::IGameModule *) noexcept;
+
 namespace {{
-const auto &Registrations() {{
-    static const std::array<Horo::Gameplay::BehaviorRegistration, {count}> registrations{{{{
-        {initializers}
+const auto &Descriptors() {{
+    static const std::array<Horo::Gameplay::BehaviorDescriptor, {count}> descriptors{{{{
+        {descriptors}
     }}}};
-    return registrations;
+    return descriptors;
+}}
+
+const auto &Factories() {{
+    static const std::array<Horo::Gameplay::GeneratedBehaviorFactoryBinding, {count}> factories{{{{
+        {factories}
+    }}}};
+    return factories;
 }}
 }}
+'''
+
+
+def generated_exports(module_id: str, fingerprint: str, revision: int, count: int) -> str:
+    behavior_pointer = "Descriptors().data()" if count else "nullptr"
+    factory_pointer = "Factories().data()" if count else "nullptr"
+    return f'''
 
 extern "C" HORO_GAME_EXPORT const Horo::Gameplay::GameModuleDescriptor *GetGameModuleDescriptor() noexcept {{
     static const Horo::Gameplay::GameModuleDescriptor descriptor{{
-        sizeof(Horo::Gameplay::GameModuleDescriptor), Horo::Gameplay::GameplaySdkBoundaryVersion,
-        "{args.module_id}", "{args.fingerprint}"}};
+        .structSize = sizeof(Horo::Gameplay::GameModuleDescriptor),
+        .sdkBoundaryVersion = Horo::Gameplay::GameplaySdkBoundaryVersion,
+        .moduleId = {json.dumps(module_id)},
+        .buildFingerprint = {json.dumps(fingerprint)},
+    }};
     return &descriptor;
 }}
 
 extern "C" HORO_GAME_EXPORT const Horo::Gameplay::GeneratedGameplayDescriptorBundle *GetGameplayDescriptorBundle() noexcept {{
     static const Horo::Gameplay::GeneratedGameplayDescriptorBundle bundle{{
-        sizeof(Horo::Gameplay::GeneratedGameplayDescriptorBundle), "{args.module_id}", "{args.fingerprint}", 1,
-        Registrations().data(), Registrations().size()}};
+        .structSize = sizeof(Horo::Gameplay::GeneratedGameplayDescriptorBundle),
+        .schemaVersion = Horo::Gameplay::GameplayDescriptorBundleSchemaVersion,
+        .sdkBoundaryVersion = Horo::Gameplay::GameplaySdkBoundaryVersion,
+        .moduleId = {json.dumps(module_id)},
+        .buildFingerprint = {json.dumps(fingerprint)},
+        .descriptorRevision = {revision}ULL,
+        .behaviors = {behavior_pointer},
+        .behaviorCount = {count},
+        .nativeFactoryBindings = {factory_pointer},
+        .nativeFactoryBindingCount = {count},
+        .diagnostics = nullptr,
+        .diagnosticCount = 0,
+        .lifecycle = {{.create = &CreateGameModule, .destroy = &DestroyGameModule}},
+    }};
     return &bundle;
 }}
 '''
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(output, encoding="utf-8")
+
+
+def generated_source(
+    module_id: str,
+    fingerprint: str,
+    revision: int,
+    annotations: list[tuple[str, str, pathlib.Path]],
+) -> str:
+    return generated_storage(annotations) + generated_exports(module_id, fingerprint, revision, len(annotations))
+
+
+def main() -> int:
+    args = parse()
+    if not MODULE_ID.fullmatch(args.module_id) or not args.fingerprint or len(args.fingerprint.encode("utf-8")) > 256:
+        raise ValueError("module identity or build fingerprint is invalid")
+    sources = read_sources(args.sources)
+    annotations = [
+        (symbol, type_id, source)
+        for source, text, _ in sources
+        for symbol, type_id in annotations_in(text, source)
+    ]
+    annotations.sort(key=lambda annotation: (annotation[1], annotation[0]))
+    validate_annotations(annotations)
+    revision = descriptor_revision(args.module_id, annotations, [record[2] for record in sources])
+    write_atomic(args.output, generated_source(args.module_id, args.fingerprint, revision, annotations))
+    write_atomic(args.revision_output, f"{revision}\n")
     return 0
 
 
 if __name__ == "__main__":
     try:
         raise SystemExit(main())
-    except (OSError, ValueError) as error:
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError) as error:
         print(f"gameplay descriptor generation failed: {error}", file=sys.stderr)
         raise SystemExit(1)

--- a/src/application/gameplay/GameplayBuildService.cpp
+++ b/src/application/gameplay/GameplayBuildService.cpp
@@ -524,15 +524,20 @@ namespace Horo::Application {
 
         [[nodiscard]] Result<std::filesystem::path> ValidateCandidateManifest(const nlohmann::json &manifest) {
             if (manifest.value("schemaVersion", 0) != 1 ||
-                manifest.value("buildFingerprint", "") != Gameplay::CurrentGameplayBuildFingerprint() ||
+                manifest.value("buildFingerprint", "") != Gameplay::CurrentGameplayBuildFingerprint() || !manifest.contains("moduleId") ||
+                !manifest["moduleId"].is_string() || manifest.value("descriptorRevision", std::uint64_t{0}) == 0 ||
                 !manifest.contains("artifactPath") || !manifest["artifactPath"].is_string())
                 return Result<std::filesystem::path>::Failure(MakeError(ValidationFailed, "Candidate manifest identity is incompatible."));
             return Result<std::filesystem::path>::Success(manifest["artifactPath"].get<std::string>());
         }
 
-        [[nodiscard]] Result<void> ValidateArtifactLoad(const std::filesystem::path &artifact, const std::filesystem::path &buildRoot) {
+        [[nodiscard]] Result<void> ValidateArtifactLoad(const std::filesystem::path &artifact, const std::filesystem::path &buildRoot,
+                                                        const nlohmann::json &manifest) {
             Gameplay::GameModuleHost host;
-            auto loaded = host.LoadShadowCopy(artifact, buildRoot / "validation-shadow", Gameplay::CurrentGameplayBuildFingerprint());
+            auto loaded = host.LoadShadowCopy(artifact, buildRoot / "validation-shadow",
+                                              {.moduleId = manifest.value("moduleId", ""),
+                                               .buildFingerprint = Gameplay::CurrentGameplayBuildFingerprint(),
+                                               .descriptorRevision = manifest.value("descriptorRevision", std::uint64_t{0})});
             if (loaded.HasError())
                 return Result<void>::Failure(loaded.ErrorValue());
             std::unique_ptr<Gameplay::LoadedGameModule> validatedModule = std::move(loaded).Value();
@@ -660,7 +665,7 @@ namespace Horo::Application {
             Result<std::filesystem::path> artifact = ValidateCandidateManifest(manifest.Value());
             if (artifact.HasError())
                 return Result<void>::Failure(artifact.ErrorValue());
-            if (Result<void> loaded = ValidateArtifactLoad(artifact.Value(), buildRoot); loaded.HasError())
+            if (Result<void> loaded = ValidateArtifactLoad(artifact.Value(), buildRoot, manifest.Value()); loaded.HasError())
                 return loaded;
 
             Result<std::string> postHash = ComputeInputHash(session->request);

--- a/src/editor/gameplay/ProjectGameplayRegistry.cpp
+++ b/src/editor/gameplay/ProjectGameplayRegistry.cpp
@@ -111,8 +111,7 @@ namespace Horo::Editor {
             diagnostics_.emplace_back(nativeManifestPath, ManifestError("the artifact was built for a different Horo SDK generation."));
             return;
         }
-        LoadNativeModule(projectRoot, nativeManifestPath, manifest.Value().artifactPath, manifest.Value().moduleId,
-                         manifest.Value().descriptorRevision);
+        LoadNativeModule(projectRoot, manifest.Value().artifactPath, manifest.Value().moduleId, manifest.Value().descriptorRevision);
     }
 
     bool ProjectGameplayRegistry::PrepareNativeManifestPath(const std::filesystem::path &projectRoot,
@@ -148,22 +147,18 @@ namespace Horo::Editor {
         return true;
     }
 
-    void ProjectGameplayRegistry::LoadNativeModule(const std::filesystem::path &projectRoot, const std::filesystem::path &manifestPath,
-                                                   const std::filesystem::path &artifactPath, const std::string_view moduleId,
-                                                   const std::uint64_t descriptorRevision) {
+    void ProjectGameplayRegistry::LoadNativeModule(const std::filesystem::path &projectRoot, const std::filesystem::path &artifactPath,
+                                                   const std::string_view moduleId, const std::uint64_t descriptorRevision) {
         Gameplay::GameModuleHost host;
         Result<std::unique_ptr<Gameplay::LoadedGameModule>> loaded =
             host.LoadShadowCopy(artifactPath, projectRoot / ".horo" / "local" / "gameplay_module_shadow",
-                                Gameplay::CurrentGameplayBuildFingerprint());
+                                {.moduleId = moduleId,
+                                 .buildFingerprint = Gameplay::CurrentGameplayBuildFingerprint(),
+                                 .descriptorRevision = descriptorRevision});
         if (loaded.HasError()) {
             diagnostics_.emplace_back(artifactPath, loaded.ErrorValue());
             return;
         }
-        if (loaded.Value()->ModuleId() != moduleId || loaded.Value()->DescriptorRevision() != descriptorRevision) {
-            diagnostics_.emplace_back(manifestPath, ManifestError("module identity or descriptor revision does not match the artifact."));
-            return;
-        }
-
         nativeModule_ = std::move(loaded).Value();
         for (const Gameplay::BehaviorRegistration &registration : nativeModule_->Registry().Registrations()) {
             if (Result<void> registered = registry_.Register(registration); registered.HasError()) {

--- a/src/editor/gameplay/ProjectGameplayRegistry.h
+++ b/src/editor/gameplay/ProjectGameplayRegistry.h
@@ -63,8 +63,8 @@ namespace Horo::Editor {
 
         [[nodiscard]] bool PrepareNativeManifestPath(const std::filesystem::path &projectRoot, const std::filesystem::path &manifestPath);
 
-        void LoadNativeModule(const std::filesystem::path &projectRoot, const std::filesystem::path &manifestPath,
-                              const std::filesystem::path &artifactPath, std::string_view moduleId, std::uint64_t descriptorRevision);
+        void LoadNativeModule(const std::filesystem::path &projectRoot, const std::filesystem::path &artifactPath,
+                              std::string_view moduleId, std::uint64_t descriptorRevision);
 
         void DiscoverLuaPrograms(const std::filesystem::path &projectRoot);
 

--- a/src/gameplay/api/GameModule.cpp
+++ b/src/gameplay/api/GameModule.cpp
@@ -1,12 +1,111 @@
 #include "Horo/Gameplay/GameModule.h"
 
+#include "Horo/Gameplay/GameplayErrors.h"
+
+#include <format>
+#include <optional>
+
 #if !defined(HORO_GAMEPLAY_SDK_FINGERPRINT)
 #define HORO_GAMEPLAY_SDK_FINGERPRINT "horo-unknown-gameplay-sdk"
 #endif
 
 namespace Horo::Gameplay {
+    namespace {
+        constexpr std::size_t MaximumModuleIdentityBytes = 256;
+
+        [[nodiscard]] std::optional<std::string_view> BoundedText(const char *value, const std::size_t maximumBytes) noexcept {
+            if (value == nullptr)
+                return std::nullopt;
+            std::size_t length = 0;
+            while (length <= maximumBytes && value[length] != '\0')
+                ++length;
+            if (length == 0 || length > maximumBytes)
+                return std::nullopt;
+            return std::string_view{value, length};
+        }
+
+        [[nodiscard]] bool IsBoundedArray(const std::size_t count, const std::size_t maximum, const void *records) noexcept {
+            return count <= maximum && (count == 0) == (records == nullptr);
+        }
+
+        [[nodiscard]] Result<void> ValidateBundleShape(const GeneratedGameplayDescriptorBundle &bundle) {
+            const bool behaviorsValid = IsBoundedArray(bundle.behaviorCount, MaximumGeneratedBehaviorDescriptors, bundle.behaviors);
+            const bool factoriesValid =
+                bundle.nativeFactoryBindingCount == bundle.behaviorCount &&
+                IsBoundedArray(bundle.nativeFactoryBindingCount, MaximumGeneratedBehaviorDescriptors, bundle.nativeFactoryBindings);
+            const bool diagnosticsValid = IsBoundedArray(bundle.diagnosticCount, MaximumGeneratedDescriptorDiagnostics, bundle.diagnostics);
+            if (bundle.structSize != sizeof(GeneratedGameplayDescriptorBundle) ||
+                bundle.schemaVersion != GameplayDescriptorBundleSchemaVersion || bundle.sdkBoundaryVersion != GameplaySdkBoundaryVersion ||
+                !behaviorsValid || !factoriesValid || !diagnosticsValid || bundle.lifecycle.create == nullptr ||
+                bundle.lifecycle.destroy == nullptr)
+                return Result<void>::Failure(MakeError(GameplayErrors::InvalidGeneratedDescriptorBundle));
+            return Result<void>::Success();
+        }
+
+        [[nodiscard]] Result<void> ValidateBundleIdentity(const GeneratedGameplayDescriptorBundle &bundle,
+                                                          const GameModuleLoadExpectation &expectation) {
+            const auto moduleId = BoundedText(bundle.moduleId, MaximumModuleIdentityBytes);
+            const auto fingerprint = BoundedText(bundle.buildFingerprint, MaximumModuleIdentityBytes);
+            if (!moduleId || !fingerprint || bundle.descriptorRevision == 0)
+                return Result<void>::Failure(MakeError(GameplayErrors::InvalidGeneratedDescriptorBundle));
+            if (*moduleId != expectation.moduleId || *fingerprint != expectation.buildFingerprint ||
+                bundle.descriptorRevision != expectation.descriptorRevision)
+                return Result<void>::Failure(MakeError(GameplayErrors::IncompatibleGameModule));
+            return Result<void>::Success();
+        }
+
+        [[nodiscard]] Result<void> ValidateGeneratedDiagnostics(const GeneratedGameplayDescriptorBundle &bundle) {
+            if (bundle.diagnosticCount == 0)
+                return Result<void>::Success();
+            for (std::size_t index = 0; index < bundle.diagnosticCount; ++index) {
+                const auto code = BoundedText(bundle.diagnostics[index].code, MaximumGeneratedDiagnosticCodeBytes);
+                const auto message = BoundedText(bundle.diagnostics[index].message, MaximumGeneratedDiagnosticMessageBytes);
+                if (!code || !message)
+                    return Result<void>::Failure(MakeError(GameplayErrors::InvalidGeneratedDescriptorBundle));
+            }
+            const GeneratedDescriptorDiagnostic &first = bundle.diagnostics[0];
+            return Result<void>::Failure(
+                MakeError(GameplayErrors::GeneratedDescriptorDiagnosticsPresent, std::format("{}: {}", first.code, first.message)));
+        }
+
+        [[nodiscard]] Result<void> ValidateFactoryBindings(const GeneratedGameplayDescriptorBundle &bundle) {
+            for (std::size_t index = 0; index < bundle.behaviorCount; ++index) {
+                const GeneratedBehaviorFactoryBinding &binding = bundle.nativeFactoryBindings[index];
+                if (!bundle.behaviors[index].typeId.IsValid() || binding.typeId != bundle.behaviors[index].typeId ||
+                    binding.factory.create == nullptr || binding.factory.destroy == nullptr)
+                    return Result<void>::Failure(MakeError(GameplayErrors::InvalidGeneratedDescriptorBundle));
+            }
+            return Result<void>::Success();
+        }
+    }  // namespace
+
     /** @copydoc CurrentGameplayBuildFingerprint */
     std::string_view CurrentGameplayBuildFingerprint() noexcept {
         return HORO_GAMEPLAY_SDK_FINGERPRINT;
+    }
+
+    /** @copydoc ValidateGameModuleDescriptor */
+    Result<void> ValidateGameModuleDescriptor(const GameModuleDescriptor &descriptor, const GameModuleLoadExpectation &expectation) {
+        const auto moduleId = BoundedText(descriptor.moduleId, MaximumModuleIdentityBytes);
+        const auto fingerprint = BoundedText(descriptor.buildFingerprint, MaximumModuleIdentityBytes);
+        if (descriptor.structSize != sizeof(GameModuleDescriptor) || !moduleId || !fingerprint || expectation.moduleId.empty() ||
+            expectation.buildFingerprint.empty() || expectation.descriptorRevision == 0)
+            return Result<void>::Failure(MakeError(GameplayErrors::InvalidGameModuleDescriptor));
+        if (descriptor.sdkBoundaryVersion != GameplaySdkBoundaryVersion || *moduleId != expectation.moduleId ||
+            *fingerprint != expectation.buildFingerprint)
+            return Result<void>::Failure(MakeError(GameplayErrors::IncompatibleGameModule));
+        return Result<void>::Success();
+    }
+
+    /** @copydoc ValidateGeneratedGameplayDescriptorBundle */
+    Result<void> ValidateGeneratedGameplayDescriptorBundle(const GeneratedGameplayDescriptorBundle &bundle,
+                                                           const GameModuleLoadExpectation &expectation) {
+        if (const Result<void> shape = ValidateBundleShape(bundle); shape.HasError())
+            return shape;
+        if (const Result<void> identity = ValidateBundleIdentity(bundle, expectation); identity.HasError())
+            return identity;
+        if (const Result<void> diagnostics = ValidateGeneratedDiagnostics(bundle); diagnostics.HasError())
+            return diagnostics;
+        return ValidateFactoryBindings(bundle);
     }
 }  // namespace Horo::Gameplay

--- a/src/gameplay/api/GameModule.cpp
+++ b/src/gameplay/api/GameModule.cpp
@@ -24,20 +24,19 @@ namespace Horo::Gameplay {
             return std::string_view{value, length};
         }
 
-        [[nodiscard]] bool IsBoundedArray(const std::size_t count, const std::size_t maximum, const void *records) noexcept {
+        template <typename Record>
+        [[nodiscard]] bool IsBoundedArray(const std::size_t count, const std::size_t maximum, const Record *records) noexcept {
             return count <= maximum && (count == 0) == (records == nullptr);
         }
 
         [[nodiscard]] Result<void> ValidateBundleShape(const GeneratedGameplayDescriptorBundle &bundle) {
-            const bool behaviorsValid = IsBoundedArray(bundle.behaviorCount, MaximumGeneratedBehaviorDescriptors, bundle.behaviors);
-            const bool factoriesValid =
-                bundle.nativeFactoryBindingCount == bundle.behaviorCount &&
-                IsBoundedArray(bundle.nativeFactoryBindingCount, MaximumGeneratedBehaviorDescriptors, bundle.nativeFactoryBindings);
-            const bool diagnosticsValid = IsBoundedArray(bundle.diagnosticCount, MaximumGeneratedDescriptorDiagnostics, bundle.diagnostics);
             if (bundle.structSize != sizeof(GeneratedGameplayDescriptorBundle) ||
                 bundle.schemaVersion != GameplayDescriptorBundleSchemaVersion || bundle.sdkBoundaryVersion != GameplaySdkBoundaryVersion ||
-                !behaviorsValid || !factoriesValid || !diagnosticsValid || bundle.lifecycle.create == nullptr ||
-                bundle.lifecycle.destroy == nullptr)
+                !IsBoundedArray(bundle.behaviorCount, MaximumGeneratedBehaviorDescriptors, bundle.behaviors) ||
+                bundle.nativeFactoryBindingCount != bundle.behaviorCount ||
+                !IsBoundedArray(bundle.nativeFactoryBindingCount, MaximumGeneratedBehaviorDescriptors, bundle.nativeFactoryBindings) ||
+                !IsBoundedArray(bundle.diagnosticCount, MaximumGeneratedDescriptorDiagnostics, bundle.diagnostics) ||
+                bundle.lifecycle.create == nullptr || bundle.lifecycle.destroy == nullptr)
                 return Result<void>::Failure(MakeError(GameplayErrors::InvalidGeneratedDescriptorBundle));
             return Result<void>::Success();
         }

--- a/src/gameplay/api/GameplayErrors.cpp
+++ b/src/gameplay/api/GameplayErrors.cpp
@@ -75,4 +75,40 @@ namespace Horo::Gameplay::GameplayErrors {
                                            "Use a registered event type, valid target, and bounded schema payload.",
                                            false,
                                            true};
+    const ErrorCodeDescriptor InvalidGameModuleDescriptor{
+        .domain = GameplayDomain,
+        .code = ErrorCode{"gameplay.module_descriptor_invalid"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "The gameplay module descriptor is malformed.",
+        .remediationHint = "Rebuild the project gameplay module from valid generated inputs.",
+        .retryable = false,
+        .userActionable = true,
+    };
+    const ErrorCodeDescriptor IncompatibleGameModule{
+        .domain = GameplayDomain,
+        .code = ErrorCode{"gameplay.module_incompatible"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "The gameplay module does not match the requested build identity.",
+        .remediationHint = "Rebuild the gameplay module with the active Horo SDK and project manifest.",
+        .retryable = false,
+        .userActionable = true,
+    };
+    const ErrorCodeDescriptor InvalidGeneratedDescriptorBundle{
+        .domain = GameplayDomain,
+        .code = ErrorCode{"gameplay.generated_descriptor_bundle_invalid"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "The generated gameplay descriptor bundle is malformed or incomplete.",
+        .remediationHint = "Regenerate the complete descriptor bundle and rebuild the gameplay module.",
+        .retryable = false,
+        .userActionable = true,
+    };
+    const ErrorCodeDescriptor GeneratedDescriptorDiagnosticsPresent{
+        .domain = GameplayDomain,
+        .code = ErrorCode{"gameplay.generated_descriptor_diagnostics_present"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "The generated gameplay descriptor bundle contains blocking diagnostics.",
+        .remediationHint = "Resolve every generated descriptor diagnostic before activating gameplay code.",
+        .retryable = false,
+        .userActionable = true,
+    };
 }  // namespace Horo::Gameplay::GameplayErrors

--- a/src/gameplay/module/GameModuleHost.cpp
+++ b/src/gameplay/module/GameModuleHost.cpp
@@ -206,8 +206,8 @@ namespace Horo::Gameplay {
                                             libraryPath.extension().string());
             std::error_code error;
             const std::filesystem::path canonicalShadow = std::filesystem::weakly_canonical(shadowPath, error);
-            const std::filesystem::path relativeShadow = canonicalShadow.lexically_relative(canonicalRoot);
-            if (error || relativeShadow.empty() || relativeShadow.is_absolute() || *relativeShadow.begin() == "..")
+            if (const std::filesystem::path relativeShadow = canonicalShadow.lexically_relative(canonicalRoot);
+                error || relativeShadow.empty() || relativeShadow.is_absolute() || *relativeShadow.begin() == "..")
                 return Result<std::filesystem::path>::Failure(ShadowCopyError("shadow path validation failed"));
             return Result<std::filesystem::path>::Success(canonicalShadow);
         }

--- a/src/gameplay/module/GameModuleHost.cpp
+++ b/src/gameplay/module/GameModuleHost.cpp
@@ -23,13 +23,6 @@ namespace Horo::Gameplay {
             return func;
         }
 
-        [[nodiscard]] Result<void> ValidateText(const char *value, const std::string_view field) {
-            if (value == nullptr || *value == '\0' || std::string_view{value}.size() > 256)
-                return Result<void>::Failure(
-                    MakeError(GameplayErrors::InvalidBehaviorComponent, std::format("Gameplay module {} is invalid.", field)));
-            return Result<void>::Success();
-        }
-
         [[nodiscard]] Error ShadowCopyError(const std::string &message) {
             return MakeError(GameplayErrors::InvalidBehaviorComponent, "Gameplay module shadow copy failed: " + message);
         }
@@ -49,6 +42,50 @@ namespace Horo::Gameplay {
         bool removeArtifactOnUnload{};
         bool started{};
     };
+
+    namespace {
+        struct ValidatedModuleExports {
+            const GameModuleDescriptor *descriptor{};
+            const GeneratedGameplayDescriptorBundle *bundle{};
+        };
+
+        [[nodiscard]] Result<ValidatedModuleExports> ReadValidatedExports(const Platform::DynamicLibrary &library,
+                                                                          const GameModuleLoadExpectation &expectation) {
+            const auto getDescriptor = Resolve<GetGameModuleDescriptorFunction>(library, GetGameModuleDescriptorSymbol);
+            const auto getBundle = Resolve<GetGameplayDescriptorBundleFunction>(library, GetGameplayDescriptorBundleSymbol);
+            if (getDescriptor == nullptr || getBundle == nullptr)
+                return Result<ValidatedModuleExports>::Failure(
+                    MakeError(GameplayErrors::InvalidGameModuleDescriptor, "Gameplay module is missing required descriptor exports."));
+            const GameModuleDescriptor *descriptor = getDescriptor();
+            const GeneratedGameplayDescriptorBundle *bundle = getBundle();
+            if (descriptor == nullptr)
+                return Result<ValidatedModuleExports>::Failure(
+                    MakeError(GameplayErrors::InvalidGameModuleDescriptor, "Gameplay module descriptor export returned null."));
+            if (bundle == nullptr)
+                return Result<ValidatedModuleExports>::Failure(
+                    MakeError(GameplayErrors::InvalidGeneratedDescriptorBundle, "Generated gameplay descriptor export returned null."));
+            if (const Result<void> valid = ValidateGameModuleDescriptor(*descriptor, expectation); valid.HasError())
+                return Result<ValidatedModuleExports>::Failure(valid.ErrorValue());
+            if (const Result<void> valid = ValidateGeneratedGameplayDescriptorBundle(*bundle, expectation); valid.HasError())
+                return Result<ValidatedModuleExports>::Failure(valid.ErrorValue());
+            return Result<ValidatedModuleExports>::Success({descriptor, bundle});
+        }
+
+        [[nodiscard]] Result<std::unique_ptr<BehaviorRegistry>> BuildRegistry(const GeneratedGameplayDescriptorBundle &bundle) {
+            auto registry = std::make_unique<BehaviorRegistry>();
+            for (std::size_t index = 0; index < bundle.behaviorCount; ++index) {
+                BehaviorRegistration registration{
+                    .descriptor = bundle.behaviors[index],
+                    .factory = bundle.nativeFactoryBindings[index].factory,
+                };
+                if (Result<void> registered = registry->Register(std::move(registration)); registered.HasError())
+                    return Result<std::unique_ptr<BehaviorRegistry>>::Failure(registered.ErrorValue());
+            }
+            if (Result<void> frozen = registry->Freeze(); frozen.HasError())
+                return Result<std::unique_ptr<BehaviorRegistry>>::Failure(frozen.ErrorValue());
+            return Result<std::unique_ptr<BehaviorRegistry>>::Success(std::move(registry));
+        }
+    }  // namespace
 
     LoadedGameModule::LoadedGameModule(std::unique_ptr<Impl> impl) noexcept : impl_(std::move(impl)) {}
 
@@ -100,10 +137,10 @@ namespace Horo::Gameplay {
 
     /** @copydoc GameModuleHost::Load */
     Result<std::unique_ptr<LoadedGameModule>> GameModuleHost::Load(const std::filesystem::path &libraryPath,
-                                                                   const std::string_view expectedBuildFingerprint) const {
-        if (!libraryPath.is_absolute() || expectedBuildFingerprint.empty())
+                                                                   const GameModuleLoadExpectation &expectation) const {
+        if (!libraryPath.is_absolute())
             return Result<std::unique_ptr<LoadedGameModule>>::Failure(
-                MakeError(GameplayErrors::InvalidBehaviorComponent, "Gameplay module path or expected fingerprint is invalid."));
+                MakeError(GameplayErrors::InvalidGameModuleDescriptor, "Gameplay module path must be absolute."));
 
         auto loaded = Platform::LoadDynamicLibrary(libraryPath.string());
         if (loaded.HasError())
@@ -112,41 +149,21 @@ namespace Horo::Gameplay {
         impl->library = std::move(loaded).Value();
         impl->loadedArtifactPath = libraryPath;
 
-        const auto getDescriptor = Resolve<GetGameModuleDescriptorFunction>(*impl->library, GetGameModuleDescriptorSymbol);
-        const auto getBundle = Resolve<GetGameplayDescriptorBundleFunction>(*impl->library, GetGameplayDescriptorBundleSymbol);
-        const auto create = Resolve<CreateGameModuleFunction>(*impl->library, CreateGameModuleSymbol);
-        impl->destroy = Resolve<DestroyGameModuleFunction>(*impl->library, DestroyGameModuleSymbol);
-        if (getDescriptor == nullptr || getBundle == nullptr || create == nullptr || impl->destroy == nullptr)
-            return Result<std::unique_ptr<LoadedGameModule>>::Failure(
-                MakeError(GameplayErrors::InvalidBehaviorComponent, "Gameplay module is missing required exported symbols."));
+        auto exports = ReadValidatedExports(*impl->library, expectation);
+        if (exports.HasError())
+            return Result<std::unique_ptr<LoadedGameModule>>::Failure(exports.ErrorValue());
+        const ValidatedModuleExports validated = exports.Value();
+        impl->moduleId = validated.descriptor->moduleId;
+        impl->buildFingerprint = validated.descriptor->buildFingerprint;
+        impl->descriptorRevision = validated.bundle->descriptorRevision;
+        impl->destroy = validated.bundle->lifecycle.destroy;
 
-        const GameModuleDescriptor *descriptor = getDescriptor();
-        if (descriptor == nullptr || descriptor->structSize != sizeof(GameModuleDescriptor) ||
-            descriptor->sdkBoundaryVersion != GameplaySdkBoundaryVersion || ValidateText(descriptor->moduleId, "moduleId").HasError() ||
-            ValidateText(descriptor->buildFingerprint, "buildFingerprint").HasError() ||
-            descriptor->buildFingerprint != expectedBuildFingerprint)
-            return Result<std::unique_ptr<LoadedGameModule>>::Failure(
-                MakeError(GameplayErrors::InvalidBehaviorComponent, "Gameplay module SDK boundary or build fingerprint is incompatible."));
-        impl->moduleId = descriptor->moduleId;
-        impl->buildFingerprint = descriptor->buildFingerprint;
+        auto registry = BuildRegistry(*validated.bundle);
+        if (registry.HasError())
+            return Result<std::unique_ptr<LoadedGameModule>>::Failure(registry.ErrorValue());
+        impl->registry = std::move(registry).Value();
 
-        const GeneratedGameplayDescriptorBundle *bundle = getBundle();
-        if (bundle == nullptr || bundle->structSize != sizeof(GeneratedGameplayDescriptorBundle) || bundle->descriptorRevision == 0 ||
-            bundle->moduleId == nullptr || bundle->buildFingerprint == nullptr || bundle->moduleId != impl->moduleId ||
-            bundle->buildFingerprint != impl->buildFingerprint || (bundle->behaviorCount != 0 && bundle->behaviors == nullptr))
-            return Result<std::unique_ptr<LoadedGameModule>>::Failure(
-                MakeError(GameplayErrors::InvalidBehaviorComponent, "Generated gameplay descriptor bundle is stale or incomplete."));
-        impl->descriptorRevision = bundle->descriptorRevision;
-
-        impl->registry = std::make_unique<BehaviorRegistry>();
-        for (std::size_t index = 0; index < bundle->behaviorCount; ++index) {
-            if (Result<void> registered = impl->registry->Register(bundle->behaviors[index]); registered.HasError())
-                return Result<std::unique_ptr<LoadedGameModule>>::Failure(registered.ErrorValue());
-        }
-        if (Result<void> frozen = impl->registry->Freeze(); frozen.HasError())
-            return Result<std::unique_ptr<LoadedGameModule>>::Failure(frozen.ErrorValue());
-
-        impl->gameplayModule = create();
+        impl->gameplayModule = validated.bundle->lifecycle.create();
         if (impl->gameplayModule == nullptr)
             return Result<std::unique_ptr<LoadedGameModule>>::Failure(
                 MakeError(GameplayErrors::InvalidBehaviorComponent, "Gameplay module factory returned no module object."));
@@ -168,39 +185,61 @@ namespace Horo::Gameplay {
         });
     }
 
+    namespace {
+        [[nodiscard]] Result<std::filesystem::path> PrepareShadowRoot(const std::filesystem::path &shadowRoot) {
+            std::error_code error;
+            std::filesystem::create_directories(shadowRoot, error);  // NOSONAR
+            if (error)
+                return Result<std::filesystem::path>::Failure(ShadowCopyError(error.message()));
+            const std::filesystem::path canonicalRoot = std::filesystem::weakly_canonical(shadowRoot, error);
+            if (error || !IsSafeAbsolutePath(canonicalRoot))
+                return Result<std::filesystem::path>::Failure(ShadowCopyError("shadow root validation failed"));
+            return Result<std::filesystem::path>::Success(canonicalRoot);
+        }
+
+        [[nodiscard]] Result<std::filesystem::path> MakeShadowPath(const std::filesystem::path &libraryPath,
+                                                                   const std::filesystem::path &canonicalRoot) {
+            static std::atomic<std::uint64_t> sequence{1};
+            const auto timestamp = std::chrono::steady_clock::now().time_since_epoch().count();
+            const std::filesystem::path shadowPath =
+                canonicalRoot / std::format("{}.horo_reload_{}_{}{}", libraryPath.stem().string(), timestamp, sequence.fetch_add(1),
+                                            libraryPath.extension().string());
+            std::error_code error;
+            const std::filesystem::path canonicalShadow = std::filesystem::weakly_canonical(shadowPath, error);
+            const std::filesystem::path relativeShadow = canonicalShadow.lexically_relative(canonicalRoot);
+            if (error || relativeShadow.empty() || relativeShadow.is_absolute() || *relativeShadow.begin() == "..")
+                return Result<std::filesystem::path>::Failure(ShadowCopyError("shadow path validation failed"));
+            return Result<std::filesystem::path>::Success(canonicalShadow);
+        }
+
+        [[nodiscard]] Result<void> CopyShadowArtifact(const std::filesystem::path &source, const std::filesystem::path &destination) {
+            std::error_code error;
+            if (std::filesystem::copy_file(source, destination, std::filesystem::copy_options::none, error))  // NOSONAR
+                return Result<void>::Success();
+            return Result<void>::Failure(ShadowCopyError(error ? error.message() : "candidate could not be copied."));
+        }
+    }  // namespace
+
     Result<std::unique_ptr<LoadedGameModule>> GameModuleHost::LoadShadowCopy(const std::filesystem::path &libraryPath,
                                                                              const std::filesystem::path &shadowRoot,
-                                                                             const std::string_view expectedBuildFingerprint) const {
+                                                                             const GameModuleLoadExpectation &expectation) const {
         if (!IsSafeAbsolutePath(libraryPath) || !IsSafeAbsolutePath(shadowRoot))
             return Result<std::unique_ptr<LoadedGameModule>>::Failure(
                 ShadowCopyError("source and destination paths must be absolute and without traversal."));
 
-        std::error_code filesystemError;
-        std::filesystem::create_directories(shadowRoot, filesystemError);  // NOSONAR
-        if (filesystemError)
-            return Result<std::unique_ptr<LoadedGameModule>>::Failure(ShadowCopyError(filesystemError.message()));
+        auto canonicalRoot = PrepareShadowRoot(shadowRoot);
+        if (canonicalRoot.HasError())
+            return Result<std::unique_ptr<LoadedGameModule>>::Failure(canonicalRoot.ErrorValue());
+        auto shadowPath = MakeShadowPath(libraryPath, canonicalRoot.Value());
+        if (shadowPath.HasError())
+            return Result<std::unique_ptr<LoadedGameModule>>::Failure(shadowPath.ErrorValue());
+        if (const Result<void> copied = CopyShadowArtifact(libraryPath, shadowPath.Value()); copied.HasError())
+            return Result<std::unique_ptr<LoadedGameModule>>::Failure(copied.ErrorValue());
 
-        const std::filesystem::path canonicalRoot = std::filesystem::weakly_canonical(shadowRoot, filesystemError);
-        if (filesystemError || !IsSafeAbsolutePath(canonicalRoot))
-            return Result<std::unique_ptr<LoadedGameModule>>::Failure(ShadowCopyError("shadow root validation failed"));
-        static std::atomic<std::uint64_t> sequence{1};
-        const auto timestamp = std::chrono::steady_clock::now().time_since_epoch().count();
-        const std::filesystem::path shadowPath =
-            canonicalRoot / std::format("{}.horo_reload_{}_{}{}", libraryPath.stem().string(), timestamp, sequence.fetch_add(1),
-                                        libraryPath.extension().string());
-        const std::filesystem::path canonicalShadow = std::filesystem::weakly_canonical(shadowPath, filesystemError);
-        if (const std::filesystem::path relativeShadow = canonicalShadow.lexically_relative(canonicalRoot);
-            filesystemError || relativeShadow.empty() || relativeShadow.is_absolute() || *relativeShadow.begin() == "..")
-            return Result<std::unique_ptr<LoadedGameModule>>::Failure(ShadowCopyError("shadow path validation failed"));
-        if (!std::filesystem::copy_file(libraryPath, shadowPath, std::filesystem::copy_options::none, filesystemError)) {  // NOSONAR
-            const std::string message = filesystemError ? filesystemError.message() : "candidate could not be copied.";
-            return Result<std::unique_ptr<LoadedGameModule>>::Failure(ShadowCopyError(message));
-        }
-
-        Result<std::unique_ptr<LoadedGameModule>> loaded = Load(shadowPath, expectedBuildFingerprint);
+        Result<std::unique_ptr<LoadedGameModule>> loaded = Load(shadowPath.Value(), expectation);
         if (loaded.HasError()) {
             std::error_code ignored;
-            std::filesystem::remove(shadowPath, ignored);  // NOSONAR
+            std::filesystem::remove(shadowPath.Value(), ignored);  // NOSONAR
             return loaded;
         }
         loaded.Value()->impl_->removeArtifactOnUnload = true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,11 +134,15 @@ horo_add_gameplay_module(HoroTestGameModule
         NO_MANIFEST
         SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/fixtures/gameplay_module/TestGameModule.cpp
 )
+get_property(HORO_TEST_GAME_MODULE_REVISION_FILE TARGET HoroTestGameModule PROPERTY HORO_GAMEPLAY_DESCRIPTOR_REVISION_FILE)
 add_executable(HoroGameModuleHostTests
         unit/gameplay/GameModuleHostTests.cpp
 )
 target_compile_features(HoroGameModuleHostTests PRIVATE cxx_std_20)
-target_compile_definitions(HoroGameModuleHostTests PRIVATE HORO_TEST_GAME_MODULE_PATH="$<TARGET_FILE:HoroTestGameModule>")
+target_compile_definitions(HoroGameModuleHostTests PRIVATE
+        HORO_TEST_GAME_MODULE_PATH="$<TARGET_FILE:HoroTestGameModule>"
+        HORO_TEST_GAME_MODULE_REVISION_PATH="${HORO_TEST_GAME_MODULE_REVISION_FILE}"
+)
 target_link_libraries(HoroGameModuleHostTests PRIVATE HoroEngine::GameplayModuleHost)
 add_dependencies(HoroGameModuleHostTests HoroTestGameModule)
 add_executable(HoroLuaBehaviorTests
@@ -155,7 +159,10 @@ add_executable(HoroProjectGameplayRegistryTests
         unit/editor/ProjectGameplayRegistryTests.cpp
 )
 target_compile_features(HoroProjectGameplayRegistryTests PRIVATE cxx_std_20)
-target_compile_definitions(HoroProjectGameplayRegistryTests PRIVATE HORO_TEST_GAME_MODULE_PATH="$<TARGET_FILE:HoroTestGameModule>")
+target_compile_definitions(HoroProjectGameplayRegistryTests PRIVATE
+        HORO_TEST_GAME_MODULE_PATH="$<TARGET_FILE:HoroTestGameModule>"
+        HORO_TEST_GAME_MODULE_REVISION_PATH="${HORO_TEST_GAME_MODULE_REVISION_FILE}"
+)
 target_link_libraries(HoroProjectGameplayRegistryTests PRIVATE HoroEngine::EditorServices)
 add_dependencies(HoroProjectGameplayRegistryTests HoroTestGameModule)
 add_executable(HoroSceneMathTests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,14 @@ add_test(NAME HoroDependencyDirectionNegativeConfigureTest
 set_tests_properties(HoroDependencyDirectionNegativeConfigureTest PROPERTIES
     LABELS "architecture;cmake")
 
+add_test(NAME HoroGameplayManifestRevisionValidationTest
+    COMMAND "${CMAKE_COMMAND}"
+        "-DHORO_ENGINE_SOURCE_DIR=${PROJECT_SOURCE_DIR}"
+        "-DHORO_TEST_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}/gameplay-manifest-validation"
+        -P "${PROJECT_SOURCE_DIR}/tests/cmake/RunGameplayManifestRevisionValidationTest.cmake")
+set_tests_properties(HoroGameplayManifestRevisionValidationTest PROPERTIES
+    LABELS "gameplay;cmake")
+
 # One translation unit per registered public header verifies that consumers can
 # compile the contract using only its owning target's usage requirements.
 horo_add_public_header_consumer_targets()
@@ -138,6 +146,7 @@ get_property(HORO_TEST_GAME_MODULE_REVISION_FILE TARGET HoroTestGameModule PROPE
 add_executable(HoroGameModuleHostTests
         unit/gameplay/GameModuleHostTests.cpp
 )
+target_include_directories(HoroGameModuleHostTests PRIVATE "${PROJECT_SOURCE_DIR}/tests/helpers")
 target_compile_features(HoroGameModuleHostTests PRIVATE cxx_std_20)
 target_compile_definitions(HoroGameModuleHostTests PRIVATE
         HORO_TEST_GAME_MODULE_PATH="$<TARGET_FILE:HoroTestGameModule>"
@@ -158,6 +167,7 @@ target_link_libraries(HoroEditorPlaySessionControllerTests PRIVATE HoroEngine::E
 add_executable(HoroProjectGameplayRegistryTests
         unit/editor/ProjectGameplayRegistryTests.cpp
 )
+target_include_directories(HoroProjectGameplayRegistryTests PRIVATE "${PROJECT_SOURCE_DIR}/tests/helpers")
 target_compile_features(HoroProjectGameplayRegistryTests PRIVATE cxx_std_20)
 target_compile_definitions(HoroProjectGameplayRegistryTests PRIVATE
         HORO_TEST_GAME_MODULE_PATH="$<TARGET_FILE:HoroTestGameModule>"

--- a/tests/cmake/RunGameplayManifestRevisionValidationTest.cmake
+++ b/tests/cmake/RunGameplayManifestRevisionValidationTest.cmake
@@ -1,0 +1,33 @@
+if(NOT DEFINED HORO_ENGINE_SOURCE_DIR OR NOT DEFINED HORO_TEST_BINARY_DIR)
+    message(FATAL_ERROR "Gameplay manifest validation test inputs are incomplete")
+endif()
+
+set(_writer "${HORO_ENGINE_SOURCE_DIR}/cmake/WriteGameplayModuleManifest.cmake")
+set(_manifest "${HORO_TEST_BINARY_DIR}/gameplay_module.json")
+set(_revision "${HORO_TEST_BINARY_DIR}/descriptor.revision")
+file(MAKE_DIRECTORY "${HORO_TEST_BINARY_DIR}")
+file(REMOVE "${_manifest}" "${_revision}")
+
+function(expect_manifest_failure label)
+    execute_process(
+        COMMAND "${CMAKE_COMMAND}"
+            "-DMANIFEST_OUTPUT=${_manifest}"
+            "-DMODULE_ID=game.tests"
+            "-DBUILD_FINGERPRINT=test-fingerprint"
+            "-DMODULE_PATH=${HORO_TEST_BINARY_DIR}/module"
+            "-DDESCRIPTOR_REVISION_FILE=${_revision}"
+            -P "${_writer}"
+        RESULT_VARIABLE _result
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+    if(_result EQUAL 0 OR EXISTS "${_manifest}")
+        message(FATAL_ERROR "Manifest publication accepted ${label}")
+    endif()
+endfunction()
+
+expect_manifest_failure("a missing descriptor revision")
+foreach(_invalid IN ITEMS "" "0" "invalid" "18446744073709551616")
+    file(WRITE "${_revision}" "${_invalid}")
+    expect_manifest_failure("invalid descriptor revision '${_invalid}'")
+endforeach()

--- a/tests/helpers/GameplayModuleTestSupport.h
+++ b/tests/helpers/GameplayModuleTestSupport.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+
+namespace Horo::Tests {
+    inline std::uint64_t ReadDescriptorRevision(const std::filesystem::path &path) {
+        std::ifstream stream{path};
+        std::uint64_t revision{};
+        if (!(stream >> revision) || revision == 0)
+            throw std::runtime_error{"test gameplay descriptor revision is missing or invalid"};
+        return revision;
+    }
+}  // namespace Horo::Tests

--- a/tests/python/test_gameplay_descriptor_generator.py
+++ b/tests/python/test_gameplay_descriptor_generator.py
@@ -1,33 +1,33 @@
 from __future__ import annotations
 
-import subprocess
-import sys
+import importlib.util
 from pathlib import Path
 
-
-REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
-GENERATOR = REPOSITORY_ROOT / "scripts" / "generate_gameplay_behavior_bundle.py"
+import pytest
 
 
-def generate(output: Path, revision: Path, sources: list[Path]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        [
-            sys.executable,
-            str(GENERATOR),
-            "--output",
-            str(output),
-            "--revision-output",
-            str(revision),
-            "--module-id",
-            "game.tests",
-            "--fingerprint",
-            "test-fingerprint",
-            *(str(source) for source in sources),
-        ],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+GENERATOR_PATH = Path(__file__).resolve().parents[2] / "scripts" / "generate_gameplay_behavior_bundle.py"
+GENERATOR_SPEC = importlib.util.spec_from_file_location("horo_gameplay_descriptor_generator", GENERATOR_PATH)
+if GENERATOR_SPEC is None or GENERATOR_SPEC.loader is None:
+    raise RuntimeError(f"could not load gameplay descriptor generator from {GENERATOR_PATH}")
+generator = importlib.util.module_from_spec(GENERATOR_SPEC)
+GENERATOR_SPEC.loader.exec_module(generator)
+
+
+def generate(
+    output: Path,
+    revision: Path,
+    sources: list[Path],
+    *,
+    module_id: str = "game.tests",
+    fingerprint: str = "test-fingerprint",
+) -> None:
+    generator.generate_bundle(output, revision, output.parent, module_id, fingerprint, sources)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
 
 
 def test_generation_is_deterministic_across_source_order(tmp_path: Path) -> None:
@@ -40,12 +40,12 @@ def test_generation_is_deterministic_across_source_order(tmp_path: Path) -> None
     first_revision = tmp_path / "first.revision"
     second_output = tmp_path / "bundle-second.cpp"
     second_revision = tmp_path / "second.revision"
-    assert generate(first_output, first_revision, [second, first]).returncode == 0
-    assert generate(second_output, second_revision, [first, second]).returncode == 0
+    generate(first_output, first_revision, [second, first])
+    generate(second_output, second_revision, [first, second])
 
-    assert first_output.read_bytes() == second_output.read_bytes()
-    assert first_revision.read_bytes() == second_revision.read_bytes()
-    assert int(first_revision.read_text(encoding="utf-8")) > 0
+    require(first_output.read_bytes() == second_output.read_bytes(), "generated source depends on input order")
+    require(first_revision.read_bytes() == second_revision.read_bytes(), "descriptor revision depends on input order")
+    require(int(first_revision.read_text(encoding="utf-8")) > 0, "descriptor revision must be nonzero")
 
 
 def test_generation_ignores_annotation_text_in_comments_and_strings(tmp_path: Path) -> None:
@@ -59,13 +59,12 @@ def test_generation_ignores_annotation_text_in_comments_and_strings(tmp_path: Pa
         encoding="utf-8",
     )
     output = tmp_path / "bundle.cpp"
-    result = generate(output, tmp_path / "bundle.revision", [source])
+    generate(output, tmp_path / "bundle.revision", [source])
 
-    assert result.returncode == 0, result.stderr
     generated = output.read_text(encoding="utf-8")
-    assert "HoroGeneratedBehaviorDescriptor_RealBehavior" in generated
-    assert "CommentBehavior" not in generated
-    assert "StringBehavior" not in generated
+    require("HoroGeneratedBehaviorDescriptor_RealBehavior" in generated, "real annotation was not emitted")
+    require("CommentBehavior" not in generated, "comment annotation was emitted")
+    require("StringBehavior" not in generated, "string annotation was emitted")
 
 
 def test_generation_rejects_duplicate_stable_type_ids(tmp_path: Path) -> None:
@@ -77,8 +76,62 @@ def test_generation_rejects_duplicate_stable_type_ids(tmp_path: Path) -> None:
         ''',
         encoding="utf-8",
     )
-    result = generate(tmp_path / "bundle.cpp", tmp_path / "bundle.revision", [source])
+    output = tmp_path / "bundle.cpp"
 
-    assert result.returncode == 1
-    assert "duplicate native behavior type ID" in result.stderr
-    assert not (tmp_path / "bundle.cpp").exists()
+    with pytest.raises(ValueError, match="duplicate native behavior type ID"):
+        generate(output, tmp_path / "bundle.revision", [source])
+    require(not output.exists(), "failed generation published an output")
+
+
+@pytest.mark.parametrize(
+    ("module_id", "fingerprint"),
+    [
+        ("game." + "a" * 252, "test-fingerprint"),
+        ("game.tests", "unsafe fingerprint"),
+        ("invalid", "test-fingerprint"),
+    ],
+)
+def test_generation_rejects_invalid_or_oversized_identity(
+    tmp_path: Path,
+    module_id: str,
+    fingerprint: str,
+) -> None:
+    source = tmp_path / "Behavior.cpp"
+    source.write_text('HORO_BEHAVIOR(Behavior, "game.tests.valid")\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="module identity or build fingerprint is invalid"):
+        generate(tmp_path / "bundle.cpp", tmp_path / "bundle.revision", [source], module_id=module_id, fingerprint=fingerprint)
+
+
+def test_generation_rejects_more_than_the_supported_behavior_count(tmp_path: Path) -> None:
+    source = tmp_path / "Many.cpp"
+    source.write_text(
+        "\n".join(f'HORO_BEHAVIOR(Behavior{index}, "game.tests.behavior_{index}")' for index in range(4097)),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="annotation count exceeds"):
+        generate(tmp_path / "bundle.cpp", tmp_path / "bundle.revision", [source])
+
+
+def test_generation_confines_outputs_to_the_declared_root(tmp_path: Path) -> None:
+    source = tmp_path / "Behavior.cpp"
+    source.write_text('HORO_BEHAVIOR(Behavior, "game.tests.valid")\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="must remain inside"):
+        generator.generate_bundle(
+            tmp_path.parent / "escaped.cpp",
+            tmp_path / "bundle.revision",
+            tmp_path,
+            "game.tests",
+            "test-fingerprint",
+            [source],
+        )
+
+
+def test_generation_rejects_duplicate_source_paths_and_malformed_annotations(tmp_path: Path) -> None:
+    source = tmp_path / "Behavior.cpp"
+    source.write_text('HORO_BEHAVIOR(Behavior, "game.tests.valid")\n', encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate paths"):
+        generate(tmp_path / "bundle.cpp", tmp_path / "bundle.revision", [source, source])
+
+    source.write_text("HORO_BEHAVIOR(Behavior)\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="malformed HORO_BEHAVIOR annotation"):
+        generate(tmp_path / "bundle.cpp", tmp_path / "bundle.revision", [source])

--- a/tests/python/test_gameplay_descriptor_generator.py
+++ b/tests/python/test_gameplay_descriptor_generator.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+GENERATOR = REPOSITORY_ROOT / "scripts" / "generate_gameplay_behavior_bundle.py"
+
+
+def generate(output: Path, revision: Path, sources: list[Path]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(GENERATOR),
+            "--output",
+            str(output),
+            "--revision-output",
+            str(revision),
+            "--module-id",
+            "game.tests",
+            "--fingerprint",
+            "test-fingerprint",
+            *(str(source) for source in sources),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_generation_is_deterministic_across_source_order(tmp_path: Path) -> None:
+    first = tmp_path / "First.cpp"
+    second = tmp_path / "Second.cpp"
+    first.write_text('HORO_BEHAVIOR(FirstBehavior, "game.tests.first")\n', encoding="utf-8")
+    second.write_text('HORO_BEHAVIOR(SecondBehavior, "game.tests.second")\n', encoding="utf-8")
+
+    first_output = tmp_path / "bundle-first.cpp"
+    first_revision = tmp_path / "first.revision"
+    second_output = tmp_path / "bundle-second.cpp"
+    second_revision = tmp_path / "second.revision"
+    assert generate(first_output, first_revision, [second, first]).returncode == 0
+    assert generate(second_output, second_revision, [first, second]).returncode == 0
+
+    assert first_output.read_bytes() == second_output.read_bytes()
+    assert first_revision.read_bytes() == second_revision.read_bytes()
+    assert int(first_revision.read_text(encoding="utf-8")) > 0
+
+
+def test_generation_ignores_annotation_text_in_comments_and_strings(tmp_path: Path) -> None:
+    source = tmp_path / "Behavior.cpp"
+    source.write_text(
+        '''
+        // HORO_BEHAVIOR(CommentBehavior, "game.tests.comment")
+        const char *example = "HORO_BEHAVIOR(StringBehavior, game.tests.string)";
+        HORO_BEHAVIOR(RealBehavior, "game.tests.real")
+        ''',
+        encoding="utf-8",
+    )
+    output = tmp_path / "bundle.cpp"
+    result = generate(output, tmp_path / "bundle.revision", [source])
+
+    assert result.returncode == 0, result.stderr
+    generated = output.read_text(encoding="utf-8")
+    assert "HoroGeneratedBehaviorDescriptor_RealBehavior" in generated
+    assert "CommentBehavior" not in generated
+    assert "StringBehavior" not in generated
+
+
+def test_generation_rejects_duplicate_stable_type_ids(tmp_path: Path) -> None:
+    source = tmp_path / "Duplicate.cpp"
+    source.write_text(
+        '''
+        HORO_BEHAVIOR(FirstBehavior, "game.tests.duplicate")
+        HORO_BEHAVIOR(SecondBehavior, "game.tests.duplicate")
+        ''',
+        encoding="utf-8",
+    )
+    result = generate(tmp_path / "bundle.cpp", tmp_path / "bundle.revision", [source])
+
+    assert result.returncode == 1
+    assert "duplicate native behavior type ID" in result.stderr
+    assert not (tmp_path / "bundle.cpp").exists()

--- a/tests/unit/editor/ProjectGameplayRegistryTests.cpp
+++ b/tests/unit/editor/ProjectGameplayRegistryTests.cpp
@@ -33,6 +33,15 @@ namespace {
         REQUIRE(stream.good());
     }
 
+    std::uint64_t DescriptorRevision() {
+        std::ifstream stream{HORO_TEST_GAME_MODULE_REVISION_PATH};
+        std::uint64_t revision{};
+        stream >> revision;
+        REQUIRE((stream.good() || stream.eof()));
+        REQUIRE(revision != 0);
+        return revision;
+    }
+
     std::string Source(const int amount) {
         return "return horo.behavior { type_id='game.tests.watched', display_name='Watched', "
                "on_fixed_update=function(ctx, dt) local x,y,z=ctx.transform.position(); "
@@ -85,7 +94,7 @@ TEST_CASE("project gameplay registry merges a fingerprinted native module with L
     Write(source.string() + ".meta", R"({"schemaVersion":1,"runtime":"lua","behaviorTypeId":"game.tests.watched"})");
     const std::string manifest = "{\n  \"schemaVersion\": 1,\n  \"moduleId\": \"game.tests\",\n  \"buildFingerprint\": \"" +
                                  std::string{Gameplay::CurrentGameplayBuildFingerprint()} +
-                                 "\",\n  \"descriptorRevision\": 1,\n  \"artifactPath\": \"" +
+                                 "\",\n  \"descriptorRevision\": " + std::to_string(DescriptorRevision()) + ",\n  \"artifactPath\": \"" +
                                  std::filesystem::path{HORO_TEST_GAME_MODULE_PATH}.string() + "\"\n}\n";
     Write(project.root / ".horo" / "local" / "gameplay_module.json", manifest);
 

--- a/tests/unit/editor/ProjectGameplayRegistryTests.cpp
+++ b/tests/unit/editor/ProjectGameplayRegistryTests.cpp
@@ -1,3 +1,4 @@
+#include "GameplayModuleTestSupport.h"
 #include "Horo/Gameplay/BehaviorRuntime.h"
 #include "editor/gameplay/ProjectGameplayRegistry.h"
 
@@ -31,15 +32,6 @@ namespace {
         stream << value;
         stream.close();
         REQUIRE(stream.good());
-    }
-
-    std::uint64_t DescriptorRevision() {
-        std::ifstream stream{HORO_TEST_GAME_MODULE_REVISION_PATH};
-        std::uint64_t revision{};
-        stream >> revision;
-        REQUIRE((stream.good() || stream.eof()));
-        REQUIRE(revision != 0);
-        return revision;
     }
 
     std::string Source(const int amount) {
@@ -93,9 +85,9 @@ TEST_CASE("project gameplay registry merges a fingerprinted native module with L
     Write(source, Source(1));
     Write(source.string() + ".meta", R"({"schemaVersion":1,"runtime":"lua","behaviorTypeId":"game.tests.watched"})");
     const std::string manifest = "{\n  \"schemaVersion\": 1,\n  \"moduleId\": \"game.tests\",\n  \"buildFingerprint\": \"" +
-                                 std::string{Gameplay::CurrentGameplayBuildFingerprint()} +
-                                 "\",\n  \"descriptorRevision\": " + std::to_string(DescriptorRevision()) + ",\n  \"artifactPath\": \"" +
-                                 std::filesystem::path{HORO_TEST_GAME_MODULE_PATH}.string() + "\"\n}\n";
+                                 std::string{Gameplay::CurrentGameplayBuildFingerprint()} + "\",\n  \"descriptorRevision\": " +
+                                 std::to_string(Tests::ReadDescriptorRevision(HORO_TEST_GAME_MODULE_REVISION_PATH)) +
+                                 ",\n  \"artifactPath\": \"" + std::filesystem::path{HORO_TEST_GAME_MODULE_PATH}.string() + "\"\n}\n";
     Write(project.root / ".horo" / "local" / "gameplay_module.json", manifest);
 
     auto registry = Editor::ProjectGameplayRegistry::Discover(project.root);

--- a/tests/unit/gameplay/GameModuleHostTests.cpp
+++ b/tests/unit/gameplay/GameModuleHostTests.cpp
@@ -1,30 +1,21 @@
+#include "GameplayModuleTestSupport.h"
 #include "Horo/Gameplay/BehaviorRuntime.h"
 #include "Horo/Gameplay/GameModuleHost.h"
 #include "Horo/Gameplay/GameplayErrors.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <filesystem>
-#include <fstream>
 
 namespace {
     using namespace Horo;
     using namespace Horo::Gameplay;
     using namespace Horo::Runtime;
 
-    std::uint64_t DescriptorRevision() {
-        std::ifstream stream{HORO_TEST_GAME_MODULE_REVISION_PATH};
-        std::uint64_t revision{};
-        stream >> revision;
-        REQUIRE((stream.good() || stream.eof()));
-        REQUIRE(revision != 0);
-        return revision;
-    }
-
     GameModuleLoadExpectation Expectation() {
         return {
             .moduleId = "game.tests",
             .buildFingerprint = CurrentGameplayBuildFingerprint(),
-            .descriptorRevision = DescriptorRevision(),
+            .descriptorRevision = Tests::ReadDescriptorRevision(HORO_TEST_GAME_MODULE_REVISION_PATH),
         };
     }
 

--- a/tests/unit/gameplay/GameModuleHostTests.cpp
+++ b/tests/unit/gameplay/GameModuleHostTests.cpp
@@ -1,13 +1,73 @@
 #include "Horo/Gameplay/BehaviorRuntime.h"
 #include "Horo/Gameplay/GameModuleHost.h"
+#include "Horo/Gameplay/GameplayErrors.h"
 
 #include <catch2/catch_test_macros.hpp>
 #include <filesystem>
+#include <fstream>
 
 namespace {
     using namespace Horo;
     using namespace Horo::Gameplay;
     using namespace Horo::Runtime;
+
+    std::uint64_t DescriptorRevision() {
+        std::ifstream stream{HORO_TEST_GAME_MODULE_REVISION_PATH};
+        std::uint64_t revision{};
+        stream >> revision;
+        REQUIRE((stream.good() || stream.eof()));
+        REQUIRE(revision != 0);
+        return revision;
+    }
+
+    GameModuleLoadExpectation Expectation() {
+        return {
+            .moduleId = "game.tests",
+            .buildFingerprint = CurrentGameplayBuildFingerprint(),
+            .descriptorRevision = DescriptorRevision(),
+        };
+    }
+
+    IGameModule *CreateTestModule() noexcept {
+        return nullptr;
+    }
+
+    void DestroyTestModule(IGameModule *) noexcept {}
+
+    IBehaviorInstance *CreateTestBehavior(void *) {
+        return nullptr;
+    }
+
+    void DestroyTestBehavior(void *, IBehaviorInstance *) noexcept {}
+
+    struct ValidBundleStorage {
+        BehaviorDescriptor behavior;
+        GeneratedBehaviorFactoryBinding binding;
+        GeneratedGameplayDescriptorBundle bundle;
+
+        ValidBundleStorage() {
+            behavior.typeId = BehaviorTypeId::Parse("game.tests.valid").Value();
+            binding = {
+                .typeId = behavior.typeId,
+                .factory = {.userData = nullptr, .create = &CreateTestBehavior, .destroy = &DestroyTestBehavior},
+            };
+            bundle = {
+                .structSize = sizeof(GeneratedGameplayDescriptorBundle),
+                .schemaVersion = GameplayDescriptorBundleSchemaVersion,
+                .sdkBoundaryVersion = GameplaySdkBoundaryVersion,
+                .moduleId = "game.tests",
+                .buildFingerprint = CurrentGameplayBuildFingerprint().data(),
+                .descriptorRevision = 7,
+                .behaviors = &behavior,
+                .behaviorCount = 1,
+                .nativeFactoryBindings = &binding,
+                .nativeFactoryBindingCount = 1,
+                .diagnostics = nullptr,
+                .diagnosticCount = 0,
+                .lifecycle = {.create = &CreateTestModule, .destroy = &DestroyTestModule},
+            };
+        }
+    };
 
     RuntimeSceneDefinition Definition() {
         RuntimeComponentSet components;
@@ -22,12 +82,15 @@ namespace {
 
 TEST_CASE("game module host validates fingerprint and keeps factories alive through behavior shutdown") {
     GameModuleHost host;
-    auto relative = host.Load(std::filesystem::path{HORO_TEST_GAME_MODULE_PATH}.filename(), CurrentGameplayBuildFingerprint());
+    auto relative = host.Load(std::filesystem::path{HORO_TEST_GAME_MODULE_PATH}.filename(), Expectation());
     REQUIRE(relative.HasError());
-    auto mismatch = host.Load(HORO_TEST_GAME_MODULE_PATH, "wrong-fingerprint");
+    GameModuleLoadExpectation mismatchExpectation = Expectation();
+    mismatchExpectation.buildFingerprint = "wrong-fingerprint";
+    auto mismatch = host.Load(HORO_TEST_GAME_MODULE_PATH, mismatchExpectation);
     REQUIRE(mismatch.HasError());
+    REQUIRE(mismatch.ErrorValue().code.Value() == GameplayErrors::IncompatibleGameModule.code.Value());
 
-    auto loaded = host.Load(HORO_TEST_GAME_MODULE_PATH, CurrentGameplayBuildFingerprint());
+    auto loaded = host.Load(HORO_TEST_GAME_MODULE_PATH, Expectation());
     REQUIRE(loaded.HasValue());
     REQUIRE(loaded.Value()->ModuleId() == "game.tests");
     REQUIRE(loaded.Value()->Registry().IsFrozen());
@@ -53,7 +116,7 @@ TEST_CASE("game module host validates an independent shadow artifact and removes
     std::filesystem::remove_all(root, ignored);
 
     GameModuleHost host;
-    auto loaded = host.LoadShadowCopy(std::filesystem::path{HORO_TEST_GAME_MODULE_PATH}, root, CurrentGameplayBuildFingerprint());
+    auto loaded = host.LoadShadowCopy(std::filesystem::path{HORO_TEST_GAME_MODULE_PATH}, root, Expectation());
     REQUIRE(loaded.HasValue());
     std::unique_ptr<LoadedGameModule> module = std::move(loaded).Value();
     const std::filesystem::path shadowPath = module->LoadedArtifactPath();
@@ -64,4 +127,41 @@ TEST_CASE("game module host validates an independent shadow artifact and removes
     module.reset();
     REQUIRE_FALSE(std::filesystem::exists(shadowPath));
     std::filesystem::remove_all(root, ignored);
+}
+
+TEST_CASE("generated gameplay bundle validation rejects incompatible identity before lifecycle activation") {
+    ValidBundleStorage storage;
+    const GameModuleLoadExpectation expected{
+        .moduleId = "game.tests",
+        .buildFingerprint = CurrentGameplayBuildFingerprint(),
+        .descriptorRevision = 7,
+    };
+    REQUIRE(ValidateGeneratedGameplayDescriptorBundle(storage.bundle, expected).HasValue());
+
+    storage.bundle.descriptorRevision = 8;
+    const auto mismatch = ValidateGeneratedGameplayDescriptorBundle(storage.bundle, expected);
+    REQUIRE(mismatch.HasError());
+    REQUIRE(mismatch.ErrorValue().code.Value() == GameplayErrors::IncompatibleGameModule.code.Value());
+}
+
+TEST_CASE("generated gameplay bundle validation rejects incomplete bindings and bounded diagnostics") {
+    ValidBundleStorage storage;
+    const GameModuleLoadExpectation expected{
+        .moduleId = "game.tests",
+        .buildFingerprint = CurrentGameplayBuildFingerprint(),
+        .descriptorRevision = 7,
+    };
+
+    storage.binding.factory.create = nullptr;
+    const auto invalidBinding = ValidateGeneratedGameplayDescriptorBundle(storage.bundle, expected);
+    REQUIRE(invalidBinding.HasError());
+    REQUIRE(invalidBinding.ErrorValue().code.Value() == GameplayErrors::InvalidGeneratedDescriptorBundle.code.Value());
+
+    storage.binding.factory.create = &CreateTestBehavior;
+    const GeneratedDescriptorDiagnostic diagnostic{.code = "gameplay.codegen.failure", .message = "annotation rejected"};
+    storage.bundle.diagnostics = &diagnostic;
+    storage.bundle.diagnosticCount = 1;
+    const auto diagnostics = ValidateGeneratedGameplayDescriptorBundle(storage.bundle, expected);
+    REQUIRE(diagnostics.HasError());
+    REQUIRE(diagnostics.ErrorValue().code.Value() == GameplayErrors::GeneratedDescriptorDiagnosticsPresent.code.Value());
 }


### PR DESCRIPTION
## Summary

- generate a deterministic, versioned gameplay descriptor bundle with separate metadata, native factory bindings, diagnostics, and lifecycle callbacks
- validate manifest, module, bundle, and lifecycle identity before any project gameplay code starts
- publish the generated descriptor revision through the artifact manifest and preserve it through editor/build validation
- add generator, host, registry, and build-service regression coverage

## Validation

- `python3 scripts/dev.py format --check`
- `python -m pytest -q tests/python/test_gameplay_descriptor_generator.py`
- `cmake --build build/skeleton --parallel 8`
- relevant native CTest selection: 8/8 passed after rebase
- full native suite: 671/671 passed after rerunning the corrected gameplay build-service case; one unrelated local Python tooling test is affected by the machine global Git ignore configuration
- Codacy CLI (Lizard, Opengrep, Pylint): 0 findings on changed files
- Sonar CLI secrets: 0 findings; organization Vortex pre-PR analysis unavailable (403), so PR analysis is authoritative
- instrumented core line coverage: 81.10% (`GameModule.cpp`: 91.36%)

## Contract

This intentionally increments the exact-generation gameplay SDK boundary from 1 to 2. Existing native gameplay modules must be rebuilt; the generated manifest revision now derives deterministically from module descriptor inputs.

Closes #144