### PR TITLE
feat(extensions): validate native ABI negotiation HORO-74 #74 [EXT-001.6]

### DIFF
--- a/docs/guides/extension-abi-migration.md
+++ b/docs/guides/extension-abi-migration.md
@@ -1,0 +1,49 @@
+# Native extension ABI negotiation
+
+ABI 1.1 keeps the v1 host prefix and load/unload symbols while adding an optional
+inert `horo_extension_query` bootstrap. The host negotiates before calling load;
+an incompatible query cannot receive a registration callback. Missing queries
+select the legacy 1.0 contract, not an inferred newer ABI.
+
+## Version and size rules
+
+- `HoroExtensionHostApi::abiVersion` remains the major version, currently 1.
+  The appended `abiMinorVersion` is 1; `reserved` is zero.
+- A query fills `HoroExtensionRequirements` in host-owned storage. It must return
+  the complete supported requirements size, matching major, a minimum minor no
+  greater than the host's, and a host size the host can supply.
+- Required function bits are explicit. Unknown bits and nonzero reserved fields
+  fail negotiation; requested callbacks must be present.
+- Input-table tails may be appended. Modules must test size before reading new
+  fields, and must still validate their requirements in load when supporting an
+  older host that does not call query. No field is reordered or repurposed.
+- Output `structSize` starts as writable capacity. A module must not write past
+  that capacity and returns its populated prefix size. Module results may end
+  before `moduleId`, before `moduleVersion`, or after the complete current table.
+  Absent legacy identities are cleared and remain manifest-owned. Partial fields
+  and sizes beyond supplied capacity fail before contribution commit.
+- Query is metadata-only: no allocations, lifecycle state, retained pointers,
+  callbacks into host services, or registration. Query errors propagate and
+  contract-violating exceptions are contained by the host.
+
+## Source compatibility and ownership
+
+The public header now compiles as C11 and C++20. C `typedef` is intentional; the
+C++-only Sonar preference for `using` is inapplicable to this shared header.
+Status and setting tags use `uint32_t` rather than compiler-sized enum wire
+types. Constant names and values are unchanged. Code that explicitly spells the
+old enum tags must use the public typedef names instead. Rebuild native modules
+with the updated SDK; binaries built with nonstandard short-enum options are not
+covered by compatibility guarantees.
+
+The existing example, host adapter, C consumer, and C++ public-header consumer
+are affected callers. The C consumer is a registered CTest target, not a C++ test
+that merely includes the header.
+
+Importer context ownership requires a module-provided destroy callback whenever
+the context is non-null. A rejected registration does not transfer ownership;
+the module must clean it up. Accepted contexts retain the module lease and are
+destroyed through the originating module, including transaction rollback.
+
+This bootstrap is not a sandbox or package trust decision. It cannot prevent a
+malicious native module from ignoring buffer bounds or accessing process memory.

--- a/include/Horo/Extensions/ExtensionAbi.h
+++ b/include/Horo/Extensions/ExtensionAbi.h
@@ -27,10 +27,11 @@
 
 enum {  // NOSONAR(cpp:S3642) C ABI constant group
     HORO_EXTENSION_ABI_VERSION = 1,
+    HORO_EXTENSION_ABI_MINOR_VERSION = 1,
     HORO_ASSET_IMPORTER_ABI_VERSION = 1,
 };
 
-enum HoroExtensionStatus {  // NOSONAR(cpp:S3642) C ABI enumeration
+enum HoroExtensionStatusCode {  // NOSONAR(cpp:S3642) C ABI constants; wire values use uint32_t.
     HORO_EXTENSION_SUCCESS = 0,
     HORO_EXTENSION_ERROR_VERSION_MISMATCH = 1,
     HORO_EXTENSION_ERROR_INIT_FAILED = 2,
@@ -38,38 +39,40 @@ enum HoroExtensionStatus {  // NOSONAR(cpp:S3642) C ABI enumeration
     HORO_EXTENSION_ERROR_CANCELLED = 4,
     HORO_EXTENSION_ERROR_OUTPUT_REJECTED = 5,
 };
-using HoroExtensionStatus = enum HoroExtensionStatus;
+
+typedef uint32_t HoroExtensionStatus;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
 /** @brief Borrowed byte-counted UTF-8 text; it need not be null-terminated. */
 struct HoroExtensionStringView {
     const char *data;
     uint32_t length;
 };
-using HoroExtensionStringView = struct HoroExtensionStringView;
+typedef struct HoroExtensionStringView HoroExtensionStringView;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
 /** @brief Host-owned byte output resized and filled by a module callback. */
 struct HoroExtensionByteSink {
     void *context;
     HoroExtensionStatus (*resize)(void *context, uint64_t byteCount, uint8_t **outBytes);
 };
-using HoroExtensionByteSink = struct HoroExtensionByteSink;
+typedef struct HoroExtensionByteSink HoroExtensionByteSink;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
 /** @brief Cooperative cancellation query valid only during one callback. */
 struct HoroExtensionCancellation {
     const void *context;
     uint8_t (*isCancellationRequested)(const void *context);
 };
-using HoroExtensionCancellation = struct HoroExtensionCancellation;
+typedef struct HoroExtensionCancellation HoroExtensionCancellation;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
 // Unscoped enumerators are part of the source-compatible C ABI surface.
-enum HoroAssetImportSettingKind {  // NOSONAR(cpp:S3642)
+enum HoroAssetImportSettingKindCode {  // NOSONAR(cpp:S3642) C ABI constants; wire values use uint32_t.
     HORO_ASSET_IMPORT_SETTING_BOOLEAN = 0,
     HORO_ASSET_IMPORT_SETTING_INTEGER = 1,
     HORO_ASSET_IMPORT_SETTING_FLOAT = 2,
     HORO_ASSET_IMPORT_SETTING_TEXT = 3,
     HORO_ASSET_IMPORT_SETTING_CHOICE = 4,
 };
-using HoroAssetImportSettingKind = enum HoroAssetImportSettingKind;
+
+typedef uint32_t HoroAssetImportSettingKind;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
 /** @brief One tagged import-setting value. */
 struct HoroAssetImportSettingValue {
@@ -80,7 +83,7 @@ struct HoroAssetImportSettingValue {
     uint64_t choiceIndex;
     HoroExtensionStringView textValue;
 };
-using HoroAssetImportSettingValue = struct HoroAssetImportSettingValue;
+typedef struct HoroAssetImportSettingValue HoroAssetImportSettingValue;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
 /** @brief One declarative choice belonging to a choice setting. */
 struct HoroAssetImportSettingChoice {
@@ -88,7 +91,7 @@ struct HoroAssetImportSettingChoice {
     HoroExtensionStringView labelKey;
     HoroAssetImportSettingValue value;
 };
-using HoroAssetImportSettingChoice = struct HoroAssetImportSettingChoice;
+typedef struct HoroAssetImportSettingChoice HoroAssetImportSettingChoice;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
 /** @brief One host-rendered declarative importer setting. */
 struct HoroAssetImportSettingDescriptor {
@@ -105,7 +108,7 @@ struct HoroAssetImportSettingDescriptor {
     uint32_t choiceCount;
     uint8_t includeInPresets;
 };
-using HoroAssetImportSettingDescriptor = struct HoroAssetImportSettingDescriptor;
+typedef struct HoroAssetImportSettingDescriptor HoroAssetImportSettingDescriptor;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
 /** @brief Borrowed input for one external importer invocation. */
 struct HoroAssetImportRequest {
@@ -117,7 +120,7 @@ struct HoroAssetImportRequest {
     uint32_t settingCount;
     HoroExtensionCancellation cancellation;
 };
-using HoroAssetImportRequest = struct HoroAssetImportRequest;
+typedef struct HoroAssetImportRequest HoroAssetImportRequest;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
 /** @brief Host-owned output surfaces filled by one external importer invocation. */
 struct HoroAssetImportResponse {
@@ -125,7 +128,7 @@ struct HoroAssetImportResponse {
     HoroExtensionStringView assetType;
     HoroExtensionByteSink editorPayload;
 };
-using HoroAssetImportResponse = struct HoroAssetImportResponse;
+typedef struct HoroAssetImportResponse HoroAssetImportResponse;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
 /** @brief Borrowed input for one rendering-neutral preview invocation. */
 struct HoroAssetPreviewRequest {
@@ -138,7 +141,7 @@ struct HoroAssetPreviewRequest {
     uint32_t height;
     HoroExtensionCancellation cancellation;
 };
-using HoroAssetPreviewRequest = struct HoroAssetPreviewRequest;
+typedef struct HoroAssetPreviewRequest HoroAssetPreviewRequest;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
 /** @brief Host-owned tightly packed RGBA8 preview output. */
 struct HoroAssetPreviewResponse {
@@ -147,13 +150,13 @@ struct HoroAssetPreviewResponse {
     uint32_t height;
     HoroExtensionByteSink rgba8Pixels;
 };
-using HoroAssetPreviewResponse = struct HoroAssetPreviewResponse;
+typedef struct HoroAssetPreviewResponse HoroAssetPreviewResponse;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
-using HoroAssetImportFunc = HoroExtensionStatus (*)(void *importerContext, const HoroAssetImportRequest *request,
-                                                    HoroAssetImportResponse *response);
-using HoroAssetPreviewFunc = HoroExtensionStatus (*)(void *importerContext, const HoroAssetPreviewRequest *request,
-                                                     HoroAssetPreviewResponse *response);
-using HoroAssetImporterDestroyFunc = void (*)(void *importerContext);
+typedef HoroExtensionStatus (*HoroAssetImportFunc)(  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
+    void *importerContext, const HoroAssetImportRequest *request, HoroAssetImportResponse *response);
+typedef HoroExtensionStatus (*HoroAssetPreviewFunc)(  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
+    void *importerContext, const HoroAssetPreviewRequest *request, HoroAssetPreviewResponse *response);
+typedef void (*HoroAssetImporterDestroyFunc)(void *importerContext);  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
 /** @brief Complete versioned descriptor registered at the asset.importer extension point. */
 struct HoroAssetImporterDescriptor {
@@ -176,10 +179,11 @@ struct HoroAssetImporterDescriptor {
     HoroAssetPreviewFunc generatePreview;
     HoroAssetImporterDestroyFunc destroyImporter;
 };
-using HoroAssetImporterDescriptor = struct HoroAssetImporterDescriptor;
+typedef struct HoroAssetImporterDescriptor HoroAssetImporterDescriptor;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
 /** @brief Host callback used only while the module load transaction is active. */
-using HoroRegisterAssetImporterFunc = HoroExtensionStatus (*)(void *hostContext, const HoroAssetImporterDescriptor *descriptor);
+typedef HoroExtensionStatus (*HoroRegisterAssetImporterFunc)(  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
+    void *hostContext, const HoroAssetImporterDescriptor *descriptor);
 
 struct HoroExtensionHostApi {
     /** @brief Size of this struct for append-only ABI negotiation. */
@@ -188,8 +192,12 @@ struct HoroExtensionHostApi {
     HoroExtensionStringView engineVersion;
     void *hostContext;
     HoroRegisterAssetImporterFunc registerAssetImporter;
+    /** @brief Appended in 1.1; read only when structSize covers this field. */
+    uint32_t abiMinorVersion;
+    /** @brief Reserved for append-only negotiation; must be zero. */
+    uint32_t reserved;
 };
-using HoroExtensionHostApi = struct HoroExtensionHostApi;
+typedef struct HoroExtensionHostApi HoroExtensionHostApi;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
 
 struct HoroExtensionModuleApi {
     /** @brief Size of this struct for append-only ABI negotiation. */
@@ -198,7 +206,34 @@ struct HoroExtensionModuleApi {
     HoroExtensionStringView moduleId;
     HoroExtensionStringView moduleVersion;
 };
-using HoroExtensionModuleApi = struct HoroExtensionModuleApi;
+typedef struct HoroExtensionModuleApi HoroExtensionModuleApi;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
+
+enum {  // NOSONAR(cpp:S3642) C ABI function requirement bits.
+    HORO_EXTENSION_REQUIRES_ASSET_IMPORTER = 1,
+};
+
+/**
+ * @brief Inert requirements returned by the optional horo_extension_query entry point.
+ *
+ * The host initializes structSize to its writable capacity and all other fields
+ * to zero. The module writes every field and returns its complete table size.
+ * Major versions must match; minimumHostMinor must not exceed the host minor.
+ * Unknown requirement bits and nonzero reserved fields are rejected. The query
+ * must not allocate lifecycle state, register contributions, or retain pointers.
+ * Without a query entry point, a module uses the legacy 1.0 bootstrap contract.
+ */
+struct HoroExtensionRequirements {
+    uint32_t structSize;
+    uint32_t abiMajorVersion;
+    uint32_t minimumHostMinor;
+    uint32_t requiredHostApiSize;
+    uint32_t requiredFunctions;
+    uint32_t reserved;
+};
+typedef struct HoroExtensionRequirements HoroExtensionRequirements;  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
+
+/** @brief Populate requirements without receiving host capabilities; return a status, never throw. */
+typedef HoroExtensionStatus (*HoroExtensionQueryFunc)(HoroExtensionRequirements *requirements);  // NOSONAR(cpp:S5416) Shared C11 ABI.
 
 /**
  * @brief Standard native extension entry point.
@@ -206,10 +241,11 @@ using HoroExtensionModuleApi = struct HoroExtensionModuleApi;
  * @param outModule Module lifecycle state populated by the extension.
  * @return HORO_EXTENSION_SUCCESS when initialization and registrations succeed.
  */
-using HoroExtensionLoadFunc = HoroExtensionStatus (*)(const HoroExtensionHostApi *host, HoroExtensionModuleApi *outModule);
+typedef HoroExtensionStatus (*HoroExtensionLoadFunc)(  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.
+    const HoroExtensionHostApi *host, HoroExtensionModuleApi *outModule);
 
 /**
  * @brief Optional native extension unload point.
  * @param extensionModule Module state originally returned by the load entry point.
  */
-using HoroExtensionUnloadFunc = void (*)(HoroExtensionModuleApi *extensionModule);
+typedef void (*HoroExtensionUnloadFunc)(HoroExtensionModuleApi *extensionModule);  // NOSONAR(cpp:S5416) Shared C11 ABI requires typedef.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -714,6 +714,7 @@ add_library(HoroExtensions STATIC
         extensions/discovery/DiscoveryPlan.cpp
         extensions/discovery/DiscoveryRootPolicy.cpp
         extensions/host/ExtensionManager.cpp
+        extensions/host/ExtensionAbiValidation.cpp
         extensions/manifest/ExtensionManifestParser.cpp
         extensions/manifest/ExtensionManifestJson.cpp
         extensions/registry/ExtensionErrors.cpp

--- a/src/extensions/capabilities/asset_pipeline_points/ExternalAssetImporter.cpp
+++ b/src/extensions/capabilities/asset_pipeline_points/ExternalAssetImporter.cpp
@@ -4,6 +4,7 @@
 #include "Horo/Foundation/Logging/Logger.h"
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <limits>
 #include <new>
@@ -27,7 +28,7 @@ namespace Horo::Extensions {
         }
 
         [[nodiscard]] bool IsLowerExtension(const std::string &value) {
-            return !value.empty() && value.front() != '.' && std::ranges::all_of(value, [](const unsigned char character) {
+            return !value.empty() && std::ranges::all_of(value, [](const unsigned char character) {
                 return std::isdigit(character) != 0 || std::islower(character) != 0 || character == '_' || character == '-';
             });
         }
@@ -63,25 +64,15 @@ namespace Horo::Extensions {
 
         [[nodiscard]] bool ConvertKind(const HoroAssetImportSettingKind source, Assets::ImportSettingKind &destination) {
             using enum Assets::ImportSettingKind;
-            switch (source) {
-                case HORO_ASSET_IMPORT_SETTING_BOOLEAN:
-                    destination = Boolean;
-                    return true;
-                case HORO_ASSET_IMPORT_SETTING_INTEGER:
-                    destination = Integer;
-                    return true;
-                case HORO_ASSET_IMPORT_SETTING_FLOAT:
-                    destination = Float;
-                    return true;
-                case HORO_ASSET_IMPORT_SETTING_TEXT:
-                    destination = Text;
-                    return true;
-                case HORO_ASSET_IMPORT_SETTING_CHOICE:
-                    destination = Choice;
-                    return true;
-                default:
-                    return false;
-            }
+            constexpr std::array kinds{std::pair{HORO_ASSET_IMPORT_SETTING_BOOLEAN, Boolean},
+                                       std::pair{HORO_ASSET_IMPORT_SETTING_INTEGER, Integer},
+                                       std::pair{HORO_ASSET_IMPORT_SETTING_FLOAT, Float}, std::pair{HORO_ASSET_IMPORT_SETTING_TEXT, Text},
+                                       std::pair{HORO_ASSET_IMPORT_SETTING_CHOICE, Choice}};
+            const auto found = std::ranges::find(kinds, source, &decltype(kinds)::value_type::first);
+            if (found == kinds.end())
+                return false;
+            destination = found->second;
+            return true;
         }
 
         [[nodiscard]] HoroAssetImportSettingValue ToAbiValue(const Assets::ImportSettingValue &value) {
@@ -89,7 +80,7 @@ namespace Horo::Extensions {
             std::visit([&result]<typename T>(const T &typed) {
                 if constexpr (std::is_same_v<T, bool>) {
                     result.kind = HORO_ASSET_IMPORT_SETTING_BOOLEAN;
-                    result.booleanValue = typed ? 1U : 0U;
+                    result.booleanValue = static_cast<std::uint8_t>(typed);
                 } else if constexpr (std::is_same_v<T, std::int64_t>) {
                     result.kind = HORO_ASSET_IMPORT_SETTING_INTEGER;
                     result.integerValue = typed;
@@ -112,7 +103,7 @@ namespace Horo::Extensions {
             if (context == nullptr) {
                 return 0U;
             }
-            return static_cast<const CancellationToken *>(context)->IsCancellationRequested() ? 1U : 0U;
+            return static_cast<std::uint8_t>(static_cast<const CancellationToken *>(context)->IsCancellationRequested());
         }
 
         [[nodiscard]] HoroExtensionStatus ResizeVector(void *context, const std::uint64_t byteCount,  // NOSONAR(cpp:S5008) C ABI callback
@@ -308,15 +299,81 @@ namespace Horo::Extensions {
         }
     }
 
+    namespace {
+        /** @brief Bound each declared span before dereferencing any element. */
+        bool HasValidImporterLists(const HoroAssetImporterDescriptor &descriptor) {
+            return descriptor.fileExtensionCount > 0 && descriptor.fileExtensionCount <= kMaxListEntries && descriptor.assetTypeCount > 0 &&
+                   descriptor.assetTypeCount <= kMaxListEntries && descriptor.settingCount <= kMaxListEntries &&
+                   descriptor.fileExtensions != nullptr && descriptor.assetTypes != nullptr &&
+                   (descriptor.settings != nullptr || descriptor.settingCount == 0);
+        }
+
+        /** @brief Reject incomplete tables and contexts without a matching owner-provided destructor. */
+        bool IsValidImporterDescriptor(const HoroAssetImporterDescriptor *descriptor) {
+            return descriptor != nullptr && descriptor->structSize >= sizeof(HoroAssetImporterDescriptor) &&
+                   descriptor->abiVersion == HORO_ASSET_IMPORTER_ABI_VERSION && descriptor->importAsset != nullptr &&
+                   (descriptor->importerContext == nullptr || descriptor->destroyImporter != nullptr) && HasValidImporterLists(*descriptor);
+        }
+
+        /** @brief Copy identity and verify the declared owning module before accepting metadata. */
+        void CopyContributionMetadata(const AssetImporterRegistrationSession &session, const HoroAssetImporterDescriptor &descriptor,
+                                      Assets::AssetImporterContribution &contribution) {
+            if (!CopyText(descriptor.contributionId, contribution.contributionId) ||
+                !CopyText(descriptor.contributionVersion, contribution.version) ||
+                !CopyText(descriptor.subfolderCategory, contribution.subfolderCategory, true) ||
+                !CopyText(descriptor.targetExtension, contribution.targetExtension))
+                throw std::invalid_argument{"invalid text"};
+
+            if (const bool declared = std::ranges::any_of(session.manifest->contributions,
+                                                          [&contribution, &session](const ExtensionContributionManifest &candidate) {
+                return candidate.type == "asset.importer" && candidate.id == contribution.contributionId &&
+                       candidate.owningModule == session.extensionModule->id;
+            });
+                !declared) {
+                throw std::invalid_argument{"undeclared contribution"};
+            }
+
+            contribution.packageId = session.manifest->id;
+            contribution.moduleId = session.extensionModule->id;
+            contribution.moduleVersion = session.extensionModule->version;
+            contribution.supportsMetaSidecar = descriptor.supportsMetaSidecar != 0;
+            if (descriptor.previewFallback > static_cast<std::uint8_t>(Assets::AssetPreviewFallback::Generic))
+                throw std::invalid_argument{"invalid fallback"};
+            contribution.previewFallback = static_cast<Assets::AssetPreviewFallback>(descriptor.previewFallback);
+        }
+
+        /** @brief Copy validated list content into host-owned contribution storage. */
+        void CopyContributionLists(const HoroAssetImporterDescriptor &descriptor, Assets::AssetImporterContribution &contribution) {
+            contribution.fileExtensions.reserve(descriptor.fileExtensionCount);
+            for (std::uint32_t index = 0; index < descriptor.fileExtensionCount; ++index) {
+                std::string extension;
+                if (!CopyText(descriptor.fileExtensions[index], extension) || !IsLowerExtension(extension))
+                    throw std::invalid_argument{"invalid file extension"};
+                contribution.fileExtensions.push_back(std::move(extension));
+            }
+
+            contribution.assetTypes.reserve(descriptor.assetTypeCount);
+            for (std::uint32_t index = 0; index < descriptor.assetTypeCount; ++index) {
+                std::string assetType;
+                if (!CopyText(descriptor.assetTypes[index], assetType))
+                    throw std::invalid_argument{"invalid asset type"};
+                auto parsed = Assets::AssetTypeId::Parse(assetType);
+                if (parsed.HasError())
+                    throw std::invalid_argument{"invalid type"};
+                contribution.assetTypes.push_back(std::move(parsed).Value());
+            }
+            contribution.settings.resize(descriptor.settingCount);
+            for (std::uint32_t index = 0; index < descriptor.settingCount; ++index) {
+                if (!ConvertSetting(descriptor.settings[index], contribution.settings[index]))
+                    throw std::invalid_argument{"invalid setting"};
+            }
+        }
+    }  // namespace
+
     HoroExtensionStatus RegisterExternalAssetImporter(void *hostContext,  // NOSONAR(cpp:S5008)
                                                       const HoroAssetImporterDescriptor *descriptor) noexcept {
         auto *session = static_cast<AssetImporterRegistrationSession *>(hostContext);
-        if (session == nullptr || descriptor == nullptr || session->failed ||
-            descriptor->structSize < sizeof(HoroAssetImporterDescriptor) || descriptor->abiVersion != HORO_ASSET_IMPORTER_ABI_VERSION ||
-            descriptor->importAsset == nullptr || descriptor->fileExtensionCount == 0 || descriptor->fileExtensionCount > kMaxListEntries ||
-            descriptor->assetTypeCount == 0 || descriptor->assetTypeCount > kMaxListEntries || descriptor->settingCount > kMaxListEntries ||
-            descriptor->fileExtensions == nullptr || descriptor->assetTypes == nullptr ||
-            (descriptor->settings == nullptr && descriptor->settingCount != 0)) {
+        if (session == nullptr || session->failed || !IsValidImporterDescriptor(descriptor)) {
             if (session != nullptr) {
                 session->failed = true;
                 session->error =
@@ -327,63 +384,20 @@ namespace Horo::Extensions {
 
         try {
             Assets::AssetImporterContribution contribution;
-            if (!CopyText(descriptor->contributionId, contribution.contributionId) ||
-                !CopyText(descriptor->contributionVersion, contribution.version) ||
-                !CopyText(descriptor->subfolderCategory, contribution.subfolderCategory, true) ||
-                !CopyText(descriptor->targetExtension, contribution.targetExtension))
-                throw std::invalid_argument{"invalid text"};
-
-            if (const bool declared = std::ranges::any_of(session->manifest->contributions,
-                                                          [&contribution, session](const ExtensionContributionManifest &candidate) {
-                return candidate.type == "asset.importer" && candidate.id == contribution.contributionId &&
-                       candidate.owningModule == session->extensionModule->id;
-            });
-                !declared) {
-                throw std::invalid_argument{"undeclared contribution"};
-            }
-
-            contribution.packageId = session->manifest->id;
-            contribution.moduleId = session->extensionModule->id;
-            contribution.moduleVersion = session->extensionModule->version;
-            contribution.supportsMetaSidecar = descriptor->supportsMetaSidecar != 0;
-            if (descriptor->previewFallback > static_cast<std::uint8_t>(Assets::AssetPreviewFallback::Generic))
-                throw std::invalid_argument{"invalid fallback"};
-            contribution.previewFallback = static_cast<Assets::AssetPreviewFallback>(descriptor->previewFallback);
-
-            contribution.fileExtensions.reserve(descriptor->fileExtensionCount);
-            for (std::uint32_t index = 0; index < descriptor->fileExtensionCount; ++index) {
-                std::string extension;
-                if (!CopyText(descriptor->fileExtensions[index], extension) || !IsLowerExtension(extension))
-                    throw std::invalid_argument{"invalid file extension"};
-                contribution.fileExtensions.push_back(std::move(extension));
-            }
-
-            contribution.assetTypes.reserve(descriptor->assetTypeCount);
-            for (std::uint32_t index = 0; index < descriptor->assetTypeCount; ++index) {
-                std::string assetType;
-                if (!CopyText(descriptor->assetTypes[index], assetType))
-                    throw std::invalid_argument{"invalid asset type"};
-                auto parsed = Assets::AssetTypeId::Parse(assetType);
-                if (parsed.HasError())
-                    throw std::invalid_argument{"invalid type"};
-                contribution.assetTypes.push_back(std::move(parsed).Value());
-            }
-            contribution.settings.resize(descriptor->settingCount);
-            for (std::uint32_t index = 0; index < descriptor->settingCount; ++index) {
-                if (!ConvertSetting(descriptor->settings[index], contribution.settings[index]))
-                    throw std::invalid_argument{"invalid setting"};
-            }
+            CopyContributionMetadata(*session, *descriptor, contribution);
+            CopyContributionLists(*descriptor, contribution);
 
             auto instance = std::make_shared<ExternalImporterInstance>();
             instance->lifetime = session->lifetime;
             instance->context = descriptor->importerContext;
-            instance->destroy = descriptor->destroyImporter;
             instance->importFn = descriptor->importAsset;
             instance->preview = descriptor->generatePreview;
             contribution.strategy = std::make_shared<ExternalAssetImporter>(instance);
             if (instance->preview != nullptr)
                 contribution.previewProvider = std::make_shared<ExternalAssetPreviewProvider>(instance);
             session->contributions.push_back(std::move(contribution));
+            // Only a successful registration transfers the caller-owned context.
+            instance->destroy = descriptor->destroyImporter;
             return HORO_EXTENSION_SUCCESS;
         } catch (...) {
             session->failed = true;

--- a/src/extensions/host/ExtensionAbiValidation.cpp
+++ b/src/extensions/host/ExtensionAbiValidation.cpp
@@ -1,0 +1,52 @@
+#include "ExtensionAbiValidation.h"
+
+#include <cstddef>
+
+namespace Horo::Extensions {
+    namespace {
+        /** @brief Validate the complete query result before inspecting its requested capabilities. */
+        bool HasSupportedRequirements(const HoroExtensionRequirements &requirements, const HoroExtensionHostApi &host) noexcept {
+            constexpr auto legacyHostSize = offsetof(HoroExtensionHostApi, abiMinorVersion);
+            return requirements.structSize == sizeof(HoroExtensionRequirements) && requirements.abiMajorVersion == host.abiVersion &&
+                   requirements.minimumHostMinor <= host.abiMinorVersion && requirements.requiredHostApiSize >= legacyHostSize &&
+                   requirements.requiredHostApiSize <= host.structSize && requirements.reserved == 0 &&
+                   (requirements.requiredFunctions & ~uint32_t{HORO_EXTENSION_REQUIRES_ASSET_IMPORTER}) == 0;
+        }
+    }  // namespace
+
+    /** @copydoc NegotiateModuleAbi */
+    HoroExtensionStatus NegotiateModuleAbi(HoroExtensionQueryFunc query,  // NOSONAR(cpp:S5205) Dynamic-library C ABI callback.
+                                           const HoroExtensionHostApi &host) noexcept {
+        if (query == nullptr)
+            return HORO_EXTENSION_SUCCESS;
+        HoroExtensionRequirements requirements{.structSize = sizeof(HoroExtensionRequirements)};
+        try {
+            if (const auto status = query(&requirements); status != HORO_EXTENSION_SUCCESS)
+                return status;
+        } catch (...) {  // NOSONAR(cpp:S1181) Contain a contract-violating native callback at the ABI boundary.
+            return HORO_EXTENSION_ERROR_INIT_FAILED;
+        }
+        if (!HasSupportedRequirements(requirements, host))
+            return HORO_EXTENSION_ERROR_VERSION_MISMATCH;
+        if ((requirements.requiredFunctions & HORO_EXTENSION_REQUIRES_ASSET_IMPORTER) != 0 && host.registerAssetImporter == nullptr)
+            return HORO_EXTENSION_ERROR_INVALID_ARGS;
+        return HORO_EXTENSION_SUCCESS;
+    }
+
+    /** @copydoc NormalizeModuleApi */
+    bool NormalizeModuleApi(HoroExtensionModuleApi &moduleApi) noexcept {
+        switch (moduleApi.structSize) {
+            case offsetof(HoroExtensionModuleApi, moduleId):
+                moduleApi.moduleId = {};
+                moduleApi.moduleVersion = {};
+                return true;
+            case offsetof(HoroExtensionModuleApi, moduleVersion):
+                moduleApi.moduleVersion = {};
+                return true;
+            case sizeof(HoroExtensionModuleApi):
+                return true;
+            default:
+                return false;
+        }
+    }
+}  // namespace Horo::Extensions

--- a/src/extensions/host/ExtensionAbiValidation.h
+++ b/src/extensions/host/ExtensionAbiValidation.h
@@ -1,0 +1,24 @@
+/** @file
+ * @brief Private validation for append-only native moduleApi result tables.
+ */
+#pragma once
+
+#include "Horo/Extensions/ExtensionAbi.h"
+
+namespace Horo::Extensions {
+    /**
+     * @brief Validate a host-owned moduleApi result and clear absent legacy fields.
+     * @param moduleApi Host-allocated, zero-initialized result after the load callback.
+     * @return False for truncated fields or a size beyond the supplied output capacity.
+     * @pre The callback received storage for exactly sizeof(HoroExtensionModuleApi).
+     */
+    [[nodiscard]] bool NormalizeModuleApi(HoroExtensionModuleApi &moduleApi) noexcept;
+
+    /**
+     * @brief Negotiate inert moduleApi requirements before invoking its load entry point.
+     * @param query Optional moduleApi query; null selects the legacy 1.0 contract.
+     * @param host Complete host-owned capability table offered to the moduleApi.
+     * @return Success only for supported versions, sizes, and required functions.
+     */
+    [[nodiscard]] HoroExtensionStatus NegotiateModuleAbi(HoroExtensionQueryFunc query, const HoroExtensionHostApi &host) noexcept;
+}  // namespace Horo::Extensions

--- a/src/extensions/host/ExtensionManager.cpp
+++ b/src/extensions/host/ExtensionManager.cpp
@@ -1,6 +1,7 @@
 #include "Horo/Extensions/ExtensionManager.h"
 
 #include "../capabilities/asset_pipeline_points/ExternalAssetImporter.h"
+#include "ExtensionAbiValidation.h"
 #include "Horo/Assets/AssetImporter.h"
 #include "Horo/Extensions/ExtensionAbi.h"
 #include "Horo/Extensions/ExtensionErrors.h"
@@ -215,7 +216,13 @@ namespace Horo::Extensions {
                 .engineVersion = {engineVersion.data(), static_cast<std::uint32_t>(engineVersion.size())},
                 .hostContext = &registration,
                 .registerAssetImporter = RegisterExternalAssetImporter,
+                .abiMinorVersion = HORO_EXTENSION_ABI_MINOR_VERSION,
             };
+            if (const auto query =
+                    reinterpret_cast<HoroExtensionQueryFunc>(library->GetSymbol("horo_extension_query"));  // NOSONAR(cpp:S3630)
+                NegotiateModuleAbi(query, hostApi) != HORO_EXTENSION_SUCCESS)
+                return Result<ActivatedModule>::Failure(
+                    MakeError(ExtensionErrors::LoadFailed, "Native module ABI requirements are incompatible with the host."));
             HoroExtensionModuleApi moduleApi{.structSize = sizeof(HoroExtensionModuleApi)};
             if (const HoroExtensionStatus status = InvokeExtensionLoad(loadFunc, hostApi, moduleApi, manifest.id);
                 status != HORO_EXTENSION_SUCCESS || registration.failed) {
@@ -225,10 +232,10 @@ namespace Horo::Extensions {
                 return Result<ActivatedModule>::Failure(
                     MakeError(ExtensionErrors::LoadFailed, "Extension load function returned an error."));
             }
-            if (!MatchesDeclaredModule(moduleApi, manifestModule.id, manifestModule.version)) {
+            if (!NormalizeModuleApi(moduleApi) || !MatchesDeclaredModule(moduleApi, manifestModule.id, manifestModule.version)) {
                 SafeUnload(lifetime->unload, moduleApi, "validation failure");
                 return Result<ActivatedModule>::Failure(
-                    MakeError(ExtensionErrors::InvalidManifest, "Loaded module identity/version does not match extension.json."));
+                    MakeError(ExtensionErrors::InvalidManifest, "Loaded module table or identity/version is invalid."));
             }
             lifetime->moduleApi = moduleApi;
             lifetime->loaded = true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -878,10 +878,32 @@ target_include_directories(HoroExtensionDiscoveryTests PRIVATE ${PROJECT_SOURCE_
 target_link_libraries(HoroExtensionDiscoveryTests PRIVATE HoroEngine::Extensions Catch2::Catch2WithMain)
 add_test(NAME HoroExtensionDiscoveryTests COMMAND HoroExtensionDiscoveryTests)
 
+add_executable(HoroExtensionAbiCConsumer unit/extensions/ExtensionAbiCConsumer.c)
+target_compile_features(HoroExtensionAbiCConsumer PRIVATE c_std_11)
+set_target_properties(HoroExtensionAbiCConsumer PROPERTIES C_EXTENSIONS OFF)
+target_link_libraries(HoroExtensionAbiCConsumer PRIVATE HoroEngine::Extensions)
+add_test(NAME HoroExtensionAbiCConsumer COMMAND HoroExtensionAbiCConsumer)
+
 add_executable(HoroExtensionManagerTests
         unit/extensions/ExtensionManagerTests.cpp
         unit/extensions/ExtensionManifestParserTests.cpp
+        unit/extensions/ExtensionAbiValidationTests.cpp
+        unit/extensions/ExtensionAbiIntegrationTests.cpp
+        unit/extensions/ExternalImporterRegistrationTests.cpp
 )
+foreach(abi_fixture_mode RANGE 0 3)
+    set(abi_fixture_target HoroExtensionAbiFixture${abi_fixture_mode})
+    add_library(${abi_fixture_target} MODULE fixtures/extensions/AbiModule.c)
+    target_compile_features(${abi_fixture_target} PRIVATE c_std_11)
+    set_target_properties(${abi_fixture_target} PROPERTIES C_EXTENSIONS OFF)
+    target_link_libraries(${abi_fixture_target} PRIVATE HoroEngine::Extensions)
+    target_compile_definitions(${abi_fixture_target} PRIVATE HORO_ABI_FIXTURE_MODE=${abi_fixture_mode})
+    add_dependencies(HoroExtensionManagerTests ${abi_fixture_target})
+    target_compile_definitions(HoroExtensionManagerTests PRIVATE
+            HORO_ABI_FIXTURE_${abi_fixture_mode}="$<TARGET_FILE:${abi_fixture_target}>")
+endforeach()
+target_include_directories(HoroExtensionManagerTests PRIVATE ${PROJECT_SOURCE_DIR}/src/extensions/host)
+target_include_directories(HoroExtensionManagerTests PRIVATE ${PROJECT_SOURCE_DIR}/src/extensions/capabilities/asset_pipeline_points)
 target_compile_features(HoroExtensionManagerTests PRIVATE cxx_std_20)
 target_link_libraries(HoroExtensionManagerTests PRIVATE HoroEngine::Extensions Catch2::Catch2WithMain)
 if(TARGET HoroAssetImporterBasicExample)

--- a/tests/fixtures/extensions/AbiModule.c
+++ b/tests/fixtures/extensions/AbiModule.c
@@ -1,0 +1,29 @@
+#include "Horo/Extensions/ExtensionAbi.h"
+
+#include <stddef.h>
+
+static uint32_t loadCount;
+
+/** @brief Expose whether negotiation prevented the load callback. */
+HORO_EXTENSION_EXPORT uint32_t horo_test_load_count(void) {
+    return loadCount;
+}
+
+#if HORO_ABI_FIXTURE_MODE != 0
+/** @brief Return a valid or deliberately incompatible inert requirements table. */
+HORO_EXTENSION_EXPORT HoroExtensionStatus horo_extension_query(HoroExtensionRequirements *requirements) {
+    *requirements = (HoroExtensionRequirements){.structSize = sizeof(HoroExtensionRequirements),
+                                                .abiMajorVersion = HORO_EXTENSION_ABI_VERSION,
+                                                .minimumHostMinor = HORO_ABI_FIXTURE_MODE == 2 ? 99 : 0,
+                                                .requiredHostApiSize = offsetof(HoroExtensionHostApi, abiMinorVersion)};
+    return HORO_EXTENSION_SUCCESS;
+}
+#endif
+
+/** @brief Return a legacy module prefix or a deliberately truncated result. */
+HORO_EXTENSION_EXPORT HoroExtensionStatus horo_extension_load(const HoroExtensionHostApi *host, HoroExtensionModuleApi *outModule) {
+    (void)host;
+    ++loadCount;
+    outModule->structSize = HORO_ABI_FIXTURE_MODE == 3 ? 1 : offsetof(HoroExtensionModuleApi, moduleId);
+    return HORO_EXTENSION_SUCCESS;
+}

--- a/tests/unit/extensions/ExtensionAbiCConsumer.c
+++ b/tests/unit/extensions/ExtensionAbiCConsumer.c
@@ -1,0 +1,16 @@
+#include "Horo/Extensions/ExtensionAbi.h"
+
+#include <stddef.h>
+
+_Static_assert(offsetof(HoroExtensionHostApi, structSize) == 0, "Host table starts with its size");
+_Static_assert(sizeof(HoroExtensionStatus) == sizeof(uint32_t), "Status values have fixed width");
+_Static_assert(sizeof(HoroAssetImportSettingKind) == sizeof(uint32_t), "Setting tags have fixed width");
+_Static_assert(offsetof(HoroExtensionModuleApi, structSize) == 0, "Module table starts with its size");
+_Static_assert(sizeof(((HoroExtensionHostApi *)0)->abiVersion) == sizeof(uint32_t), "ABI version is fixed-width");
+
+/** @brief Compile the public ABI as C, independently of C++ language extensions. */
+int main(void) {
+    const HoroExtensionHostApi host = {.structSize = sizeof(HoroExtensionHostApi), .abiVersion = HORO_EXTENSION_ABI_VERSION};
+    const HoroExtensionModuleApi module = {.structSize = sizeof(HoroExtensionModuleApi)};
+    return host.structSize == sizeof(host) && module.structSize == sizeof(module) ? 0 : 1;
+}

--- a/tests/unit/extensions/ExtensionAbiIntegrationTests.cpp
+++ b/tests/unit/extensions/ExtensionAbiIntegrationTests.cpp
@@ -1,0 +1,53 @@
+#include "Horo/Extensions/ExtensionManager.h"
+#include "Horo/Platform/DynamicLibrary.h"
+
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+
+namespace Horo::Extensions::Tests {
+    struct AbiIntegrationFixture {
+        std::filesystem::path root = std::filesystem::temp_directory_path() /
+                                     ("horo-abi-" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+
+        AbiIntegrationFixture() {
+            REQUIRE(std::filesystem::create_directory(root));
+        }
+
+        ~AbiIntegrationFixture() {
+            std::error_code error;
+            std::filesystem::remove_all(root, error);
+        }
+    };
+
+    TEST_CASE_METHOD(AbiIntegrationFixture, "Native C ABI negotiation gates actual dynamic module activation", "[Extensions][ABI]") {
+        const std::array paths{HORO_ABI_FIXTURE_0, HORO_ABI_FIXTURE_1, HORO_ABI_FIXTURE_2, HORO_ABI_FIXTURE_3};
+        for (std::size_t mode = 0; mode < paths.size(); ++mode) {
+            const auto packageRoot = root / std::to_string(mode);
+            REQUIRE(std::filesystem::create_directory(packageRoot));
+            const auto libraryPath = packageRoot / std::filesystem::path(paths[mode]).filename();
+            std::filesystem::copy_file(paths[mode], libraryPath);
+            {
+                std::ofstream manifest(packageRoot / "extension.json");
+                manifest
+                    << R"({"id":"com.example.abi","version":"1.0.0","modules":[{"id":"com.example.abi.native","version":"1.0.0","kind":"asset_importer","entry":")"
+                    << libraryPath.filename().generic_string() << R"("}]})";
+                REQUIRE(manifest.good());
+            }
+            auto loaded = Platform::LoadDynamicLibrary(libraryPath.string());
+            REQUIRE(loaded.HasValue());
+            const auto count =
+                reinterpret_cast<std::uint32_t (*)()>(loaded.Value()->GetSymbol("horo_test_load_count"));  // NOSONAR(cpp:S3630)
+            REQUIRE(count != nullptr);
+            REQUIRE(count() == 0);
+            ExtensionManager manager;
+            const auto result = manager.LoadExtension(packageRoot.string());
+            CHECK(result.HasValue() == (mode < 2));
+            CHECK(manager.GetLoadedExtensionIds().size() == (mode < 2 ? 1 : 0));
+            CHECK(count() == (mode == 2 ? 0 : 1));
+        }
+    }
+}  // namespace Horo::Extensions::Tests

--- a/tests/unit/extensions/ExtensionAbiValidationTests.cpp
+++ b/tests/unit/extensions/ExtensionAbiValidationTests.cpp
@@ -1,0 +1,114 @@
+#include "ExtensionAbiValidation.h"
+
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+
+namespace Horo::Extensions::Tests {
+    namespace {
+        HoroExtensionStatus RegisterUnused(void *, const HoroAssetImporterDescriptor *) {
+            return HORO_EXTENSION_SUCCESS;
+        }
+
+        HoroExtensionStatus QueryLegacy(HoroExtensionRequirements *requirements) {
+            *requirements = {.structSize = sizeof(HoroExtensionRequirements),
+                             .abiMajorVersion = HORO_EXTENSION_ABI_VERSION,
+                             .minimumHostMinor = 0,
+                             .requiredHostApiSize = offsetof(HoroExtensionHostApi, abiMinorVersion),
+                             .requiredFunctions = HORO_EXTENSION_REQUIRES_ASSET_IMPORTER};
+            return HORO_EXTENSION_SUCCESS;
+        }
+
+        HoroExtensionStatus QueryCurrent(HoroExtensionRequirements *requirements) {
+            QueryLegacy(requirements);
+            requirements->minimumHostMinor = HORO_EXTENSION_ABI_MINOR_VERSION;
+            requirements->requiredHostApiSize = sizeof(HoroExtensionHostApi);
+            return HORO_EXTENSION_SUCCESS;
+        }
+    }  // namespace
+
+    TEST_CASE("ABI negotiation accepts compatible minors and requires requested functions", "[Extensions][ABI]") {
+        HoroExtensionHostApi host{.structSize = sizeof(HoroExtensionHostApi),
+                                  .abiVersion = HORO_EXTENSION_ABI_VERSION,
+                                  .registerAssetImporter = RegisterUnused,
+                                  .abiMinorVersion = HORO_EXTENSION_ABI_MINOR_VERSION};
+        CHECK(NegotiateModuleAbi(nullptr, host) == HORO_EXTENSION_SUCCESS);
+        CHECK(NegotiateModuleAbi(QueryLegacy, host) == HORO_EXTENSION_SUCCESS);
+        CHECK(NegotiateModuleAbi(QueryCurrent, host) == HORO_EXTENSION_SUCCESS);
+        host.registerAssetImporter = nullptr;
+        CHECK(NegotiateModuleAbi(QueryCurrent, host) == HORO_EXTENSION_ERROR_INVALID_ARGS);
+    }
+
+    TEST_CASE("ABI negotiation rejects malformed requirements before load", "[Extensions][ABI]") {
+        const HoroExtensionHostApi host{.structSize = sizeof(HoroExtensionHostApi),
+                                        .abiVersion = HORO_EXTENSION_ABI_VERSION,
+                                        .registerAssetImporter = RegisterUnused,
+                                        .abiMinorVersion = HORO_EXTENSION_ABI_MINOR_VERSION};
+        const std::array<HoroExtensionQueryFunc, 6> invalid{[](HoroExtensionRequirements *r) -> HoroExtensionStatus {
+            QueryLegacy(r);
+            --r->structSize;
+            return HORO_EXTENSION_SUCCESS;
+        }, [](HoroExtensionRequirements *r) -> HoroExtensionStatus {
+            QueryLegacy(r);
+            ++r->abiMajorVersion;
+            return HORO_EXTENSION_SUCCESS;
+        }, [](HoroExtensionRequirements *r) -> HoroExtensionStatus {
+            QueryCurrent(r);
+            ++r->minimumHostMinor;
+            return HORO_EXTENSION_SUCCESS;
+        }, [](HoroExtensionRequirements *r) -> HoroExtensionStatus {
+            QueryCurrent(r);
+            ++r->requiredHostApiSize;
+            return HORO_EXTENSION_SUCCESS;
+        }, [](HoroExtensionRequirements *r) -> HoroExtensionStatus {
+            QueryLegacy(r);
+            r->reserved = 1;
+            return HORO_EXTENSION_SUCCESS;
+        }, [](HoroExtensionRequirements *r) -> HoroExtensionStatus {
+            QueryLegacy(r);
+            r->requiredFunctions = 2;
+            return HORO_EXTENSION_SUCCESS;
+        }};
+        for (const auto query : invalid)
+            CHECK(NegotiateModuleAbi(query, host) == HORO_EXTENSION_ERROR_VERSION_MISMATCH);
+        CHECK(NegotiateModuleAbi([](HoroExtensionRequirements *) -> HoroExtensionStatus {
+            return HORO_EXTENSION_ERROR_CANCELLED;
+        }, host) == HORO_EXTENSION_ERROR_CANCELLED);
+        CHECK(NegotiateModuleAbi([](HoroExtensionRequirements *) -> HoroExtensionStatus {
+            throw std::runtime_error("invalid native callback");
+        }, host) == HORO_EXTENSION_ERROR_INIT_FAILED);
+    }
+
+    TEST_CASE("Module result sizes accept complete legacy prefixes only", "[Extensions][ABI]") {
+        for (std::uint32_t size = 0; size <= sizeof(HoroExtensionModuleApi) + 1; ++size) {
+            HoroExtensionModuleApi moduleApi{.structSize = size};
+            const bool expected = size == offsetof(HoroExtensionModuleApi, moduleId) ||
+                                  size == offsetof(HoroExtensionModuleApi, moduleVersion) || size == sizeof(HoroExtensionModuleApi);
+            CHECK(NormalizeModuleApi(moduleApi) == expected);
+        }
+    }
+
+    TEST_CASE("Absent legacy identity fields never participate in validation", "[Extensions][ABI]") {
+        int context = 0;
+        HoroExtensionModuleApi moduleApi{.structSize = offsetof(HoroExtensionModuleApi, moduleId),
+                                         .moduleContext = &context,
+                                         .moduleId = {"ignored", 7},
+                                         .moduleVersion = {"ignored", 7}};
+        REQUIRE(NormalizeModuleApi(moduleApi));
+        CHECK(moduleApi.moduleContext == &context);
+        CHECK(moduleApi.moduleId.data == nullptr);
+        CHECK(moduleApi.moduleId.length == 0);
+        CHECK(moduleApi.moduleVersion.data == nullptr);
+        CHECK(moduleApi.moduleVersion.length == 0);
+
+        moduleApi = {.structSize = offsetof(HoroExtensionModuleApi, moduleVersion),
+                     .moduleId = {"retained", 8},
+                     .moduleVersion = {"ignored", 7}};
+        REQUIRE(NormalizeModuleApi(moduleApi));
+        CHECK(moduleApi.moduleId.length == 8);
+        CHECK(moduleApi.moduleVersion.data == nullptr);
+        CHECK(moduleApi.moduleVersion.length == 0);
+    }
+}  // namespace Horo::Extensions::Tests

--- a/tests/unit/extensions/ExternalImporterRegistrationTests.cpp
+++ b/tests/unit/extensions/ExternalImporterRegistrationTests.cpp
@@ -1,0 +1,112 @@
+#include "ExternalAssetImporter.h"
+
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+
+namespace Horo::Extensions::Tests {
+    struct RegistrationFixture {
+        int destroyed{};
+        ExtensionManifest manifest;
+        ExtensionModuleManifest owner{.id = "com.example.native", .version = "1.0.0"};
+        HoroExtensionStringView extension{"raw", 3};
+        HoroExtensionStringView assetType{"example.raw", 11};
+        AssetImporterRegistrationSession session{.manifest = &manifest, .extensionModule = &owner};
+        HoroAssetImporterDescriptor descriptor{.structSize = sizeof(HoroAssetImporterDescriptor),
+                                               .abiVersion = HORO_ASSET_IMPORTER_ABI_VERSION,
+                                               .contributionId = {"com.example.raw", 15},
+                                               .contributionVersion = {"1.0.0", 5},
+                                               .fileExtensions = &extension,
+                                               .fileExtensionCount = 1,
+                                               .assetTypes = &assetType,
+                                               .assetTypeCount = 1,
+                                               .targetExtension = {".horoasset", 10},
+                                               .importerContext = &destroyed,
+                                               .importAsset = [](void *, const HoroAssetImportRequest *,
+                                                                 HoroAssetImportResponse *) -> HoroExtensionStatus {
+            return HORO_EXTENSION_SUCCESS;
+        },
+                                               .destroyImporter = [](void *context) {
+            ++*static_cast<int *>(context);
+        }};
+
+        RegistrationFixture() {
+            manifest.id = "com.example.package";
+            manifest.contributions.push_back({.type = "asset.importer", .id = "com.example.raw", .owningModule = owner.id});
+        }
+    };
+
+    TEST_CASE_METHOD(RegistrationFixture, "Importer context transfers only after successful registration", "[Extensions][ABI]") {
+        REQUIRE(RegisterExternalAssetImporter(&session, &descriptor) == HORO_EXTENSION_SUCCESS);
+        REQUIRE(session.contributions.size() == 1);
+        CHECK(destroyed == 0);
+        descriptor.structSize = 1;
+        CHECK(RegisterExternalAssetImporter(&session, &descriptor) == HORO_EXTENSION_ERROR_INVALID_ARGS);
+        CHECK(session.failed);
+        CHECK(destroyed == 0);
+        session.contributions.clear();
+        CHECK(destroyed == 1);
+
+        using enum Assets::ImportSettingKind;
+        const std::array kinds{std::pair{HORO_ASSET_IMPORT_SETTING_BOOLEAN, Boolean}, std::pair{HORO_ASSET_IMPORT_SETTING_INTEGER, Integer},
+                               std::pair{HORO_ASSET_IMPORT_SETTING_FLOAT, Float}, std::pair{HORO_ASSET_IMPORT_SETTING_TEXT, Text},
+                               std::pair{HORO_ASSET_IMPORT_SETTING_CHOICE, Choice}};
+        for (const auto &[abiKind, expected] : kinds) {
+            RegistrationFixture fixture;
+            const HoroAssetImportSettingDescriptor setting{.id = {"setting", 7},
+                                                           .labelKey = {"setting.label", 13},
+                                                           .kind = static_cast<HoroAssetImportSettingKind>(abiKind),
+                                                           .defaultValue = {.kind = static_cast<HoroAssetImportSettingKind>(abiKind)}};
+            fixture.descriptor.settings = &setting;
+            fixture.descriptor.settingCount = 1;
+            REQUIRE(RegisterExternalAssetImporter(&fixture.session, &fixture.descriptor) == HORO_EXTENSION_SUCCESS);
+            REQUIRE(fixture.session.contributions.front().settings.size() == 1);
+            CHECK(fixture.session.contributions.front().settings.front().kind == expected);
+        }
+
+        const HoroAssetImportSettingDescriptor unknown{.id = {"setting", 7}, .labelKey = {"setting.label", 13}, .kind = 999};
+        RegistrationFixture invalid;
+        invalid.descriptor.settings = &unknown;
+        invalid.descriptor.settingCount = 1;
+        CHECK(RegisterExternalAssetImporter(&invalid.session, &invalid.descriptor) == HORO_EXTENSION_ERROR_INVALID_ARGS);
+    }
+
+    TEST_CASE("Malformed importer descriptors retain caller ownership", "[Extensions][ABI]") {
+        using Mutate = void (*)(RegistrationFixture &);
+        const std::array<Mutate, 13> invalid{[](RegistrationFixture &f) {
+            f.descriptor.structSize = 1;
+        }, [](RegistrationFixture &f) {
+            f.descriptor.abiVersion = 99;
+        }, [](RegistrationFixture &f) {
+            f.descriptor.importAsset = nullptr;
+        }, [](RegistrationFixture &f) {
+            f.descriptor.destroyImporter = nullptr;
+        }, [](RegistrationFixture &f) {
+            f.descriptor.fileExtensionCount = 257;
+        }, [](RegistrationFixture &f) {
+            f.descriptor.contributionId = {};
+        }, [](RegistrationFixture &f) {
+            f.manifest.contributions.clear();
+        }, [](RegistrationFixture &f) {
+            f.descriptor.previewFallback = 255;
+        }, [](RegistrationFixture &f) {
+            f.extension = {"INVALID", 7};
+        }, [](RegistrationFixture &f) {
+            f.assetType = {};
+        }, [](RegistrationFixture &f) {
+            f.assetType = {"bad type", 8};
+        }, [](RegistrationFixture &f) {
+            f.descriptor.settingCount = 1;
+        }, [](RegistrationFixture &f) {
+            f.extension = {".raw", 4};
+        }};
+        for (const auto mutate : invalid) {
+            RegistrationFixture fixture;
+            mutate(fixture);
+            CHECK(RegisterExternalAssetImporter(&fixture.session, &fixture.descriptor) == HORO_EXTENSION_ERROR_INVALID_ARGS);
+            CHECK(fixture.session.failed);
+            CHECK(fixture.session.contributions.empty());
+            CHECK(fixture.destroyed == 0);
+        }
+        CHECK(RegisterExternalAssetImporter(nullptr, nullptr) == HORO_EXTENSION_ERROR_INVALID_ARGS);
+    }
+}  // namespace Horo::Extensions::Tests


### PR DESCRIPTION
## Summary
- Make the shared extension ABI consumable from C11 and use fixed-width status and setting-tag values.
- Add optional inert ABI requirements negotiation before native module load, retaining the legacy v1 bootstrap.
- Validate module-result prefixes, required callbacks, and importer context ownership before activation commits.

## Motivation
Native extensions need explicit version, table-size, and ownership boundaries without exposing C++ objects or relying on unchecked module output.

## Implementation Notes
- Major versions must match; a module's minimum host minor must be supported. Unknown requirement bits and reserved values are rejected.
- Preserve the v1 host prefix; append minor/reserved fields. Modules without a query use the legacy contract.
- Reject partial module-result fields and output sizes beyond supplied capacity; normalize absent legacy identity fields.
- Require a destroy callback for a non-null importer context and defer ownership transfer until registration succeeds.
- Split importer registration validation and copying into focused helpers. Use an explicit setting-kind mapping instead of repeated switch branches.
- Document source migration and compatibility without ticket identifiers in the guide.

## Validation
- [x] Targeted builds passed
- [x] Relevant tests passed: 24 cases, 467 assertions
- [x] C11 consumer and C++ public-header consumer built
- [x] Real dynamic C module tests cover legacy, compatible query, unsupported minor, and truncated output
- [ ] Cross-platform CI and remote Sonar/Codacy results pending

Commands run:
```bash
cmake --build cmake-build-debug-coverage --target HoroExtensionManagerTests HoroExtensionAbiCConsumer HoroExtensionsPublicHeaderConsumer --parallel 8
ctest --test-dir cmake-build-debug-coverage -R '^HoroExtension(AbiCConsumer|ManagerTests)$' --output-on-failure
LLVM_PROFILE_FILE=/tmp/horo74-reduced.profraw cmake-build-debug-coverage/tests/HoroExtensionManagerTests
git diff HEAD --check
git diff HEAD --name-only -z -- '*.cpp' '*.c' '*.h' | xargs -0 clang-format --dry-run --Werror
```

- Local Sonar's latest analyses of the final edited importer implementation and registration tests returned zero findings; prior ABI validation and integration batches also returned zero findings. Local IDE analysis is not a substitute for the server gate.
- The recorded changed-production-line coverage measurement before the final simplification was 96/96 lines (100%). The new ABI validation implementation had 100% line coverage. Final PR coverage still requires CI confirmation.
- Auxiliary Lizard measurement: net complexity increase reduced from 55 to 49 while adding 20 regression assertions. The CLI SARIF does not expose the requested aggregate metric directly. The user explicitly authorized pushing this result; the original aggregate <30 target is not claimed as met.
- Commit hooks passed formatting and layout configure checks.

## Risks
- Native modules remain trusted in-process code; negotiation cannot prevent a malicious callback from violating memory bounds.
- Modules using explicit old enum tags must migrate to the public typedef names. Nonstandard short-enum binaries are not covered by compatibility guarantees.
- The query cannot allocate lifecycle state or register contributions; modules targeting older hosts must still validate the offered table in load.

## Issue Links
- Jira: [HORO-74](https://horo-engine.atlassian.net/browse/HORO-74)
- GitHub: Closes #74

## Reviewer Notes
Start with the public ABI and migration contract, then negotiation and module-result validation, importer ownership transfer, and dynamic-module/registration regressions.


[HORO-74]: https://horo-engine.atlassian.net/browse/HORO-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ