### PR TITLE
feat(extensions): constrain package discovery to approved roots HORO-72 #72 [EXT-001.4]

### DIFF
--- a/cmake/HoroPublicHeaderOwnership.cmake
+++ b/cmake/HoroPublicHeaderOwnership.cmake
@@ -203,6 +203,7 @@ horo_configure_target_header_boundary(HoroGui PUBLIC_HEADERS
 
 horo_configure_target_header_boundary(HoroExtensions PUBLIC_HEADERS
     Horo/Extensions/ExtensionAbi.h
+    Horo/Extensions/ExtensionDiscovery.h
     Horo/Extensions/ExtensionErrors.h
     Horo/Extensions/ExtensionInventory.h
     Horo/Extensions/ExtensionManager.h

--- a/docs/guides/extension-discovery-migration.md
+++ b/docs/guides/extension-discovery-migration.md
@@ -1,0 +1,33 @@
+# Approved extension discovery migration
+
+HORO-72 replaces `ExtensionManager::DiscoverExtensions(directory)` with
+`Horo::Extensions::Discovery::DiscoverDeclaredPackages`, declared by
+`Horo/Extensions/ExtensionDiscovery.h` and owned by `HoroExtensions`.
+
+The removed API scanned arbitrary directories for `extension.json`, without
+root approval or containment checks. Its only repository callers were the
+extension manager tests; those now exercise declared-package discovery through
+the public header. Public-header consumer generation covers the new header.
+
+Host/package composition now supplies root requests with explicit provenance,
+local approval decisions and the package locations selected by its package
+graph. No environment variable, working directory, manifest or directory entry
+can implicitly add a root or a package. A project request does not approve itself.
+
+System roots require product-policy provenance; user and development roots
+require user-local provenance. Project roots require explicit approval of their
+portable request. Development roots additionally require both the development
+profile and invocation opt-in, and produce non-portable diagnostics.
+
+Accepted paths must exist and canonicalize strictly inside their approved root.
+Parent traversal and symlink escapes fail. Unknown root references and duplicate
+accepted package IDs fail without a partial result. Successful packages and root
+diagnostics are ordered by their stable IDs, not filesystem enumeration.
+
+This API is a discovery preflight, not a package verifier or activation candidate.
+It neither selects versions nor implements development graph substitution. Those
+remain package-system responsibilities under ADR-054 and ADR-058. Callers must
+retain verified install identity, trust and lifetime ownership through activation;
+a canonical path alone is not an execution grant or protection from later file
+mutation. The existing directory-based loader and legacy inventory are not
+upgraded to verified-install activation by this change.

--- a/include/Horo/Extensions/ExtensionDiscovery.h
+++ b/include/Horo/Extensions/ExtensionDiscovery.h
@@ -1,0 +1,109 @@
+/** @file
+ * @brief Approved, declared extension package discovery without activation or directory scanning.
+ */
+#pragma once
+
+#include "Horo/Foundation/Result.h"
+
+#include <filesystem>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace Horo::Extensions::Discovery {
+    /** @brief Provenance supplied by package/product composition, never by an extension manifest. */
+    enum class RootKind {
+        System,
+        User,
+        Project,
+        Development
+    };
+    /** @brief Local policy approval of a root; this does not approve execution of its contents. */
+    enum class RootApproval {
+        Pending,
+        Approved
+    };
+    /** @brief Configuration authority from which a root request was obtained. */
+    enum class ConfigurationOrigin {
+        ProductPolicy,
+        UserLocal,
+        ProjectPortable
+    };
+    /** @brief Operation class restricting development overrides. */
+    enum class DiscoveryProfile {
+        Development,
+        Normal,
+        ContinuousIntegration,
+        Release,
+        OfflineReproducible
+    };
+
+    /** @brief Trusted host input associating one stable root ID with its policy decision. */
+    struct RootRequest {
+        std::string id;
+        std::filesystem::path path;
+        RootKind kind{RootKind::User};
+        RootApproval approval{RootApproval::Pending};
+        ConfigurationOrigin configuration{ConfigurationOrigin::ProjectPortable};
+    };
+
+    /** @brief Explicit invocation policy; development is disabled by default. */
+    struct RootPolicy {
+        DiscoveryProfile profile{DiscoveryProfile::Normal};
+        bool enableDevelopmentOverrides{false};
+    };
+
+    /** @brief Reason recorded for every requested root without reading ignored paths. */
+    enum class RootDisposition {
+        Accepted,
+        ApprovalRequired,
+        InvalidAuthority,
+        DevelopmentDisabled,
+        DevelopmentNonPortable
+    };
+
+    /** @brief Stable diagnostic identity and policy outcome, suitable for CLI or host presentation. */
+    struct RootDiagnostic {
+        std::string rootId;
+        RootDisposition disposition;
+    };
+
+    /**
+     * @brief One package location supplied by the owning package graph, not by directory enumeration.
+     * @note Identity and approval originate outside extension manifests. Discovery does not verify
+     *       signatures, resolve versions, approve execution, or replace a verified install lease.
+     */
+    struct PackageLocation {
+        std::string packageId;
+        std::string rootId;
+        std::filesystem::path relativePath;
+    };
+
+    /** @brief Canonical package location retaining the source identity for downstream diagnostics. */
+    struct DiscoveredPackage {
+        std::string packageId;
+        std::string rootId;
+        std::filesystem::path canonicalPath;
+        RootKind kind;
+    };
+
+    /** @brief Discovery snapshot; packages are ordered by package ID, never filesystem enumeration. */
+    struct DiscoveryPlan {
+        std::vector<DiscoveredPackage> packages;
+        std::vector<RootDiagnostic> rootDiagnostics;
+        bool nonPortable{false};
+    };
+
+    /**
+     * @brief Discover only explicitly declared package locations from approved roots.
+     * @param roots Product/package composition's root requests and approval provenance.
+     * @param locations At most 4096 locations from the already selected package graph.
+     * @param policy Invocation profile and explicit development opt-in.
+     * @return Deterministic snapshot, or an error without partial results.
+     * @note Locations under ignored roots are not probed. Unknown roots and duplicate accepted
+     *       package IDs fail; discovery never chooses a version or silently shadows a package.
+     *       Package-system development substitution must happen before this hand-off.
+     */
+    [[nodiscard]] Result<DiscoveryPlan> DiscoverDeclaredPackages(std::span<const RootRequest> roots,
+                                                                 std::span<const PackageLocation> locations, const RootPolicy &policy);
+}  // namespace Horo::Extensions::Discovery

--- a/include/Horo/Extensions/ExtensionManager.h
+++ b/include/Horo/Extensions/ExtensionManager.h
@@ -24,7 +24,7 @@ namespace Horo::Extensions {
     };
 
     /**
-     * @brief Manages discovery, loading, and lifecycle of extensions.
+     * @brief Manages loading and lifecycle of extensions.
      */
     class ExtensionManager {
     public:
@@ -38,13 +38,6 @@ namespace Horo::Extensions {
         ExtensionManager &operator=(const ExtensionManager &) = delete;
         ExtensionManager(ExtensionManager &&) noexcept;
         ExtensionManager &operator=(ExtensionManager &&) noexcept;
-
-        /**
-         * @brief Discovers extensions in the specified directory.
-         * @param directoryPath Path to the extensions directory (e.g. ~/.horo/plugins).
-         * @return A list of discovered manifest paths.
-         */
-        [[nodiscard]] std::vector<std::string> DiscoverExtensions(const std::string &directoryPath) const;
 
         /**
          * @brief Loads an extension from the given directory path.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -710,6 +710,9 @@ if (HORO_BUILD_EDITOR_GUI)
 endif ()
 
 add_library(HoroExtensions STATIC
+        extensions/discovery/DiscoveryPaths.cpp
+        extensions/discovery/DiscoveryPlan.cpp
+        extensions/discovery/DiscoveryRootPolicy.cpp
         extensions/host/ExtensionManager.cpp
         extensions/manifest/ExtensionManifestParser.cpp
         extensions/manifest/ExtensionManifestJson.cpp

--- a/src/extensions/discovery/DiscoveryPaths.cpp
+++ b/src/extensions/discovery/DiscoveryPaths.cpp
@@ -28,7 +28,7 @@ namespace Horo::Extensions::Discovery {
 
         /** @brief Compare complete components, never textual prefixes such as root and root-other. */
         bool IsStrictDescendant(const std::filesystem::path &root, const std::filesystem::path &candidate) {
-            const auto [rootPosition, candidatePosition] = std::mismatch(root.begin(), root.end(), candidate.begin(), candidate.end());
+            const auto [rootPosition, candidatePosition] = std::ranges::mismatch(root, candidate);
             return rootPosition == root.end() && candidatePosition != candidate.end();
         }
     }  // namespace
@@ -42,7 +42,7 @@ namespace Horo::Extensions::Discovery {
         if (error)
             return PathFailure(root, error.message());
         if (!std::filesystem::is_directory(canonical, error))
-            return PathFailure(root, "The approved root must be an accessible directory.");
+            return PathFailure(root, error ? error.message() : "The approved root must be an accessible directory.");
         return Result<std::filesystem::path>::Success(canonical);
     }
 

--- a/src/extensions/discovery/DiscoveryPaths.cpp
+++ b/src/extensions/discovery/DiscoveryPaths.cpp
@@ -1,0 +1,62 @@
+#include "DiscoveryPaths.h"
+
+#include <algorithm>
+#include <string>
+#include <system_error>
+
+namespace Horo::Extensions::Discovery {
+    namespace {
+        const ErrorCodeDescriptor InvalidDiscoveryPath{
+            .domain = ErrorDomainId{"horo.extensions"},
+            .code = ErrorCode{"invalid_discovery_path"},
+            .defaultSeverity = ErrorSeverity::Error,
+            .summary = "The extension discovery path is invalid or outside its approved root.",
+            .remediationHint = "Use an existing approved root and declared paths contained within it.",
+            .retryable = false,
+            .userActionable = true,
+        };
+
+        /** @brief Preserve the failing path and filesystem reason in a typed discovery error. */
+        Result<std::filesystem::path> PathFailure(const std::filesystem::path &path, const std::string &reason) {
+            return Result<std::filesystem::path>::Failure(MakeError(InvalidDiscoveryPath, path.generic_string() + ": " + reason));
+        }
+
+        /** @brief Reject ambiguous root names and parent traversal before filesystem resolution. */
+        bool IsDeclaredRelativePath(const std::filesystem::path &path) {
+            return !path.empty() && !path.has_root_path() && std::ranges::find(path, "..") == path.end();
+        }
+
+        /** @brief Compare complete components, never textual prefixes such as root and root-other. */
+        bool IsStrictDescendant(const std::filesystem::path &root, const std::filesystem::path &candidate) {
+            const auto [rootPosition, candidatePosition] = std::mismatch(root.begin(), root.end(), candidate.begin(), candidate.end());
+            return rootPosition == root.end() && candidatePosition != candidate.end();
+        }
+    }  // namespace
+
+    /** @copydoc CanonicalRoot */
+    Result<std::filesystem::path> CanonicalRoot(const std::filesystem::path &root) {
+        if (!root.is_absolute())
+            return PathFailure(root, "The approved root must be absolute.");
+        std::error_code error;
+        const auto canonical = std::filesystem::canonical(root, error);
+        if (error)
+            return PathFailure(root, error.message());
+        if (!std::filesystem::is_directory(canonical, error))
+            return PathFailure(root, "The approved root must be an accessible directory.");
+        return Result<std::filesystem::path>::Success(canonical);
+    }
+
+    /** @copydoc ResolveContainedPath */
+    Result<std::filesystem::path> ResolveContainedPath(const std::filesystem::path &canonicalRoot,
+                                                       const std::filesystem::path &relativePath) {
+        if (!IsDeclaredRelativePath(relativePath))
+            return PathFailure(relativePath, "Expected a relative path without parent traversal.");
+        std::error_code error;
+        const auto canonical = std::filesystem::canonical(canonicalRoot / relativePath, error);
+        if (error)
+            return PathFailure(relativePath, error.message());
+        if (!IsStrictDescendant(canonicalRoot, canonical))
+            return PathFailure(relativePath, "Resolved content escapes or aliases the approved root.");
+        return Result<std::filesystem::path>::Success(canonical);
+    }
+}  // namespace Horo::Extensions::Discovery

--- a/src/extensions/discovery/DiscoveryPaths.h
+++ b/src/extensions/discovery/DiscoveryPaths.h
@@ -1,0 +1,28 @@
+/** @file
+ * @brief Filesystem containment checks for approved extension discovery records.
+ */
+#pragma once
+
+#include "Horo/Foundation/Result.h"
+
+#include <filesystem>
+
+namespace Horo::Extensions::Discovery {
+    /**
+     * @brief Canonicalize an existing absolute discovery root without granting approval.
+     * @param root Product/package-policy supplied absolute directory.
+     * @return Existing canonical directory, or a typed path validation error.
+     */
+    [[nodiscard]] Result<std::filesystem::path> CanonicalRoot(const std::filesystem::path &root);
+
+    /**
+     * @brief Resolve a declared relative path strictly inside an approved canonical root.
+     * @param canonicalRoot Existing canonical root returned by CanonicalRoot.
+     * @param relativePath Nonempty relative path without parent traversal components.
+     * @return Canonical existing descendant, or a typed error for missing or escaping content.
+     * @note This is a discovery-time check, not a file lease or execution trust grant.
+     *       The install-record owner must protect content from mutation before activation.
+     */
+    [[nodiscard]] Result<std::filesystem::path> ResolveContainedPath(const std::filesystem::path &canonicalRoot,
+                                                                     const std::filesystem::path &relativePath);
+}  // namespace Horo::Extensions::Discovery

--- a/src/extensions/discovery/DiscoveryPlan.cpp
+++ b/src/extensions/discovery/DiscoveryPlan.cpp
@@ -1,0 +1,69 @@
+#include "DiscoveryPaths.h"
+#include "DiscoveryRootPolicy.h"
+#include "Horo/Extensions/ExtensionDiscovery.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace Horo::Extensions::Discovery {
+    namespace {
+        const ErrorCodeDescriptor InvalidDiscoveryPlan{
+            .domain = ErrorDomainId{"horo.extensions"},
+            .code = ErrorCode{"invalid_discovery_plan"},
+            .defaultSeverity = ErrorSeverity::Error,
+            .summary = "The declared package discovery plan is invalid.",
+            .remediationHint = "Supply bounded package locations with unique package IDs and known approved roots.",
+            .retryable = false,
+            .userActionable = true,
+        };
+
+        /** @brief Validate graph references before any package path is probed. */
+        bool IsInvalidLocation(const PackageLocation &location, const RootSelection &selection) {
+            return location.packageId.empty() ||
+                   std::ranges::find(selection.diagnostics, location.rootId, &RootDiagnostic::rootId) == selection.diagnostics.end();
+        }
+
+        /** @brief Resolve one graph-owned package directory without treating it as trusted executable content. */
+        Result<DiscoveredPackage> ResolvePackage(const PackageLocation &location, const ApprovedRoot &root) {
+            auto path = ResolveContainedPath(root.canonicalPath, location.relativePath);
+            if (path.HasError())
+                return Result<DiscoveredPackage>::Failure(path.ErrorValue());
+            if (std::error_code error; !std::filesystem::is_directory(path.Value(), error))
+                return Result<DiscoveredPackage>::Failure(
+                    MakeError(InvalidDiscoveryPlan, "Package location is not a directory: " + location.packageId));
+            return Result<DiscoveredPackage>::Success({location.packageId, root.id, std::move(path).Value(), root.kind});
+        }
+    }  // namespace
+
+    /** @copydoc DiscoverDeclaredPackages */
+    Result<DiscoveryPlan> DiscoverDeclaredPackages(std::span<const RootRequest> roots, std::span<const PackageLocation> locations,
+                                                   const RootPolicy &policy) {
+        if (locations.size() > 4096)
+            return Result<DiscoveryPlan>::Failure(MakeError(InvalidDiscoveryPlan, "Too many declared package locations."));
+        auto selected = SelectApprovedRoots(roots, policy);
+        if (selected.HasError())
+            return Result<DiscoveryPlan>::Failure(selected.ErrorValue());
+        const auto &selection = selected.Value();
+        if (std::ranges::any_of(locations, [&](const PackageLocation &location) {
+            return IsInvalidLocation(location, selection);
+        }))
+            return Result<DiscoveryPlan>::Failure(MakeError(InvalidDiscoveryPlan, "Empty package identity or unknown discovery root."));
+        DiscoveryPlan plan;
+        for (const auto &location : locations) {
+            const auto root = std::ranges::find(selection.roots, location.rootId, &ApprovedRoot::id);
+            if (root == selection.roots.end())
+                continue;
+            auto package = ResolvePackage(location, *root);
+            if (package.HasError())
+                return Result<DiscoveryPlan>::Failure(package.ErrorValue());
+            plan.packages.push_back(std::move(package).Value());
+        }
+        std::ranges::sort(plan.packages, {}, &DiscoveredPackage::packageId);
+        if (const auto duplicate = std::ranges::adjacent_find(plan.packages, {}, &DiscoveredPackage::packageId);
+            duplicate != plan.packages.end())
+            return Result<DiscoveryPlan>::Failure(MakeError(InvalidDiscoveryPlan, "Duplicate package identity: " + duplicate->packageId));
+        plan.rootDiagnostics = selection.diagnostics;
+        plan.nonPortable = selection.nonPortable;
+        return Result<DiscoveryPlan>::Success(std::move(plan));
+    }
+}  // namespace Horo::Extensions::Discovery

--- a/src/extensions/discovery/DiscoveryPlan.cpp
+++ b/src/extensions/discovery/DiscoveryPlan.cpp
@@ -20,7 +20,7 @@ namespace Horo::Extensions::Discovery {
         /** @brief Validate graph references before any package path is probed. */
         bool IsInvalidLocation(const PackageLocation &location, const RootSelection &selection) {
             return location.packageId.empty() ||
-                   std::ranges::find(selection.diagnostics, location.rootId, &RootDiagnostic::rootId) == selection.diagnostics.end();
+                   !std::ranges::binary_search(selection.diagnostics, location.rootId, {}, &RootDiagnostic::rootId);
         }
 
         /** @brief Resolve one graph-owned package directory without treating it as trusted executable content. */
@@ -30,8 +30,10 @@ namespace Horo::Extensions::Discovery {
                 return Result<DiscoveredPackage>::Failure(path.ErrorValue());
             if (std::error_code error; !std::filesystem::is_directory(path.Value(), error))
                 return Result<DiscoveredPackage>::Failure(
-                    MakeError(InvalidDiscoveryPlan, "Package location is not a directory: " + location.packageId));
-            return Result<DiscoveredPackage>::Success({location.packageId, root.id, std::move(path).Value(), root.kind});
+                    MakeError(InvalidDiscoveryPlan,
+                              location.packageId + ": " + (error ? error.message() : "Package location is not a directory.")));
+            return Result<DiscoveredPackage>::Success(
+                {.packageId = location.packageId, .rootId = root.id, .canonicalPath = std::move(path).Value(), .kind = root.kind});
         }
     }  // namespace
 
@@ -50,8 +52,8 @@ namespace Horo::Extensions::Discovery {
             return Result<DiscoveryPlan>::Failure(MakeError(InvalidDiscoveryPlan, "Empty package identity or unknown discovery root."));
         DiscoveryPlan plan;
         for (const auto &location : locations) {
-            const auto root = std::ranges::find(selection.roots, location.rootId, &ApprovedRoot::id);
-            if (root == selection.roots.end())
+            const auto root = std::ranges::lower_bound(selection.roots, location.rootId, {}, &ApprovedRoot::id);
+            if (root == selection.roots.end() || root->id != location.rootId)
                 continue;
             auto package = ResolvePackage(location, *root);
             if (package.HasError())

--- a/src/extensions/discovery/DiscoveryRootPolicy.cpp
+++ b/src/extensions/discovery/DiscoveryRootPolicy.cpp
@@ -1,0 +1,75 @@
+#include "DiscoveryRootPolicy.h"
+
+#include "DiscoveryPaths.h"
+
+#include <algorithm>
+#include <array>
+#include <utility>
+
+namespace Horo::Extensions::Discovery {
+    namespace {
+        const ErrorCodeDescriptor InvalidRootPolicy{
+            .domain = ErrorDomainId{"horo.extensions"},
+            .code = ErrorCode{"invalid_discovery_root_policy"},
+            .defaultSeverity = ErrorSeverity::Error,
+            .summary = "The discovery root policy is invalid.",
+            .remediationHint = "Supply no more than 64 roots with unique nonempty stable IDs.",
+            .retryable = false,
+            .userActionable = true,
+        };
+
+        /** @brief Require product ownership for system roots and local ownership for overrides. */
+        bool HasValidAuthority(const RootRequest &request) {
+            using enum RootKind;
+            using enum ConfigurationOrigin;
+            constexpr std::array allowedAuthorities{std::pair{System, ProductPolicy}, std::pair{User, UserLocal},
+                                                    std::pair{Development, UserLocal}, std::pair{Project, ProjectPortable}};
+            return std::ranges::find(allowedAuthorities, std::pair{request.kind, request.configuration}) != allowedAuthorities.end();
+        }
+
+        /** @brief Determine ignored requests without probing their paths. */
+        RootDisposition Disposition(const RootRequest &request, const RootPolicy &policy) {
+            using enum RootDisposition;
+            if (!HasValidAuthority(request))
+                return InvalidAuthority;
+            if (request.approval != RootApproval::Approved)
+                return ApprovalRequired;
+            if (request.kind != RootKind::Development)
+                return Accepted;
+            if (policy.profile != DiscoveryProfile::Development || !policy.enableDevelopmentOverrides)
+                return DevelopmentDisabled;
+            return DevelopmentNonPortable;
+        }
+
+        /** @brief Validate identities before sorting so malformed inputs cannot affect accepted roots. */
+        bool HasInvalidIds(std::span<const RootRequest> requests) {
+            return std::ranges::any_of(requests, [](const RootRequest &request) {
+                return request.id.empty();
+            });
+        }
+    }  // namespace
+
+    /** @copydoc SelectApprovedRoots */
+    Result<RootSelection> SelectApprovedRoots(std::span<const RootRequest> requests, const RootPolicy &policy) {
+        if (requests.size() > 64 || HasInvalidIds(requests))
+            return Result<RootSelection>::Failure(MakeError(InvalidRootPolicy));
+        std::vector<RootRequest> ordered(requests.begin(), requests.end());
+        std::ranges::sort(ordered, {}, &RootRequest::id);
+        if (std::ranges::adjacent_find(ordered, {}, &RootRequest::id) != ordered.end())
+            return Result<RootSelection>::Failure(MakeError(InvalidRootPolicy, "Duplicate discovery root IDs."));
+        RootSelection selection;
+        for (const auto &request : ordered) {
+            using enum RootDisposition;
+            const auto disposition = Disposition(request, policy);
+            selection.diagnostics.emplace_back(request.id, disposition);
+            if (disposition != Accepted && disposition != DevelopmentNonPortable)
+                continue;
+            auto canonical = CanonicalRoot(request.path);
+            if (canonical.HasError())
+                return Result<RootSelection>::Failure(canonical.ErrorValue());
+            selection.roots.emplace_back(request.id, std::move(canonical).Value(), request.kind);
+            selection.nonPortable = selection.nonPortable || disposition == DevelopmentNonPortable;
+        }
+        return Result<RootSelection>::Success(std::move(selection));
+    }
+}  // namespace Horo::Extensions::Discovery

--- a/src/extensions/discovery/DiscoveryRootPolicy.h
+++ b/src/extensions/discovery/DiscoveryRootPolicy.h
@@ -1,0 +1,32 @@
+/** @file
+ * @brief Internal root-policy selection for extension discovery.
+ */
+#pragma once
+
+#include "Horo/Extensions/ExtensionDiscovery.h"
+
+namespace Horo::Extensions::Discovery {
+    /** @brief Canonical approved discovery boundary, not a verified package or activation grant. */
+    struct ApprovedRoot {
+        std::string id;
+        std::filesystem::path canonicalPath;
+        RootKind kind;
+    };
+
+    /** @brief Deterministic approved roots and diagnostics sorted by stable root ID. */
+    struct RootSelection {
+        std::vector<ApprovedRoot> roots;
+        std::vector<RootDiagnostic> diagnostics;
+        bool nonPortable{false}; /**< True only when a development override is accepted. */
+    };
+
+    /**
+     * @brief Apply explicit approval and local-only override policy before filesystem access.
+     * @param requests At most 64 roots supplied by trusted product/package composition.
+     * @param policy Invocation profile and explicit override opt-in.
+     * @return Canonical approved boundaries, or a typed error for invalid IDs or accepted paths.
+     * @note Does not read project configuration, environment variables or extension manifests;
+     *       callers must preserve configuration provenance and actual local approval decisions.
+     */
+    [[nodiscard]] Result<RootSelection> SelectApprovedRoots(std::span<const RootRequest> requests, const RootPolicy &policy);
+}  // namespace Horo::Extensions::Discovery

--- a/src/extensions/host/ExtensionManager.cpp
+++ b/src/extensions/host/ExtensionManager.cpp
@@ -263,27 +263,6 @@ namespace Horo::Extensions {
     ExtensionManager::ExtensionManager(ExtensionManager &&) noexcept = default;
     ExtensionManager &ExtensionManager::operator=(ExtensionManager &&) noexcept = default;
 
-    std::vector<std::string> ExtensionManager::DiscoverExtensions(const std::string &directoryPath) const {
-        std::vector<std::string> discovered;
-        std::error_code ec;
-
-        const fs::path dir{directoryPath};
-        if (!fs::exists(dir, ec) || !fs::is_directory(dir, ec)) {
-            LOG_WARN("extensions", "Discovery path does not exist or is not a directory: %s", directoryPath.c_str());
-            return discovered;
-        }
-
-        for (const auto &entry : fs::directory_iterator(dir, ec)) {
-            if (entry.is_directory()) {
-                const fs::path manifestPath = entry.path() / "extension.json";
-                if (fs::exists(manifestPath, ec))
-                    discovered.push_back(entry.path().string());
-            }
-        }
-        std::ranges::sort(discovered);
-        return discovered;
-    }
-
     Result<std::string> ExtensionManager::LoadExtension(const std::string &extensionDir) {
         auto manifestResult = ReadAndValidateManifest(fs::path{extensionDir}, m_loadedExtensions);
         if (manifestResult.HasError())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -868,6 +868,16 @@ target_include_directories(HoroModularAssetImportIntegrationTests PRIVATE
         ${PROJECT_SOURCE_DIR}/src/runtime/assets/cooker/builtin
         ${PROJECT_SOURCE_DIR}/src/runtime/assets/importer
 )
+add_executable(HoroExtensionDiscoveryTests
+        unit/extensions/DiscoveryPathsTests.cpp
+        unit/extensions/DiscoveryPlanTests.cpp
+        unit/extensions/DiscoveryRootPolicyTests.cpp
+)
+target_compile_features(HoroExtensionDiscoveryTests PRIVATE cxx_std_20)
+target_include_directories(HoroExtensionDiscoveryTests PRIVATE ${PROJECT_SOURCE_DIR}/src/extensions/discovery)
+target_link_libraries(HoroExtensionDiscoveryTests PRIVATE HoroEngine::Extensions Catch2::Catch2WithMain)
+add_test(NAME HoroExtensionDiscoveryTests COMMAND HoroExtensionDiscoveryTests)
+
 add_executable(HoroExtensionManagerTests
         unit/extensions/ExtensionManagerTests.cpp
         unit/extensions/ExtensionManifestParserTests.cpp

--- a/tests/unit/extensions/DiscoveryPathsTests.cpp
+++ b/tests/unit/extensions/DiscoveryPathsTests.cpp
@@ -1,0 +1,69 @@
+#include "DiscoveryPaths.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace Horo::Extensions::Discovery::Tests {
+    namespace fs = std::filesystem;
+
+    struct DiscoveryPathFixture {
+        fs::path directory =
+            fs::temp_directory_path() / ("horo-discovery-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+        fs::path root = directory / "approved space";
+
+        DiscoveryPathFixture() {
+            REQUIRE(fs::create_directory(directory));
+            fs::create_directories(root / "paket-ç" / "nested");
+            fs::create_directories(directory / "approved space-other");
+            std::ofstream(root / "paket-ç" / "extension.json") << "{}";
+            root = fs::canonical(root);
+        }
+
+        ~DiscoveryPathFixture() {
+            std::error_code error;
+            fs::remove_all(directory, error);
+        }
+    };
+
+    TEST_CASE_METHOD(DiscoveryPathFixture, "Discovery roots must be existing absolute directories", "[Extensions][Discovery]") {
+        CHECK(CanonicalRoot(root).HasValue());
+        CHECK(CanonicalRoot(root / "paket-ç" / ".").Value() == fs::canonical(root / "paket-ç"));
+        CHECK(CanonicalRoot("relative").HasError());
+        CHECK(CanonicalRoot({}).HasError());
+        CHECK(CanonicalRoot(root / "missing").HasError());
+        CHECK(CanonicalRoot(root / "paket-ç" / "extension.json").HasError());
+    }
+
+    TEST_CASE_METHOD(DiscoveryPathFixture, "Discovery only accepts existing strict descendants", "[Extensions][Discovery]") {
+        const auto file = ResolveContainedPath(root, "paket-ç/extension.json");
+        REQUIRE(file.HasValue());
+        CHECK(file.Value() == root / "paket-ç" / "extension.json");
+        CHECK(ResolveContainedPath(root, "paket-ç/nested").HasValue());
+        CHECK(ResolveContainedPath(root, "paket-ç/./extension.json").HasValue());
+        CHECK(ResolveContainedPath(root, "missing").HasError());
+        CHECK(ResolveContainedPath(root, {}).HasError());
+        CHECK(ResolveContainedPath(root, ".").HasError());
+        CHECK(ResolveContainedPath(root, root / "paket-ç").HasError());
+        CHECK(ResolveContainedPath(root, "../approved space-other").HasError());
+        CHECK(ResolveContainedPath(root, "paket-ç/../paket-ç/extension.json").HasError());
+    }
+
+    TEST_CASE_METHOD(DiscoveryPathFixture, "Discovery resolves links without permitting escapes", "[Extensions][Discovery]") {
+        std::error_code error;
+        fs::create_directory_symlink(root / "paket-ç", root / "inside", error);
+        if (error)
+            SKIP("This host does not permit creation of directory symlinks: " << error.message());
+        fs::create_directory_symlink(directory / "approved space-other", root / "outside");
+        fs::create_directory_symlink(root, root / "self");
+        fs::create_directory_symlink(root / "absent", root / "dangling");
+        fs::create_symlink(directory / "approved space-other", root / "paket-ç" / "escaped.json");
+        CHECK(ResolveContainedPath(root, "inside/extension.json").Value() == root / "paket-ç" / "extension.json");
+        CHECK(ResolveContainedPath(root, "outside").HasError());
+        CHECK(ResolveContainedPath(root, "self").HasError());
+        CHECK(ResolveContainedPath(root, "dangling").HasError());
+        CHECK(ResolveContainedPath(root, "paket-ç/escaped.json").HasError());
+    }
+}  // namespace Horo::Extensions::Discovery::Tests

--- a/tests/unit/extensions/DiscoveryPlanTests.cpp
+++ b/tests/unit/extensions/DiscoveryPlanTests.cpp
@@ -73,6 +73,28 @@ namespace Horo::Extensions::Discovery::Tests {
         CHECK(plan.Value().rootDiagnostics[0].disposition == RootDisposition::ApprovalRequired);
     }
 
+    TEST_CASE_METHOD(DiscoveryPlanFixture, "Ignored root IDs do not alias the next approved root", "[Extensions][Discovery]") {
+        auto ignored = root;
+        ignored.id = "aaa";
+        ignored.approval = RootApproval::Pending;
+        ignored.path.clear();
+        const std::array roots{root, ignored};
+        const std::array locations{PackageLocation{"ignored", "aaa", "../missing"}, PackageLocation{"accepted", "user", "alpha"}};
+        const auto plan = DiscoverDeclaredPackages(roots, locations, {});
+        REQUIRE(plan.HasValue());
+        REQUIRE(plan.Value().packages.size() == 1);
+        CHECK(plan.Value().packages[0].packageId == "accepted");
+        CHECK(plan.Value().packages[0].rootId == "user");
+    }
+
+    TEST_CASE_METHOD(DiscoveryPlanFixture, "Non-directory packages report a meaningful failure", "[Extensions][Discovery]") {
+        const std::array locations{PackageLocation{"com.example.file", "user", "not-a-directory"}};
+        const auto plan = Discover(locations);
+        REQUIRE(plan.HasError());
+        CHECK(plan.ErrorValue().message.find("com.example.file") != std::string::npos);
+        CHECK(plan.ErrorValue().message.find("not a directory") != std::string::npos);
+    }
+
     TEST_CASE_METHOD(DiscoveryPlanFixture, "Development provenance remains visible and opt-in", "[Extensions][Discovery]") {
         root.kind = RootKind::Development;
         const std::array locations{PackageLocation{"com.example.alpha", "user", "alpha"}};

--- a/tests/unit/extensions/DiscoveryPlanTests.cpp
+++ b/tests/unit/extensions/DiscoveryPlanTests.cpp
@@ -1,0 +1,99 @@
+#include "Horo/Extensions/ExtensionDiscovery.h"
+
+#include <algorithm>
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <fstream>
+
+namespace Horo::Extensions::Discovery::Tests {
+    struct DiscoveryPlanFixture {
+        std::filesystem::path directory = std::filesystem::temp_directory_path() /
+                                          ("horo-plan-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+        RootRequest root{.id = "user",
+                         .path = directory,
+                         .kind = RootKind::User,
+                         .approval = RootApproval::Approved,
+                         .configuration = ConfigurationOrigin::UserLocal};
+
+        DiscoveryPlanFixture() {
+            REQUIRE(std::filesystem::create_directory(directory));
+            std::filesystem::create_directory(directory / "alpha");
+            std::filesystem::create_directory(directory / "beta");
+            std::filesystem::create_directory(directory / "not-declared");
+            std::ofstream(directory / "not-a-directory") << "{}";
+        }
+
+        ~DiscoveryPlanFixture() {
+            std::error_code error;
+            std::filesystem::remove_all(directory, error);
+        }
+
+        Result<DiscoveryPlan> Discover(std::span<const PackageLocation> locations, RootPolicy policy = {}) const {
+            return DiscoverDeclaredPackages(std::span(&root, 1), locations, policy);
+        }
+    };
+
+    TEST_CASE_METHOD(DiscoveryPlanFixture, "Only declared packages are discovered in stable identity order", "[Extensions][Discovery]") {
+        std::array locations{PackageLocation{"com.example.beta", "user", "beta"}, PackageLocation{"com.example.alpha", "user", "alpha"}};
+        for (int permutation = 0; permutation < 2; ++permutation) {
+            const auto plan = Discover(locations);
+            REQUIRE(plan.HasValue());
+            REQUIRE(plan.Value().packages.size() == 2);
+            CHECK(plan.Value().packages[0].packageId == "com.example.alpha");
+            CHECK(plan.Value().packages[1].packageId == "com.example.beta");
+            CHECK(plan.Value().packages[0].canonicalPath == std::filesystem::canonical(directory / "alpha"));
+            CHECK(plan.Value().packages[0].rootId == "user");
+            CHECK(plan.Value().packages[0].kind == RootKind::User);
+            CHECK_FALSE(plan.Value().nonPortable);
+            std::ranges::reverse(locations);
+        }
+        REQUIRE(Discover({}).HasValue());
+        CHECK(Discover({}).Value().packages.empty());
+    }
+
+    TEST_CASE_METHOD(DiscoveryPlanFixture, "Duplicate packages fail instead of winning by input order", "[Extensions][Discovery]") {
+        std::array locations{PackageLocation{"com.example.same", "user", "beta"}, PackageLocation{"com.example.same", "user", "alpha"}};
+        const auto first = Discover(locations);
+        REQUIRE(first.HasError());
+        std::ranges::reverse(locations);
+        const auto second = Discover(locations);
+        REQUIRE(second.HasError());
+        CHECK(first.ErrorValue().message == second.ErrorValue().message);
+    }
+
+    TEST_CASE_METHOD(DiscoveryPlanFixture, "Ignored roots never probe declared content", "[Extensions][Discovery]") {
+        const std::array locations{PackageLocation{"com.example.alpha", "user", "../missing"}};
+        root.approval = RootApproval::Pending;
+        root.path.clear();
+        const auto plan = Discover(locations);
+        REQUIRE(plan.HasValue());
+        CHECK(plan.Value().packages.empty());
+        REQUIRE(plan.Value().rootDiagnostics.size() == 1);
+        CHECK(plan.Value().rootDiagnostics[0].disposition == RootDisposition::ApprovalRequired);
+    }
+
+    TEST_CASE_METHOD(DiscoveryPlanFixture, "Development provenance remains visible and opt-in", "[Extensions][Discovery]") {
+        root.kind = RootKind::Development;
+        const std::array locations{PackageLocation{"com.example.alpha", "user", "alpha"}};
+        CHECK(Discover(locations).Value().packages.empty());
+        const auto plan = Discover(locations, {.profile = DiscoveryProfile::Development, .enableDevelopmentOverrides = true});
+        REQUIRE(plan.HasValue());
+        REQUIRE(plan.Value().packages.size() == 1);
+        CHECK(plan.Value().nonPortable);
+        CHECK(plan.Value().packages[0].kind == RootKind::Development);
+    }
+
+    TEST_CASE_METHOD(DiscoveryPlanFixture, "Invalid graph references and package paths reject the whole plan", "[Extensions][Discovery]") {
+        const std::array invalid{PackageLocation{"", "user", "alpha"}, PackageLocation{"com.example.alpha", "unknown", "alpha"},
+                                 PackageLocation{"com.example.alpha", "user", "missing"},
+                                 PackageLocation{"com.example.alpha", "user", "not-a-directory"},
+                                 PackageLocation{"com.example.alpha", "user", "../alpha"}};
+        for (const auto &location : invalid)
+            CHECK(Discover(std::span(&location, 1)).HasError());
+        std::vector<PackageLocation> oversized(4097);
+        CHECK(Discover(oversized).HasError());
+        root.path.clear();
+        CHECK(Discover({}).HasError());
+    }
+}  // namespace Horo::Extensions::Discovery::Tests

--- a/tests/unit/extensions/DiscoveryRootPolicyTests.cpp
+++ b/tests/unit/extensions/DiscoveryRootPolicyTests.cpp
@@ -1,0 +1,111 @@
+#include "DiscoveryRootPolicy.h"
+
+#include <algorithm>
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <filesystem>
+#include <vector>
+
+namespace Horo::Extensions::Discovery::Tests {
+    namespace {
+        RootRequest ApprovedRequest(RootKind kind, ConfigurationOrigin configuration) {
+            return {.id = "test-root",
+                    .path = std::filesystem::temp_directory_path(),
+                    .kind = kind,
+                    .approval = RootApproval::Approved,
+                    .configuration = configuration};
+        }
+
+        RootSelection SelectOne(const RootRequest &request, const RootPolicy policy = {}) {
+            auto selected = SelectApprovedRoots(std::span(&request, 1), policy);
+            REQUIRE(selected.HasValue());
+            REQUIRE(selected.Value().diagnostics.size() == 1);
+            return std::move(selected).Value();
+        }
+    }  // namespace
+
+    TEST_CASE("Discovery root approval is explicit for every source kind", "[Extensions][Discovery]") {
+        const std::array requests{ApprovedRequest(RootKind::System, ConfigurationOrigin::ProductPolicy),
+                                  ApprovedRequest(RootKind::User, ConfigurationOrigin::UserLocal),
+                                  ApprovedRequest(RootKind::Project, ConfigurationOrigin::ProjectPortable),
+                                  ApprovedRequest(RootKind::Development, ConfigurationOrigin::UserLocal)};
+        for (auto request : requests) {
+            request.approval = RootApproval::Pending;
+            request.path.clear();
+            const auto selection = SelectOne(request, {.profile = DiscoveryProfile::Development, .enableDevelopmentOverrides = true});
+            CHECK(selection.roots.empty());
+            CHECK_FALSE(selection.nonPortable);
+            CHECK(selection.diagnostics.front().disposition == RootDisposition::ApprovalRequired);
+        }
+    }
+
+    TEST_CASE("Only the expected configuration authority can supply a discovery root", "[Extensions][Discovery]") {
+        const std::array requests{ApprovedRequest(RootKind::System, ConfigurationOrigin::ProjectPortable),
+                                  ApprovedRequest(RootKind::User, ConfigurationOrigin::ProjectPortable),
+                                  ApprovedRequest(RootKind::Project, ConfigurationOrigin::UserLocal),
+                                  ApprovedRequest(RootKind::Development, ConfigurationOrigin::ProjectPortable),
+                                  ApprovedRequest(static_cast<RootKind>(-1), ConfigurationOrigin::UserLocal),
+                                  ApprovedRequest(RootKind::User, static_cast<ConfigurationOrigin>(-1))};
+        for (auto request : requests) {
+            request.path.clear();
+            const auto selection = SelectOne(request, {.profile = DiscoveryProfile::Development, .enableDevelopmentOverrides = true});
+            CHECK(selection.roots.empty());
+            CHECK(selection.diagnostics.front().disposition == RootDisposition::InvalidAuthority);
+        }
+    }
+
+    TEST_CASE("Approved portable roots are canonical and independent of input ordering", "[Extensions][Discovery]") {
+        auto user = ApprovedRequest(RootKind::User, ConfigurationOrigin::UserLocal);
+        auto system = ApprovedRequest(RootKind::System, ConfigurationOrigin::ProductPolicy);
+        auto project = ApprovedRequest(RootKind::Project, ConfigurationOrigin::ProjectPortable);
+        user.id = "c-user";
+        system.id = "b-system";
+        project.id = "a-project";
+        std::array requests{user, system, project};
+        for (int permutation = 0; permutation < 3; ++permutation) {
+            auto selected = SelectApprovedRoots(requests, {});
+            REQUIRE(selected.HasValue());
+            REQUIRE(selected.Value().roots.size() == 3);
+            CHECK(selected.Value().roots[0].id == project.id);
+            CHECK(selected.Value().roots[1].id == system.id);
+            CHECK(selected.Value().roots[2].id == user.id);
+            CHECK(selected.Value().roots[0].canonicalPath == std::filesystem::canonical(project.path));
+            CHECK(selected.Value().diagnostics[0].disposition == RootDisposition::Accepted);
+            CHECK_FALSE(selected.Value().nonPortable);
+            std::ranges::rotate(requests, requests.begin() + 1);
+        }
+    }
+
+    TEST_CASE("Development roots require explicit opt-in and cannot enter reproducible profiles", "[Extensions][Discovery]") {
+        auto request = ApprovedRequest(RootKind::Development, ConfigurationOrigin::UserLocal);
+        const std::array profiles{DiscoveryProfile::Normal, DiscoveryProfile::ContinuousIntegration, DiscoveryProfile::Release,
+                                  DiscoveryProfile::OfflineReproducible};
+        for (const auto profile : profiles) {
+            const auto selection = SelectOne(request, {.profile = profile, .enableDevelopmentOverrides = true});
+            CHECK(selection.roots.empty());
+            CHECK_FALSE(selection.nonPortable);
+            CHECK(selection.diagnostics.front().disposition == RootDisposition::DevelopmentDisabled);
+        }
+        CHECK(SelectOne(request, {.profile = DiscoveryProfile::Development}).roots.empty());
+        const auto enabled = SelectOne(request, {.profile = DiscoveryProfile::Development, .enableDevelopmentOverrides = true});
+        REQUIRE(enabled.roots.size() == 1);
+        CHECK(enabled.nonPortable);
+        CHECK(enabled.diagnostics.front().disposition == RootDisposition::DevelopmentNonPortable);
+        request.path.clear();
+        CHECK(SelectOne(request).roots.empty());
+    }
+
+    TEST_CASE("Invalid root selection fails atomically", "[Extensions][Discovery]") {
+        auto request = ApprovedRequest(RootKind::User, ConfigurationOrigin::UserLocal);
+        std::vector requests{request, request};
+        CHECK(SelectApprovedRoots(requests, {}).HasError());
+        requests = {request};
+        requests.front().id.clear();
+        CHECK(SelectApprovedRoots(requests, {}).HasError());
+        requests.assign(65, request);
+        CHECK(SelectApprovedRoots(requests, {}).HasError());
+        request.path.clear();
+        CHECK(SelectApprovedRoots(std::span(&request, 1), {}).HasError());
+        CHECK(SelectApprovedRoots({}, {}).Value().roots.empty());
+    }
+}  // namespace Horo::Extensions::Discovery::Tests

--- a/tests/unit/extensions/ExtensionManagerTests.cpp
+++ b/tests/unit/extensions/ExtensionManagerTests.cpp
@@ -1,5 +1,6 @@
 #include "Horo/Assets/AssetImportMetadata.h"
 #include "Horo/Assets/AssetReimport.h"
+#include "Horo/Extensions/ExtensionDiscovery.h"
 #include "Horo/Extensions/ExtensionErrors.h"
 #include "Horo/Extensions/ExtensionInventory.h"
 #include "Horo/Extensions/ExtensionManager.h"
@@ -88,31 +89,26 @@ namespace Horo::Extensions::Tests {
     };
 
     TEST_CASE_METHOD(ExtensionManagerTestFixture, "ExtensionManager Discovery", "[Extensions]") {
-        ExtensionManager manager;
+        const Discovery::RootRequest root{.id = "user",
+                                          .path = fs::absolute(tempDir),
+                                          .kind = Discovery::RootKind::User,
+                                          .approval = Discovery::RootApproval::Approved,
+                                          .configuration = Discovery::ConfigurationOrigin::UserLocal};
 
-        SECTION("Empty directory returns empty list") {
-            auto discovered = manager.DiscoverExtensions(tempDir.string());
-            REQUIRE(discovered.empty());
+        SECTION("No declared packages returns an empty list") {
+            const auto discovered = Discovery::DiscoverDeclaredPackages(std::span(&root, 1), {}, {});
+            REQUIRE(discovered.HasValue());
+            REQUIRE(discovered.Value().packages.empty());
         }
 
-        SECTION("Directory with valid manifest finds plugin") {
+        SECTION("An approved declared package resolves to a canonical directory") {
             fs::path pluginDir = tempDir / "com.example.test_plugin";
             fs::create_directories(pluginDir);
-
-            fs::path manifestPath = pluginDir / "extension.json";
-            std::ofstream manifestFile(manifestPath);
-            manifestFile << R"({
-                "package": {
-                    "id": "com.example.test_plugin",
-                    "version": "1.0.0"
-                }
-            })";
-            manifestFile.close();
-
-            auto discovered = manager.DiscoverExtensions(tempDir.string());
-
-            REQUIRE(discovered.size() == 1);
-            REQUIRE(discovered[0] == pluginDir.string());
+            const Discovery::PackageLocation location{"com.example.test-plugin", "user", "com.example.test_plugin"};
+            const auto discovered = Discovery::DiscoverDeclaredPackages(std::span(&root, 1), std::span(&location, 1), {});
+            REQUIRE(discovered.HasValue());
+            REQUIRE(discovered.Value().packages.size() == 1);
+            REQUIRE(discovered.Value().packages[0].canonicalPath == fs::canonical(pluginDir));
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace raw extension-directory discovery with a typed, declared-package discovery API.
- Validate approved roots, configuration authority, development overrides, canonical containment, and duplicate package identities.

## Motivation
- Discovery must use explicitly approved roots without silently scanning or trusting arbitrary executable content.

## Implementation Notes
- System, user, project, and development roots have explicit authority and approval requirements.
- Development overrides require the development profile and explicit opt-in; ignored roots are not probed.
- Reject parent traversal, symlink escapes, malformed references, and duplicate accepted identities. Sort output deterministically.
- Register the public header with its owning target and document migration from the removed discovery method.
- Discovery is preflight only: package graph resolution, trust verification, activation grants, and protection against subsequent filesystem mutation remain separate responsibilities.

## Validation
- [x] Targeted build passed
- [x] Relevant tests passed
- [x] Public-header consumer built
- [ ] Cross-platform CI and PR Sonar/Codacy gates pending

Commands run:
```bash
cmake --build cmake-build-debug-coverage --target HoroExtensionDiscoveryTests HoroExtensionManagerTests HoroExtensionsPublicHeaderConsumer --parallel 8
ctest --test-dir cmake-build-debug-coverage -R '^HoroExtension(Discovery|Manager)Tests$' --output-on-failure
LLVM_PROFILE_FILE=/tmp/horo72-pr.profraw cmake-build-debug-coverage/tests/HoroExtensionDiscoveryTests
xcrun llvm-profdata merge -sparse /tmp/horo72-pr.profraw -o /tmp/horo72-pr.profdata
xcrun llvm-cov report cmake-build-debug-coverage/tests/HoroExtensionDiscoveryTests -instr-profile=/tmp/horo72-pr.profdata src/extensions/discovery/DiscoveryPaths.cpp src/extensions/discovery/DiscoveryPlan.cpp src/extensions/discovery/DiscoveryRootPolicy.cpp
git diff --cached --check
git diff --cached --name-only -z -- '*.cpp' '*.h' | xargs -0 clang-format --dry-run --Werror
```

- Discovery suite: 13 cases, 170 assertions. Both targeted CTest suites pass.
- Three new implementation files: 100% line coverage, 98.61% branch coverage locally.
- Local Sonar reported no findings for analyzed implementation/test/public-header files, but private-header IDE indexing prevented complete verification. This is not a claim of a fully clean local Sonar run.
- Auxiliary Lizard aggregate for the six new implementation/test files is 71; the CLI SARIF did not expose an aggregate score. The project lead explicitly accepted the complexity result and authorized proceeding to PR-based Sonar validation.

## Risks
- Cross-platform behavior and server-side quality gates still require CI validation.
- Canonicalization does not provide an immutable verified install lease or close later filesystem mutation races.
- Legacy loading and inventory APIs are not upgraded into an activation security boundary by this change.

## Issue Links
- Jira: [HORO-72](https://horo-engine.atlassian.net/browse/HORO-72)
- GitHub: Closes #72

## Reviewer Notes
- Review the public discovery contract, root authority policy, path containment, then plan composition and regression cases.
- Migration details are in `docs/guides/extension-discovery-migration.md`.


[HORO-72]: https://horo-engine.atlassian.net/browse/HORO-72?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ