### PR TITLE
feat(audio): add typed identity and handle contracts HORO-526 #526 [AUD-001.2]

### DIFF
--- a/cmake/HoroDependencyPolicy.cmake
+++ b/cmake/HoroDependencyPolicy.cmake
@@ -9,6 +9,7 @@ horo_allow_target_dependencies(TARGET HoroApplication DEPENDENCIES HoroFoundatio
 horo_allow_target_dependencies(TARGET HoroProjectMigrations DEPENDENCIES HoroApplication)
 horo_allow_target_dependencies(TARGET HoroRuntime DEPENDENCIES HoroFoundation)
 horo_allow_target_dependencies(TARGET HoroAssets DEPENDENCIES HoroFoundation)
+horo_allow_target_dependencies(TARGET HoroAudioApi DEPENDENCIES HoroFoundation HoroAssets)
 horo_allow_target_dependencies(TARGET HoroInput DEPENDENCIES HoroFoundation)
 horo_allow_target_dependencies(TARGET HoroInputSdl DEPENDENCIES HoroInput)
 

--- a/cmake/HoroPublicHeaderOwnership.cmake
+++ b/cmake/HoroPublicHeaderOwnership.cmake
@@ -107,6 +107,10 @@ horo_configure_target_header_boundary(HoroAssets PUBLIC_HEADERS
     Horo/Assets/CookCatalog.h
     Horo/Assets/MeshEditorPayload.h
 )
+horo_configure_target_header_boundary(HoroAudioApi PUBLIC_HEADERS
+    Horo/Audio/AudioErrors.h
+    Horo/Audio/AudioIdentity.h
+)
 horo_configure_target_header_boundary(HoroInput PUBLIC_HEADERS
     Horo/Runtime/Input.h
 )

--- a/docs/architecture/foundation/current-target-and-dependency-inventory.md
+++ b/docs/architecture/foundation/current-target-and-dependency-inventory.md
@@ -179,7 +179,7 @@ conflicts are recorded rather than treated as additional implementations.
 | `HoroEngine::SceneModel` | Partial | Target exists but publicly depends on RenderApi, contrary to the documented Foundation-only level. |
 | `HoroEngine::RuntimeScene` | Implemented | `HoroRuntimeScene`; Build System still calls this `HoroEngine::SceneRuntime`. |
 | `HoroEngine::Physics` | Planned | Architecture and placeholder paths exist; no production target. |
-| `HoroEngine::AudioApi` | Planned | Architecture and placeholder public path exist; no production target. |
+| `HoroEngine::AudioApi` | Partial | Target owns typed audio identities, generation-safe handles and stable errors; runtime commands and processing contracts remain planned. |
 | `HoroEngine::AudioRuntime` | Planned | Architecture exists; no production target. |
 | `HoroEngine::AudioPlatform` | Absent | No target or implementation path. |
 | `HoroEngine::AudioNull` | Absent | No target or implementation path. |

--- a/docs/architecture/foundation/header-visibility-and-ownership.md
+++ b/docs/architecture/foundation/header-visibility-and-ownership.md
@@ -88,3 +88,11 @@ It may become private only after those signatures migrate to Horo-owned types.
 `ProjectAssetImportCommitter` remains target-private behind an out-of-line
 `AssetImportModal` destructor; do not reintroduce its `src/` include in the public
 modal header.
+
+## AUD-001.2 Migration Notes
+
+`HoroEngine::AudioApi` now owns `Horo/Audio/AudioIdentity.h` and
+`Horo/Audio/AudioErrors.h`. New audio consumers must link that target instead of
+copying untyped integers or depending on a concrete device backend. There are no
+existing audio API callers to migrate. The handle registry remains target-private;
+only stable IDs and generation-safe client handles cross the public boundary.

--- a/docs/architecture/runtime/audio-architecture.md
+++ b/docs/architecture/runtime/audio-architecture.md
@@ -192,13 +192,31 @@ by ADR-062.
 ## Handles
 
 ```cpp
-using AudioClipHandle = Handle<AudioClipTag>;
-using AudioVoiceHandle = Handle<AudioVoiceTag>;
-using AudioBusHandle = Handle<AudioBusTag>;
+template<typename Tag>
+struct AudioHandle {
+    AudioRuntimeId owner;
+    uint32_t slot;
+    uint32_t generation;
+};
+
+using AudioClipHandle = AudioHandle<AudioClipHandleTag>;
+using AudioVoiceHandle = AudioHandle<AudioVoiceHandleTag>;
+using AudioBusHandle = AudioHandle<AudioBusHandleTag>;
 ```
 
-Handles are generation checked. Asset IDs remain the persistent identity for
-clips and streams.
+Handles are process-local, registry-owned, and generation checked. The non-zero
+`AudioRuntimeId` owner prevents a numerically equal slot/generation from another
+runtime replacement from aliasing current state. Slot generations never wrap;
+an exhausted slot is retired permanently. Asset IDs remain the persistent
+identity for clips and sound definitions through distinct `AudioClipId` and
+`AudioSoundId` wrappers. `AudioBusId`, `AudioParameterId`, and `AudioEventId` are
+distinct stable numeric identities resolved before real-time processing.
+
+Malformed, foreign-owner, stale, capacity-exhausted, and generation-exhausted
+handles produce distinct `horo.audio` errors. Operation-specific error messages
+carry bounded owner/slot/generation context; callers branch only on the stable
+descriptor code. Native device identifiers never enter these public values;
+`AudioDeviceId` is a generation-scoped Horo handle.
 
 ## Internal Processing Format
 

--- a/include/Horo/Audio/AudioErrors.h
+++ b/include/Horo/Audio/AudioErrors.h
@@ -1,0 +1,23 @@
+#pragma once
+
+/**
+ * @file AudioErrors.h
+ * @brief Stable backend-neutral audio failure identities.
+ */
+
+#include "Horo/Foundation/ErrorCode.h"
+
+namespace Horo::Audio::AudioErrors {
+    extern const ErrorCodeDescriptor IdentityInvalid;
+    extern const ErrorCodeDescriptor HandleMalformed;
+    extern const ErrorCodeDescriptor HandleOwnerMismatch;
+    extern const ErrorCodeDescriptor HandleStale;
+    extern const ErrorCodeDescriptor HandleCapacityExhausted;
+    extern const ErrorCodeDescriptor HandleGenerationExhausted;
+    extern const ErrorCodeDescriptor CapabilityUnavailable;
+    extern const ErrorCodeDescriptor OperationUnsupported;
+    extern const ErrorCodeDescriptor OperationCancelled;
+    extern const ErrorCodeDescriptor RuntimeInactive;
+    extern const ErrorCodeDescriptor DeviceUnavailable;
+    extern const ErrorCodeDescriptor BackendFailed;
+}  // namespace Horo::Audio::AudioErrors

--- a/include/Horo/Audio/AudioIdentity.h
+++ b/include/Horo/Audio/AudioIdentity.h
@@ -1,0 +1,145 @@
+#pragma once
+
+/**
+ * @file AudioIdentity.h
+ * @brief Stable audio identities and generation-safe process-local handles.
+ */
+
+#include "Horo/Assets/AssetId.h"
+#include "Horo/Audio/AudioErrors.h"
+#include "Horo/Foundation/Result.h"
+
+#include <compare>
+#include <cstdint>
+
+namespace Horo::Audio {
+    /** @brief Maximum number of live or reusable slots admitted by one audio handle registry. */
+    inline constexpr std::uint32_t MaximumAudioHandleSlots = 1'048'576;
+
+    /** @brief Strong persistent identity backed by the canonical Assets identity. */
+    template <typename Tag> class AudioAssetIdentity final {
+    public:
+        AudioAssetIdentity() = default;
+
+        /**
+         * @brief Creates an audio identity from a persistent asset identity.
+         * @param asset Canonical asset identity owned by the Assets subsystem.
+         * @return Typed audio identity or an identity validation error.
+         */
+        [[nodiscard]] static Result<AudioAssetIdentity> Create(const Assets::AssetId &asset) {
+            if (!asset.IsValid())
+                return Result<AudioAssetIdentity>::Failure(MakeError(AudioErrors::IdentityInvalid));
+            return Result<AudioAssetIdentity>::Success(AudioAssetIdentity{asset});
+        }
+
+        /** @brief Returns the persistent asset identity. @return Borrowed canonical Assets identity. */
+        [[nodiscard]] const Assets::AssetId &Asset() const noexcept {
+            return asset_;
+        }
+
+        /** @brief Reports whether this value contains a non-zero persistent identity. @return True for a usable identity. */
+        [[nodiscard]] bool IsValid() const noexcept {
+            return asset_.IsValid();
+        }
+
+        [[nodiscard]] auto operator<=>(const AudioAssetIdentity &) const noexcept = default;
+
+    private:
+        explicit AudioAssetIdentity(const Assets::AssetId &asset) : asset_(asset) {}
+
+        Assets::AssetId asset_;
+    };
+
+    /** @brief Strong stable numeric identity resolved before real-time processing. */
+    template <typename Tag> class AudioStableIdentity final {
+    public:
+        AudioStableIdentity() = default;
+
+        /**
+         * @brief Creates a stable identity from its canonical encoded value.
+         * @param value Non-zero persistent value assigned by the owning model or registry.
+         * @return Typed identity or an identity validation error.
+         */
+        [[nodiscard]] static Result<AudioStableIdentity> Create(const std::uint64_t value) {
+            if (value == 0)
+                return Result<AudioStableIdentity>::Failure(MakeError(AudioErrors::IdentityInvalid));
+            return Result<AudioStableIdentity>::Success(AudioStableIdentity{value});
+        }
+
+        /** @brief Returns the canonical encoded value. @return Non-zero value for a valid identity. */
+        [[nodiscard]] constexpr std::uint64_t Value() const noexcept {
+            return value_;
+        }
+
+        /** @brief Reports whether this value contains a non-zero identity. @return True for a usable identity. */
+        [[nodiscard]] constexpr bool IsValid() const noexcept {
+            return value_ != 0;
+        }
+
+        [[nodiscard]] auto operator<=>(const AudioStableIdentity &) const noexcept = default;
+
+    private:
+        explicit constexpr AudioStableIdentity(const std::uint64_t value) : value_(value) {}
+
+        std::uint64_t value_{};
+    };
+
+    struct AudioClipIdentityTag;
+    struct AudioSoundIdentityTag;
+    struct AudioBusIdentityTag;
+    struct AudioParameterIdentityTag;
+    struct AudioEventIdentityTag;
+    struct AudioRuntimeIdentityTag;
+
+    /** @brief Persistent identity of one authored or cooked audio clip asset. */
+    using AudioClipId = AudioAssetIdentity<AudioClipIdentityTag>;
+    /** @brief Persistent identity of one playable audio sound definition. */
+    using AudioSoundId = AudioAssetIdentity<AudioSoundIdentityTag>;
+    /** @brief Stable identity of one mixer bus; display names and positions are not identity. */
+    using AudioBusId = AudioStableIdentity<AudioBusIdentityTag>;
+    /** @brief Stable parameter identity resolved before callback submission. */
+    using AudioParameterId = AudioStableIdentity<AudioParameterIdentityTag>;
+    /** @brief Stable event identity resolved before callback submission. */
+    using AudioEventId = AudioStableIdentity<AudioEventIdentityTag>;
+    /** @brief Process-local owner identity of one audio runtime generation. */
+    using AudioRuntimeId = AudioStableIdentity<AudioRuntimeIdentityTag>;
+
+    /** @brief Alias used by middleware contracts for stable parameter identity. */
+    using StableParameterId = AudioParameterId;
+    /** @brief Alias used by middleware contracts for stable event identity. */
+    using StableEventId = AudioEventId;
+
+    /** @brief Registry-owned process-local handle that cannot be serialized. */
+    template <typename Tag> struct AudioHandle final {
+        AudioRuntimeId owner;       /**< Exact audio runtime generation that issued the handle. */
+        std::uint32_t slot{};       /**< Non-zero slot in the owning typed registry. */
+        std::uint32_t generation{}; /**< Non-zero slot generation; retired values never wrap. */
+
+        /** @brief Reports whether owner, slot, and generation are all present. @return True for a well-formed handle. */
+        [[nodiscard]] constexpr bool IsValid() const noexcept {
+            return owner.IsValid() && slot != 0 && generation != 0;
+        }
+
+        [[nodiscard]] constexpr auto operator<=>(const AudioHandle &) const noexcept = default;
+    };
+
+    struct AudioClipHandleTag;
+    struct AudioVoiceHandleTag;
+    struct AudioBusHandleTag;
+    struct AudioEventInstanceTag;
+    struct AudioDeviceIdentityTag;
+    struct AudioSceneContextHandleTag;
+
+    /** @brief Generation-safe handle to one prepared runtime clip. */
+    using AudioClipHandle = AudioHandle<AudioClipHandleTag>;
+    /** @brief Generation-safe handle to one admitted playback voice. */
+    using AudioVoiceHandle = AudioHandle<AudioVoiceHandleTag>;
+    /** @brief Generation-safe handle to one active mixer bus generation. */
+    using AudioBusHandle = AudioHandle<AudioBusHandleTag>;
+    /** @brief Generation-safe identity of one active middleware event instance. */
+    using AudioEventInstanceId = AudioHandle<AudioEventInstanceTag>;
+    /** @brief Generation-scoped Horo device identity that exposes no native device value. */
+    using AudioDeviceId = AudioHandle<AudioDeviceIdentityTag>;
+    /** @brief Generation-safe client handle to one active scene audio context. */
+    using AudioSceneContextHandle = AudioHandle<AudioSceneContextHandleTag>;
+}  // namespace Horo::Audio

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -247,6 +247,14 @@ target_link_libraries(HoroAssets
 )
 target_link_libraries(HoroRuntimeScene PUBLIC HoroEngine::Assets)
 
+add_library(HoroAudioApi STATIC
+        audio/api/AudioErrors.cpp
+        audio/api/AudioHandleRegistry.h
+)
+add_library(HoroEngine::AudioApi ALIAS HoroAudioApi)
+target_compile_features(HoroAudioApi PUBLIC cxx_std_20)
+target_link_libraries(HoroAudioApi PUBLIC HoroEngine::Foundation HoroEngine::Assets)
+
 add_library(HoroInput STATIC
         runtime/input/Input.cpp
         runtime/input/InputErrors.cpp

--- a/src/audio/api/AudioErrors.cpp
+++ b/src/audio/api/AudioErrors.cpp
@@ -1,0 +1,116 @@
+#include "Horo/Audio/AudioErrors.h"
+
+namespace Horo::Audio::AudioErrors {
+    namespace {
+        const ErrorDomainId AudioDomain{"horo.audio"};
+    }
+
+    const ErrorCodeDescriptor IdentityInvalid{
+        .domain = AudioDomain,
+        .code = ErrorCode{"audio.identity.invalid"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "The audio identity is invalid.",
+        .remediationHint = "Provide a non-zero stable value or persistent asset identity from its owning registry.",
+        .retryable = false,
+        .userActionable = true,
+    };
+    const ErrorCodeDescriptor HandleMalformed{
+        .domain = AudioDomain,
+        .code = ErrorCode{"audio.handle.malformed"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "The audio handle is malformed.",
+        .remediationHint = "Use a handle issued by the active audio runtime registry.",
+        .retryable = false,
+        .userActionable = false,
+    };
+    const ErrorCodeDescriptor HandleOwnerMismatch{
+        .domain = AudioDomain,
+        .code = ErrorCode{"audio.handle.owner_mismatch"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "The audio handle belongs to another runtime generation.",
+        .remediationHint = "Resolve the stable audio identity again after runtime replacement.",
+        .retryable = false,
+        .userActionable = false,
+    };
+    const ErrorCodeDescriptor HandleStale{
+        .domain = AudioDomain,
+        .code = ErrorCode{"audio.handle.stale"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "The audio handle generation is stale or retired.",
+        .remediationHint = "Discard the handle and resolve the stable audio identity against the current runtime.",
+        .retryable = false,
+        .userActionable = false,
+    };
+    const ErrorCodeDescriptor HandleCapacityExhausted{
+        .domain = AudioDomain,
+        .code = ErrorCode{"audio.handle.capacity_exhausted"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "The bounded audio handle registry has no available slot.",
+        .remediationHint = "Release inactive objects or increase the validated control-runtime capacity.",
+        .retryable = true,
+        .userActionable = true,
+    };
+    const ErrorCodeDescriptor HandleGenerationExhausted{
+        .domain = AudioDomain,
+        .code = ErrorCode{"audio.handle.generation_exhausted"},
+        .defaultSeverity = ErrorSeverity::Critical,
+        .summary = "Every remaining audio handle slot exhausted its generation range.",
+        .remediationHint = "Replace the audio runtime; exhausted slots are never reused.",
+        .retryable = false,
+        .userActionable = false,
+    };
+    const ErrorCodeDescriptor CapabilityUnavailable{
+        .domain = AudioDomain,
+        .code = ErrorCode{"audio.capability.unavailable"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "A required audio capability is unavailable.",
+        .remediationHint = "Select a composition that explicitly provides the required capability.",
+        .retryable = false,
+        .userActionable = true,
+    };
+    const ErrorCodeDescriptor OperationUnsupported{
+        .domain = AudioDomain,
+        .code = ErrorCode{"audio.operation.unsupported"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "The selected audio composition does not support this operation.",
+        .remediationHint = "Choose a supported operation or an audio provider that declares the capability.",
+        .retryable = false,
+        .userActionable = true,
+    };
+    const ErrorCodeDescriptor OperationCancelled{
+        .domain = AudioDomain,
+        .code = ErrorCode{"audio.operation.cancelled"},
+        .defaultSeverity = ErrorSeverity::Info,
+        .summary = "The audio operation was cancelled.",
+        .remediationHint = "Retry only if the owning runtime and producer generation remain active.",
+        .retryable = true,
+        .userActionable = false,
+    };
+    const ErrorCodeDescriptor RuntimeInactive{
+        .domain = AudioDomain,
+        .code = ErrorCode{"audio.runtime.inactive"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "The audio runtime is not active.",
+        .remediationHint = "Submit work only after successful runtime activation and before shutdown begins.",
+        .retryable = true,
+        .userActionable = false,
+    };
+    const ErrorCodeDescriptor DeviceUnavailable{
+        .domain = AudioDomain,
+        .code = ErrorCode{"audio.device.unavailable"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "The selected audio device is unavailable.",
+        .remediationHint = "Re-enumerate through the active backend or select an explicitly supported composition.",
+        .retryable = true,
+        .userActionable = true,
+    };
+    const ErrorCodeDescriptor BackendFailed{
+        .domain = AudioDomain,
+        .code = ErrorCode{"audio.backend.failed"},
+        .defaultSeverity = ErrorSeverity::Error,
+        .summary = "The selected audio backend failed.",
+        .remediationHint = "Inspect the bounded backend diagnostic cause and follow host recovery policy.",
+        .retryable = true,
+        .userActionable = false,
+    };
+}  // namespace Horo::Audio::AudioErrors

--- a/src/audio/api/AudioHandleRegistry.h
+++ b/src/audio/api/AudioHandleRegistry.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include "Horo/Audio/AudioIdentity.h"
+
+#include <cstddef>
+#include <format>
+#include <limits>
+#include <new>
+#include <vector>
+
+namespace Horo::Audio::Detail {
+    struct AudioHandleRegistryLimits {
+        std::uint32_t maximumSlots{65'535};
+        std::uint32_t maximumGeneration{std::numeric_limits<std::uint32_t>::max()};
+
+        [[nodiscard]] bool IsValid() const noexcept {
+            return maximumSlots > 0 && maximumSlots <= MaximumAudioHandleSlots && maximumGeneration > 0;
+        }
+    };
+
+    template <typename Handle> class AudioHandleRegistry final {
+    public:
+        [[nodiscard]] static Result<AudioHandleRegistry> Create(const AudioRuntimeId owner, const AudioHandleRegistryLimits limits = {}) {
+            if (!owner.IsValid() || !limits.IsValid())
+                return Result<AudioHandleRegistry>::Failure(MakeError(AudioErrors::IdentityInvalid));
+            try {
+                return Result<AudioHandleRegistry>::Success(AudioHandleRegistry{owner, limits});
+            } catch (const std::bad_alloc &) {
+                return Result<AudioHandleRegistry>::Failure(MakeError(AudioErrors::HandleCapacityExhausted));
+            }
+        }
+
+        AudioHandleRegistry(const AudioHandleRegistry &) = delete;
+        AudioHandleRegistry &operator=(const AudioHandleRegistry &) = delete;
+        AudioHandleRegistry(AudioHandleRegistry &&) noexcept = default;
+        AudioHandleRegistry &operator=(AudioHandleRegistry &&) noexcept = default;
+
+        [[nodiscard]] Result<Handle> Acquire() {
+            if (!freeSlots_.empty()) {
+                const std::uint32_t slot = freeSlots_.back();
+                freeSlots_.pop_back();
+                entries_[slot].active = true;
+                ++activeCount_;
+                return Result<Handle>::Success(Handle{owner_, slot, entries_[slot].generation});
+            }
+            if (entries_.size() - 1 >= limits_.maximumSlots) {
+                const ErrorCodeDescriptor &error =
+                    exhaustedSlots_ == limits_.maximumSlots ? AudioErrors::HandleGenerationExhausted : AudioErrors::HandleCapacityExhausted;
+                return Result<Handle>::Failure(MakeError(error));
+            }
+            entries_.emplace_back();
+            ++activeCount_;
+            const auto slot = static_cast<std::uint32_t>(entries_.size() - 1);
+            return Result<Handle>::Success(Handle{owner_, slot, entries_.back().generation});
+        }
+
+        [[nodiscard]] Result<std::uint32_t> Resolve(const Handle &handle) const {
+            if (!handle.IsValid())
+                return Result<std::uint32_t>::Failure(MakeError(AudioErrors::HandleMalformed));
+            if (handle.owner != owner_)
+                return Result<std::uint32_t>::Failure(HandleError(AudioErrors::HandleOwnerMismatch, handle));
+            if (handle.slot >= entries_.size())
+                return Result<std::uint32_t>::Failure(HandleError(AudioErrors::HandleStale, handle));
+            const Entry &entry = entries_[handle.slot];
+            if (!entry.active || entry.generation != handle.generation)
+                return Result<std::uint32_t>::Failure(HandleError(AudioErrors::HandleStale, handle));
+            return Result<std::uint32_t>::Success(handle.slot);
+        }
+
+        [[nodiscard]] Result<void> Release(const Handle &handle) {
+            Result<std::uint32_t> resolved = Resolve(handle);
+            if (resolved.HasError())
+                return Result<void>::Failure(resolved.ErrorValue());
+            Entry &entry = entries_[resolved.Value()];
+            entry.active = false;
+            --activeCount_;
+            if (entry.generation == limits_.maximumGeneration) {
+                ++exhaustedSlots_;
+                return Result<void>::Success();
+            }
+            ++entry.generation;
+            freeSlots_.push_back(handle.slot);
+            return Result<void>::Success();
+        }
+
+        [[nodiscard]] std::size_t ActiveCount() const noexcept {
+            return activeCount_;
+        }
+
+    private:
+        struct Entry {
+            std::uint32_t generation{1};
+            bool active{true};
+        };
+
+        AudioHandleRegistry(const AudioRuntimeId owner, const AudioHandleRegistryLimits limits) : owner_(owner), limits_(limits) {
+            entries_.reserve(static_cast<std::size_t>(limits.maximumSlots) + 1);
+            freeSlots_.reserve(limits.maximumSlots);
+            entries_.push_back({.generation = 0, .active = false});
+        }
+
+        [[nodiscard]] static Error HandleError(const ErrorCodeDescriptor &descriptor, const Handle &handle) {
+            return MakeError(descriptor, std::format("Audio handle owner {}, slot {}, generation {} is not current.", handle.owner.Value(),
+                                                     handle.slot, handle.generation));
+        }
+
+        AudioRuntimeId owner_;
+        AudioHandleRegistryLimits limits_;
+        std::vector<Entry> entries_;
+        std::vector<std::uint32_t> freeSlots_;
+        std::size_t activeCount_{};
+        std::uint32_t exhaustedSlots_{};
+    };
+}  // namespace Horo::Audio::Detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -132,6 +132,13 @@ add_executable(HoroInputTests
 )
 target_compile_features(HoroInputTests PRIVATE cxx_std_20)
 target_link_libraries(HoroInputTests PRIVATE HoroEngine::Input)
+add_executable(HoroAudioApiTests
+        unit/runtime/audio/AudioIdentityTests.cpp
+)
+target_include_directories(HoroAudioApiTests PRIVATE ${PROJECT_SOURCE_DIR}/src/audio/api)
+target_compile_features(HoroAudioApiTests PRIVATE cxx_std_20)
+target_link_libraries(HoroAudioApiTests PRIVATE HoroEngine::AudioApi)
+horo_register_catch_test(HoroAudioApiTests LABELS "unit;audio;headless")
 add_executable(HoroGameplayRuntimeTests
         unit/gameplay/BehaviorRuntimeTests.cpp
         unit/gameplay/ComponentRegistryTests.cpp

--- a/tests/unit/runtime/audio/AudioIdentityTests.cpp
+++ b/tests/unit/runtime/audio/AudioIdentityTests.cpp
@@ -1,0 +1,141 @@
+#include "AudioHandleRegistry.h"
+#include "Horo/Audio/AudioErrors.h"
+#include "Horo/Audio/AudioIdentity.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include <type_traits>
+
+namespace Horo::Audio {
+    namespace {
+        template <typename Id> Id StableId(const std::uint64_t value) {
+            Result<Id> parsed = Id::Create(value);
+            REQUIRE(parsed.HasValue());
+            return std::move(parsed).Value();
+        }
+
+        TEST_CASE("Audio identities are strongly typed and reject zero values", "[unit][audio][identity]") {
+            REQUIRE(AudioBusId::Create(0).HasError());
+            REQUIRE(AudioParameterId::Create(0).HasError());
+            REQUIRE(AudioEventId::Create(0).HasError());
+
+            const AudioBusId bus = StableId<AudioBusId>(11);
+            const AudioParameterId parameter = StableId<AudioParameterId>(11);
+            const AudioEventId event = StableId<AudioEventId>(11);
+            REQUIRE(bus.IsValid());
+            REQUIRE(parameter.IsValid());
+            REQUIRE(event.IsValid());
+            static_assert(!std::is_same_v<AudioBusId, AudioParameterId>);
+            static_assert(!std::is_same_v<AudioParameterId, AudioEventId>);
+        }
+
+        TEST_CASE("Audio asset identities preserve canonical asset identity", "[unit][audio][identity]") {
+            REQUIRE(AudioClipId::Create({}).HasError());
+            REQUIRE(AudioSoundId::Create({}).HasError());
+
+            const auto asset = Assets::AssetId::Parse("032bc03d-4b5f-48dc-9ae7-493cbce36e12");
+            REQUIRE(asset.HasValue());
+            const auto clip = AudioClipId::Create(asset.Value());
+            const auto sound = AudioSoundId::Create(asset.Value());
+            REQUIRE(clip.HasValue());
+            REQUIRE(sound.HasValue());
+            REQUIRE((clip.Value().Asset() == asset.Value()));
+            REQUIRE((sound.Value().Asset() == asset.Value()));
+            static_assert(!std::is_same_v<AudioClipId, AudioSoundId>);
+        }
+
+        TEST_CASE("Audio handles require owner slot and generation", "[unit][audio][identity]") {
+            const AudioRuntimeId owner = StableId<AudioRuntimeId>(7);
+            REQUIRE_FALSE(AudioVoiceHandle{}.IsValid());
+            REQUIRE_FALSE(AudioVoiceHandle{owner, 1, 0}.IsValid());
+            REQUIRE(AudioVoiceHandle{owner, 1, 1}.IsValid());
+            static_assert(!std::is_same_v<AudioVoiceHandle, AudioClipHandle>);
+            static_assert(!std::is_same_v<AudioDeviceId, AudioEventInstanceId>);
+        }
+
+        TEST_CASE("Audio registry rejects malformed and foreign handles", "[unit][audio][identity]") {
+            const AudioRuntimeId owner = StableId<AudioRuntimeId>(7);
+            auto created = Detail::AudioHandleRegistry<AudioVoiceHandle>::Create(owner, {.maximumSlots = 2});
+            REQUIRE(created.HasValue());
+            auto registry = std::move(created).Value();
+
+            const auto malformed = registry.Resolve({});
+            REQUIRE(malformed.HasError());
+            REQUIRE((malformed.ErrorValue().code.Value() == AudioErrors::HandleMalformed.code.Value()));
+
+            const AudioVoiceHandle foreign{StableId<AudioRuntimeId>(8), 1, 1};
+            const auto mismatched = registry.Resolve(foreign);
+            REQUIRE(mismatched.HasError());
+            REQUIRE((mismatched.ErrorValue().code.Value() == AudioErrors::HandleOwnerMismatch.code.Value()));
+            REQUIRE((mismatched.ErrorValue().message.find("owner 8, slot 1, generation 1") != std::string::npos));
+        }
+
+        TEST_CASE("Stale audio handle cannot resolve a reused slot", "[unit][audio][identity]") {
+            const AudioRuntimeId owner = StableId<AudioRuntimeId>(21);
+            auto created = Detail::AudioHandleRegistry<AudioVoiceHandle>::Create(owner, {.maximumSlots = 1});
+            REQUIRE(created.HasValue());
+            auto registry = std::move(created).Value();
+
+            const auto first = registry.Acquire();
+            REQUIRE(first.HasValue());
+            REQUIRE((registry.ActiveCount() == 1));
+            const auto full = registry.Acquire();
+            REQUIRE(full.HasError());
+            REQUIRE((full.ErrorValue().code.Value() == AudioErrors::HandleCapacityExhausted.code.Value()));
+            REQUIRE(registry.Release(first.Value()).HasValue());
+            REQUIRE(registry.Release(first.Value()).HasError());
+
+            const auto replacement = registry.Acquire();
+            REQUIRE(replacement.HasValue());
+            REQUIRE((replacement.Value().slot == first.Value().slot));
+            REQUIRE((replacement.Value().generation == first.Value().generation + 1));
+            REQUIRE(registry.Resolve(replacement.Value()).HasValue());
+
+            const auto stale = registry.Resolve(first.Value());
+            REQUIRE(stale.HasError());
+            REQUIRE((stale.ErrorValue().code.Value() == AudioErrors::HandleStale.code.Value()));
+            REQUIRE((stale.ErrorValue().message.find("slot 1, generation 1") != std::string::npos));
+            const auto absent = registry.Resolve(AudioVoiceHandle{owner, 2, 1});
+            REQUIRE(absent.HasError());
+            REQUIRE((absent.ErrorValue().code.Value() == AudioErrors::HandleStale.code.Value()));
+        }
+
+        TEST_CASE("Exhausted audio handle generations are never reused", "[unit][audio][identity]") {
+            const AudioRuntimeId owner = StableId<AudioRuntimeId>(34);
+            auto created = Detail::AudioHandleRegistry<AudioVoiceHandle>::Create(owner, {.maximumSlots = 1, .maximumGeneration = 2});
+            REQUIRE(created.HasValue());
+            auto registry = std::move(created).Value();
+
+            const auto first = registry.Acquire();
+            REQUIRE(first.HasValue());
+            REQUIRE(registry.Release(first.Value()).HasValue());
+            const auto second = registry.Acquire();
+            REQUIRE(second.HasValue());
+            REQUIRE((second.Value().generation == 2));
+            REQUIRE(registry.Release(second.Value()).HasValue());
+
+            const auto exhausted = registry.Acquire();
+            REQUIRE(exhausted.HasError());
+            REQUIRE((exhausted.ErrorValue().code.Value() == AudioErrors::HandleGenerationExhausted.code.Value()));
+            REQUIRE((registry.ActiveCount() == 0));
+        }
+
+        TEST_CASE("Audio handle registry validates bounded construction", "[unit][audio][identity]") {
+            REQUIRE(Detail::AudioHandleRegistry<AudioVoiceHandle>::Create({}, {}).HasError());
+            const AudioRuntimeId owner = StableId<AudioRuntimeId>(55);
+            REQUIRE(Detail::AudioHandleRegistry<AudioVoiceHandle>::Create(owner, {.maximumSlots = 0}).HasError());
+            REQUIRE(Detail::AudioHandleRegistry<AudioVoiceHandle>::Create(owner, {.maximumGeneration = 0}).HasError());
+            REQUIRE(Detail::AudioHandleRegistry<AudioVoiceHandle>::Create(owner, {.maximumSlots = MaximumAudioHandleSlots + 1}).HasError());
+        }
+
+        TEST_CASE("Audio errors expose stable definitive descriptors", "[unit][audio][errors]") {
+            REQUIRE((AudioErrors::IdentityInvalid.domain.Value() == "horo.audio"));
+            REQUIRE((AudioErrors::IdentityInvalid.code.Value() == "audio.identity.invalid"));
+            REQUIRE((AudioErrors::HandleStale.code.Value() == "audio.handle.stale"));
+            REQUIRE_FALSE(AudioErrors::HandleStale.retryable);
+            REQUIRE(AudioErrors::HandleCapacityExhausted.retryable);
+            REQUIRE((AudioErrors::DeviceUnavailable.code.Value() == "audio.device.unavailable"));
+            REQUIRE((AudioErrors::BackendFailed.code.Value() == "audio.backend.failed"));
+        }
+    }  // namespace
+}  // namespace Horo::Audio


### PR DESCRIPTION
## Summary
- Adds the first narrow `HoroEngine::AudioApi` public contract for persistent audio asset identities, stable control identities, and generation-safe process-local handles.
- Adds definitive `horo.audio` error descriptors and a bounded private handle registry with stale, foreign-owner, capacity, and generation-exhaustion handling.

## Motivation
- AUD-001.2 requires typed, backend-neutral identities and handles before later device, routing, scene, and event runtime work can safely build on the audio boundary.

## Implementation Notes
- Persistent clip and sound identities wrap canonical `Assets::AssetId`; bus, parameter, event, and runtime identities use distinct strong types.
- Handles carry runtime owner, slot, and generation. Exhausted generations retire their slot instead of wrapping.
- The registry remains target-private; public headers expose only stable value contracts.
- Error descriptors use the repository definitive designated-field format.

## Validation
- [x] Build passed
- [x] Relevant tests passed
- [x] Manual smoke tested if applicable (not applicable: headless value contracts)

Commands run:
```bash
cmake -S . -B build/skeleton -DBUILD_TESTING=ON
cmake --build build/skeleton --parallel
ctest --test-dir build/skeleton -R "HoroAudioApiTests::" --output-on-failure
ctest --test-dir build/skeleton --output-on-failure -j 4
codacy-cli analyze --tool lizard --format sarif
codacy-cli analyze --tool opengrep --format sarif
sonar analyze --staged --depth DEEP --force --format json
```

Coverage: 94.29% line and 90.00% branch coverage for executable new production code.
Local quality: 0 changed-file Codacy Lizard results, 0 OpenGrep results, 0 Sonar CLI findings.
Full suite: 692/692 tests passed.

## Risks
- Later runtime registries must preserve the owner/slot/generation validation boundary and must not serialize process-local handles.
- No device, backend, callback, routing, or playback implementation is introduced in this ticket.

## Issue Links
- Jira: HORO-526
- GitHub: Closes #526

## Reviewer Notes
- Review `AudioIdentity.h` and `AudioErrors.cpp` first for the public contract, then `AudioHandleRegistry.h` and its tests for lifecycle invariants.
